### PR TITLE
Add generate_ids property to Code Generation interface

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -152,6 +152,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_folding, "folding" },
     { prop_font, "font" },
     { prop_foreground_colour, "foreground_colour" },
+    { prop_generate_ids, "generate_ids" },
     { prop_get_function, "get_function" },
     { prop_grid_line_color, "grid_line_color" },
     { prop_grid_lines, "grid_lines" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -152,6 +152,7 @@ namespace GenEnum
         prop_folding,
         prop_font,
         prop_foreground_colour,
+        prop_generate_ids,
         prop_get_function,
         prop_grid_line_color,
         prop_grid_lines,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -771,6 +771,9 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const wxString& cla
 
 void BaseCodeGenerator::GenEnumIds(Node* class_node)
 {
+    if (!class_node->prop_as_bool(prop_generate_ids))
+        return;
+
     std::set<std::string> set_ids;
     CollectIDs(class_node, set_ids);
     if (set_ids.empty())

--- a/src/xml/interface.xml
+++ b/src/xml/interface.xml
@@ -370,6 +370,9 @@
         DerivedClass
       </property>
       <property name="derived_file" type="file" help="The filename of the derived class."/>
+      <property name="generate_ids" type="bool" help="If checked, any non-wxWidgets ids will be created as an enumerated list. If you want to use your own id values, uncheck this and add the header file containing the ids to either base_src_includes or base_hdr_includes.">
+        1
+      </property>
   </gen>
 
   <gen class="Text Validator" type="interface">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Default is true. When the property is unchecked, no enumerated ids are generated for the current form.