### PR TITLE
Add PropName versions of prop_as...() functions

### DIFF
--- a/src/generate/btn_widgets.cpp
+++ b/src/generate/btn_widgets.cpp
@@ -24,40 +24,40 @@ using namespace GenEnum;
 wxObject* ButtonGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
-        new wxButton(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString, node->prop_as_wxPoint("pos"),
-                     node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+        new wxButton(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString, node->prop_as_wxPoint(prop_pos),
+                     node->prop_as_wxSize(prop_size), node->prop_as_int(prop_style) | node->prop_as_int(prop_window_style));
 
-    if (node->prop_as_bool("markup"))
-        widget->SetLabelMarkup(node->prop_as_wxString(txt_label));
+    if (node->prop_as_bool(prop_markup))
+        widget->SetLabelMarkup(node->prop_as_wxString(prop_label));
     else
-        widget->SetLabel(node->prop_as_wxString(txt_label));
+        widget->SetLabel(node->prop_as_wxString(prop_label));
 
-    if (node->prop_as_bool("default_btn"))
+    if (node->prop_as_bool(prop_default_btn))
         widget->SetDefault();
 
-    if (node->prop_as_bool("auth_needed"))
+    if (node->prop_as_bool(prop_auth_needed))
         widget->SetAuthNeeded();
 
     if (node->HasValue(prop_bitmap))
-        widget->SetBitmap(node->prop_as_wxBitmap("bitmap"));
+        widget->SetBitmap(node->prop_as_wxBitmap(prop_bitmap));
 
-    if (node->HasValue("disabled_bmp"))
-        widget->SetBitmapDisabled(node->prop_as_wxBitmap("disabled_bmp"));
+    if (node->HasValue(prop_disabled_bmp))
+        widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));
 
-    if (node->HasValue("pressed_bmp"))
-        widget->SetBitmapPressed(node->prop_as_wxBitmap("pressed_bmp"));
+    if (node->HasValue(prop_pressed_bmp))
+        widget->SetBitmapPressed(node->prop_as_wxBitmap(prop_pressed_bmp));
 
-    if (node->HasValue("focus"))
-        widget->SetBitmapFocus(node->prop_as_wxBitmap("focus"));
+    if (node->HasValue(prop_focus))
+        widget->SetBitmapFocus(node->prop_as_wxBitmap(prop_focus));
 
-    if (node->HasValue("current"))
-        widget->SetBitmapCurrent(node->prop_as_wxBitmap("current"));
+    if (node->HasValue(prop_current))
+        widget->SetBitmapCurrent(node->prop_as_wxBitmap(prop_current));
 
-    if (node->HasValue("position"))
-        widget->SetBitmapPosition(static_cast<wxDirection>(node->prop_as_int("position")));
+    if (node->HasValue(prop_position))
+        widget->SetBitmapPosition(static_cast<wxDirection>(node->prop_as_int(prop_position)));
 
-    if (node->HasValue("margins"))
-        widget->SetBitmapMargins(node->prop_as_wxSize("margins"));
+    if (node->HasValue(prop_margins))
+        widget->SetBitmapMargins(node->prop_as_wxSize(prop_margins));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -73,10 +73,10 @@ bool ButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePropert
     if (prop->isProp(prop_label))
     {
         auto ctrl = wxStaticCast(widget, wxButton);
-        if (node->prop_as_bool("markup"))
-            ctrl->SetLabelMarkup(node->prop_as_wxString(txt_label));
+        if (node->prop_as_bool(prop_markup))
+            ctrl->SetLabelMarkup(node->prop_as_wxString(prop_label));
         else
-            ctrl->SetLabel(node->prop_as_wxString(txt_label));
+            ctrl->SetLabel(node->prop_as_wxString(prop_label));
 
         return true;
     }
@@ -85,9 +85,9 @@ bool ButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePropert
         // Turning markup on switches to generic rending of the button. However, you have to recreate it to switch it
         // off and go back to native rendering.
 
-        if (node->prop_as_bool("markup"))
+        if (node->prop_as_bool(prop_markup))
         {
-            wxStaticCast(widget, wxButton)->SetLabelMarkup(node->prop_as_wxString(txt_label));
+            wxStaticCast(widget, wxButton)->SetLabelMarkup(node->prop_as_wxString(prop_label));
             return true;
         }
     }
