### PR TITLE
If no mask and not a PNG conversion, process as binary

### DIFF
--- a/src/ui/embedimg.cpp
+++ b/src/ui/embedimg.cpp
@@ -451,7 +451,18 @@ void EmbedImage::ImgageInHeaderOut()
     }
     else
     {
-        m_hdrImage.SaveFile(save_stream, m_mime_type);
+        if (!m_ForceHdrMask || m_mime_type.is_sameas_wx("image/x-ani"))
+        {
+            wxFFileInputStream stream_in(m_fileOriginal->GetTextCtrlValue());
+            if (stream_in.IsOk())
+            {
+                stream_in.Read(save_stream);
+            }
+        }
+        else
+        {
+            m_hdrImage.SaveFile(save_stream, m_mime_type);
+        }
     }
 
     auto read_stream = save_stream.GetOutputStreamBuffer();


### PR DESCRIPTION
Closes #196

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how the stream in Convert Image is filled in when saving to a Header file. If the image will not be converted to PNG and Force mask is _not_ specified (or the mime type is image/x-ani) then the original file is read directly into the stream for conversion. Only if there is a mask or it's being converted to PNG will the image be written to the stream using **wxImage**.