### PR TITLE
Add variant property as a standard wxWindow property

### DIFF
--- a/src/generate/btn_widgets.cpp
+++ b/src/generate/btn_widgets.cpp
@@ -59,6 +59,16 @@ wxObject* ButtonGenerator::Create(Node* node, wxObject* parent)
     if (node->HasValue(prop_margins))
         widget->SetBitmapMargins(node->prop_as_wxSize(prop_margins));
 
+    if (!node->isPropValue(prop_variant, "normal"))
+    {
+        if (node->isPropValue(prop_variant, "small"))
+            widget->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
+        else if (node->isPropValue(prop_variant, "mini"))
+            widget->SetWindowVariant(wxWINDOW_VARIANT_MINI);
+        else
+            widget->SetWindowVariant(wxWINDOW_VARIANT_LARGE);
+    }
+
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
     return widget;

--- a/src/generate/gen_inherit.cpp
+++ b/src/generate/gen_inherit.cpp
@@ -194,6 +194,20 @@ void GenerateWindowSettings(Node* node, ttlib::cstr& code)
         }
     }
 
+    if (!node->IsForm() && !node->isPropValue(prop_variant, "normal"))
+    {
+        if (code.size())
+            code << "\n    ";
+        code << node->get_node_name() << "->SetWindowVariant(";
+
+        if (node->isPropValue(prop_variant, "small"))
+            code << "wxWINDOW_VARIANT_SMALL);";
+        else if (node->isPropValue(prop_variant, "mini"))
+            code << "wxWINDOW_VARIANT_MINI);";
+        else
+            code << "wxWINDOW_VARIANT_LARGE);";
+    }
+
     if (node->prop_as_string(prop_tooltip).size())
     {
         if (code.size())

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -32,15 +32,6 @@ wxObject* ActivityIndicatorGenerator::Create(Node* node, wxObject* parent)
 {
     auto widget = new wxActivityIndicator(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(prop_pos),
                                           node->prop_as_wxSize(prop_size), node->prop_as_int(prop_window_style));
-    if (!node->isPropValue(prop_variant, "normal"))
-    {
-        if (node->isPropValue(prop_variant, "small"))
-            widget->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
-        else if (node->isPropValue(prop_variant, "mini"))
-            widget->SetWindowVariant(wxWINDOW_VARIANT_MINI);
-        else
-            widget->SetWindowVariant(wxWINDOW_VARIANT_LARGE);
-    }
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
     widget->Start();
@@ -57,18 +48,6 @@ std::optional<ttlib::cstr> ActivityIndicatorGenerator::GenConstruction(Node* nod
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
 
     GeneratePosSizeFlags(node, code);
-
-    if (!node->isPropValue(prop_variant, "normal"))
-    {
-        code << "\n    " << node->get_node_name() << "->SetWindowVariant(";
-
-        if (node->isPropValue(prop_variant, "small"))
-            code << "wxWINDOW_VARIANT_SMALL);";
-        else if (node->isPropValue(prop_variant, "mini"))
-            code << "wxWINDOW_VARIANT_MINI);";
-        else
-            code << "wxWINDOW_VARIANT_LARGE);";
-    }
 
     return code;
 }

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -278,6 +278,16 @@ void MockupContent::SetWindowProperties(Node* node, wxWindow* window)
         window->SetMaxSize(maxsize);
     }
 
+    if (!node->isPropValue(prop_variant, "normal"))
+    {
+        if (node->isPropValue(prop_variant, "small"))
+            window->SetWindowVariant(wxWINDOW_VARIANT_SMALL);
+        else if (node->isPropValue(prop_variant, "mini"))
+            window->SetWindowVariant(wxWINDOW_VARIANT_MINI);
+        else
+            window->SetWindowVariant(wxWINDOW_VARIANT_LARGE);
+    }
+
     if (node->HasValue(prop_font))
     {
         window->SetFont(node->prop_as_font(prop_font));

--- a/src/xml/interface.xml
+++ b/src/xml/interface.xml
@@ -35,6 +35,13 @@
         help="Sets the minimum size of the window, to indicate to the sizer layout mechanism that this is the minimum required size."/>
     <property name="maximum_size" type="wxSize"
         help="Sets the maximum size of the window, to indicate to the sizer layout mechanism that this is the maximum allowable size."/>
+    <property name="variant" type="option">
+      <option name="normal" help="Normal size"/>
+      <option name="small" help="About 25% smaller than normal."/>
+      <option name="mini" help="About 33% smaller than normal."/>
+      <option name="large" help="About 35% larger than normal."/>
+      normal
+    </property>
     <property name="window_style" type="bitlist">
       <option name="wxBORDER_DEFAULT" help="The window class will decide the kind of border to show, if any."/>
       <option name="wxBORDER_SIMPLE" help="Displays a thin border around the window. wxSIMPLE_BORDER is the old name for this style."/>

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -1646,13 +1646,6 @@
       <option name="public:"/>
       protected:
     </property>
-    <property name="variant" type="option">
-      <option name="normal" help="Normal size"/>
-      <option name="small" help="About 25% smaller than normal."/>
-      <option name="mini" help="About 33% smaller than normal."/>
-      <option name="large" help="About 35% larger than normal."/>
-      normal
-    </property>
   </gen>
 
   <gen class="wxBannerWindow" image="wxBannerWindow" type="widget">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `variant` property to the `wxWindow` interface, and removes the individual property by the same name previously added to **wxActivityIndicator** since it inherits from the wxWindow interface. If the property is anything other than `normal` and the widget inherits from `wxWindow` then **SetWindowVariant** will be called (with the exception of forms, where it does not appear to have any effect).

This fixes the bug in importing `variants.xrc` from the **wxWidgets** sample (see issue #149).