### PR TITLE
Change default_btn property back to just default

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -115,7 +115,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_context_menu, "context_menu" },
     { prop_converted_art, "converted_art" },
     { prop_current, "current" },
-    { prop_default_btn, "default_btn" },
+    { prop_default, "default" },
     { prop_default_button, "default_button" },
     { prop_default_pane, "default_pane" },
     { prop_defaultfilter, "defaultfilter" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -115,7 +115,7 @@ namespace GenEnum
         prop_context_menu,
         prop_converted_art,
         prop_current,
-        prop_default_btn,
+        prop_default,
         prop_default_button,
         prop_default_pane,
         prop_defaultfilter,

--- a/src/generate/btn_widgets.cpp
+++ b/src/generate/btn_widgets.cpp
@@ -32,7 +32,7 @@ wxObject* ButtonGenerator::Create(Node* node, wxObject* parent)
     else
         widget->SetLabel(node->prop_as_wxString(prop_label));
 
-    if (node->prop_as_bool(prop_default_btn))
+    if (node->prop_as_bool(prop_default))
         widget->SetDefault();
 
     if (node->prop_as_bool(prop_auth_needed))
@@ -101,7 +101,7 @@ bool ButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePropert
             return true;
         }
     }
-    else if (prop->isProp(prop_default_btn))
+    else if (prop->isProp(prop_default))
     {
         // You can change a button to be the default, but you cannot change it back without recreating it.
         if (prop->as_bool())
@@ -156,7 +156,7 @@ std::optional<ttlib::cstr> ButtonGenerator::GenSettings(Node* node, size_t& /* a
              << ");";
     }
 
-    if (node->prop_as_bool(prop_default_btn))
+    if (node->prop_as_bool(prop_default))
     {
         if (code.size())
             code << '\n';
@@ -414,7 +414,7 @@ std::optional<ttlib::cstr> CommandLinkBtnGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxCommandLinkButton(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", ";
 
-    // BUGBUG: [KeyWorks - 04-09-2021] Need to support default_btn property
+    // BUGBUG: [KeyWorks - 04-09-2021] Need to support default property
 
     if (node->HasValue(prop_main_label))
     {

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -150,7 +150,7 @@
         help="This can be used to apply fonts or colours to different parts of the label.">
       0
     </property>
-    <property name="default_btn" type="bool" help="Set the button to be the default item in its top-level window">0</property>
+    <property name="default" type="bool" help="Set the button to be the default item in its top-level window">0</property>
     <property name="auth_needed" type="bool"
         help="Sets whether an authentication needed symbol should be displayed on the button. This method doesn't do anything if the platform is not Windows Vista or newer.">
       0
@@ -177,7 +177,7 @@
     <property name="var_name" type="string">m_btn</property>
     <property name="main_label" type="string_edit">MyButton</property>
     <property name="note" type="string_edit_escapes"/>
-    <property name="default_btn" type="bool" help="If true, this will be the default button (it will be depressed when the return key is pressed)">0</property>
+    <property name="default" type="bool" help="If true, this will be the default button (it will be depressed when the return key is pressed)">0</property>
     <event name="wxEVT_BUTTON" class="wxCommandEvent" help="Generated when the button is clicked"/>
   </gen>
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Closes #134

This PR changes the `default_btn` property back to `default`.

When we were first setting up the property enumerations, we weren't using a prefix, and the clang compiler would not accept `default` as an enumeration name. Since we wanted the enumeration name to match the property name, we changed the property name to `default_btn`. That solved the problem but broke the **wxFormBuilder** import (and possibly XRC imports as well). Now that we use a `prop_` prefix to the enumeration name, there's no advantage to `default_btn` versus just `default`.