@@ -110,10 +110,10 @@ std::optional<ttlib::cstr> ButtonGenerator::GenConstruction(Node* node)
     if (node->IsLocal())
         code << "auto ";
     code << node->get_node_name() << " = new wxButton(";
-    code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
+    code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", ";
 
     auto& label = node->prop_as_string(txt_label);
-    if (label.size() && !node->prop_as_bool("markup"))
+    if (label.size() && !node->prop_as_bool(prop_markup))
     {
         code << GenerateQuotedString(label);
     }
@@ -138,15 +138,15 @@ std::optional<ttlib::cstr> ButtonGenerator::GenSettings(Node* node, size_t& /* a
 {
     ttlib::cstr code;
 
-    if (node->prop_as_bool("markup"))
+    if (node->prop_as_bool(prop_markup))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetLabelMarkup(" << GenerateQuotedString(node->prop_as_string(txt_label))
+        code << node->get_node_name() << "->SetLabelMarkup(" << GenerateQuotedString(node->prop_as_string(prop_label))
              << ");";
     }
 
-    if (node->prop_as_bool("default_btn"))
+    if (node->prop_as_bool(prop_default_btn))
     {
         if (code.size())
             code << '\n';
@@ -154,48 +154,48 @@ std::optional<ttlib::cstr> ButtonGenerator::GenSettings(Node* node, size_t& /* a
         code << node->get_node_name() << "->SetDefault();";
     }
 
-    if (node->prop_as_bool("auth_needed"))
+    if (node->prop_as_bool(prop_auth_needed))
     {
         if (code.size())
             code << '\n';
         code << node->get_node_name() << "->SetAuthNeeded();";
     }
 
-    if (node->HasValue("bitmap"))
+    if (node->HasValue(prop_bitmap))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetBitmap(" << GenerateBitmapCode(node->prop_as_string("bitmap")) << ");";
+        code << node->get_node_name() << "->SetBitmap(" << GenerateBitmapCode(node->prop_as_string(prop_bitmap)) << ");";
     }
 
-    if (node->HasValue("disabled_bmp"))
+    if (node->HasValue(prop_disabled_bmp))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetBitmapDisabled(" << GenerateBitmapCode(node->prop_as_string("disabled_bmp"))
+        code << node->get_node_name() << "->SetBitmapDisabled("
+             << GenerateBitmapCode(node->prop_as_string(prop_disabled_bmp)) << ");";
+    }
+
+    if (node->HasValue(prop_pressed_bmp))
+    {
+        if (code.size())
+            code << '\n';
+        code << node->get_node_name() << "->SetBitmapPressed(" << GenerateBitmapCode(node->prop_as_string(prop_pressed_bmp))
              << ");";
     }
 
-    if (node->HasValue("pressed_bmp"))
+    if (node->HasValue(prop_focus))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetBitmapPressed(" << GenerateBitmapCode(node->prop_as_string("pressed_bmp"))
-             << ");";
+        code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string(prop_focus)) << ");";
     }
 
-    if (node->HasValue("focus"))
+    if (node->HasValue(prop_current))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string("focus")) << ");";
-    }
-
-    if (node->HasValue("current"))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string("current"))
+        code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string(prop_current))
              << ");";
     }
 
@@ -212,37 +212,37 @@ bool ButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, st
 
 wxObject* ToggleButtonGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget =
-        new wxToggleButton(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString, node->prop_as_wxPoint("pos"),
-                           node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+    auto widget = new wxToggleButton(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString,
+                                     node->prop_as_wxPoint(prop_pos), node->prop_as_wxSize(prop_size),
+                                     node->prop_as_int(prop_style) | node->prop_as_int(prop_window_style));
 
-    if (node->prop_as_bool("markup"))
-        widget->SetLabelMarkup(node->prop_as_wxString(txt_label));
+    if (node->prop_as_bool(prop_markup))
+        widget->SetLabelMarkup(node->prop_as_wxString(prop_label));
     else
-        widget->SetLabel(node->prop_as_wxString(txt_label));
+        widget->SetLabel(node->prop_as_wxString(prop_label));
 
-    widget->SetValue((node->prop_as_bool("pressed")));
+    widget->SetValue((node->prop_as_bool(prop_pressed)));
 
-    if (node->HasValue("bitmap"))
-        widget->SetBitmap(node->prop_as_wxBitmap("bitmap"));
+    if (node->HasValue(prop_bitmap))
+        widget->SetBitmap(node->prop_as_wxBitmap(prop_bitmap));
 
-    if (node->HasValue("disabled_bmp"))
-        widget->SetBitmapDisabled(node->prop_as_wxBitmap("disdisabled_bmp"));
+    if (node->HasValue(prop_disabled_bmp))
+        widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));
 
-    if (node->HasValue("pressed_bmp"))
-        widget->SetBitmapPressed(node->prop_as_wxBitmap("pressed_bmp"));
+    if (node->HasValue(prop_pressed_bmp))
+        widget->SetBitmapPressed(node->prop_as_wxBitmap(prop_pressed_bmp));
 
-    if (node->HasValue("focus"))
-        widget->SetBitmapFocus(node->prop_as_wxBitmap("focus"));
+    if (node->HasValue(prop_focus))
+        widget->SetBitmapFocus(node->prop_as_wxBitmap(prop_focus));
 
-    if (node->HasValue("current"))
-        widget->SetBitmapCurrent(node->prop_as_wxBitmap("current"));
+    if (node->HasValue(prop_current))
+        widget->SetBitmapCurrent(node->prop_as_wxBitmap(prop_current));
 
-    if (node->HasValue("position"))
-        widget->SetBitmapPosition(static_cast<wxDirection>(node->prop_as_int("position")));
+    if (node->HasValue(prop_position))
+        widget->SetBitmapPosition(static_cast<wxDirection>(node->prop_as_int(prop_position)));
 
-    if (node->HasValue("margins"))
-        widget->SetBitmapMargins(node->prop_as_wxSize("margins"));
+    if (node->HasValue(prop_margins))
+        widget->SetBitmapMargins(node->prop_as_wxSize(prop_margins));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -258,10 +258,10 @@ bool ToggleButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodeP
     if (prop->isProp(prop_label))
     {
         auto ctrl = wxStaticCast(widget, wxToggleButton);
-        if (node->prop_as_bool("markup"))
-            ctrl->SetLabelMarkup(node->prop_as_wxString(txt_label));
+        if (node->prop_as_bool(prop_markup))
+            ctrl->SetLabelMarkup(node->prop_as_wxString(prop_label));
         else
-            ctrl->SetLabel(node->prop_as_wxString(txt_label));
+            ctrl->SetLabel(node->prop_as_wxString(prop_label));
 
         return true;
     }
@@ -270,9 +270,9 @@ bool ToggleButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodeP
         // Turning markup on switches to generic rending of the button. However, you have to recreate it to switch it
         // off and go back to native rendering.
 
-        if (node->prop_as_bool("markup"))
+        if (node->prop_as_bool(prop_markup))
         {
-            wxStaticCast(widget, wxToggleButton)->SetLabelMarkup(node->prop_as_wxString(txt_label));
+            wxStaticCast(widget, wxToggleButton)->SetLabelMarkup(node->prop_as_wxString(prop_label));
             return true;
         }
     }
@@ -291,12 +291,12 @@ std::optional<ttlib::cstr> ToggleButtonGenerator::GenConstruction(Node* node)
     if (node->IsLocal())
         code << "auto ";
     code << node->get_node_name() << " = new wxToggleButton(";
-    code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
+    code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
 
     // If markup is true, then the label has to be set in the GenSettings() section
-    if (label.size() && !node->prop_as_bool("markup"))
+    if (label.size() && !node->prop_as_bool(prop_markup))
     {
         code << GenerateQuotedString(label);
     }
@@ -321,56 +321,56 @@ std::optional<ttlib::cstr> ToggleButtonGenerator::GenSettings(Node* node, size_t
 {
     ttlib::cstr code;
 
-    if (node->prop_as_bool("pressed"))
+    if (node->prop_as_bool(prop_pressed))
     {
         if (code.size())
             code << '\n';
         code << node->get_node_name() << "->SetValue(true)";
     }
 
-    if (node->prop_as_bool("markup"))
+    if (node->prop_as_bool(prop_markup))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetLabelMarkup(" << GenerateQuotedString(node->prop_as_string(txt_label))
+        code << node->get_node_name() << "->SetLabelMarkup(" << GenerateQuotedString(node->prop_as_string(prop_label))
              << ");";
     }
 
-    if (node->HasValue("bitmap"))
+    if (node->HasValue(prop_bitmap))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetBitmap(" << GenerateBitmapCode(node->prop_as_string("bitmap")) << ");";
+        code << node->get_node_name() << "->SetBitmap(" << GenerateBitmapCode(node->prop_as_string(prop_bitmap)) << ");";
     }
 
-    if (node->HasValue("disabled_bmp"))
+    if (node->HasValue(prop_disabled_bmp))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetBitmapDisabled(" << GenerateBitmapCode(node->prop_as_string("disabled_bmp"))
+        code << node->get_node_name() << "->SetBitmapDisabled("
+             << GenerateBitmapCode(node->prop_as_string(prop_disabled_bmp)) << ");";
+    }
+
+    if (node->HasValue(prop_pressed_bmp))
+    {
+        if (code.size())
+            code << '\n';
+        code << node->get_node_name() << "->SetBitmapPressed(" << GenerateBitmapCode(node->prop_as_string(prop_pressed_bmp))
              << ");";
     }
 
-    if (node->HasValue("pressed_bmp"))
+    if (node->HasValue(prop_focus))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetBitmapPressed(" << GenerateBitmapCode(node->prop_as_string("pressed_bmp"))
-             << ");";
+        code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string(prop_focus)) << ");";
     }
 
-    if (node->HasValue("focus"))
+    if (node->HasValue(prop_current))
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string("focus")) << ");";
-    }
-
-    if (node->HasValue("current"))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string("current"))
+        code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string(prop_current))
              << ");";
     }
 
@@ -387,9 +387,9 @@ bool ToggleButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
 
 wxObject* CommandLinkBtnGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget = new wxCommandLinkButton(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString("main_label"),
-                                          node->prop_as_wxString("note"), node->prop_as_wxPoint("pos"),
-                                          node->prop_as_wxSize("size"), node->prop_as_int("window_style"));
+    auto widget = new wxCommandLinkButton(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_main_label),
+                                          node->prop_as_wxString(prop_note), node->prop_as_wxPoint(prop_pos),
+                                          node->prop_as_wxSize(prop_size), node->prop_as_int(prop_window_style));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -402,13 +402,13 @@ std::optional<ttlib::cstr> CommandLinkBtnGenerator::GenConstruction(Node* node)
     if (node->IsLocal())
         code << "auto ";
     code << node->get_node_name() << " = new wxCommandLinkButton(";
-    code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
+    code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", ";
 
     // BUGBUG: [KeyWorks - 04-09-2021] Need to support default_btn property
 
-    if (node->HasValue("main_label"))
+    if (node->HasValue(prop_main_label))
     {
-        code << GenerateQuotedString(node->prop_as_string("main_label"));
+        code << GenerateQuotedString(node->prop_as_string(prop_main_label));
     }
     else
     {
@@ -417,9 +417,9 @@ std::optional<ttlib::cstr> CommandLinkBtnGenerator::GenConstruction(Node* node)
 
     code << ",\n        ";
 
-    if (node->HasValue("note"))
+    if (node->HasValue(prop_note))
     {
-        code << GenerateQuotedString(node->prop_as_string("note"));
+        code << GenerateQuotedString(node->prop_as_string(prop_note));
     }
     else
     {

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -199,9 +199,10 @@ bool Node::IsChildAllowed(Node* child)
     auto child_type = child->GetNodeType();
     int_t max_children;
 
-    if (GetNodeTypeName() == "form")
+    if (isType(type_form))
     {
-        max_children = GetNodeDeclaration()->GetNodeType()->GetAllowableChildren(child_type, prop_as_bool("aui_managed"));
+        // max_children = GetNodeDeclaration()->GetNodeType()->GetAllowableChildren(child_type, prop_as_bool(prop_aui));
+        max_children = GetNodeDeclaration()->GetNodeType()->GetAllowableChildren(child_type, false);
     }
     else
         max_children = GetNodeDeclaration()->GetNodeType()->GetAllowableChildren(child_type);
@@ -295,14 +296,106 @@ bool Node::IsLocal()
 
 bool Node::HasValue(PropName name)
 {
-    auto prop = get_prop_ptr(name);
-    return (prop && prop->HasValue());
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].HasValue();
+    else
+        return false;
 }
 
 bool Node::prop_as_bool(PropName name)
 {
-    auto prop = get_prop_ptr(name);
-    return (prop && prop->as_bool());
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_bool();
+    else
+        return false;
+}
+
+int Node::prop_as_int(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_int();
+    else
+        return 0;
+}
+
+wxColour Node::prop_as_wxColour(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_color();
+    else
+        return wxColour();
+}
+
+wxFont Node::prop_as_font(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_font();
+    else
+        return *wxNORMAL_FONT;
+}
+
+wxPoint Node::prop_as_wxPoint(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_point();
+    else
+        return wxDefaultPosition;
+}
+
+wxSize Node::prop_as_wxSize(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_size();
+    else
+        return wxDefaultSize;
+}
+
+wxBitmap Node::prop_as_wxBitmap(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_bitmap();
+    else
+        return wxNullBitmap;
+}
+
+wxArrayString Node::prop_as_wxArrayString(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_wxArrayString();
+    else
+        return wxArrayString();
+}
+
+FontProperty Node::prop_as_font_prop(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_font_prop();
+    else
+        return FontProperty(wxNORMAL_FONT);
+}
+
+double Node::prop_as_double(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_float();
+    else
+        return 0;
+}
+
+wxString Node::prop_as_wxString(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_wxString();
+    else
+        return wxString();
+}
+
+const ttlib::cstr& Node::prop_as_string(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].get_value();
+    else
+        return tt_empty_cstr;
 }
 
 bool Node::HasValue(ttlib::cview name)
@@ -373,9 +466,9 @@ const ttlib::cstr& Node::prop_as_string(ttlib::cview name)
 
 const ttlib::cstr& Node::get_node_name()
 {
-    if (auto it = m_prop_map.find(txt_var_name); it != m_prop_map.end())
+    if (auto it = m_prop_indices.find(prop_var_name); it != m_prop_indices.end())
         return m_properties[it->second].get_value();
-    else if (it = m_prop_map.find(txt_class_name); it != m_prop_map.end())
+    else if (it = m_prop_indices.find(prop_class_name); it != m_prop_indices.end())
         return m_properties[it->second].get_value();
     else
         return tt_empty_cstr;

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -138,6 +138,24 @@ public:
     bool HasValue(PropName name);
 
     bool prop_as_bool(PropName name);
+    int prop_as_int(PropName name);
+
+    wxColour prop_as_wxColour(PropName name);
+    wxFont prop_as_font(PropName name);
+    wxPoint prop_as_wxPoint(PropName name);
+    wxSize prop_as_wxSize(PropName name);
+    wxBitmap prop_as_wxBitmap(PropName name);
+    wxArrayString prop_as_wxArrayString(PropName name);
+
+    FontProperty prop_as_font_prop(PropName name);
+    double prop_as_double(PropName name);
+
+    const ttlib::cstr& prop_as_string(PropName name);
+
+    // This will convert the string from UTF8 to UTF16 on Windows
+    wxString prop_as_wxString(PropName name);
+
+    //// Begin old style lookups ///
 
     bool HasValue(ttlib::cview name);
 
@@ -146,7 +164,6 @@ public:
     bool prop_has_value(ttlib::cview name);
 
     bool prop_as_bool(ttlib::cview name);
-
     int prop_as_int(ttlib::cview name);
 
     wxColour prop_as_wxColour(ttlib::cview name);
@@ -164,6 +181,8 @@ public:
 
     const ttlib::cstr& prop_as_string(ttlib::cview name);
     wxString prop_as_wxString(ttlib::cview name) { return GetPropertyAsString(name); }
+
+    //// End old style lookups ///
 
     wxSizerFlags GetSizerFlags();
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds `PropName` enumeration versions of the `Node` class `prop_as_...()` functions, and tests it out on all the button generators.

As expected, switching to compile time checking for accessing properties uncovered a few misnamed or removed property names which have been fixed.