### PR TITLE
Add variant property to wxActivityIndicator

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -291,6 +291,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_validator_variable, "validator_variable" },
     { prop_value, "value" },
     { prop_var_name, "var_name" },
+    { prop_variant, "variant" },
     { prop_vgap, "vgap" },
     { prop_view_eol, "view_eol" },
     { prop_view_whitespace, "view_whitespace" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -291,6 +291,7 @@ namespace GenEnum
         prop_validator_variable,
         prop_value,
         prop_var_name,
+        prop_variant,
         prop_vgap,
         prop_view_eol,
         prop_view_whitespace,

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -32,8 +32,18 @@ wxObject* ActivityIndicatorGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxActivityIndicator(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(prop_pos),
                                           node->prop_as_wxSize(prop_size), node->prop_as_int(prop_window_style));
+    if (!node->isPropValue(prop_variant, "normal"))
+    {
+        if (node->isPropValue(prop_variant, "small"))
+            widget->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
+        else if (node->isPropValue(prop_variant, "mini"))
+            widget->SetWindowVariant(wxWINDOW_VARIANT_MINI);
+        else
+            widget->SetWindowVariant(wxWINDOW_VARIANT_LARGE);
+    }
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
+    widget->Start();
 
     return widget;
 }
@@ -47,6 +57,18 @@ std::optional<ttlib::cstr> ActivityIndicatorGenerator::GenConstruction(Node* nod
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
 
     GeneratePosSizeFlags(node, code);
+
+    if (!node->isPropValue(prop_variant, "normal"))
+    {
+        code << "\n    " << node->get_node_name() << "->SetWindowVariant(";
+
+        if (node->isPropValue(prop_variant, "small"))
+            code << "wxWINDOW_VARIANT_SMALL);";
+        else if (node->isPropValue(prop_variant, "mini"))
+            code << "wxWINDOW_VARIANT_MINI);";
+        else
+            code << "wxWINDOW_VARIANT_LARGE);";
+    }
 
     return code;
 }

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -1646,6 +1646,13 @@
       <option name="public:"/>
       protected:
     </property>
+    <property name="variant" type="option">
+      <option name="normal" help="Normal size"/>
+      <option name="small" help="About 25% smaller than normal."/>
+      <option name="mini" help="About 33% smaller than normal."/>
+      <option name="large" help="About 35% larger than normal."/>
+      normal
+    </property>
   </gen>
 
   <gen class="wxBannerWindow" image="wxBannerWindow" type="widget">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a variant property to **wxActivityIndicator** for setting one of the `wxWINDOW_VARIANT_...` properties (via `SetWindowVariant()`). It also adds `Start()` to the Mockup window so that the activity indicator is always running.

Note that this property that this fixes a problem with XRC import which specifies this property (see #149).
