### PR TITLE
Improved Clipboard handling

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -27,6 +27,8 @@ bool isClipboardDataAvailable()
         return true;
     else if (wxTheClipboard->IsSupported(wxDataFormat("wxSmith XML")))
         return true;
+    else if (wxTheClipboard->IsSupported(wxDataFormat("DataObject")) && wxTheClipboard->IsSupported(wxDF_TEXT))
+        return true;
 
     return false;
 }
@@ -78,13 +80,14 @@ NodeSharedPtr GetClipboardNode()
             FormBuilder fb;
             return fb.CreateFbpNode(root, nullptr);
         }
-        else if (wxTheClipboard->IsSupported(wxDataFormat("wxSmith XML")))
+        else if (ttlib::is_sameas(root.name(), "resource", tt::CASE::either))
         {
             // wxSmith encloses the object with "<resource>"
             auto child = root.first_child();
             WxSmith smith;
             return smith.CreateXrcNode(child, nullptr);
         }
+
     }
 
     return {};

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1036,7 +1036,11 @@ void MainFrame::PasteNode(Node* parent)
         }
     }
 
-    ASSERT_MSG(m_clipboard, "m_clipboard is null and clipboard is empty -- PasteNode should not have been enabled!");
+    if (!m_clipboard)
+    {
+        appMsgBox("There is nothing in the clipboard that can be pasted!", "Paste Clipboard");
+        return;
+    }
 
     if (!parent)
     {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates clipboard handling to look at any wxDF_TEXT format that also has a "DataObject". That works for both wxSmith and DialogBlocks who copy XRC to the clipboard. For apps like LibreOffice which also use "DataObject", the user will get two warnings -- the first that the object cannot be parsed. Then, if there is nothing in the internal clipboard, the user is notified that there is nothing to paste.

Closes #229