### PR TITLE
Create custom property grid validation

### DIFF
--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -95,6 +95,7 @@ Files:
     nodes/node_prop.cpp         # NodeProperty class
     nodes/node_types.cpp        # Stores node types and allowable child count
 
+    panels/cstm_propgrid.cpp    # Derived wxPropertyGrid class
     panels/code_display.cpp     # Display code in scintilla control
     panels/base_panel.cpp       # Code generation panel
     panels/nav_panel.cpp        # Navigation panel

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -49,6 +49,7 @@ public:
     ~MainFrame() override;
 
     MockupParent* GetMockup() { return m_mockupPanel; }
+    PropGridPanel* GetPropPanel() { return m_property_panel; }
 
     void AddCustomEventHandler(wxEvtHandler* handler) { m_custom_event_handlers.push_back(handler); }
 

--- a/src/panels/cstm_propgrid.cpp
+++ b/src/panels/cstm_propgrid.cpp
@@ -1,0 +1,74 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Derived wxPropertyGrid class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "pch.h"
+
+#include <wx/msgdlg.h>
+
+#include "cstm_propgrid.h"
+
+#include "mainframe.h"       // Main window frame
+#include "propgrid_panel.h"  // PropGridPanel -- PropertyGrid class for node properties and events
+
+// Most of this code is copied from wxWidgets/src/propgrid/propgrid.cpp, updated to Modern C++ coding practices. The call to
+// WasFailureHandled is specific to wxUiEditor, so remove if you use this code in another project. Also note that because the
+// message text has been converted to proper English grammar, it will not be automatically translated by wxWidgets in
+// non-English languages.
+
+bool CustomPropertyGrid::DoOnValidationFailure(wxPGProperty* property, wxVariant& WXUNUSED(invalidValue))
+{
+    auto vfb = m_validationInfo.GetFailureBehavior();
+
+    if (vfb & wxPG_VFB_BEEP)
+        ::wxBell();
+
+    if ((vfb & wxPG_VFB_MARK_CELL) && !property->HasFlag(wxPG_PROP_INVALID_VALUE))
+    {
+        auto vfbFg = *wxWHITE;
+        auto vfbBg = *wxRED;
+
+        for (unsigned int column = 0; column < m_pState->GetColumnCount(); ++column)
+        {
+            wxPGCell& cell = property->GetCell(column);
+            cell.SetFgCol(vfbFg);
+            cell.SetBgCol(vfbBg);
+        }
+
+        if (property == GetSelection())
+        {
+            SetInternalFlag(wxPG_FL_CELL_OVERRIDES_SEL);
+
+            auto editor = GetEditorControl();
+            if (editor)
+            {
+                editor->SetForegroundColour(vfbFg);
+                editor->SetBackgroundColour(vfbBg);
+            }
+        }
+
+        DrawItemAndChildren(property);
+    }
+
+    if (wxGetFrame().GetPropPanel()->WasFailureHandled())
+    {
+        return (vfb & wxPG_VFB_STAY_IN_PROPERTY) ? false : true;
+    }
+
+    if (vfb & wxPG_VFB_SHOW_MESSAGEBOX)
+    {
+        auto msg = m_validationInfo.GetFailureMessage();
+
+        if (msg.empty())
+            msg =
+                _("You have entered an invalid value. Either change the value, or press ESC to restore the original value.");
+
+        /* TRANSLATORS: Caption of message box displaying any property error */
+        ::wxMessageBox(msg, _("Property Error"));
+    }
+
+    return (vfb & wxPG_VFB_STAY_IN_PROPERTY) ? false : true;
+}

--- a/src/panels/cstm_propgrid.h
+++ b/src/panels/cstm_propgrid.h
@@ -1,0 +1,21 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Derived wxPropertyGrid class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <wx/propgrid/propgrid.h>
+
+class CustomPropertyGrid : public wxPropertyGrid
+{
+public:
+    CustomPropertyGrid() : wxPropertyGrid() {}
+
+protected:
+    bool DoOnValidationFailure(wxPGProperty* property, wxVariant& invalidValue) override;
+
+private:
+};

--- a/src/panels/cstm_propman.h
+++ b/src/panels/cstm_propman.h
@@ -1,0 +1,24 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Derived wxPropertyGrid class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+// In order to use a custom wxPropertyGrid, you have to create a class derived from wxPropertyGridManager and override the
+// CreatePropertyGrid method.
+
+#pragma once
+
+#include <wx/propgrid/manager.h>  // wxPropertyGridManager
+
+#include "cstm_propgrid.h"  // CustomPropertyGrid -- Derived wxPropertyGrid class
+
+class CustomPropertyManager : public wxPropertyGridManager
+{
+public:
+    CustomPropertyManager() : wxPropertyGridManager() {}
+
+protected:
+    wxPropertyGrid* CreatePropertyGrid() const { return new CustomPropertyGrid(); };
+};

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -59,8 +59,10 @@ PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(paren
     m_notebook_parent = new wxAuiNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxAUI_NB_TOP);
     m_notebook_parent->SetArtProvider(new wxAuiSimpleTabArt());
 
-    m_prop_grid = new wxPropertyGridManager(m_notebook_parent, PROPERTY_ID, wxDefaultPosition, wxDefaultSize,
-                                            wxPG_BOLD_MODIFIED | wxPG_SPLITTER_AUTO_CENTER | wxPG_DESCRIPTION);
+    m_prop_grid = new CustomPropertyManager;
+    m_prop_grid->Create(m_notebook_parent, PROPERTY_ID, wxDefaultPosition, wxDefaultSize,
+                        wxPG_BOLD_MODIFIED | wxPG_SPLITTER_AUTO_CENTER | wxPG_DESCRIPTION);
+
     m_event_grid = new wxPropertyGridManager(m_notebook_parent, EVENT_ID, wxDefaultPosition, wxDefaultSize,
                                              wxPG_BOLD_MODIFIED | wxPG_SPLITTER_AUTO_CENTER | wxPG_DESCRIPTION);
 
@@ -1624,7 +1626,8 @@ void PropGridPanel::VerifyChangeFile(wxPropertyGridEvent& event, NodeProperty* p
             if (project->GetChild(child_idx)->prop_as_string("base_file") == filename)
             {
                 appMsgBox(ttlib::cstr() << "The base filename " << filename << " is already in use by "
-                                        << project->GetChild(child_idx)->prop_as_string(txt_class_name));
+                                        << project->GetChild(child_idx)->prop_as_string(txt_class_name)
+                                        << "\n\nEither change the name, or press ESC to restore the original name.");
                 m_failure_handled = true;
                 event.Veto();
                 return;

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -12,6 +12,7 @@
 #include <wx/propgrid/manager.h>  // wxPropertyGridManager
 
 #include "../nodes/node_classes.h"  // Forward defintions of Node classes
+#include "cstm_propman.h"           // CustomPropertyManager -- Derived wxPropertyGrid class
 
 using EventMap = std::map<std::string, NodeEvent*>;
 using PropertyMap = std::map<std::string, NodeProperty*>;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR creates a custom **wxPropertyGrid** class so that we can can handle invalid property entries without displaying a broken English message box. This also creates a template for `VerifyChange...()` functions that can display their own custom message box instead of the default one used by our new **CustomPropertyGrid**.
