### PR TITLE
Replace txt_ strings with prop_ enumerations

### DIFF
--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -38,8 +38,8 @@ static void BookCtorAddImagelist(ttlib::cstr& code, Node* node);
 wxObject* BookPageGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
-        new wxPanel(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(txt_pos), node->prop_as_wxSize(txt_size),
-                    node->prop_as_int(txt_style) | node->prop_as_int(txt_window_style));
+        new wxPanel(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(prop_pos),
+                    node->prop_as_wxSize(prop_size), node->prop_as_int(prop_style) | node->prop_as_int(prop_window_style));
 
     auto node_parent = node->GetParent();
     auto book = wxDynamicCast(parent, wxBookCtrlBase);
@@ -53,7 +53,7 @@ wxObject* BookPageGenerator::Create(Node* node, wxObject* parent)
                 if (node_parent->GetChild(idx_child) == node)
                     break;
             }
-            book->AddPage(widget, node->prop_as_wxString(txt_label), false, idx_image);
+            book->AddPage(widget, node->prop_as_wxString(prop_label), false, idx_image);
         }
         else if (node->HasValue("bitmap") && node_parent->prop_as_bool("display_images"))
         {
@@ -66,11 +66,11 @@ wxObject* BookPageGenerator::Create(Node* node, wxObject* parent)
                     ++idx_image;
             }
 
-            book->AddPage(widget, node->prop_as_wxString(txt_label), false, idx_image);
+            book->AddPage(widget, node->prop_as_wxString(prop_label), false, idx_image);
         }
         else
         {
-            book->AddPage(widget, node->prop_as_wxString(txt_label));
+            book->AddPage(widget, node->prop_as_wxString(prop_label));
         }
 
         auto cur_selection = book->GetSelection();
@@ -107,8 +107,8 @@ std::optional<ttlib::cstr> BookPageGenerator::GenConstruction(Node* node)
 
     code << '\n';
     code << GetParentName(node) << "->AddPage(" << node->get_node_name() << ", ";
-    if (node->HasValue(txt_label))
-        code << GenerateQuotedString(node->prop_as_string(txt_label));
+    if (node->HasValue(prop_label))
+        code << GenerateQuotedString(node->prop_as_string(prop_label));
     else
         code << "wxEmptyString";
 
@@ -145,7 +145,7 @@ wxObject* NotebookGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxNotebook(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     AddBookImageList(node, widget);
 
@@ -206,7 +206,7 @@ wxObject* ChoicebookGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxChoicebook(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
-                         node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                         node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
     widget->Bind(wxEVT_CHOICEBOOK_PAGE_CHANGED, &ChoicebookGenerator::OnPageChanged, this);
@@ -256,7 +256,7 @@ wxObject* ListbookGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxListbook(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     AddBookImageList(node, widget);
 
@@ -317,7 +317,7 @@ wxObject* ToolbookGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxToolbook(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     // A toolbook always has images, so we can't use AddBookImageList
 
@@ -398,7 +398,7 @@ wxObject* TreebookGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxTreebook(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     AddBookImageList(node, widget);
 

--- a/src/generate/btn_widgets.cpp
+++ b/src/generate/btn_widgets.cpp
@@ -112,7 +112,7 @@ std::optional<ttlib::cstr> ButtonGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxButton(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size() && !node->prop_as_bool(prop_markup))
     {
         code << GenerateQuotedString(label);

--- a/src/generate/checkbox_widgets.cpp
+++ b/src/generate/checkbox_widgets.cpp
@@ -19,10 +19,10 @@
 wxObject* CheckBoxGenerator::Create(Node* node, wxObject* parent)
 {
     long style_value = 0;
-    if (node->prop_as_string(txt_style).contains("wxALIGN_RIGHT"))
+    if (node->prop_as_string(prop_style).contains("wxALIGN_RIGHT"))
         style_value |= wxALIGN_RIGHT;
 
-    auto widget = new wxCheckBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(txt_label),
+    auto widget = new wxCheckBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
                                  node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
                                  style_value | node->prop_as_int("window_style"));
 
@@ -38,7 +38,7 @@ bool CheckBoxGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePrope
 {
     if (prop->GetPropName() == "label")
     {
-        wxStaticCast(widget, wxCheckBox)->SetLabel(node->prop_as_wxString(txt_label));
+        wxStaticCast(widget, wxCheckBox)->SetLabel(node->prop_as_wxString(prop_label));
         return true;
     }
     else if (prop->GetPropName() == "checked")
@@ -58,7 +58,7 @@ std::optional<ttlib::cstr> CheckBoxGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxCheckBox(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
     {
         code << GenerateQuotedString(label);
@@ -98,9 +98,9 @@ bool CheckBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 
 wxObject* Check3StateGenerator::Create(Node* node, wxObject* parent)
 {
-    long style_value = wxCHK_3STATE | node->prop_as_int(txt_style) | node->prop_as_int("window_style");
+    long style_value = wxCHK_3STATE | node->prop_as_int(prop_style) | node->prop_as_int("window_style");
 
-    auto widget = new wxCheckBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(txt_label),
+    auto widget = new wxCheckBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
                                  node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"), style_value);
 
     auto& state = node->prop_as_string("initial_state");
@@ -120,7 +120,7 @@ bool Check3StateGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePr
 {
     if (prop->GetPropName() == "label")
     {
-        wxStaticCast(widget, wxCheckBox)->SetLabel(node->prop_as_wxString(txt_label));
+        wxStaticCast(widget, wxCheckBox)->SetLabel(node->prop_as_wxString(prop_label));
         return true;
     }
     else if (prop->GetPropName() == "initial_state")
@@ -146,7 +146,7 @@ std::optional<ttlib::cstr> Check3StateGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxCheckBox(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
     {
         code << GenerateQuotedString(label);
@@ -162,7 +162,7 @@ std::optional<ttlib::cstr> Check3StateGenerator::GenConstruction(Node* node)
     GenSize(node, code);
     code << ", ";
     code << "wxCHK_3STATE";
-    auto& style = node->prop_as_string(txt_style);
+    auto& style = node->prop_as_string(prop_style);
     if (style.size())
         code << '|' << style;
     auto& win_style = node->prop_as_string("window_style");

--- a/src/generate/combo_widgets.cpp
+++ b/src/generate/combo_widgets.cpp
@@ -19,24 +19,24 @@
 
 wxObject* ComboBoxGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget = new wxComboBox(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString, node->prop_as_wxPoint("pos"),
-                                 node->prop_as_wxSize("size"), 0, NULL,
-                                 node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+    auto widget = new wxComboBox(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString, node->prop_as_wxPoint(prop_pos),
+                                 node->prop_as_wxSize(prop_size), 0, NULL,
+                                 node->prop_as_int(prop_style) | node->prop_as_int(prop_window_style));
 
-    auto& choices = node->prop_as_string(txt_choices);
+    auto& choices = node->prop_as_string(prop_choices);
     if (choices.size())
     {
         auto array = ConvertToArrayString(choices);
         for (auto& iter: array)
             widget->Append(iter);
 
-        if (node->prop_as_string("selection_string").size())
+        if (node->prop_as_string(prop_selection_string).size())
         {
-            widget->SetStringSelection(node->prop_as_string("selection_string"));
+            widget->SetStringSelection(node->prop_as_string(prop_selection_string));
         }
         else
         {
-            int sel = node->prop_as_int("selection_int");
+            int sel = node->prop_as_int(prop_selection_int);
             if (sel > -1 && sel < static_cast<int>(array.size()))
                 widget->SetSelection(sel);
         }
@@ -77,7 +77,7 @@ std::optional<ttlib::cstr> ComboBoxGenerator::GenConstruction(Node* node)
     // after all strings have been appended.
     code << "wxEmptyString";
 
-    if (node->prop_as_string("window_name").empty() && node->prop_as_string(txt_style).empty() &&
+    if (node->prop_as_string("window_name").empty() && node->prop_as_string(prop_style).empty() &&
         node->prop_as_string("window_style").empty())
     {
         GeneratePosSizeFlags(node, code);
@@ -108,9 +108,9 @@ std::optional<ttlib::cstr> ComboBoxGenerator::GenSettings(Node* node, size_t& /*
 {
     ttlib::cstr code;
 
-    if (node->prop_as_string(txt_choices).size())
+    if (node->prop_as_string(prop_choices).size())
     {
-        auto array = ConvertToArrayString(node->prop_as_string(txt_choices));
+        auto array = ConvertToArrayString(node->prop_as_string(prop_choices));
         for (auto& iter: array)
         {
             if (code.size())
@@ -153,11 +153,11 @@ bool ComboBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 
 wxObject* ChoiceGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget =
-        new wxChoice(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"), 0,
-                     NULL, node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+    auto widget = new wxChoice(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(prop_pos),
+                               node->prop_as_wxSize(prop_size), 0, NULL,
+                               node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
-    auto& items = node->prop_as_string(txt_choices);
+    auto& items = node->prop_as_string(prop_choices);
     if (items.size())
     {
         auto array = ConvertToArrayString(items);
@@ -204,7 +204,7 @@ std::optional<ttlib::cstr> ChoiceGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxChoice(";
     code << GetParentName(node) << ", " << node->prop_as_string("id");
 
-    if (node->prop_as_string("window_name").empty() && node->prop_as_string(txt_style).empty() &&
+    if (node->prop_as_string("window_name").empty() && node->prop_as_string(prop_style).empty() &&
         node->prop_as_string("window_style").empty())
     {
         GeneratePosSizeFlags(node, code);
@@ -235,9 +235,9 @@ std::optional<ttlib::cstr> ChoiceGenerator::GenSettings(Node* node, size_t& /* a
 {
     ttlib::cstr code;
 
-    if (node->prop_as_string(txt_choices).size())
+    if (node->prop_as_string(prop_choices).size())
     {
-        auto array = ConvertToArrayString(node->prop_as_string(txt_choices));
+        auto array = ConvertToArrayString(node->prop_as_string(prop_choices));
         for (auto& iter: array)
         {
             if (code.size())
@@ -280,11 +280,11 @@ bool ChoiceGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, st
 
 wxObject* BitmapComboBoxGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget = new wxBitmapComboBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->GetPropertyAsString(txt_value),
+    auto widget = new wxBitmapComboBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_value),
                                        node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"), 0, NULL,
-                                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
-    auto& choices = node->prop_as_string(txt_choices);
+    auto& choices = node->prop_as_string(prop_choices);
     if (choices.size())
     {
         auto array = ConvertToArrayString(choices);
@@ -335,7 +335,7 @@ std::optional<ttlib::cstr> BitmapComboBoxGenerator::GenConstruction(Node* node)
     // after all strings have been appended.
     code << "wxEmptyString";
 
-    if (node->prop_as_string("window_name").empty() && node->prop_as_string(txt_style).empty() &&
+    if (node->prop_as_string("window_name").empty() && node->prop_as_string(prop_style).empty() &&
         node->prop_as_string("window_style").empty())
     {
         GeneratePosSizeFlags(node, code);
@@ -368,9 +368,9 @@ std::optional<ttlib::cstr> BitmapComboBoxGenerator::GenSettings(Node* node, size
 {
     ttlib::cstr code;
 
-    if (node->prop_as_string(txt_choices).size())
+    if (node->prop_as_string(prop_choices).size())
     {
-        auto array = ConvertToArrayString(node->prop_as_string(txt_choices));
+        auto array = ConvertToArrayString(node->prop_as_string(prop_choices));
         for (auto& iter: array)
         {
             if (code.size())

--- a/src/generate/ctrl_widgets.cpp
+++ b/src/generate/ctrl_widgets.cpp
@@ -25,7 +25,7 @@ wxObject* CalendarCtrlGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxCalendarCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, wxDefaultDateTime, node->prop_as_wxPoint("pos"),
-                           node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                           node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -69,10 +69,10 @@ wxObject* FileCtrlGenerator::Create(Node* node, wxObject* parent)
 
     auto widget = new wxFileCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString("initial_folder"),
                                  node->prop_as_wxString("initial_filename"), wild,
-                                 node->prop_as_int(txt_style) | node->prop_as_int("window_style"),
+                                 node->prop_as_int(prop_style) | node->prop_as_int("window_style"),
                                  node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"));
 
-    if (!(node->prop_as_int(txt_style) & wxFC_NOSHOWHIDDEN))
+    if (!(node->prop_as_int(prop_style) & wxFC_NOSHOWHIDDEN))
         widget->ShowHidden(node->prop_as_bool("show_hidden"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
@@ -145,7 +145,7 @@ wxObject* GenericDirCtrlGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxGenericDirCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->GetPropertyAsString("defaultfolder"),
                                        node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"),
+                                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"),
                                        node->GetPropertyAsString("filter"), node->prop_as_int("defaultfilter"));
 
     widget->ShowHidden(node->prop_as_bool("show_hidden"));
@@ -212,9 +212,9 @@ bool GenericDirCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set
 
 wxObject* SearchCtrlGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget = new wxSearchCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->GetPropertyAsString(txt_value),
+    auto widget = new wxSearchCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_value),
                                    node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                                   node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                   node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (node->HasValue("search_button"))
     {
@@ -239,8 +239,8 @@ std::optional<ttlib::cstr> SearchCtrlGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxSearchCtrl(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    if (node->HasValue(txt_value))
-        code << GenerateQuotedString(node->prop_as_string(txt_value));
+    if (node->HasValue(prop_value))
+        code << GenerateQuotedString(node->prop_as_string(prop_value));
     else
         code << "wxEmptyString";
 

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -34,7 +34,7 @@ wxObject* DataViewCtrl::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxDataViewCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
-                           node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                           node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     wxObjectDataPtr<DataViewModel> model;
     model = new DataViewModel;
@@ -59,9 +59,9 @@ void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
             if (childObj->GetPropertyAsString("type") == "Text")
             {
                 auto* col = list->AppendTextColumn(
-                    childObj->GetPropertyAsString(txt_label), childObj->prop_as_int("model_column"),
-                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(txt_width),
-                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), childObj->prop_as_int("model_column"),
+                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(prop_width),
+                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -70,9 +70,9 @@ void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
             else if (childObj->GetPropertyAsString("type") == "Toggle")
             {
                 auto* col = list->AppendToggleColumn(
-                    childObj->GetPropertyAsString(txt_label), childObj->prop_as_int("model_column"),
-                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(txt_width),
-                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), childObj->prop_as_int("model_column"),
+                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(prop_width),
+                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -81,9 +81,9 @@ void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
             else if (childObj->GetPropertyAsString("type") == "Progress")
             {
                 auto* col = list->AppendProgressColumn(
-                    childObj->GetPropertyAsString(txt_label), childObj->prop_as_int("model_column"),
-                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(txt_width),
-                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), childObj->prop_as_int("model_column"),
+                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(prop_width),
+                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -92,9 +92,9 @@ void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
             else if (childObj->GetPropertyAsString("type") == "IconText")
             {
                 auto* col = list->AppendIconTextColumn(
-                    childObj->GetPropertyAsString(txt_label), childObj->prop_as_int("model_column"),
-                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(txt_width),
-                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), childObj->prop_as_int("model_column"),
+                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(prop_width),
+                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -103,9 +103,9 @@ void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
             else if (childObj->GetPropertyAsString("type") == "Date")
             {
                 auto* col = list->AppendDateColumn(
-                    childObj->GetPropertyAsString(txt_label), childObj->prop_as_int("model_column"),
-                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(txt_width),
-                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), childObj->prop_as_int("model_column"),
+                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(prop_width),
+                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -114,9 +114,9 @@ void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
             else if (childObj->GetPropertyAsString("type") == "Bitmap")
             {
                 auto* col = list->AppendBitmapColumn(
-                    childObj->GetPropertyAsString(txt_label), childObj->prop_as_int("model_column"),
-                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(txt_width),
-                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), childObj->prop_as_int("model_column"),
+                    static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")), childObj->prop_as_int(prop_width),
+                    static_cast<wxAlignment>(childObj->prop_as_int("align")), childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -155,7 +155,7 @@ wxObject* DataViewListCtrl::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxDataViewListCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
                                          node->prop_as_wxSize("size"),
-                                         node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                         node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -176,9 +176,9 @@ void DataViewListCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent *
             if (childObj->GetPropertyAsString("type") == "Text")
             {
                 auto col = list->AppendTextColumn(
-                    childObj->GetPropertyAsString(txt_label), static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")),
-                    childObj->prop_as_int(txt_width), static_cast<wxAlignment>(childObj->prop_as_int("align")),
-                    childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")),
+                    childObj->prop_as_int(prop_width), static_cast<wxAlignment>(childObj->prop_as_int("align")),
+                    childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -187,9 +187,9 @@ void DataViewListCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent *
             else if (childObj->GetPropertyAsString("type") == "Toggle")
             {
                 auto col = list->AppendToggleColumn(
-                    childObj->GetPropertyAsString(txt_label), static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")),
-                    childObj->prop_as_int(txt_width), static_cast<wxAlignment>(childObj->prop_as_int("align")),
-                    childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")),
+                    childObj->prop_as_int(prop_width), static_cast<wxAlignment>(childObj->prop_as_int("align")),
+                    childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -198,9 +198,9 @@ void DataViewListCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent *
             else if (childObj->GetPropertyAsString("type") == "Progress")
             {
                 auto col = list->AppendProgressColumn(
-                    childObj->GetPropertyAsString(txt_label), static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")),
-                    childObj->prop_as_int(txt_width), static_cast<wxAlignment>(childObj->prop_as_int("align")),
-                    childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")),
+                    childObj->prop_as_int(prop_width), static_cast<wxAlignment>(childObj->prop_as_int("align")),
+                    childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -209,9 +209,9 @@ void DataViewListCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent *
             else if (childObj->GetPropertyAsString("type") == "IconText")
             {
                 auto col = list->AppendIconTextColumn(
-                    childObj->GetPropertyAsString(txt_label), static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")),
-                    childObj->prop_as_int(txt_width), static_cast<wxAlignment>(childObj->prop_as_int("align")),
-                    childObj->prop_as_int(txt_flags));
+                    childObj->prop_as_wxString(prop_label), static_cast<wxDataViewCellMode>(childObj->prop_as_int("mode")),
+                    childObj->prop_as_int(prop_width), static_cast<wxAlignment>(childObj->prop_as_int("align")),
+                    childObj->prop_as_int(prop_flags));
                 if (childObj->HasValue("ellipsize"))
                 {
                     col->GetRenderer()->EnableEllipsize(static_cast<wxEllipsizeMode>(childObj->prop_as_int("ellipsize")));
@@ -250,7 +250,7 @@ wxObject* DataViewTreeCtrl::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxDataViewTreeCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
                                          node->prop_as_wxSize("size"),
-                                         node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                         node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -288,17 +288,17 @@ std::optional<ttlib::cstr> DataViewColumn::GenConstruction(Node* node)
     if (node->IsLocal())
         code << "auto ";
     code << node->get_node_name() << " = " << node->get_parent_name() << "->Append";
-    code << node->prop_as_string("type") << "Column(" << GenerateQuotedString(node->prop_as_string(txt_label))
+    code << node->prop_as_string("type") << "Column(" << GenerateQuotedString(node->prop_as_string(prop_label))
          << ",\n            ";
 
     code << node->prop_as_string("model_column") << ", " << node->prop_as_string("mode") << ", ";
-    code << node->prop_as_string(txt_width) << ", ";
+    code << node->prop_as_string(prop_width) << ", ";
 
     // BUGBUG: [KeyWorks - 12-14-2020] Currently the user is allowed to combine multiple alignment types such as right and
     // left which is invalid.
 
     code << "static_cast<wxAlignment>(" << node->prop_as_string("align") << "), ";
-    code << node->prop_as_string(txt_flags) << ");";
+    code << node->prop_as_string(prop_flags) << ");";
 
     if (node->HasValue("ellipsize"))
     {
@@ -317,15 +317,15 @@ std::optional<ttlib::cstr> DataViewListColumn::GenConstruction(Node* node)
     if (node->IsLocal())
         code << "auto ";
     code << node->get_node_name() << " = " << node->get_parent_name() << "->Append";
-    code << node->prop_as_string("type") << "Column(" << GenerateQuotedString(node->prop_as_string(txt_label))
+    code << node->prop_as_string("type") << "Column(" << GenerateQuotedString(node->prop_as_string(prop_label))
          << ",\n            ";
-    code << node->prop_as_string("mode") << ", " << node->prop_as_string(txt_width) << ", ";
+    code << node->prop_as_string("mode") << ", " << node->prop_as_string(prop_width) << ", ";
 
     // BUGBUG: [KeyWorks - 12-14-2020] Currently the user is allowed to combine multiple alignment types such as right and
     // left which is invalid.
 
     code << "static_cast<wxAlignment>(" << node->prop_as_string("align") << "), ";
-    code << node->prop_as_string(txt_flags) << ");";
+    code << node->prop_as_string(prop_flags) << ");";
 
     if (node->HasValue("ellipsize"))
     {

--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -23,7 +23,7 @@ std::optional<ttlib::cstr> DialogFormGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
 
     // This is the code to add to the source file
-    code << node->prop_as_string(txt_class_name) << "::" << node->prop_as_string(txt_class_name);
+    code << node->prop_as_string(prop_class_name) << "::" << node->prop_as_string(prop_class_name);
     code << "(wxWindow* parent, wxWindowID id, const wxString& title,";
     code << "\n\t\tconst wxPoint& pos, const wxSize& size, long style";
     if (node->prop_as_string("window_name").size())
@@ -65,7 +65,7 @@ std::optional<ttlib::cstr> FrameFormGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
 
     // This is the code to add to the source file
-    code << node->prop_as_string(txt_class_name) << "::" << node->prop_as_string(txt_class_name);
+    code << node->prop_as_string(prop_class_name) << "::" << node->prop_as_string(prop_class_name);
     code << "(wxWindow* parent, wxWindowID id, const wxString& title,";
     code << "\n\t\tconst wxPoint& pos, const wxSize& size, long style";
     if (node->prop_as_string("window_name").size())
@@ -110,7 +110,7 @@ std::optional<ttlib::cstr> PopupWinGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
 
     // This is the code to add to the source file
-    code << node->prop_as_string(txt_class_name) << "::" << node->prop_as_string(txt_class_name);
+    code << node->prop_as_string(prop_class_name) << "::" << node->prop_as_string(prop_class_name);
     code << "(wxWindow* parent, int border) : wxPopupTransientWindow(parent, border)\n{";
 
     return code;
@@ -158,7 +158,7 @@ std::optional<ttlib::cstr> PanelFormGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
 
     // This is the code to add to the source file
-    code << node->prop_as_string(txt_class_name) << "::" << node->prop_as_string(txt_class_name);
+    code << node->prop_as_string(prop_class_name) << "::" << node->prop_as_string(prop_class_name);
     code << "(wxWindow* parent, wxWindowID id,";
     code << "\n\t\tconst wxPoint& pos, const wxSize& size, long style";
     if (node->prop_as_string("window_name").size())

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -197,8 +197,7 @@ void MainFrame::OnGenInhertedClass(wxCommandEvent& WXUNUSED(e))
         }
         else
         {
-            results.emplace_back() << _tt("No filename specified for ") << form->get_value_ptr(txt_var_name)->c_str()
-                                   << '\n';
+            results.emplace_back() << _tt("No filename specified for ") << form->get_value_ptr("var_name")->c_str() << '\n';
             continue;
         }
 

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -21,7 +21,7 @@ ttlib::cstr GenerateSizerFlags(Node* node)
 {
     ttlib::cstr code("wxSizerFlags");
 
-    if (auto& prop = node->prop_as_string(txt_proportion); prop != "0")
+    if (auto& prop = node->prop_as_string(prop_proportion); prop != "0")
     {
         code << '(' << prop << ')';
     }
@@ -30,7 +30,7 @@ ttlib::cstr GenerateSizerFlags(Node* node)
         code << "()";
     }
 
-    if (auto& prop = node->prop_as_string(txt_alignment); prop.size())
+    if (auto& prop = node->prop_as_string(prop_alignment); prop.size())
     {
         if (prop.contains("wxALIGN_CENTER"))
         {
@@ -59,7 +59,7 @@ ttlib::cstr GenerateSizerFlags(Node* node)
         }
     }
 
-    if (auto& prop = node->prop_as_string(txt_flags); prop.size())
+    if (auto& prop = node->prop_as_string(prop_flags); prop.size())
     {
         if (prop.contains("wxEXPAND"))
         {
@@ -79,9 +79,9 @@ ttlib::cstr GenerateSizerFlags(Node* node)
         }
     }
 
-    if (auto& prop = node->prop_as_string(txt_borders); prop.size())
+    if (auto& prop = node->prop_as_string(prop_borders); prop.size())
     {
-        auto border_size = node->prop_as_string(txt_border_size);
+        auto border_size = node->prop_as_string(prop_border_size);
         if (prop.contains("wxALL"))
         {
             if (border_size == "5")
@@ -249,7 +249,7 @@ void GenSize(Node* node, ttlib::cstr& code)
 
 void GenStyle(Node* node, ttlib::cstr& code, ttlib::cview extra_style, ttlib::cview extra_def_value)
 {
-    auto& style = node->prop_as_string(txt_style);
+    auto& style = node->prop_as_string(prop_style);
     auto& win_style = node->prop_as_string("window_style");
 
     if (style.empty() && win_style.empty() && extra_style.empty())
@@ -295,7 +295,7 @@ void GeneratePosSizeFlags(Node* node, ttlib::cstr& code, bool uses_def_validator
 {
     auto pos = node->prop_as_wxPoint("pos");
     auto size = node->prop_as_wxPoint("size");
-    auto& style = node->prop_as_string(txt_style);
+    auto& style = node->prop_as_string(prop_style);
     auto& win_style = node->prop_as_string("window_style");
     auto& win_name = node->prop_as_string("window_name");
 
@@ -684,7 +684,7 @@ ttlib::cstr GenFormCode(const std::string& cmd, Node* node, const std::string& c
             code << "wxDefaultSize";
 
         code << ",\n    long style = ";
-        auto& style = node->prop_as_string(txt_style);
+        auto& style = node->prop_as_string(prop_style);
         auto& win_style = node->prop_as_string("window_style");
         if (style.empty() && win_style.empty())
             code << "0";
@@ -716,9 +716,9 @@ ttlib::cstr GenFormCode(const std::string& cmd, Node* node, const std::string& c
     else if (cmd == "base")
     {
         code << "public ";
-        if (node->HasValue(txt_base_class_name))
+        if (node->HasValue(prop_base_class_name))
         {
-            code << node->prop_as_string(txt_base_class_name);
+            code << node->prop_as_string(prop_base_class_name);
         }
         else
         {
@@ -767,7 +767,7 @@ ttlib::cstr GenFormSettings(Node* node)
 
     if (node->GetClassName() != "PanelForm" && node->GetClassName() != "wxToolBar")
     {
-        auto min_size = node->prop_as_wxSize(txt_minimum_size);
+        auto min_size = node->prop_as_wxSize(prop_minimum_size);
         auto max_size = node->prop_as_wxSize("maximum_size");
 
         if (min_size.x == -1 && min_size.y == -1 && max_size.x == -1 && max_size.y == -1)

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -103,7 +103,7 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_TYP
         }
     }
 
-    auto derived_name = form->prop_as_string(txt_derived_class_name);
+    auto derived_name = form->prop_as_string(prop_derived_class_name);
 
     m_header->Clear();
     m_source->Clear();
@@ -155,9 +155,9 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_TYP
             m_source->writeLine();
         }
 
-        if (project->prop_has_value(txt_src_preamble))
+        if (project->HasValue(prop_src_preamble))
         {
-            ttlib::cstr code(project->prop_as_string(txt_src_preamble));
+            ttlib::cstr code(project->prop_as_string(prop_src_preamble));
 
             // The multi-line editor may have been used in which case there are escaped newlines and tabs -- we convert
             // those to the actual characters before generating the code. It's common with that editor to have a trailing

--- a/src/generate/gen_inherit.cpp
+++ b/src/generate/gen_inherit.cpp
@@ -170,7 +170,7 @@ void GenerateWindowSettings(Node* node, ttlib::cstr& code)
     if (node->IsForm() && node->GetClassName() != "PanelForm" && node->GetClassName() != "wxToolBar")
         allow_minmax = false;
 
-    auto size = node->prop_as_wxPoint(txt_minimum_size);
+    auto size = node->prop_as_wxPoint(prop_minimum_size);
     if (size.x != -1 || size.y != -1)
     {
         if (allow_minmax)

--- a/src/generate/grid_widgets.cpp
+++ b/src/generate/grid_widgets.cpp
@@ -218,8 +218,8 @@ std::optional<ttlib::cstr> GridGenerator::GenSettings(Node* node, size_t& auto_i
         code << "\n        " << node->get_node_name() << "->SetLabelBackgroundColour(" << GenerateColorCode(node, "label_bg")
              << ");";
 
-// TODO: [KeyWorks - 02-27-2021] GenerateFontCode() was removed because it was obsolete and broken. It needs to be replaced, but it
-// should be part of an entire wxGrid overhaul.
+        // TODO: [KeyWorks - 02-27-2021] GenerateFontCode() was removed because it was obsolete and broken. It needs to be
+        // replaced, but it should be part of an entire wxGrid overhaul.
 
 #if 0
     if (node->HasValue("label_font"))
@@ -267,7 +267,7 @@ wxObject* PropertyGridGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxPropertyGrid(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
-                           node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                           node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (!node->GetPropertyAsString("extra_style").empty())
     {
@@ -291,8 +291,8 @@ void PropertyGridGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
         {
             if (childObj->prop_as_string("type") == "Category")
             {
-                pg->Append(new wxPropertyCategory(childObj->GetPropertyAsString(txt_label),
-                                                  childObj->GetPropertyAsString(txt_label)));
+                pg->Append(
+                    new wxPropertyCategory(childObj->prop_as_wxString(prop_label), childObj->prop_as_wxString(prop_label)));
             }
             else
             {
@@ -300,8 +300,8 @@ void PropertyGridGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
                     wxCreateDynamicObject("wx" + (childObj->GetPropertyAsString("type")) + "Property"), wxPGProperty);
                 if (prop)
                 {
-                    prop->SetLabel(childObj->GetPropertyAsString(txt_label));
-                    prop->SetName(childObj->GetPropertyAsString(txt_label));
+                    prop->SetLabel(childObj->prop_as_wxString(prop_label));
+                    prop->SetName(childObj->prop_as_wxString(prop_label));
                     pg->Append(prop);
 
                     if (childObj->GetPropertyAsString("help") != wxEmptyString)
@@ -351,7 +351,7 @@ wxObject* PropertyGridManagerGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxPropertyGridManager(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
                                             node->prop_as_wxSize("size"),
-                                            node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                            node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (!node->GetPropertyAsString("extra_style").empty())
     {
@@ -377,7 +377,7 @@ void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /
         if (childObj->GetClassName() == "propGridPage")
         {
             wxPropertyGridPage* page =
-                pgm->AddPage(childObj->GetPropertyAsString(txt_label), childObj->prop_as_wxBitmap("bitmap"));
+                pgm->AddPage(childObj->prop_as_wxString(prop_label), childObj->prop_as_wxBitmap("bitmap"));
 
             for (size_t j = 0; j < childObj->GetChildCount(); ++j)
             {
@@ -386,8 +386,8 @@ void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /
                 {
                     if (innerChildObj->GetPropertyAsString("type") == "Category")
                     {
-                        page->Append(new wxPropertyCategory(innerChildObj->GetPropertyAsString(txt_label),
-                                                            innerChildObj->GetPropertyAsString(txt_label)));
+                        page->Append(new wxPropertyCategory(innerChildObj->prop_as_wxString(prop_label),
+                                                            innerChildObj->prop_as_wxString(prop_label)));
                     }
                     else
                     {
@@ -396,8 +396,8 @@ void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /
                             wxPGProperty);
                         if (prop)
                         {
-                            prop->SetLabel(innerChildObj->GetPropertyAsString(txt_label));
-                            prop->SetName(innerChildObj->GetPropertyAsString(txt_label));
+                            prop->SetLabel(innerChildObj->prop_as_wxString(prop_label));
+                            prop->SetName(innerChildObj->prop_as_wxString(prop_label));
                             page->Append(prop);
 
                             if (innerChildObj->GetPropertyAsString("help") != wxEmptyString)
@@ -464,13 +464,13 @@ std::optional<ttlib::cstr> PropertyGridItemGenerator::GenConstruction(Node* node
     if (node->prop_as_string("type") == "Category")
     {
         code << "->Append(new wxPropertyCategory(";
-        code << GenerateQuotedString(node->prop_as_string(txt_label)) << ", "
-             << GenerateQuotedString(node->prop_as_string(txt_label)) << ");";
+        code << GenerateQuotedString(node->prop_as_string(prop_label)) << ", "
+             << GenerateQuotedString(node->prop_as_string(prop_label)) << ");";
     }
     else
     {
         code << "->Append(new wx" << node->prop_as_string("type") << "Property(";
-        code << GenerateQuotedString(node->prop_as_string(txt_label)) << ", "
+        code << GenerateQuotedString(node->prop_as_string(prop_label)) << ", "
              << GenerateQuotedString(node->prop_as_string("help")) << ");";
     }
 
@@ -486,7 +486,7 @@ std::optional<ttlib::cstr> PropertyGridPageGenerator::GenConstruction(Node* node
     if (node->IsLocal())
         code << "auto ";
     code << node->get_node_name() << " = " << node->get_parent_name() << "->AddPage(";
-    code << GenerateQuotedString(node->prop_as_string(txt_label)) << ", "
+    code << GenerateQuotedString(node->prop_as_string(prop_label)) << ", "
          << GenerateBitmapCode(node->prop_as_string("bitmap")) << ");";
 
     return code;

--- a/src/generate/listbox_widgets.cpp
+++ b/src/generate/listbox_widgets.cpp
@@ -22,11 +22,11 @@
 
 wxObject* ListBoxGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget =
-        new wxListBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                      0, NULL, node->prop_as_int("type") | node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+    auto widget = new wxListBox(
+        wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"), 0, NULL,
+        node->prop_as_int("type") | node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
-    auto& items = node->prop_as_string(txt_choices);
+    auto& items = node->prop_as_string(prop_choices);
     if (items.size())
     {
         auto array = ConvertToArrayString(items);
@@ -59,7 +59,7 @@ std::optional<ttlib::cstr> ListBoxGenerator::GenConstruction(Node* node)
     code << GetParentName(node) << ", " << node->prop_as_string("id");
 
     if (node->prop_as_string("window_name").empty() && node->prop_as_string("type") == "wxLB_SINGLE" &&
-        node->prop_as_string(txt_style).empty() && node->prop_as_string("window_style").empty())
+        node->prop_as_string(prop_style).empty() && node->prop_as_string("window_style").empty())
     {
         GeneratePosSizeFlags(node, code);
     }
@@ -76,7 +76,7 @@ std::optional<ttlib::cstr> ListBoxGenerator::GenConstruction(Node* node)
         code << ", 0, NULL, ";
 
         auto& type = node->prop_as_string("type");
-        auto& style = node->prop_as_string(txt_style);
+        auto& style = node->prop_as_string(prop_style);
         auto& win_style = node->prop_as_string("window_style");
 
         if (type == "wxLB_SINGLE" && style.empty() && win_style.empty())
@@ -108,9 +108,9 @@ std::optional<ttlib::cstr> ListBoxGenerator::GenSettings(Node* node, size_t& /* 
 {
     ttlib::cstr code;
 
-    if (node->prop_as_string(txt_choices).size())
+    if (node->prop_as_string(prop_choices).size())
     {
-        auto array = ConvertToArrayString(node->prop_as_string(txt_choices));
+        auto array = ConvertToArrayString(node->prop_as_string(prop_choices));
         for (auto& iter: array)
         {
             if (code.size())
@@ -155,9 +155,9 @@ wxObject* CheckListBoxGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxCheckListBox(
         wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"), 0, NULL,
-        node->prop_as_int("type") | node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+        node->prop_as_int("type") | node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
-    auto& items = node->prop_as_string(txt_choices);
+    auto& items = node->prop_as_string(prop_choices);
     if (items.size())
     {
         auto array = ConvertToArrayString(items);
@@ -190,7 +190,7 @@ std::optional<ttlib::cstr> CheckListBoxGenerator::GenConstruction(Node* node)
     code << GetParentName(node) << ", " << node->prop_as_string("id");
 
     if (node->prop_as_string("window_name").empty() && node->prop_as_string("type") == "wxLB_SINGLE" &&
-        node->prop_as_string(txt_style).empty() && node->prop_as_string("window_style").empty())
+        node->prop_as_string(prop_style).empty() && node->prop_as_string("window_style").empty())
     {
         GeneratePosSizeFlags(node, code);
     }
@@ -207,7 +207,7 @@ std::optional<ttlib::cstr> CheckListBoxGenerator::GenConstruction(Node* node)
         code << ", 0, NULL, ";
 
         auto& type = node->prop_as_string("type");
-        auto& style = node->prop_as_string(txt_style);
+        auto& style = node->prop_as_string(prop_style);
         auto& win_style = node->prop_as_string("window_style");
 
         if (type == "wxLB_SINGLE" && style.empty() && win_style.empty())
@@ -239,9 +239,9 @@ std::optional<ttlib::cstr> CheckListBoxGenerator::GenSettings(Node* node, size_t
 {
     ttlib::cstr code;
 
-    if (node->prop_as_string(txt_choices).size())
+    if (node->prop_as_string(prop_choices).size())
     {
-        auto array = ConvertToArrayString(node->prop_as_string(txt_choices));
+        auto array = ConvertToArrayString(node->prop_as_string(prop_choices));
         for (auto& iter: array)
         {
             if (code.size())
@@ -286,9 +286,9 @@ wxObject* HtmlListBoxGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxSimpleHtmlListBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
                                           node->prop_as_wxSize("size"), 0, NULL,
-                                          node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                          node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
-    auto& items = node->prop_as_string(txt_choices);
+    auto& items = node->prop_as_string(prop_choices);
     if (items.size())
     {
         auto array = ConvertToArrayString(items);
@@ -310,7 +310,7 @@ std::optional<ttlib::cstr> HtmlListBoxGenerator::GenConstruction(Node* node)
     code << GetParentName(node) << ", " << node->prop_as_string("id");
 
     if (node->prop_as_string("window_name").empty() && node->prop_as_string("type") == "wxLB_SINGLE" &&
-        node->prop_as_string(txt_style).empty() && node->prop_as_string("window_style").empty())
+        node->prop_as_string(prop_style).empty() && node->prop_as_string("window_style").empty())
     {
         GeneratePosSizeFlags(node, code);
     }
@@ -326,7 +326,7 @@ std::optional<ttlib::cstr> HtmlListBoxGenerator::GenConstruction(Node* node)
         GenSize(node, code);
         code << ", 0, NULL, ";
 
-        auto& style = node->prop_as_string(txt_style);
+        auto& style = node->prop_as_string(prop_style);
         auto& win_style = node->prop_as_string("window_style");
 
         if (style.empty() && win_style.empty())
@@ -359,9 +359,9 @@ std::optional<ttlib::cstr> HtmlListBoxGenerator::GenSettings(Node* node, size_t&
 {
     ttlib::cstr code;
 
-    if (node->prop_as_string(txt_choices).size())
+    if (node->prop_as_string(prop_choices).size())
     {
-        auto array = ConvertToArrayString(node->prop_as_string(txt_choices));
+        auto array = ConvertToArrayString(node->prop_as_string(prop_choices));
         for (auto& iter: array)
         {
             if (code.size())

--- a/src/generate/listctrl_widgets.cpp
+++ b/src/generate/listctrl_widgets.cpp
@@ -22,7 +22,7 @@ wxObject* ListViewGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxListView(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
 #if 0
 // REVIEW: [KeyWorks - 12-13-2020] This is the original code, but we should be able to do much better by making it possible for the user

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -30,7 +30,7 @@ wxObject* MenuBarBase::Create(Node* node, wxObject* parent)
 
     for (auto& iter: node->GetChildNodePtrs())
     {
-        auto label = new wxStaticText(panel, wxID_ANY, iter->prop_as_wxString(txt_label));
+        auto label = new wxStaticText(panel, wxID_ANY, iter->prop_as_wxString(prop_label));
         sizer->Add(label, wxSizerFlags().Border(wxALL));
         label->Bind(wxEVT_LEFT_DOWN, &MenuBarBase::OnLeftMenuClick, this);
     }
@@ -52,7 +52,7 @@ void MenuBarBase::OnLeftMenuClick(wxMouseEvent& event)
     Node* menu_node = nullptr;
     for (size_t pos_menu = 0; pos_menu < m_node_menubar->GetChildCount(); ++pos_menu)
     {
-        if (m_node_menubar->GetChild(pos_menu)->prop_as_string(txt_label) == text)
+        if (m_node_menubar->GetChild(pos_menu)->prop_as_string(prop_label) == text)
         {
             menu_node = m_node_menubar->GetChild(pos_menu);
             break;
@@ -77,7 +77,7 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
         if (menu_item->isType(type_submenu))
         {
             auto result = MakeSubMenu(menu_item.get());
-            auto item = sub_menu->AppendSubMenu(result, menu_item->GetPropertyAsString(txt_label));
+            auto item = sub_menu->AppendSubMenu(result, menu_item->prop_as_wxString(prop_label));
             if (menu_item->HasValue("bitmap"))
                 item->SetBitmap(menu_item->prop_as_wxBitmap("bitmap"));
         }
@@ -87,7 +87,7 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
         }
         else
         {
-            auto menu_label = menu_item->prop_as_string(txt_label);
+            auto menu_label = menu_item->prop_as_string(prop_label);
             auto shortcut = menu_item->prop_as_string("shortcut");
             if (shortcut.size())
             {
@@ -190,7 +190,7 @@ std::optional<ttlib::cstr> MenuBarFormGenerator::GenConstruction(Node* node)
 {
     ttlib::cstr code;
 
-    code << node->prop_as_string(txt_class_name) << "::" << node->prop_as_string(txt_class_name);
+    code << node->prop_as_string(prop_class_name) << "::" << node->prop_as_string(prop_class_name);
     code << "(long style) : wxMenuBar(style)\n{";
 
     return code;
@@ -210,9 +210,9 @@ std::optional<ttlib::cstr> MenuBarFormGenerator::GenCode(const std::string& cmd,
     else if (cmd == "base")
     {
         code << "public ";
-        if (node->HasValue(txt_base_class_name))
+        if (node->HasValue(prop_base_class_name))
         {
-            code << node->prop_as_string(txt_base_class_name);
+            code << node->prop_as_string(prop_base_class_name);
         }
         else
         {
@@ -271,13 +271,13 @@ std::optional<ttlib::cstr> MenuGenerator::GenCode(const std::string& cmd, Node* 
         if (parent_type->get_name() == "menubar")
         {
             code << "    " << node->get_parent_name() << "->Append(" << node->get_node_name() << ", ";
-            code << GenerateQuotedString(node->prop_as_string(txt_label)) << ");";
+            code << GenerateQuotedString(node->prop_as_string(prop_label)) << ");";
         }
         else if (parent_type->get_name() == "menubar_form")
         {
             code << "    "
                  << "Append(" << node->get_node_name() << ", ";
-            code << GenerateQuotedString(node->prop_as_string(txt_label)) << ");";
+            code << GenerateQuotedString(node->prop_as_string(prop_label)) << ");";
         }
         else
         {
@@ -343,7 +343,7 @@ std::optional<ttlib::cstr> SubMenuGenerator::GenCode(const std::string& cmd, Nod
     if (cmd == "after_addchild")
     {
         code << "    " << node->get_parent_name() << "->AppendSubMenu(" << node->get_node_name() << ", ";
-        code << GenerateQuotedString(node->prop_as_string(txt_label)) << ");";
+        code << GenerateQuotedString(node->prop_as_string(prop_label)) << ");";
     }
     else
     {
@@ -383,7 +383,7 @@ std::optional<ttlib::cstr> MenuItemGenerator::GenConstruction(Node* node)
 
     code << node->get_node_name() << " = new wxMenuItem(" << node->get_parent_name() << ", " << node->prop_as_string("id")
          << ", ";
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
     {
         code << GenerateQuotedString(label);

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -151,7 +151,7 @@ wxObject* StaticLineGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxStaticLine(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
-                         node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                         node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -166,7 +166,7 @@ std::optional<ttlib::cstr> StaticLineGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxStaticLine(";
     code << GetParentName(node) << ", " << node->prop_as_string("id");
 
-    if (node->prop_as_string(txt_style) != "wxLI_HORIZONTAL")
+    if (node->prop_as_string(prop_style) != "wxLI_HORIZONTAL")
     {
         GeneratePosSizeFlags(node, code);
     }
@@ -206,7 +206,7 @@ bool StaticLineGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 
 wxObject* StatusBarGenerator::Create(Node* node, wxObject* parent)
 {
-    auto org_style = node->prop_as_int(txt_style);
+    auto org_style = node->prop_as_int(prop_style);
     // Don't display the gripper as it can resize our main window rather than just the mockup window
     auto widget = new wxStatusBar(wxStaticCast(parent, wxWindow), wxID_ANY,
                                   (org_style &= ~wxSTB_SIZEGRIP) | node->prop_as_int("window_style"));
@@ -233,7 +233,7 @@ std::optional<ttlib::cstr> StatusBarGenerator::GenConstruction(Node* node)
         GenStyle(node, code);
         code << ", " << node->prop_as_string("window_name");
     }
-    else if (node->prop_as_int(txt_style) != wxSTB_DEFAULT_STYLE || node->prop_as_int("window_style") > 0)
+    else if (node->prop_as_int(prop_style) != wxSTB_DEFAULT_STYLE || node->prop_as_int("window_style") > 0)
     {
         code << node->prop_as_int("fields") << ", " << node->prop_as_string("id");
         GenStyle(node, code);
@@ -354,7 +354,7 @@ wxObject* GaugeGenerator::Create(Node* node, wxObject* parent)
     auto widget =
         new wxGauge(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_int("range"), node->prop_as_wxPoint("pos"),
                     node->prop_as_wxSize("size"),
-                    node->prop_as_int("orientation") | node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                    node->prop_as_int("orientation") | node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
     widget->SetValue(node->prop_as_int("position"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
@@ -428,9 +428,9 @@ bool GaugeGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std
 wxObject* SliderGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
-        new wxSlider(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_int(txt_value), node->prop_as_int("minValue"),
+        new wxSlider(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_int(prop_value), node->prop_as_int("minValue"),
                      node->prop_as_int("maxValue"), node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                     node->prop_as_int("orientation") | node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                     node->prop_as_int("orientation") | node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
     widget->SetValue(node->prop_as_int("position"));
     if (node->prop_as_int("line_size") > 0)
         widget->SetLineSize(node->prop_as_int("line_size"));
@@ -542,9 +542,9 @@ bool SliderGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, st
 wxObject* HyperlinkGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
-        new wxHyperlinkCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->GetPropertyAsString(txt_label),
+        new wxHyperlinkCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
                             node->GetPropertyAsString("url"), node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                            node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                            node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (node->HasValue("hover_color"))
     {
@@ -573,7 +573,7 @@ std::optional<ttlib::cstr> HyperlinkGenerator::GenConstruction(Node* node)
 
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
     {
         code << GenerateQuotedString(label);

--- a/src/generate/panel_widgets.cpp
+++ b/src/generate/panel_widgets.cpp
@@ -23,8 +23,8 @@
 wxObject* PanelGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
-        new wxPanel(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(txt_pos), node->prop_as_wxSize(txt_size),
-                    node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+        new wxPanel(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(prop_pos),
+                    node->prop_as_wxSize(prop_size), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -54,9 +54,9 @@ std::optional<ttlib::cstr> PanelGenerator::GenConstruction(Node* node)
 
 wxObject* CollapsiblePaneGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget = new wxCollapsiblePane(wxStaticCast(parent, wxWindow), wxID_ANY, node->GetPropertyAsString(txt_label),
-                                        node->prop_as_wxPoint(txt_pos), node->prop_as_wxSize(txt_size),
-                                        node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+    auto widget = new wxCollapsiblePane(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
+                                        node->prop_as_wxPoint(prop_pos), node->prop_as_wxSize(prop_size),
+                                        node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (GetMockup()->IsShowingHidden())
         widget->Collapse(false);
@@ -91,7 +91,7 @@ std::optional<ttlib::cstr> CollapsiblePaneGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxCollapsiblePane(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
     {
         code << GenerateQuotedString(label);

--- a/src/generate/picker_widgets.cpp
+++ b/src/generate/picker_widgets.cpp
@@ -24,9 +24,9 @@
 
 wxObject* DatePickerCtrlGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget =
-        new wxDatePickerCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, wxDefaultDateTime, node->prop_as_wxPoint("pos"),
-                             node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+    auto widget = new wxDatePickerCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, wxDefaultDateTime,
+                                       node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
+                                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -61,9 +61,9 @@ bool DatePickerCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set
 
 wxObject* TimePickerCtrlGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget =
-        new wxTimePickerCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, wxDefaultDateTime, node->prop_as_wxPoint("pos"),
-                             node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+    auto widget = new wxTimePickerCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, wxDefaultDateTime,
+                                       node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
+                                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -103,7 +103,7 @@ wxObject* FilePickerGenerator::Create(Node* node, wxObject* parent)
         node->prop_as_string("message").size() ? node->GetPropertyAsString("message") : wxFileSelectorPromptStr,
         node->prop_as_string("wildcard").size() ? node->GetPropertyAsString("wildcard") : wxFileSelectorDefaultWildcardStr,
         node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-        node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+        node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -181,7 +181,7 @@ wxObject* DirPickerGenerator::Create(Node* node, wxObject* parent)
         wxStaticCast(parent, wxWindow), node->prop_as_int("id"), node->GetPropertyAsString("initial_path"),
         node->prop_as_string("message").size() ? node->GetPropertyAsString("message") : wxDirSelectorPromptStr,
         node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-        node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+        node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -241,9 +241,9 @@ bool DirPickerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 wxObject* ColourPickerGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
-        new wxColourPickerCtrl(wxStaticCast(parent, wxWindow), node->prop_as_int("id"), node->prop_as_wxColour(txt_colour),
+        new wxColourPickerCtrl(wxStaticCast(parent, wxWindow), node->prop_as_int("id"), node->prop_as_wxColour(prop_colour),
                                node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                               node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                               node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -257,8 +257,8 @@ std::optional<ttlib::cstr> ColourPickerGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxColourPickerCtrl(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
-    if (node->prop_as_string(txt_colour).size())
-        code << node->prop_as_string(txt_colour);
+    if (node->prop_as_string(prop_colour).size())
+        code << node->prop_as_string(prop_colour);
     else
         code << "*wxBLACK";
     GeneratePosSizeFlags(node, code, true, "wxCLRP_DEFAULT_STYLE", "wxCLRP_DEFAULT_STYLE");
@@ -284,7 +284,7 @@ wxObject* FontPickerGenerator::Create(Node* node, wxObject* parent)
     auto widget =
         new wxFontPickerCtrl(wxStaticCast(parent, wxWindow), node->prop_as_int("id"), node->prop_as_font("initial_font"),
                              node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                             node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                             node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (node->HasValue("max_point_size"))
     {
@@ -316,8 +316,7 @@ std::optional<ttlib::cstr> FontPickerGenerator::GenConstruction(Node* node)
             code << fontprop.GetPointSize();
 
         code << ", " << ConvertFontFamilyToString(fontprop.GetFamily()) << ", " << font.GetStyleString().wx_str();
-        code << ", " << font.GetWeightString().wx_str() << ", " << (fontprop.isUnderlined() ? "true" : "false")
-             << ", ";
+        code << ", " << font.GetWeightString().wx_str() << ", " << (fontprop.isUnderlined() ? "true" : "false") << ", ";
         if (fontprop.GetFaceName().size())
             code << '\"' << fontprop.GetFaceName().wx_str() << '\"';
         else

--- a/src/generate/radio_widgets.cpp
+++ b/src/generate/radio_widgets.cpp
@@ -19,9 +19,9 @@
 
 wxObject* RadioButtonGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget = new wxRadioButton(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(txt_label),
+    auto widget = new wxRadioButton(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
                                     node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                                    node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                    node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (node->prop_as_bool("checked"))
         widget->SetValue(true);
@@ -35,7 +35,7 @@ bool RadioButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePr
 {
     if (prop->GetPropName() == "label")
     {
-        wxStaticCast(widget, wxRadioButton)->SetLabel(node->prop_as_wxString(txt_label));
+        wxStaticCast(widget, wxRadioButton)->SetLabel(node->prop_as_wxString(prop_label));
         return true;
     }
     else if (prop->GetPropName() == "checked")
@@ -55,8 +55,8 @@ std::optional<ttlib::cstr> RadioButtonGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxRadioButton(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    if (node->prop_as_string(txt_label).size())
-        code << GenerateQuotedString(node->prop_as_string(txt_label));
+    if (node->prop_as_string(prop_label).size())
+        code << GenerateQuotedString(node->prop_as_string(prop_label));
     else
         code << "wxEmptyString";
 
@@ -115,16 +115,16 @@ bool RadioButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
 
 wxObject* RadioBoxGenerator::Create(Node* node, wxObject* parent)
 {
-    auto choices = node->prop_as_wxArrayString(txt_choices);
+    auto choices = node->prop_as_wxArrayString(prop_choices);
     if (!choices.Count())
     {
         choices.Add("at least one choice required");
     }
 
-    auto widget =
-        new wxRadioBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(txt_label),
-                       node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"), choices,
-                       node->prop_as_int("majorDimension"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+    auto widget = new wxRadioBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
+                                 node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"), choices,
+                                 node->prop_as_int("majorDimension"),
+                                 node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (int selection = node->prop_as_int("selection"); static_cast<size_t>(selection) < choices.Count())
     {
@@ -141,7 +141,7 @@ bool RadioBoxGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePrope
 {
     if (prop->GetPropName() == "label")
     {
-        wxStaticCast(widget, wxRadioBox)->SetLabel(node->prop_as_wxString(txt_label));
+        wxStaticCast(widget, wxRadioBox)->SetLabel(node->prop_as_wxString(prop_label));
         return true;
     }
     else if (prop->GetPropName() == "selection")
@@ -168,7 +168,7 @@ std::optional<ttlib::cstr> RadioBoxGenerator::GenConstruction(Node* node)
         choice_name.erase(0, 2);
     choice_name << "_choices";
     code << "\twxString " << choice_name << "[] = {";
-    auto array = ConvertToArrayString(node->prop_as_string(txt_choices));
+    auto array = ConvertToArrayString(node->prop_as_string(prop_choices));
     for (auto& iter: array)
     {
         code << "\n\t\t" << GenerateQuotedString(iter) << ",";
@@ -180,7 +180,7 @@ std::optional<ttlib::cstr> RadioBoxGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxRadioBox(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
     {
         code << GenerateQuotedString(label);
@@ -214,7 +214,7 @@ std::optional<ttlib::cstr> RadioBoxGenerator::GenConstruction(Node* node)
     }
     else
     {
-        if (node->prop_as_string("window_style").size() || node->prop_as_string(txt_style) != "wxRA_SPECIFY_COLS")
+        if (node->prop_as_string("window_style").size() || node->prop_as_string(prop_style) != "wxRA_SPECIFY_COLS")
         {
             code << ", ";
             if (!isDimSet)

--- a/src/generate/ribbon_widgets.cpp
+++ b/src/generate/ribbon_widgets.cpp
@@ -23,7 +23,7 @@ wxObject* RibbonBarGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxRibbonBar(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                        node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                        node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (node->prop_as_string("theme") == "Default")
         widget->SetArtProvider(new wxRibbonDefaultArtProvider);
@@ -100,7 +100,7 @@ bool RibbonBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 wxObject* RibbonPageGenerator::Create(Node* node, wxObject* parent)
 {
     auto bmp = node->HasValue("bitmap") ? node->prop_as_wxBitmap("bitmap") : wxNullBitmap;
-    auto widget = new wxRibbonPage((wxRibbonBar*) parent, wxID_ANY, node->GetPropertyAsString(txt_label), bmp, 0);
+    auto widget = new wxRibbonPage((wxRibbonBar*) parent, wxID_ANY, node->prop_as_wxString(prop_label), bmp, 0);
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -116,7 +116,7 @@ std::optional<ttlib::cstr> RibbonPageGenerator::GenConstruction(Node* node)
     code << node->get_parent_name() << ", " << node->prop_as_string("id");
     code << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
         code << GenerateQuotedString(label);
     else
@@ -158,9 +158,9 @@ bool RibbonPageGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 wxObject* RibbonPanelGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
-        new wxRibbonPanel((wxRibbonPage*) parent, wxID_ANY, node->GetPropertyAsString(txt_label),
+        new wxRibbonPanel((wxRibbonPage*) parent, wxID_ANY, node->prop_as_wxString(prop_label),
                           node->prop_as_wxBitmap("bitmap"), node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                          node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                          node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -176,7 +176,7 @@ std::optional<ttlib::cstr> RibbonPanelGenerator::GenConstruction(Node* node)
     code << node->get_parent_name() << ", " << node->prop_as_string("id");
     code << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
         code << GenerateQuotedString(label);
     else
@@ -244,7 +244,7 @@ void RibbonButtonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxp
         if (!bmp.IsOk())
             bmp = GetXPMImage("default");
 
-        btn_bar->AddButton(wxID_ANY, childObj->GetPropertyAsString(txt_label), bmp, childObj->GetPropertyAsString("help"),
+        btn_bar->AddButton(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, childObj->GetPropertyAsString("help"),
                            (wxRibbonButtonKind) childObj->prop_as_int("kind"));
     }
 }
@@ -282,7 +282,7 @@ std::optional<ttlib::cstr> RibbonButtonGenerator::GenConstruction(Node* node)
 
     code << node->get_parent_name() << "->AddButton(" << node->prop_as_string("id") << ", ";
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
         code << GenerateQuotedString(label);
     else

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -27,8 +27,8 @@
 
 wxObject* BoxSizerGenerator::Create(Node* node, wxObject* /*parent*/)
 {
-    auto sizer = new wxBoxSizer(node->prop_as_int(txt_orientation));
-    sizer->SetMinSize(node->prop_as_wxSize(txt_minimum_size));
+    auto sizer = new wxBoxSizer(node->prop_as_int(prop_orientation));
+    sizer->SetMinSize(node->prop_as_wxSize(prop_minimum_size));
     return sizer;
 }
 
@@ -37,9 +37,9 @@ std::optional<ttlib::cstr> BoxSizerGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
     if (node->IsLocal())
         code << "auto ";
-    code << node->get_node_name() << " = new wxBoxSizer(" << node->prop_as_string(txt_orientation) << ");";
+    code << node->get_node_name() << " = new wxBoxSizer(" << node->prop_as_string(prop_orientation) << ");";
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)
     {
         code << "\n    " << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
@@ -58,10 +58,10 @@ bool BoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 
 wxObject* GridSizerGenerator::Create(Node* node, wxObject* /*parent*/)
 {
-    auto sizer = new wxGridSizer(node->prop_as_int("rows"), node->prop_as_int("cols"), node->prop_as_int(txt_vgap),
-                                 node->prop_as_int(txt_hgap));
+    auto sizer = new wxGridSizer(node->prop_as_int("rows"), node->prop_as_int("cols"), node->prop_as_int(prop_vgap),
+                                 node->prop_as_int(prop_hgap));
 
-    sizer->SetMinSize(node->prop_as_wxSize(txt_minimum_size));
+    sizer->SetMinSize(node->prop_as_wxSize(prop_minimum_size));
 
     return sizer;
 }
@@ -74,8 +74,8 @@ std::optional<ttlib::cstr> GridSizerGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxGridSizer(";
     auto rows = node->prop_as_int("rows");
     auto cols = node->prop_as_int("cols");
-    auto vgap = node->prop_as_int(txt_vgap);
-    auto hgap = node->prop_as_int(txt_hgap);
+    auto vgap = node->prop_as_int(prop_vgap);
+    auto hgap = node->prop_as_int(prop_hgap);
 
     if (rows != 0)
     {
@@ -89,7 +89,7 @@ std::optional<ttlib::cstr> GridSizerGenerator::GenConstruction(Node* node)
     }
     code << ");";
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)
     {
         code << "\n    " << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
@@ -108,8 +108,8 @@ bool GridSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 
 wxObject* WrapSizerGenerator::Create(Node* node, wxObject* /*parent*/)
 {
-    auto sizer = new wxWrapSizer(node->prop_as_int(txt_orientation), node->prop_as_int(txt_flags));
-    sizer->SetMinSize(node->prop_as_wxSize(txt_minimum_size));
+    auto sizer = new wxWrapSizer(node->prop_as_int(prop_orientation), node->prop_as_int(prop_flags));
+    sizer->SetMinSize(node->prop_as_wxSize(prop_minimum_size));
     return sizer;
 }
 
@@ -118,13 +118,13 @@ std::optional<ttlib::cstr> WrapSizerGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
     if (node->IsLocal())
         code << "auto ";
-    code << node->get_node_name() << " = new wxWrapSizer(" << node->prop_as_string(txt_orientation);
-    auto wrap_flags = node->prop_as_string(txt_wrap_flags);
+    code << node->get_node_name() << " = new wxWrapSizer(" << node->prop_as_string(prop_orientation);
+    auto wrap_flags = node->prop_as_string(prop_wrap_flags);
     if (wrap_flags.empty())
         wrap_flags = "0";
     code << ", " << wrap_flags << ");";
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.x != -1 || min_size.y != -1)
     {
         code << "\n    " << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
@@ -143,14 +143,14 @@ bool WrapSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 
 wxObject* StaticBoxSizerGenerator::Create(Node* node, wxObject* parent)
 {
-    auto sizer = new wxStaticBoxSizer(node->prop_as_int(txt_orientation), wxStaticCast(parent, wxWindow),
-                                      node->GetPropertyAsString(txt_label));
+    auto sizer = new wxStaticBoxSizer(node->prop_as_int(prop_orientation), wxStaticCast(parent, wxWindow),
+                                      node->prop_as_wxString(prop_label));
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.x != -1 || min_size.y != -1)
         sizer->SetMinSize(min_size);
 
-    if (node->prop_as_bool(txt_hidden) && !GetMockup()->IsShowingHidden())
+    if (node->prop_as_bool(prop_hidden) && !GetMockup()->IsShowingHidden())
         sizer->GetStaticBox()->Hide();
 
     return sizer;
@@ -182,17 +182,17 @@ std::optional<ttlib::cstr> StaticBoxSizerGenerator::GenConstruction(Node* node)
         }
     }
 
-    code << node->get_node_name() << " = new wxStaticBoxSizer(" << node->prop_as_string(txt_orientation) << ", "
+    code << node->get_node_name() << " = new wxStaticBoxSizer(" << node->prop_as_string(prop_orientation) << ", "
          << parent_name;
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
     {
         code << ", " << GenerateQuotedString(label);
     }
     code << ");";
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)
     {
         code << "\n    " << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
@@ -208,7 +208,7 @@ std::optional<ttlib::cstr> StaticBoxSizerGenerator::GenSettings(Node* node, size
     {
         code << node->get_node_name() << "->GetStaticBox()->Enable(false);";
     }
-    if (node->prop_as_bool(txt_hidden))
+    if (node->prop_as_bool(prop_hidden))
     {
         if (code.size())
             code << "\n    ";
@@ -235,36 +235,36 @@ bool StaticBoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set
 wxObject* StaticCheckboxBoxSizerGenerator::Create(Node* node, wxObject* parent)
 {
     long style_value = 0;
-    if (node->prop_as_string(txt_style).contains("wxALIGN_RIGHT"))
+    if (node->prop_as_string(prop_style).contains("wxALIGN_RIGHT"))
         style_value |= wxALIGN_RIGHT;
 
-    m_checkbox = new wxCheckBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(txt_label),
+    m_checkbox = new wxCheckBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
                                 wxDefaultPosition, wxDefaultSize, style_value);
     if (node->prop_as_bool("checked"))
         m_checkbox->SetValue(true);
 
     auto staticbox = new wxStaticBox(wxStaticCast(parent, wxWindow), wxID_ANY, m_checkbox);
 
-    auto sizer = new wxStaticBoxSizer(staticbox, node->prop_as_int(txt_orientation));
+    auto sizer = new wxStaticBoxSizer(staticbox, node->prop_as_int(prop_orientation));
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.x != -1 || min_size.y != -1)
         sizer->SetMinSize(min_size);
 
-    if (node->prop_as_bool(txt_hidden) && !GetMockup()->IsShowingHidden())
+    if (node->prop_as_bool(prop_hidden) && !GetMockup()->IsShowingHidden())
         sizer->GetStaticBox()->Hide();
 
-    if (node->HasValue(txt_tooltip))
-        m_checkbox->SetToolTip(node->prop_as_wxString(txt_tooltip));
+    if (node->HasValue(prop_tooltip))
+        m_checkbox->SetToolTip(node->prop_as_wxString(prop_tooltip));
 
     return sizer;
 }
 
 bool StaticCheckboxBoxSizerGenerator::OnPropertyChange(wxObject* /* widget */, Node* node, NodeProperty* prop)
 {
-    if (prop->GetPropName() == txt_tooltip)
+    if (prop->isProp(prop_tooltip))
     {
-        m_checkbox->SetToolTip(node->prop_as_wxString(txt_tooltip));
+        m_checkbox->SetToolTip(node->prop_as_wxString(prop_tooltip));
     }
 
     return false;
@@ -276,9 +276,9 @@ std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenConstruction(Node
     code << node->prop_as_string("checkbox_var_name") << " = new wxCheckBox(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    if (node->prop_as_string(txt_label).size())
+    if (node->prop_as_string(prop_label).size())
     {
-        code << GenerateQuotedString(node->prop_as_string(txt_label));
+        code << GenerateQuotedString(node->prop_as_string(prop_label));
     }
     else
     {
@@ -312,9 +312,9 @@ std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenConstruction(Node
     }
 
     code << node->get_node_name() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY, ";
-    code << node->prop_as_string("checkbox_var_name") << "), " << node->prop_as_string(txt_orientation) << ");";
+    code << node->prop_as_string("checkbox_var_name") << "), " << node->prop_as_string(prop_orientation) << ");";
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)
     {
         code << "\n    " << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
@@ -330,18 +330,18 @@ std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenSettings(Node* no
     {
         code << node->get_node_name() << "->GetStaticBox()->Enable(false);";
     }
-    if (node->prop_as_bool(txt_hidden))
+    if (node->prop_as_bool(prop_hidden))
     {
         if (code.size())
             code << "\n    ";
         code << node->get_node_name() << "->GetStaticBox()->Hide();";
     }
-    if (node->HasValue(txt_tooltip))
+    if (node->HasValue(prop_tooltip))
     {
         if (code.size())
             code << "\n    ";
         code << node->prop_as_string("checkbox_var_name") << "->SetToolTip("
-             << GenerateQuotedString(node->prop_as_string(txt_tooltip)) << ");";
+             << GenerateQuotedString(node->prop_as_string(prop_tooltip)) << ");";
     }
 
     return code;
@@ -366,32 +366,32 @@ bool StaticCheckboxBoxSizerGenerator::GetIncludes(Node* node, std::set<std::stri
 
 wxObject* StaticRadioBtnBoxSizerGenerator::Create(Node* node, wxObject* parent)
 {
-    m_radiobtn = new wxRadioButton(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(txt_label));
+    m_radiobtn = new wxRadioButton(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label));
     if (node->prop_as_bool("checked"))
         m_radiobtn->SetValue(true);
 
     auto staticbox = new wxStaticBox(wxStaticCast(parent, wxWindow), wxID_ANY, m_radiobtn);
 
-    auto sizer = new wxStaticBoxSizer(staticbox, node->prop_as_int(txt_orientation));
+    auto sizer = new wxStaticBoxSizer(staticbox, node->prop_as_int(prop_orientation));
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.x != -1 || min_size.y != -1)
         sizer->SetMinSize(min_size);
 
-    if (node->prop_as_bool(txt_hidden) && !GetMockup()->IsShowingHidden())
+    if (node->prop_as_bool(prop_hidden) && !GetMockup()->IsShowingHidden())
         sizer->GetStaticBox()->Hide();
 
-    if (node->HasValue(txt_tooltip))
-        m_radiobtn->SetToolTip(node->prop_as_wxString(txt_tooltip));
+    if (node->HasValue(prop_tooltip))
+        m_radiobtn->SetToolTip(node->prop_as_wxString(prop_tooltip));
 
     return sizer;
 }
 
 bool StaticRadioBtnBoxSizerGenerator::OnPropertyChange(wxObject* /* widget */, Node* node, NodeProperty* prop)
 {
-    if (prop->GetPropName() == txt_tooltip)
+    if (prop->isProp(prop_tooltip))
     {
-        m_radiobtn->SetToolTip(node->prop_as_wxString(txt_tooltip));
+        m_radiobtn->SetToolTip(node->prop_as_wxString(prop_tooltip));
     }
 
     return false;
@@ -403,9 +403,9 @@ std::optional<ttlib::cstr> StaticRadioBtnBoxSizerGenerator::GenConstruction(Node
     code << node->prop_as_string("radiobtn_var_name") << " = new wxRadioButton(";
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
 
-    if (node->prop_as_string(txt_label).size())
+    if (node->prop_as_string(prop_label).size())
     {
-        code << GenerateQuotedString(node->prop_as_string(txt_label));
+        code << GenerateQuotedString(node->prop_as_string(prop_label));
     }
     else
     {
@@ -437,9 +437,9 @@ std::optional<ttlib::cstr> StaticRadioBtnBoxSizerGenerator::GenConstruction(Node
     }
 
     code << node->get_node_name() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY, ";
-    code << node->prop_as_string("radiobtn_var_name") << "), " << node->prop_as_string(txt_orientation) << ");";
+    code << node->prop_as_string("radiobtn_var_name") << "), " << node->prop_as_string(prop_orientation) << ");";
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)
     {
         code << "\n    " << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
@@ -455,18 +455,18 @@ std::optional<ttlib::cstr> StaticRadioBtnBoxSizerGenerator::GenSettings(Node* no
     {
         code << node->get_node_name() << "->GetStaticBox()->Enable(false);";
     }
-    if (node->prop_as_bool(txt_hidden))
+    if (node->prop_as_bool(prop_hidden))
     {
         if (code.size())
             code << "\n    ";
         code << node->get_node_name() << "->GetStaticBox()->Hide();";
     }
-    if (node->HasValue(txt_tooltip))
+    if (node->HasValue(prop_tooltip))
     {
         if (code.size())
             code << "\n    ";
         code << node->prop_as_string("radiobtn_var_name") << "->SetToolTip("
-             << GenerateQuotedString(node->prop_as_string(txt_tooltip)) << ");";
+             << GenerateQuotedString(node->prop_as_string(prop_tooltip)) << ");";
     }
 
     return code;
@@ -492,22 +492,22 @@ bool StaticRadioBtnBoxSizerGenerator::GetIncludes(Node* node, std::set<std::stri
 wxObject* FlexGridSizerGenerator::Create(Node* node, wxObject* /*parent*/)
 {
     wxFlexGridSizer* sizer = new wxFlexGridSizer(node->prop_as_int("rows"), node->prop_as_int("cols"),
-                                                 node->prop_as_int(txt_vgap), node->prop_as_int(txt_hgap));
+                                                 node->prop_as_int(prop_vgap), node->prop_as_int(prop_hgap));
 
 #if 0
-    for (auto& col: node->GetPropertyAsVectorIntPair(txt_growablecols))
+    for (auto& col: node->GetPropertyAsVectorIntPair("growablecols"))
     {
         sizer->AddGrowableCol(col.first, col.second);
     }
-    for (auto& row: node->GetPropertyAsVectorIntPair(txt_growablerows))
+    for (auto& row: node->GetPropertyAsVectorIntPair("growablerows"))
     {
         sizer->AddGrowableRow(row.first, row.second);
     }
 #endif
 
-    sizer->SetMinSize(node->prop_as_wxSize(txt_minimum_size));
-    sizer->SetFlexibleDirection(node->prop_as_int(txt_flexible_direction));
-    sizer->SetNonFlexibleGrowMode((wxFlexSizerGrowMode) node->prop_as_int(txt_non_flexible_grow_mode));
+    sizer->SetMinSize(node->prop_as_wxSize(prop_minimum_size));
+    sizer->SetFlexibleDirection(node->prop_as_int(prop_flexible_direction));
+    sizer->SetNonFlexibleGrowMode((wxFlexSizerGrowMode) node->prop_as_int(prop_non_flexible_grow_mode));
 
     return sizer;
 }
@@ -522,8 +522,8 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxFlexGridSizer(";
     auto rows = node->prop_as_int("rows");
     auto cols = node->prop_as_int("cols");
-    auto vgap = node->prop_as_int(txt_vgap);
-    auto hgap = node->prop_as_int(txt_hgap);
+    auto vgap = node->prop_as_int(prop_vgap);
+    auto hgap = node->prop_as_int(prop_hgap);
 
     // If rows is empty, only columns are supplied and wxFlexGridSizer will deduece the number of rows to use
     if (rows != 0)
@@ -536,7 +536,7 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
     // braces
     bool isExpanded = false;
 
-    if (auto& growable = node->prop_as_string(txt_growablecols); growable.size())
+    if (auto& growable = node->prop_as_string(prop_growablecols); growable.size())
     {
         ttlib::multistr values(growable, ',');
         for (auto& iter: values)
@@ -559,7 +559,7 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
         }
     }
 
-    if (auto& growable = node->prop_as_string(txt_growablerows); growable.size())
+    if (auto& growable = node->prop_as_string(prop_growablerows); growable.size())
     {
         ttlib::multistr values(growable, ',');
         for (auto& iter: values)
@@ -582,7 +582,7 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
         }
     }
 
-    auto& direction = node->prop_as_string(txt_flexible_direction);
+    auto& direction = node->prop_as_string(prop_flexible_direction);
     if (direction.empty() || direction.is_sameas("wxBOTH"))
     {
         if (isExpanded)
@@ -593,7 +593,7 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
     code << (isExpanded ? "\n        " : "\n    ") << node->get_node_name() << "->SetFlexibleDirection(" << direction
          << ");";
 
-    auto& non_flex_growth = node->prop_as_string(txt_non_flexible_grow_mode);
+    auto& non_flex_growth = node->prop_as_string(prop_non_flexible_grow_mode);
     if (non_flex_growth.empty() || non_flex_growth.is_sameas("wxFLEX_GROWMODE_SPECIFIED"))
     {
         if (isExpanded)
@@ -618,7 +618,7 @@ bool FlexGridSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_
 
 wxObject* GridBagSizerGenerator::Create(Node* node, wxObject* /*parent*/)
 {
-    auto sizer = new wxGridBagSizer(node->prop_as_int(txt_vgap), node->prop_as_int(txt_hgap));
+    auto sizer = new wxGridBagSizer(node->prop_as_int(prop_vgap), node->prop_as_int(prop_hgap));
 
 #if 0
     for (auto& col: node->GetPropertyAsVectorIntPair(txt_growablecols))
@@ -631,13 +631,13 @@ wxObject* GridBagSizerGenerator::Create(Node* node, wxObject* /*parent*/)
     }
 #endif
 
-    sizer->SetMinSize(node->prop_as_wxSize(txt_minimum_size));
-    sizer->SetFlexibleDirection(node->prop_as_int(txt_flexible_direction));
-    sizer->SetNonFlexibleGrowMode((wxFlexSizerGrowMode) node->prop_as_int(txt_non_flexible_grow_mode));
+    sizer->SetMinSize(node->prop_as_wxSize(prop_minimum_size));
+    sizer->SetFlexibleDirection(node->prop_as_int(prop_flexible_direction));
+    sizer->SetNonFlexibleGrowMode((wxFlexSizerGrowMode) node->prop_as_int(prop_non_flexible_grow_mode));
 
-    if (node->HasValue(txt_empty_cell_size))
+    if (node->HasValue(prop_empty_cell_size))
     {
-        sizer->SetEmptyCellSize(node->prop_as_wxSize(txt_empty_cell_size));
+        sizer->SetEmptyCellSize(node->prop_as_wxSize(prop_empty_cell_size));
     }
 
     return sizer;
@@ -666,9 +666,9 @@ void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpare
         auto node = mockup->GetNode(wxsizerItem);
 
         // Get the location of the item
-        wxGBSpan span(node->prop_as_int(txt_rowspan), node->prop_as_int(txt_colspan));
+        wxGBSpan span(node->prop_as_int(prop_rowspan), node->prop_as_int(prop_colspan));
 
-        int column = node->prop_as_int(txt_column);
+        int column = node->prop_as_int(prop_column);
         if (column < 0)
         {
             // Needs to be auto positioned after the other children are added
@@ -680,7 +680,7 @@ void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpare
             continue;
         }
 
-        wxGBPosition position(node->prop_as_int(txt_row), column);
+        wxGBPosition position(node->prop_as_int(prop_row), column);
 
         if (sizer->CheckForIntersection(position, span))
         {
@@ -721,8 +721,8 @@ std::optional<ttlib::cstr> GridBagSizerGenerator::GenConstruction(Node* node)
 
     code << node->get_node_name() << " = new wxGridBagSizer(";
 
-    auto vgap = node->prop_as_int(txt_vgap);
-    auto hgap = node->prop_as_int(txt_hgap);
+    auto vgap = node->prop_as_int(prop_vgap);
+    auto hgap = node->prop_as_int(prop_hgap);
     if (vgap != 0 || hgap != 0)
     {
         code << vgap << ", " << hgap;
@@ -733,7 +733,7 @@ std::optional<ttlib::cstr> GridBagSizerGenerator::GenConstruction(Node* node)
     // braces
     bool isExpanded = false;
 
-    if (auto& growable = node->prop_as_string(txt_growablecols); growable.size())
+    if (auto& growable = node->prop_as_string(prop_growablecols); growable.size())
     {
         ttlib::multistr values(growable, ',');
         for (auto& iter: values)
@@ -756,7 +756,7 @@ std::optional<ttlib::cstr> GridBagSizerGenerator::GenConstruction(Node* node)
         }
     }
 
-    if (auto& growable = node->prop_as_string(txt_growablerows); growable.size())
+    if (auto& growable = node->prop_as_string(prop_growablerows); growable.size())
     {
         ttlib::multistr values(growable, ',');
         for (auto& iter: values)
@@ -779,7 +779,7 @@ std::optional<ttlib::cstr> GridBagSizerGenerator::GenConstruction(Node* node)
         }
     }
 
-    auto& direction = node->prop_as_string(txt_flexible_direction);
+    auto& direction = node->prop_as_string(prop_flexible_direction);
     if (direction.empty() || direction.is_sameas("wxBOTH"))
     {
         if (isExpanded)
@@ -790,7 +790,7 @@ std::optional<ttlib::cstr> GridBagSizerGenerator::GenConstruction(Node* node)
     code << (isExpanded ? "\n        " : "\n    ") << node->get_node_name() << "->SetFlexibleDirection(" << direction
          << ");";
 
-    auto non_flex_growth = node->prop_as_string(txt_non_flexible_grow_mode);
+    auto non_flex_growth = node->prop_as_string(prop_non_flexible_grow_mode);
     if (non_flex_growth.empty() || non_flex_growth.is_sameas("wxFLEX_GROWMODE_SPECIFIED"))
     {
         if (isExpanded)
@@ -818,7 +818,7 @@ wxGBSizerItem* GridBagSizerGenerator::GetGBSizerItem(Node* sizeritem, const wxGB
 
     if (sizeritem->GetClassName() == "spacer")
     {
-        return new wxGBSizerItem(sizeritem->prop_as_int(txt_width), sizeritem->prop_as_int(txt_height), position, span,
+        return new wxGBSizerItem(sizeritem->prop_as_int(prop_width), sizeritem->prop_as_int(prop_height), position, span,
                                  sizer_flags.GetFlags(), sizer_flags.GetBorderInPixels());
     }
 
@@ -851,33 +851,33 @@ std::optional<ttlib::cstr> SpacerGenerator::GenConstruction(Node* node)
 
     if (node->prop_as_int("proportion") != 0)
     {
-        code << "->AddStretchSpacer(" << node->prop_as_string(txt_proportion) << ");";
+        code << "->AddStretchSpacer(" << node->prop_as_string(prop_proportion) << ");";
     }
     else
     {
         if (node->prop_as_int("width") == node->prop_as_int("height"))
         {
-            code << "->AddSpacer(" << node->prop_as_string(txt_width);
+            code << "->AddSpacer(" << node->prop_as_string(prop_width);
         }
         else if (node->GetParent()->HasValue("orientation"))
         {
             code << "->AddSpacer(";
             if (node->GetParent()->prop_as_string("orientation") == "wxVERTICAL")
             {
-                code << node->prop_as_string(txt_height);
+                code << node->prop_as_string(prop_height);
             }
             else
             {
-                code << node->prop_as_string(txt_width);
+                code << node->prop_as_string(prop_width);
             }
         }
 
         else
         {
-            code << "->Add(" << node->prop_as_string(txt_width);
+            code << "->Add(" << node->prop_as_string(prop_width);
             if (node->prop_as_bool("add_default_border"))
                 code << " + wxSizerFlags::GetDefaultBorder()";
-            code << ", " << node->prop_as_string(txt_height);
+            code << ", " << node->prop_as_string(prop_height);
         }
 
         if (node->prop_as_bool("add_default_border"))
@@ -892,19 +892,19 @@ std::optional<ttlib::cstr> SpacerGenerator::GenConstruction(Node* node)
 #if 0
     if (node->GetParent()->GetClassName() == "wxGridBagSizer")
     {
-        code << "wxGBPosition(" << node->prop_as_string(txt_row) << ", " << node->prop_as_string(txt_column) << "), ";
+        code << "wxGBPosition(" << node->prop_as_string(prop_row) << ", " << node->prop_as_string(prop_column) << "), ";
 
         // Only write the span if it's not a default value.
-        auto row_span = node->prop_as_int(txt_rowspan);
-        auto col_span = node->prop_as_int(txt_colspan);
+        auto row_span = node->prop_as_int(prop_rowspan);
+        auto col_span = node->prop_as_int(prop_colspan);
         if (row_span <= 1 && col_span <= 1)
             code << "wxGBSpan(), ";
         else
             code << "wxGBSpan(" << row_span << ", " << col_span << "), ";
 
-        auto alignment = node->prop_as_string(txt_alignment);
-        auto flags = node->prop_as_string(txt_flags);
-        auto borders = node->prop_as_string(txt_borders);
+        auto alignment = node->prop_as_string(prop_alignment);
+        auto flags = node->prop_as_string(prop_flags);
+        auto borders = node->prop_as_string(prop_borders);
 
         if (alignment.empty() && flags.empty())
         {
@@ -1007,7 +1007,7 @@ std::optional<ttlib::cstr> SpacerGenerator::GenConstruction(Node* node)
             code << ").GetFlags(), ";
         }
 
-        auto border_size = node->prop_as_string(txt_border_size);
+        auto border_size = node->prop_as_string(prop_border_size);
 
         // Using GetDefaultBorder() means it will change correctly on high DPI displays.
         if (border_size == "5")
@@ -1039,7 +1039,7 @@ wxObject* StdDialogButtonSizerGenerator::Create(Node* node, wxObject* parent)
 {
     auto sizer = new wxStdDialogButtonSizer();
 
-    sizer->SetMinSize(node->prop_as_wxSize(txt_minimum_size));
+    sizer->SetMinSize(node->prop_as_wxSize(prop_minimum_size));
 
     if (node->prop_as_bool("OK"))
         sizer->AddButton(new wxButton(wxStaticCast(parent, wxWindow), wxID_OK));
@@ -1133,7 +1133,7 @@ std::optional<ttlib::cstr> StdDialogButtonSizerGenerator::GenConstruction(Node* 
     // The following code is used if a Save or ContextHelp button is requrested, or the parent form is not a Dialog
     code << node->get_node_name() << " = new wxStdDialogButtonSizer();";
 
-    auto min_size = node->prop_as_wxSize(txt_minimum_size);
+    auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)
     {
         code << "\n    " << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
@@ -1274,7 +1274,7 @@ std::optional<ttlib::cstr> TextSizerGenerator::GenConstruction(Node* node)
         code << " = wxTextSizerWrapper(" << parent->get_node_name() << ").CreateSizer(";
     }
 
-    code << GenerateQuotedString(node->prop_as_string("text")) << ", " << node->prop_as_string(txt_width) << ");";
+    code << GenerateQuotedString(node->prop_as_string("text")) << ", " << node->prop_as_string(prop_width) << ");";
 
     return code;
 }

--- a/src/generate/spin_widgets.cpp
+++ b/src/generate/spin_widgets.cpp
@@ -23,7 +23,7 @@ wxObject* SpinCtrlGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxSpinCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString, node->prop_as_wxPoint("pos"),
-                       node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"),
+                       node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"),
                        node->prop_as_int("min"), node->prop_as_int("max"), node->prop_as_int("initial"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
@@ -78,9 +78,9 @@ bool SpinCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 
 wxObject* SpinCtrlDoubleGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget = new wxSpinCtrlDouble(wxStaticCast(parent, wxWindow), wxID_ANY, node->GetPropertyAsString(txt_value),
+    auto widget = new wxSpinCtrlDouble(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_value),
                                        node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"),
+                                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"),
                                        node->GetPropertyAsFloat("min"), node->GetPropertyAsFloat("max"),
                                        node->GetPropertyAsFloat("initial"), node->GetPropertyAsFloat("inc"));
 
@@ -151,7 +151,7 @@ wxObject* SpinButtonGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxSpinButton(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
-                         node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                         node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -189,7 +189,7 @@ wxObject* ScrollBarGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxScrollBar(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                        node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                        node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->SetScrollbar(node->prop_as_int("position"), node->prop_as_int("thumbsize"), node->prop_as_int("range"),
                          node->prop_as_int("pagesize"));

--- a/src/generate/text_widgets.cpp
+++ b/src/generate/text_widgets.cpp
@@ -22,12 +22,12 @@ wxObject* StaticTextGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString, node->prop_as_wxPoint("pos"),
-                         node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                         node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     if (node->prop_as_bool("markup"))
-        widget->SetLabelMarkup(node->prop_as_wxString(txt_label));
+        widget->SetLabelMarkup(node->prop_as_wxString(prop_label));
     else
-        widget->SetLabel(node->prop_as_wxString(txt_label));
+        widget->SetLabel(node->prop_as_wxString(prop_label));
 
     if (node->prop_as_int("wrap") > 0)
         widget->Wrap(node->prop_as_int("wrap"));
@@ -46,9 +46,9 @@ bool StaticTextGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePro
 
         auto ctrl = wxStaticCast(widget, wxStaticText);
         if (node->prop_as_bool("markup"))
-            ctrl->SetLabelMarkup(node->prop_as_wxString(txt_label));
+            ctrl->SetLabelMarkup(node->prop_as_wxString(prop_label));
         else
-            ctrl->SetLabel(node->prop_as_wxString(txt_label));
+            ctrl->SetLabel(node->prop_as_wxString(prop_label));
 
         if (node->prop_as_int("wrap") > 0)
             ctrl->Wrap(node->prop_as_int("wrap"));
@@ -76,7 +76,7 @@ std::optional<ttlib::cstr> StaticTextGenerator::GenConstruction(Node* node)
     }
     else
     {
-        auto& label = node->prop_as_string(txt_label);
+        auto& label = node->prop_as_string(prop_label);
         if (label.size())
         {
             code << GenerateQuotedString(label);
@@ -104,7 +104,8 @@ std::optional<ttlib::cstr> StaticTextGenerator::GenSettings(Node* node, size_t& 
     {
         if (code.size())
             code << '\n';
-        code << node->get_node_name() << "->SetLabelMarkup(" << GenerateQuotedString(node->prop_as_string(txt_label)) << ");";
+        code << node->get_node_name() << "->SetLabelMarkup(" << GenerateQuotedString(node->prop_as_string(prop_label))
+             << ");";
     }
 
     // Note that wrap MUST be called after the text is set, otherwise it will be ignored.
@@ -130,9 +131,9 @@ bool StaticTextGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 
 wxObject* TextCtrlGenerator::Create(Node* node, wxObject* parent)
 {
-    auto widget = new wxTextCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(txt_value),
+    auto widget = new wxTextCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_value),
                                  node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                                 node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                 node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->SetMaxLength(node->prop_as_int("maxlength"));
 
@@ -160,8 +161,8 @@ std::optional<ttlib::cstr> TextCtrlGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxTextCtrl(";
 
     code << GetParentName(node) << ", " << node->prop_as_string("id") << ", ";
-    if (node->prop_as_string(txt_value).size())
-        code << GenerateQuotedString(node->prop_as_string(txt_value));
+    if (node->prop_as_string(prop_value).size())
+        code << GenerateQuotedString(node->prop_as_string(prop_value));
     else
         code << "wxEmptyString";
 
@@ -193,7 +194,7 @@ std::optional<ttlib::cstr> TextCtrlGenerator::GenSettings(Node* node, size_t& au
     {
         if (code.size())
             code << '\n';
-        if (node->prop_as_string(txt_style).contains("wxTE_MULTILINE"))
+        if (node->prop_as_string(prop_style).contains("wxTE_MULTILINE"))
         {
             code << "#if !defined(__WXGTK__))\n\t";
             code << node->get_node_name() << "->SetMaxLength(" << node->prop_as_string("maxlength") << ");\n";
@@ -233,7 +234,7 @@ wxObject* RichTextCtrlGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxRichTextCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, wxEmptyString, node->prop_as_wxPoint("pos"),
-                           node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                           node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -287,7 +288,7 @@ wxObject* HtmlWindowGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxHtmlWindow(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
-                         node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                         node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->SetPage("<b>wxHtmlWindow</b><br/><br/>This is a dummy page.</body></html>");
 
@@ -330,7 +331,7 @@ wxObject* StyledTextGenerator::Create(Node* node, wxObject* parent)
 
     auto scintilla = new wxStyledTextCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
                                           node->prop_as_wxSize("size"), node->prop_as_int("window_style"),
-                                          node->GetPropertyAsString(txt_var_name));
+                                          node->prop_as_wxString(prop_var_name));
 
     if (node->prop_as_int("line_numbers") != 0)
     {

--- a/src/generate/toolbar_widgets.cpp
+++ b/src/generate/toolbar_widgets.cpp
@@ -22,7 +22,7 @@ wxObject* ToolBarFormGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxToolBar(
         wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-        node->prop_as_int(txt_style) | node->prop_as_int("window_style") | wxTB_NOALIGN | wxTB_NODIVIDER | wxNO_BORDER);
+        node->prop_as_int(prop_style) | node->prop_as_int("window_style") | wxTB_NOALIGN | wxTB_NODIVIDER | wxNO_BORDER);
 
     if (node->HasValue("bitmapsize"))
         widget->SetToolBitmapSize(node->prop_as_wxSize("bitmapsize"));
@@ -63,7 +63,7 @@ void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparen
             if (!bmp.IsOk())
                 bmp = GetXPMImage("default");
 
-            toolbar->AddTool(wxID_ANY, childObj->GetPropertyAsString(txt_label), bmp, wxNullBitmap,
+            toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
                              (wxItemKind) childObj->prop_as_int("kind"), childObj->GetPropertyAsString("help"),
                              wxEmptyString, child);
         }
@@ -87,7 +87,7 @@ std::optional<ttlib::cstr> ToolBarFormGenerator::GenConstruction(Node* node)
 {
     ttlib::cstr code;
 
-    code << node->prop_as_string(txt_class_name) << "::" << node->prop_as_string(txt_class_name);
+    code << node->prop_as_string(prop_class_name) << "::" << node->prop_as_string(prop_class_name);
     code << "(wxWindow* parent, wxWindowID id, ";
     code << "\n\t\tconst wxPoint& pos, const wxSize& size, long style";
     if (node->prop_as_string("window_name").size())
@@ -144,7 +144,7 @@ std::optional<ttlib::cstr> ToolBarFormGenerator::GenEvents(NodeEvent* event, con
 {
     auto code = GenEventCode(event, class_name);
     // Since this is the base class, we don't want to use the pointer that GenEventCode() would normally create
-    code.Replace(ttlib::cstr() << event->GetNode()->prop_as_string(txt_var_name) << "->", "");
+    code.Replace(ttlib::cstr() << event->GetNode()->prop_as_string(prop_var_name) << "->", "");
     return code;
 }
 
@@ -171,7 +171,7 @@ wxObject* ToolBarGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxToolBar(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                      node->prop_as_int(txt_style) | node->prop_as_int("window_style") | wxTB_NODIVIDER | wxNO_BORDER);
+                      node->prop_as_int(prop_style) | node->prop_as_int("window_style") | wxTB_NODIVIDER | wxNO_BORDER);
 
     if (node->HasValue("bitmapsize"))
         widget->SetToolBitmapSize(node->prop_as_wxSize("bitmapsize"));
@@ -212,7 +212,7 @@ void ToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
             if (!bmp.IsOk())
                 bmp = GetXPMImage("default");
 
-            toolbar->AddTool(wxID_ANY, childObj->GetPropertyAsString(txt_label), bmp, wxNullBitmap,
+            toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
                              (wxItemKind) childObj->prop_as_int("kind"), childObj->GetPropertyAsString("help"),
                              wxEmptyString, child);
         }
@@ -237,7 +237,7 @@ std::optional<ttlib::cstr> ToolBarGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
     if (node->IsLocal())
         code << "auto ";
-    code << node->prop_as_string(txt_var_name);
+    code << node->prop_as_string(prop_var_name);
 
     // We don't currently support wxAuiMDIChildFrame, but if we ever do, it also uses CreateToolBar()
     if (node->GetParent()->GetClassName() == "wxFrame" || node->GetParent()->GetClassName() == "wxAuiMDIChildFrame")
@@ -246,7 +246,7 @@ std::optional<ttlib::cstr> ToolBarGenerator::GenConstruction(Node* node)
 
         auto& id = node->prop_as_string("id");
         auto& window_name = node->prop_as_string("window_name");
-        auto& style = node->prop_as_string(txt_style);
+        auto& style = node->prop_as_string(prop_style);
         auto& win_style = node->prop_as_string("window_style");
 
         if (window_name.size())
@@ -377,7 +377,7 @@ std::optional<ttlib::cstr> ToolGenerator::GenConstruction(Node* node)
             code << node->get_node_name() << " = AddTool(" << node->prop_as_string("id") << ", ";
     }
 
-    auto& label = node->prop_as_string(txt_label);
+    auto& label = node->prop_as_string(prop_label);
     if (label.size())
     {
         code << GenerateQuotedString(label);
@@ -389,7 +389,7 @@ std::optional<ttlib::cstr> ToolGenerator::GenConstruction(Node* node)
 
     code << ", " << GenerateBitmapCode(node->prop_as_string("bitmap"));
 
-    if (!node->HasValue(txt_tooltip) && !node->HasValue("statusbar"))
+    if (!node->HasValue(prop_tooltip) && !node->HasValue("statusbar"))
     {
         if (node->prop_as_string("kind") != "wxITEM_NORMAL")
         {
@@ -400,9 +400,9 @@ std::optional<ttlib::cstr> ToolGenerator::GenConstruction(Node* node)
         return code;
     }
 
-    if (node->HasValue(txt_tooltip) && !node->HasValue("statusbar"))
+    if (node->HasValue(prop_tooltip) && !node->HasValue("statusbar"))
     {
-        code << ",\n\t\t\t" << GenerateQuotedString(node->prop_as_string(txt_tooltip));
+        code << ",\n\t\t\t" << GenerateQuotedString(node->prop_as_string(prop_tooltip));
         if (node->prop_as_string("kind") != "wxITEM_NORMAL")
         {
             code << ", " << node->prop_as_string("kind");
@@ -414,9 +414,9 @@ std::optional<ttlib::cstr> ToolGenerator::GenConstruction(Node* node)
         code << ", wxNullBitmap, ";
         code << node->prop_as_string("kind") << ", \n\t\t\t";
 
-        if (node->HasValue(txt_tooltip))
+        if (node->HasValue(prop_tooltip))
         {
-            code << GenerateQuotedString(node->prop_as_string(txt_tooltip));
+            code << GenerateQuotedString(node->prop_as_string(prop_tooltip));
         }
         else
         {

--- a/src/generate/tree_widgets.cpp
+++ b/src/generate/tree_widgets.cpp
@@ -23,7 +23,7 @@ wxObject* TreeCtrlGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxTreeCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-                       node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                       node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
 #if 0
 // REVIEW: [KeyWorks - 12-13-2020] This is the original code.
@@ -78,7 +78,7 @@ wxObject* TreeListViewGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget =
         new wxTreeListCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
-                           node->prop_as_wxSize("size"), node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                           node->prop_as_wxSize("size"), node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -117,15 +117,15 @@ void TreeListCtrlColumnGenerator::AfterCreation(wxObject* wxobject, wxWindow* wx
     ASSERT(treeList);
     ASSERT(node);
 
-    treeList->AppendColumn(node->GetPropertyAsString(txt_var_name), node->prop_as_int(txt_width),
-                           static_cast<wxAlignment>(node->prop_as_int(txt_alignment)), node->GetSizerFlags().GetFlags());
+    treeList->AppendColumn(node->prop_as_wxString(prop_var_name), node->prop_as_int(prop_width),
+                           static_cast<wxAlignment>(node->prop_as_int(prop_alignment)), node->GetSizerFlags().GetFlags());
 }
 
 std::optional<ttlib::cstr> TreeListCtrlColumnGenerator::GenConstruction(Node* node)
 {
     ttlib::cstr code;
     code << node->get_parent_name() << "->AppendColumn(" << GenerateQuotedString(node->get_node_name()) << ", ";
-    code << node->prop_as_string(txt_width) << ", " << node->prop_as_string(txt_alignment) << ", "
+    code << node->prop_as_string(prop_width) << ", " << node->prop_as_string(prop_alignment) << ", "
          << node->prop_as_string("flag");
     code << ")";
 

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -65,7 +65,7 @@ wxObject* SplitterWindowGenerator::Create(Node* node, wxObject* parent)
 {
     auto splitter = new wxCustomSplitterWindow(
         wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"), node->prop_as_wxSize("size"),
-        (node->prop_as_int(txt_style) | node->prop_as_int("window_style")) & ~wxSP_PERMIT_UNSPLIT);
+        (node->prop_as_int(prop_style) | node->prop_as_int("window_style")) & ~wxSP_PERMIT_UNSPLIT);
 
     if (node->HasValue("sashgravity"))
     {
@@ -242,7 +242,7 @@ wxObject* ScrolledWindowGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxScrolled<wxPanel>(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint("pos"),
                                           node->prop_as_wxSize("size"),
-                                          node->prop_as_int(txt_style) | node->prop_as_int("window_style"));
+                                          node->prop_as_int(prop_style) | node->prop_as_int("window_style"));
     widget->SetScrollRate(node->prop_as_int("scroll_rate_x"), node->prop_as_int("scroll_rate_y"));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);

--- a/src/generate/wizard_form.cpp
+++ b/src/generate/wizard_form.cpp
@@ -29,7 +29,7 @@ std::optional<ttlib::cstr> WizardFormGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
 
     // This is the code to add to the source file
-    code << node->prop_as_string(txt_class_name) << "::" << node->prop_as_string(txt_class_name);
+    code << node->prop_as_string(prop_class_name) << "::" << node->prop_as_string(prop_class_name);
     code << "(wxWindow* parent, wxWindowID id, const wxString& title,";
     code << "\n        const wxBitmap& bitmap, const wxPoint& pos, long style) :";
     code << "\n    wxWizard(parent, id, title, bitmap, pos, style)";
@@ -45,7 +45,7 @@ std::optional<ttlib::cstr> WizardFormGenerator::GenCode(const std::string& cmd, 
     if (cmd == "ctor_declare")
     {
         // This is the code to add to the header file
-        code << node->prop_as_string(txt_class_name) << "(wxWindow* parent, wxWindowID id = " << node->prop_as_string("id");
+        code << node->prop_as_string(prop_class_name) << "(wxWindow* parent, wxWindowID id = " << node->prop_as_string("id");
         code << ",\n    const wxString& title = ";
         auto& title = node->prop_as_string("title");
         if (title.size())
@@ -69,7 +69,7 @@ std::optional<ttlib::cstr> WizardFormGenerator::GenCode(const std::string& cmd, 
             code << "wxDefaultPosition";
 
         code << ",\n    long style = ";
-        auto& style = node->prop_as_string(txt_style);
+        auto& style = node->prop_as_string(prop_style);
         auto& win_style = node->prop_as_string("window_style");
         if (style.empty() && win_style.empty())
             code << "0";
@@ -98,9 +98,9 @@ std::optional<ttlib::cstr> WizardFormGenerator::GenCode(const std::string& cmd, 
     else if (cmd == "base")
     {
         code << "public ";
-        if (node->HasValue(txt_base_class_name))
+        if (node->HasValue(prop_base_class_name))
         {
-            code << node->prop_as_string(txt_base_class_name);
+            code << node->prop_as_string(prop_base_class_name);
         }
         else
         {
@@ -114,15 +114,15 @@ std::optional<ttlib::cstr> WizardFormGenerator::GenCode(const std::string& cmd, 
         {
             if (panes.size() > 1)
             {
-                code << "    " << panes[0]->prop_as_string(txt_var_name) << "->Chain(" << panes[1]->prop_as_string(txt_var_name)
-                     << ")";
+                code << "    " << panes[0]->prop_as_string(prop_var_name) << "->Chain("
+                     << panes[1]->prop_as_string(prop_var_name) << ")";
                 for (size_t pos = 1; pos + 1 < panes.size(); ++pos)
                 {
-                    code << ".Chain(" << panes[pos + 1]->prop_as_string(txt_var_name) << ")";
+                    code << ".Chain(" << panes[pos + 1]->prop_as_string(prop_var_name) << ")";
                 }
                 code << ";\n";
             }
-            code << "    GetPageAreaSizer()->Add(" << panes[0]->prop_as_string(txt_var_name) << ");\n";
+            code << "    GetPageAreaSizer()->Add(" << panes[0]->prop_as_string(prop_var_name) << ");\n";
         }
 
         if (auto& center = node->prop_as_string("center"); center.size() && !center.is_sameas("no"))
@@ -191,7 +191,7 @@ std::optional<ttlib::cstr> WizardPageGenerator::GenConstruction(Node* node)
 
     if (node->IsLocal())
         code << "auto ";
-    code << node->prop_as_string(txt_var_name) << " = new wxWizardPageSimple(this";
+    code << node->prop_as_string(prop_var_name) << " = new wxWizardPageSimple(this";
 
     if (node->HasValue("bitmap"))
     {

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -850,7 +850,7 @@ void MainFrame::UpdateMoveMenu()
 
 void MainFrame::FindItemName(Node* node)
 {
-    if (auto value = node->get_value_ptr(txt_var_name); value && value->size())
+    if (auto value = node->get_value_ptr("var_name"); value && value->size())
     {
         m_generatedPanel->FindItemName(*value);
         return;
@@ -1012,7 +1012,7 @@ void MainFrame::OnToggleExpandLayout(wxCommandEvent&)
         return;
     }
 
-    auto propFlag = m_selected_node->get_prop_ptr(txt_flags);
+    auto propFlag = m_selected_node->get_prop_ptr(prop_flags);
 
     if (!propFlag)
     {
@@ -1031,7 +1031,7 @@ void MainFrame::ToggleBorderFlag(Node* node, int border)
     if (!node)
         return;
 
-    auto propFlag = node->get_prop_ptr(txt_borders);
+    auto propFlag = node->get_prop_ptr(prop_borders);
 
     if (!propFlag)
         return;
@@ -1078,7 +1078,7 @@ void MainFrame::ChangeAlignment(Node* node, int align, bool vertical)
     if (!node)
         return;
 
-    auto propFlag = node->get_prop_ptr(txt_alignment);
+    auto propFlag = node->get_prop_ptr(prop_alignment);
 
     if (!propFlag)
         return;
@@ -1132,7 +1132,7 @@ bool MainFrame::GetLayoutSettings(int* flag, int* option, int* border, int* orie
 
     auto prop_flags = m_selected_node->GetSizerFlags();
 
-    auto propOption = m_selected_node->get_prop_ptr(txt_proportion);
+    auto propOption = m_selected_node->get_prop_ptr(prop_proportion);
     if (propOption)
     {
         *option = prop_flags.GetProportion();
@@ -1147,7 +1147,7 @@ bool MainFrame::GetLayoutSettings(int* flag, int* option, int* border, int* orie
         auto parentName = sizer->GetClassName();
         if (parentName == "wxBoxSizer" || m_selected_node->IsStaticBoxSizer())
         {
-            auto propOrient = sizer->get_prop_ptr(txt_orientation);
+            auto propOrient = sizer->get_prop_ptr(prop_orientation);
             if (propOrient)
             {
                 *orient = propOrient->as_int();

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -165,7 +165,7 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
             created_sizer = wxStaticCast(created_object, wxSizer);
         }
 
-        if (auto minsize = node->prop_as_wxSize(txt_minimum_size); minsize != wxDefaultSize)
+        if (auto minsize = node->prop_as_wxSize(prop_minimum_size); minsize != wxDefaultSize)
         {
             created_sizer->SetMinSize(minsize);
             created_sizer->Layout();
@@ -216,8 +216,8 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
             if (obj_parent->isGen(gen_wxGridBagSizer))
             {
                 auto sizer = wxStaticCast(parentNode, wxGridBagSizer);
-                wxGBPosition position(child_obj->prop_as_int(txt_row), child_obj->prop_as_int(txt_column));
-                wxGBSpan span(child_obj->prop_as_int(txt_rowspan), child_obj->prop_as_int(txt_colspan));
+                wxGBPosition position(child_obj->prop_as_int(prop_row), child_obj->prop_as_int(prop_column));
+                wxGBSpan span(child_obj->prop_as_int(prop_rowspan), child_obj->prop_as_int(prop_colspan));
 
                 if (created_window)
                     sizer->Add(created_window, position, span, sizer_flags.GetFlags(), sizer_flags.GetBorderInPixels());
@@ -268,7 +268,7 @@ void MockupContent::SetWindowProperties(Node* node, wxWindow* window)
         window->SetSize(size);
     }
 
-    if (auto minsize = node->prop_as_wxSize(txt_minimum_size); minsize != wxDefaultSize)
+    if (auto minsize = node->prop_as_wxSize(prop_minimum_size); minsize != wxDefaultSize)
     {
         window->SetMinSize(minsize);
     }
@@ -298,12 +298,12 @@ void MockupContent::SetWindowProperties(Node* node, wxWindow* window)
         window->SetExtraStyle(extra_style->as_int());
     }
 
-    if (auto disabled = node->get_prop_ptr(txt_disabled); disabled && disabled->as_bool())
+    if (node->isPropValue(prop_disabled, true))
     {
         window->Disable();
     }
 
-    if (auto hidden = node->get_prop_ptr(txt_hidden); hidden && hidden->as_bool() && !m_mockupParent->IsShowingHidden())
+    if (node->isPropValue(prop_hidden, true) && !m_mockupParent->IsShowingHidden())
     {
         window->Show(false);
     }

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -121,7 +121,7 @@ void MockupParent::CreateContent()
     // Note that we show the form even if it's property has it set to hidden
     m_MockupWindow->Show();
 
-    if (auto background = m_form->get_prop_ptr(txt_background_colour); background && background->GetValue().size())
+    if (auto background = m_form->get_prop_ptr(prop_background_colour); background && background->GetValue().size())
     {
         m_panelContent->SetBackgroundColour(ConvertToColour(background->GetValue()));
     }
@@ -153,10 +153,10 @@ void MockupParent::CreateContent()
         m_panelTitleBar->Hide();
     }
 
-    auto minSize = m_form->prop_as_wxSize(txt_minimum_size);
+    auto minSize = m_form->prop_as_wxSize(prop_minimum_size);
     m_MockupWindow->SetMinSize(minSize);
 
-    auto maxSize = m_form->prop_as_wxSize(txt_maximum_size);
+    auto maxSize = m_form->prop_as_wxSize(prop_maximum_size);
     m_MockupWindow->SetMaxSize(maxSize);
 
     if (m_form->GetClassName() == "wxWizard")
@@ -164,7 +164,7 @@ void MockupParent::CreateContent()
 
     m_panelContent->CreateAllGenerators();
 
-    auto org_size = m_form->prop_as_wxSize(txt_size);
+    auto org_size = m_form->prop_as_wxSize(prop_size);
     if (m_IsMagnifyWindow && !(m_form->GetClassName() == "ToolBar" || m_form->GetClassName() == "MenuBar"))
     {
         org_size.IncTo(m_size_magnified);
@@ -202,7 +202,7 @@ void MockupParent::CreateContent()
 
     // Enable and Hidden state may have changed, so update state accordingly
 
-    if (auto disabled = m_form->prop_as_bool(txt_disabled); disabled)
+    if (m_form->isPropValue(prop_disabled, true))
     {
         m_MockupWindow->Enable(false);
     }
@@ -269,10 +269,10 @@ void MockupParent::MagnifyWindow(bool show)
     }
 
     // Need to be at least as large as any dimensions the user set.
-    new_size.IncTo(m_form->prop_as_wxSize(txt_size));
-    new_size.IncTo(m_form->prop_as_wxSize(txt_minimum_size));
+    new_size.IncTo(m_form->prop_as_wxSize(prop_size));
+    new_size.IncTo(m_form->prop_as_wxSize(prop_minimum_size));
 
-    new_size.DecToIfSpecified(m_form->prop_as_wxSize(txt_maximum_size));
+    new_size.DecToIfSpecified(m_form->prop_as_wxSize(prop_maximum_size));
 
     m_MockupWindow->SetSize(new_size);
     m_MockupWindow->Refresh();
@@ -370,7 +370,7 @@ static const auto NonUiProps = {
     "set_function",
     "show_hidden",
     "thumbsize",
-    txt_tooltip,
+    "tooltip",
     "url",
     "validator_data_type",
     "validator_style",
@@ -392,7 +392,7 @@ void MockupParent::OnNodePropModified(CustomEvent& event)
     auto prop = event.GetNodeProperty();
     auto& prop_name = prop->GetPropName();
 
-    if (prop_name == txt_tooltip)
+    if (prop->isProp(prop_tooltip))
     {
         if (auto node = wxGetFrame().GetSelectedNode(); node)
         {
@@ -423,7 +423,7 @@ void MockupParent::OnNodePropModified(CustomEvent& event)
 
     if (auto node = wxGetFrame().GetSelectedNode(); node)
     {
-        if (prop_name == txt_disabled)
+        if (prop->isProp(prop_disabled))
         {
             if (node->IsStaticBoxSizer())
                 wxStaticCast(Get_wxObject(node), wxStaticBoxSizer)->GetStaticBox()->Enable(!prop->as_bool());
@@ -453,10 +453,10 @@ void MockupParent::OnNodePropModified(CustomEvent& event)
             }
 
             // Need to be at least as large as any dimensions the user set.
-            new_size.IncTo(m_form->prop_as_wxSize(txt_size));
-            new_size.IncTo(m_form->prop_as_wxSize(txt_minimum_size));
+            new_size.IncTo(m_form->prop_as_wxSize(prop_size));
+            new_size.IncTo(m_form->prop_as_wxSize(prop_minimum_size));
 
-            new_size.DecToIfSpecified(m_form->prop_as_wxSize(txt_maximum_size));
+            new_size.DecToIfSpecified(m_form->prop_as_wxSize(prop_maximum_size));
 
             m_MockupWindow->SetSize(new_size);
             m_MockupWindow->Refresh();

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -137,6 +137,29 @@ public:
     // wxDefaultPosition, or non-sepcified bitmap)
     bool HasValue(PropName name);
 
+    // Returns true only if the property exists and it's value is equal to the parameter
+    // value.
+    bool isPropValue(PropName name, ttlib::cview value);
+
+    // Returns true only if the property exists and it's value is equal to the parameter
+    // value.
+    bool isPropValue(PropName name, bool value);
+
+    // Sets value only if the property exists, returns false if it doesn't exist.
+    template <typename T>
+    bool prop_set_value(PropName name, T value)
+    {
+        if (auto prop = get_prop_ptr(name); prop)
+        {
+            prop->set_value(value);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     bool prop_as_bool(PropName name);
     int prop_as_int(PropName name);
 
@@ -200,6 +223,10 @@ public:
 
     Node* CreateNode(ttlib::cview name);
     bool CreateToolNode(const ttlib::cstr& name);
+
+    // This will modify the property and fire a EVT_NodePropChange event if the property
+    // actually changed
+    void ModifyProperty(PropName name, ttlib::cview value);
 
     // This will modify the property and fire a EVT_NodePropChange event
     void ModifyProperty(ttlib::cview name, ttlib::cview value);

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -57,6 +57,9 @@ public:
     GenType gen_type() const noexcept { return m_gen_type; }
     GenName gen_name() const noexcept { return m_gen_name; }
 
+    bool isType(GenType type) const noexcept { return (type == m_gen_type); }
+    bool isGen(GenName name) const noexcept { return (name == m_gen_name); }
+
     const ttlib::cstr& GetClassName() const { return m_classname; }
 
     size_t AddBaseClass(NodeDeclaration* base)

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -393,7 +393,7 @@ void NodeCreator::ParseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
 
                 if (child.m_help.empty())
                 {
-                    if (child.m_name == txt_class_access)
+                    if (child.isProp(prop_class_access))
                         child.m_help = "Determines the type of access your derived class has to this item.";
                 }
 

--- a/src/nodes/prop_names.h
+++ b/src/nodes/prop_names.h
@@ -10,47 +10,10 @@
 // The advantage of using these constants is that the compiler will prevent you from accidentally misspelling the name,
 // or using a property name that no longer exists.
 
-constexpr auto txt_alignment = "alignment";
-constexpr auto txt_background_colour = "background_colour";
-constexpr auto txt_base_class_name = "base_class_name";
-constexpr auto txt_base_hdr_includes = "base_hdr_includes";
-constexpr auto txt_base_src_includes = "base_src_includes";
-constexpr auto txt_border_size = "border_size";
-constexpr auto txt_borders = "borders";
-constexpr auto txt_choices = "choices";
 constexpr auto txt_class_access = "class_access";
 constexpr auto txt_class_name = "class_name";
-constexpr auto txt_colour = "colour";
-constexpr auto txt_colspan = "colspan";
-constexpr auto txt_column = "column";
 constexpr auto txt_derived_class_name = "derived_class_name";
-constexpr auto txt_disabled = "disabled";
-constexpr auto txt_empty_cell_size = "empty_cell_size";
-constexpr auto txt_flags = "flags";
-constexpr auto txt_flexible_direction = "flexible_direction";
-constexpr auto txt_foreground_colour = "foreground_colour";
 constexpr auto txt_growablecols = "growablecols";
 constexpr auto txt_growablerows = "growablerows";
-constexpr auto txt_height = "height";
-constexpr auto txt_hgap = "hgap";
-constexpr auto txt_hidden = "hidden";
 constexpr auto txt_label = "label";
-constexpr auto txt_maximum_size = "maximum_size";
-constexpr auto txt_minimum_size = "minimum_size";
-constexpr auto txt_non_flexible_grow_mode = "non_flexible_grow_mode";
-constexpr auto txt_orientation = "orientation";
-constexpr auto txt_pos = "pos";
-constexpr auto txt_proportion = "proportion";
-constexpr auto txt_row = "row";
-constexpr auto txt_rowspan = "rowspan";
-constexpr auto txt_size = "size";
-constexpr auto txt_src_preamble = "src_preamble";
-constexpr auto txt_style = "style";
-constexpr auto txt_tooltip = "tooltip";
-constexpr auto txt_value = "value";
 constexpr auto txt_var_name = "var_name";
-constexpr auto txt_vgap = "vgap";
-constexpr auto txt_width = "width";
-constexpr auto txt_window_extra_style = "window_extra_style";
-constexpr auto txt_wrap_flags = "wrap_flags";
-constexpr auto txt_window_style = "window_style";

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -308,13 +308,13 @@ int NavigationPanel::GetImageIndex(Node* node)
     const char* name = node->GetNodeDeclaration()->GetClassName().c_str();
     if (ttlib::is_sameas(name, "VerticalBoxSizer"))
     {
-        auto& prop = node->prop_as_string(txt_orientation);
+        auto& prop = node->prop_as_string(prop_orientation);
         if (prop != "wxVERTICAL")
             name = "wxBoxSizer";
     }
     else if (ttlib::is_sameas(name, "wxBoxSizer"))
     {
-        auto& prop = node->prop_as_string(txt_orientation);
+        auto& prop = node->prop_as_string(prop_orientation);
         if (prop != "wxHORIZONTAL")
             name = "VerticalBoxSizer";
     }
@@ -328,7 +328,7 @@ int NavigationPanel::GetImageIndex(Node* node)
 void NavigationPanel::UpdateDisplayName(wxTreeItemId id, Node* node)
 {
     ttlib::cstr text;
-    auto prop = node->get_prop_ptr(txt_label);
+    auto prop = node->get_prop_ptr(prop_label);
     if (prop && prop->get_value().size())
     {
         text = prop->get_value();
@@ -341,11 +341,11 @@ void NavigationPanel::UpdateDisplayName(wxTreeItemId id, Node* node)
             text << "...";
         }
     }
-    else if (prop = node->get_prop_ptr(txt_var_name); prop)
+    else if (prop = node->get_prop_ptr(prop_var_name); prop)
     {
         text = prop->get_value();
     }
-    else if (prop = node->get_prop_ptr(txt_class_name); prop)
+    else if (prop = node->get_prop_ptr(prop_class_name); prop)
     {
         text = prop->get_value();
     }
@@ -431,7 +431,7 @@ void NavigationPanel::OnNodeSelected(CustomEvent& event)
     else
     {
         FAIL_MSG(ttlib::cstr("There is no tree item associated with this object.\n\tClass: ")
-                 << node->GetClassName() << "\n\tName: " << node->GetPropertyAsString(txt_var_name).wx_str());
+                 << node->GetClassName() << "\n\tName: " << node->prop_as_string(prop_var_name).wx_str());
     }
 }
 
@@ -439,7 +439,7 @@ void NavigationPanel::OnNodePropChange(CustomEvent& event)
 {
     auto prop = event.GetNodeProperty();
 
-    if (prop->GetPropName() == txt_var_name || prop->GetPropName() == txt_label || prop->GetPropName() == txt_class_name)
+    if (prop->isProp(prop_var_name) || prop->isProp(prop_label) || prop->isProp(prop_class_name))
     {
         auto& class_name = prop->GetNode()->GetClassName();
         if (ttlib::contains(class_name, "bookpage"))
@@ -462,7 +462,7 @@ void NavigationPanel::OnNodePropChange(CustomEvent& event)
         }
     }
 
-    else if (prop->GetPropName() == txt_orientation)
+    else if (prop->isProp(prop_orientation))
     {
         if (auto it = m_node_tree_map.find(prop->GetNode()); it != m_node_tree_map.end())
         {

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -333,7 +333,7 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
             break;
 
         case MenuRESET_MIN_SIZE:
-            m_node->ModifyProperty(txt_minimum_size, "-1,-1");
+            m_node->ModifyProperty(prop_minimum_size, "-1,-1");
             break;
 
         case MenuRESET_MAX_SIZE:
@@ -375,21 +375,21 @@ void NavPopupMenu::OnUpdateEvent(wxUpdateUIEvent& event)
             break;
 
         case MenuBORDERS_ALL:
-            event.Check(m_node->prop_as_string(txt_borders).contains("wxALL"));
+            event.Check(m_node->prop_as_string(prop_borders).contains("wxALL"));
             break;
 
         case MenuBORDERS_NONE:
-            event.Check(m_node->prop_as_string(txt_borders).empty());
+            event.Check(m_node->prop_as_string(prop_borders).empty());
             break;
 
         case MenuBORDERS_HORIZONTAL:
-            event.Check(m_node->prop_as_string(txt_borders) == "wxLEFT|wxRIGHT" ||
-                        m_node->prop_as_string(txt_borders) == "wxRIGHT|wxLEFT|");
+            event.Check(m_node->prop_as_string(prop_borders) == "wxLEFT|wxRIGHT" ||
+                        m_node->prop_as_string(prop_borders) == "wxRIGHT|wxLEFT|");
             break;
 
         case MenuBORDERS_VERTICAL:
-            event.Check(m_node->prop_as_string(txt_borders) == "wxTOP|wxBOTTOM" ||
-                        m_node->prop_as_string(txt_borders) == "wxBOTTOM|wxTOP|");
+            event.Check(m_node->prop_as_string(prop_borders) == "wxTOP|wxBOTTOM" ||
+                        m_node->prop_as_string(prop_borders) == "wxBOTTOM|wxTOP|");
             break;
     }
 }
@@ -466,7 +466,7 @@ void NavPopupMenu::OnBorders(wxCommandEvent& event)
             break;
     }
 
-    m_node->ModifyProperty(txt_borders, value);
+    m_node->ModifyProperty(prop_borders, value);
 }
 
 void NavPopupMenu::CreateProjectMenu(Node* WXUNUSED(node))

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -832,22 +832,22 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                             }
                         }
                     }
-                    else if (prop->GetPropName() == txt_class_access && wxGetApp().IsPjtMemberPrefix())
+                    else if (prop->isProp(prop_class_access) && wxGetApp().IsPjtMemberPrefix())
                     {
                         // TODO: [KeyWorks - 08-23-2020] This needs to be a preference
 
                         // If access is changed to local and the name starts with "m_", then the "m_" will be stripped off.
                         // Conversely, if the name is changed from local to a class member, a "m_" is added as a prefix (if
                         // it doesn't already have one).
-                        ttlib::cstr name = node->prop_as_string(txt_var_name);
+                        ttlib::cstr name = node->prop_as_string(prop_var_name);
                         if (value == "none" && name.is_sameprefix("m_"))
                         {
                             name.erase(0, 2);
                             auto final_name = node->GetUniqueName(name);
                             if (final_name.size())
                                 name = final_name;
-                            auto propChange = selected_node->get_prop_ptr(txt_var_name);
-                            auto grid_property = m_prop_grid->GetPropertyByLabel(txt_var_name);
+                            auto propChange = selected_node->get_prop_ptr(prop_var_name);
+                            auto grid_property = m_prop_grid->GetPropertyByLabel("var_name");
                             grid_property->SetValueFromString(name, 0);
                             modifyProperty(propChange, name);
                         }
@@ -857,8 +857,8 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                             auto final_name = node->GetUniqueName(name);
                             if (final_name.size())
                                 name = final_name;
-                            auto propChange = selected_node->get_prop_ptr(txt_var_name);
-                            auto grid_property = m_prop_grid->GetPropertyByLabel(txt_var_name);
+                            auto propChange = selected_node->get_prop_ptr(prop_var_name);
+                            auto grid_property = m_prop_grid->GetPropertyByLabel("var_name");
                             grid_property->SetValueFromString(name, 0);
                             modifyProperty(propChange, name);
                         }
@@ -923,12 +923,12 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                 ttString value = m_prop_grid->GetPropertyValueAsString(property);
                 value.Replace(" ", "");
                 value.Replace(",", "|");
-                if (prop->GetPropName() == txt_style)
+                if (prop->isProp(prop_style))
                 {
                     // Don't allow the user to combine incompatible styles
                     if (value.contains("wxFLP_OPEN") && value.contains("wxFLP_SAVE"))
                     {
-                        auto style_prop = node->get_prop_ptr(txt_style);
+                        auto style_prop = node->get_prop_ptr(prop_style);
                         auto old_value = style_prop->GetValue();
                         if (old_value.contains("wxFLP_OPEN"))
                         {
@@ -938,7 +938,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
 
                             // Change the format to what the property grid wants
                             value.Replace("|", ",");
-                            m_prop_grid->SetPropertyValue(txt_style, value);
+                            m_prop_grid->SetPropertyValue("style", value);
 
                             // Now put it back into the format we use internally
                             value.Replace(",", "|");
@@ -951,7 +951,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
 
                             // Change the format to what the property grid wants
                             value.Replace("|", ",");
-                            m_prop_grid->SetPropertyValue(txt_style, value);
+                            m_prop_grid->SetPropertyValue("style", value);
 
                             // Now put it back into the format we use internally
                             value.Replace(",", "|");
@@ -1073,7 +1073,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
             {
                 ttString newValue = property->GetValueAsString();
 
-                if (prop->GetPropName() == txt_var_name)
+                if (prop->isProp(prop_var_name))
                 {
                     if (newValue.empty())
                     {
@@ -1082,11 +1082,11 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                         auto final_name = node->GetUniqueName(new_name);
                         newValue = final_name.size() ? final_name : new_name;
 
-                        auto grid_property = m_prop_grid->GetPropertyByLabel(txt_var_name);
+                        auto grid_property = m_prop_grid->GetPropertyByLabel("var_name");
                         grid_property->SetValueFromString(newValue, 0);
                     }
                 }
-                else if (prop->GetPropName() == txt_choices)
+                else if (prop->isProp(prop_choices))
                 {
 #if defined(_WIN32)
                     // Under Windows 10 using wxWidgets 3.1.3, the last character of the string is partially clipped. Adding
@@ -1122,7 +1122,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
 
                 ModifyProperty(prop, newValue);
 
-                if (prop->GetPropName() == txt_class_name)
+                if (prop->isProp(prop_class_name))
                 {
                     auto selected_node = wxGetFrame().GetSelectedNode();
                     if (!selected_node)
@@ -1133,7 +1133,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                         if (newValue.Right(4) != "Base")
                             return;
 
-                        if (auto propType = selected_node->get_prop_ptr(txt_derived_class_name);
+                        if (auto propType = selected_node->get_prop_ptr(prop_derived_class_name);
                             propType && propType->GetValue() == "DerivedClass")
                             ReplaceDrvName(newValue, propType);
                         if (auto propType = selected_node->get_prop_ptr("base_file");
@@ -1492,7 +1492,7 @@ void PropGridPanel::CreateLayoutCategory(Node* node)
 
     if (!node->GetParent()->isGen(gen_wxGridBagSizer))
     {
-        if (auto prop = node->get_prop_ptr(txt_proportion); prop)
+        if (auto prop = node->get_prop_ptr(prop_proportion); prop)
         {
             auto id_prop = m_prop_grid->Append(GetProperty(prop));
 
@@ -1562,7 +1562,7 @@ void PropGridPanel::ReplaceDrvName(const wxString& newValue, NodeProperty* propT
 {
     wxString drvName = newValue;
     drvName.Replace("Base", wxEmptyString);
-    auto grid_property = m_prop_grid->GetPropertyByLabel(txt_derived_class_name);
+    auto grid_property = m_prop_grid->GetPropertyByLabel("derived_class_name");
     grid_property->SetValueFromString(drvName, 0);
     ModifyProperty(propType, drvName);
 }
@@ -1621,7 +1621,7 @@ void PropGridPanel::VerifyChangeFile(wxPropertyGridEvent& event, NodeProperty* p
             if (project->GetChild(child_idx)->prop_as_string("base_file") == filename)
             {
                 appMsgBox(ttlib::cstr() << "The base filename " << filename << " is already in use by "
-                                        << project->GetChild(child_idx)->prop_as_string(txt_class_name)
+                                        << project->GetChild(child_idx)->prop_as_string(prop_class_name)
                                         << "\n\nEither change the name, or press ESC to restore the original name.");
                 m_failure_handled = true;
                 event.Veto();

--- a/src/project/import_winres.cpp
+++ b/src/project/import_winres.cpp
@@ -160,11 +160,11 @@ void WinResource::FormToNode(rcForm& form)
         auto parent_sizer = g_NodeCreator.CreateNode("wxBoxSizer", dlg_node.get());
         dlg_node->AddChild(parent_sizer);
         parent_sizer->SetParent(dlg_node);
-        parent_sizer->get_prop_ptr(txt_orientation)->set_value("wxVERTICAL");
+        parent_sizer->get_prop_ptr(prop_orientation)->set_value("wxVERTICAL");
 
         if (form.m_Name.size())
         {
-            dlg_node->get_prop_ptr(txt_var_name)->set_value(form.m_Name);
+            dlg_node->get_prop_ptr(prop_var_name)->set_value(form.m_Name);
         }
         if (form.m_Title.size())
         {
@@ -177,7 +177,7 @@ void WinResource::FormToNode(rcForm& form)
 
         if (form.m_Styles.size())
         {
-            dlg_node->get_prop_ptr(txt_style)->set_value(form.m_Styles);
+            dlg_node->get_prop_ptr(prop_style)->set_value(form.m_Styles);
         }
         if (form.m_ExStyles.size())
         {

--- a/src/project/import_wxsmith.cpp
+++ b/src/project/import_wxsmith.cpp
@@ -327,7 +327,7 @@ void WxSmith::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Node*
         }
         else if (iter.cname().is_sameas("border"))
         {
-            node->get_prop_ptr(txt_border_size)->set_value(iter.text().as_string());
+            node->prop_set_value(prop_border_size, iter.text().as_string());
         }
         else if (iter.cname().is_sameas("flag") &&
                  (node->GetClassName() == "sizeritem" || node->GetClassName() == "gbsizeritem"))

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -225,7 +225,7 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
         // Convert old orient name to orientationr
         else if (iter.cname().is_sameas("orient"))
         {
-            if (auto prop = new_node->get_prop_ptr(txt_orientation); prop)
+            if (auto prop = new_node->get_prop_ptr(prop_orientation); prop)
             {
                 prop->set_value(iter.value());
                 continue;
@@ -235,7 +235,7 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
         // Convert old access name to class_access
         else if (iter.cname().is_sameas("access"))
         {
-            if (auto prop = new_node->get_prop_ptr(txt_class_access); prop)
+            if (auto prop = new_node->get_prop_ptr(prop_class_access); prop)
             {
                 prop->set_value(iter.value());
                 continue;
@@ -245,7 +245,7 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
         // Convert old derived_name to derived_class_name
         else if (iter.cname().is_sameas("derived_name"))
         {
-            if (auto prop = new_node->get_prop_ptr(txt_derived_class_name); prop)
+            if (auto prop = new_node->get_prop_ptr(prop_derived_class_name); prop)
             {
                 prop->set_value(iter.value());
                 continue;
@@ -255,7 +255,7 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
         // Convert old hdr_preamble to  to derived_class_name
         else if (iter.cname().is_sameas("hdr_preamble"))
         {
-            if (auto prop = new_node->get_prop_ptr(txt_base_hdr_includes); prop)
+            if (auto prop = new_node->get_prop_ptr(prop_base_hdr_includes); prop)
             {
                 prop->set_value(iter.value());
                 continue;

--- a/src/project/oldproject.cpp
+++ b/src/project/oldproject.cpp
@@ -445,7 +445,7 @@ NodeSharedPtr OldProject::CreateOldProjectNode(pugi::xml_node& xml_obj, Node* pa
                     if (prop_name.is_sameas("name"))
                     {
                         // This gets special-cased because "name" is still used in some places, just not as the class name
-                        if (auto prop_varname = newobject.get()->get_prop_ptr(txt_var_name); prop_varname)
+                        if (auto prop_varname = newobject.get()->get_prop_ptr(prop_var_name); prop_varname)
                         {
                             prop_varname->set_value(value);
                             xml_prop = xml_prop.next_sibling("property");
@@ -480,7 +480,7 @@ NodeSharedPtr OldProject::CreateOldProjectNode(pugi::xml_node& xml_obj, Node* pa
 
     if (class_name.is_sameas("VerticalBoxSizer"))
     {
-        auto prop = newobject->get_prop_ptr(txt_orientation);
+        auto prop = newobject->get_prop_ptr(prop_orientation);
         prop->set_value("wxVERTICAL");
     }
 
@@ -552,7 +552,7 @@ static bool ProcessCheckBox(pugi::xml_node& xml_prop, Node* node)
     auto prop_name = xml_prop.attribute("name").as_cview();
 
     // wxCHK_2STATE and wxCHK_3STATE are now part of the type property instead of style
-    if (prop_name.is_sameas(txt_style))
+    if (prop_name.is_sameas("style"))
     {
         ttlib::multistr styles(xml_prop.text().as_string(), '|');
         ttlib::cstr new_style;
@@ -575,7 +575,7 @@ static bool ProcessCheckBox(pugi::xml_node& xml_prop, Node* node)
 
         if (new_style.size())
         {
-            auto prop = node->get_prop_ptr(txt_style);
+            auto prop = node->get_prop_ptr(prop_style);
             prop->set_value(new_style);
         }
         return true;
@@ -595,22 +595,21 @@ static bool HandleDownLevelProperty(pugi::xml_node& xml_prop, ttlib::cview prop_
 
     if (prop_name.is_sameas("derived_name"))
     {
-        auto prop = node->get_prop_ptr(txt_derived_class_name);
+        auto prop = node->get_prop_ptr(prop_derived_class_name);
         prop->set_value(xml_prop.text().as_cview());
         return true;
     }
 
     if (prop_name.is_sameas("orient"))
     {
-        auto prop = node->get_prop_ptr(txt_orientation);
+        auto prop = node->get_prop_ptr(prop_orientation);
         prop->set_value(xml_prop.text().as_cview());
         return true;
     }
 
     if (prop_name.is_sameas("access"))
     {
-        auto prop = node->get_prop_ptr(txt_class_access);
-        prop->set_value(xml_prop.text().as_cview());
+        node->prop_set_value(prop_class_access, xml_prop.text().as_cview());
         return true;
     }
 
@@ -618,8 +617,7 @@ static bool HandleDownLevelProperty(pugi::xml_node& xml_prop, ttlib::cview prop_
     {
         if (node->IsForm())
         {
-            auto prop = node->get_prop_ptr(txt_class_name);
-            prop->set_value(xml_prop.text().as_cview());
+            node->prop_set_value(prop_class_name, xml_prop.text().as_cview());
             return true;
         }
     }
@@ -661,8 +659,7 @@ static bool HandleDownLevelProperty(pugi::xml_node& xml_prop, ttlib::cview prop_
 
         if (border_value.size())
         {
-            auto prop = node->get_prop_ptr(txt_borders);
-            prop->set_value(border_value);
+            node->prop_set_value(prop_borders, border_value);
         }
 
         ttlib::cstr align_value;
@@ -723,8 +720,7 @@ static bool HandleDownLevelProperty(pugi::xml_node& xml_prop, ttlib::cview prop_
         }
         if (align_value.size())
         {
-            auto prop = node->get_prop_ptr(txt_alignment);
-            prop->set_value(align_value);
+            node->prop_set_value(prop_alignment, align_value);
         }
 
         ttlib::cstr flags_value;
@@ -752,7 +748,7 @@ static bool HandleDownLevelProperty(pugi::xml_node& xml_prop, ttlib::cview prop_
         }
         if (flags_value.size())
         {
-            auto prop = node->get_prop_ptr(txt_flags);
+            auto prop = node->get_prop_ptr(prop_flags);
             prop->set_value(flags_value);
         }
 
@@ -761,13 +757,11 @@ static bool HandleDownLevelProperty(pugi::xml_node& xml_prop, ttlib::cview prop_
 
     if (prop_name.is_sameas("border"))
     {
-        auto prop = node->get_prop_ptr(txt_border_size);
-        prop->set_value(xml_prop.text().as_cview());
-
+        node->prop_set_value(prop_border_size, xml_prop.text().as_cview());
         return true;
     }
 
-    if (prop_name.is_sameas(txt_value) && class_name.is_sameas("wxComboBox"))
+    if (prop_name.is_sameas("value") && class_name.is_sameas("wxComboBox"))
     {
         auto prop = node->get_prop_ptr("selection_string");
         prop->set_value(xml_prop.text().as_cview());

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -36,38 +36,38 @@ void InsertNodeAction::Change()
         {
             for (size_t pos = 0; pos < m_parent->GetChildCount(); ++pos)
             {
-                auto child_row = m_parent->GetChild(pos)->prop_as_int(txt_row);
+                auto child_row = m_parent->GetChild(pos)->prop_as_int(prop_row);
                 if (child_row > row)
                     row = child_row;
             }
 
             m_parent->AddChild(m_node);
-            m_node->get_prop_ptr(txt_row)->set_value(row + 1);
+            m_node->get_prop_ptr(prop_row)->set_value(row + 1);
         }
         else
         {
             if (m_pos > 0)
             {
                 // This assumes the children are in row order, which is not necessarily the case
-                row = m_parent->GetChild(m_pos - 1)->prop_as_int(txt_row);
+                row = m_parent->GetChild(m_pos - 1)->prop_as_int(prop_row);
             }
             auto col = -1;
             for (size_t pos = 0; pos < m_parent->GetChildCount(); ++pos)
             {
-                if (m_parent->GetChild(pos)->prop_as_int(txt_row) == row)
+                if (m_parent->GetChild(pos)->prop_as_int(prop_row) == row)
                 {
-                    auto child_col = m_parent->GetChild(pos)->prop_as_int(txt_column);
+                    auto child_col = m_parent->GetChild(pos)->prop_as_int(prop_column);
                     if (child_col > col)
                     {
-                        auto col_span = m_parent->GetChild(pos)->prop_as_int(txt_colspan);
+                        auto col_span = m_parent->GetChild(pos)->prop_as_int(prop_colspan);
                         col = child_col + (col_span - 1);
                     }
                 }
             }
             if (row == -1)
                 ++row;
-            m_node->get_prop_ptr(txt_row)->set_value(row);
-            m_node->get_prop_ptr(txt_column)->set_value(col + 1);
+            m_node->get_prop_ptr(prop_row)->set_value(row);
+            m_node->get_prop_ptr(prop_column)->set_value(col + 1);
 
             m_parent->AddChild(m_node);
             m_parent->ChangeChildPosition(m_node, m_pos);
@@ -211,8 +211,8 @@ ChangeParentAction::ChangeParentAction(Node* node, Node* parent)
     m_revert_parent = node->GetParentPtr();
 
     m_revert_position = m_revert_parent->GetChildPosition(node);
-    m_revert_row = node->prop_as_int(txt_row);
-    m_revert_col = node->prop_as_int(txt_column);
+    m_revert_row = node->prop_as_int(prop_row);
+    m_revert_col = node->prop_as_int(prop_column);
 }
 
 void ChangeParentAction::Change()
@@ -235,9 +235,9 @@ void ChangeParentAction::Revert()
     m_node->SetParent(m_revert_parent);
     m_revert_parent->AddChild(m_node);
     m_revert_parent->ChangeChildPosition(m_node, m_revert_position);
-    if (auto prop = m_node->get_prop_ptr(txt_row); prop)
+    if (auto prop = m_node->get_prop_ptr(prop_row); prop)
         prop->set_value(m_revert_row);
-    if (auto prop = m_node->get_prop_ptr(txt_column); prop)
+    if (auto prop = m_node->get_prop_ptr(prop_column); prop)
         prop->set_value(m_revert_col);
 }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR replaces most of the constexpr `txt_` strings with a `PropName` enumerated value -- the are already identical function names that take the enumerated value instead of the string, so it's only a matter of replacing the name to get the newer function.

I also added a `Node::prop_set_value()` template function. This function always ensures the property actually exists before setting it's value, return `false` if the property doesn't exist. This is now the preferred way to set a property value since it eliminates the risk of a GPF trying to using a null pointer if the property name is changed or removed.
