### PR TITLE
Update to Combo/Choice generators

### DIFF
--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -173,6 +173,24 @@ ttlib::cstr GenerateQuotedString(const ttlib::cstr& str)
     return code;
 }
 
+ttlib::cstr GenerateQuotedString(Node* node, GenEnum::PropName prop_name)
+{
+    ttlib::cstr code;
+    if (!node->HasValue(prop_name))
+    {
+        code << "wxEmptyString";
+    }
+    else
+    {
+        auto str_with_escapes = ConvertToCodeString(node->prop_cview(prop_name));
+        if (wxGetApp().GetProject()->prop_as_bool(prop_internationalize))
+            code << "_(wxString::FromUTF8(\"" << str_with_escapes << "\"))";
+        else
+            code << "wxString::FromUTF8(\"" << str_with_escapes << "\")";
+    }
+    return code;
+}
+
 // clang-format off
 
 // List of valid component parent types

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -31,6 +31,7 @@ ttlib::cstr GenerateSizerFlags(Node* node);
 
 // If internationalize property is true, returns _("str") otherwise it just returns the string in quotes
 ttlib::cstr GenerateQuotedString(const ttlib::cstr& str);
+ttlib::cstr GenerateQuotedString(Node* node, GenEnum::PropName prop_name);
 
 // Insert a required include file into either src or hdr set (depending on "class_access" property)
 void InsertGeneratorInclude(Node* node, const std::string& include, std::set<std::string>& set_src,

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -400,6 +400,14 @@ const ttlib::cstr& Node::prop_as_string(PropName name)
         return tt_empty_cstr;
 }
 
+ttlib::cview Node::prop_cview(PropName name)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_cview();
+    else
+        return tt_empty_cstr.subview();
+}
+
 const ttlib::cstr& Node::get_node_name()
 {
     if (auto it = m_prop_indices.find(prop_var_name); it != m_prop_indices.end())

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -176,6 +176,7 @@ public:
     double prop_as_double(PropName name);
 
     const ttlib::cstr& prop_as_string(PropName name);
+    ttlib::cview prop_cview(PropName name);
 
     // This will convert the string from UTF8 to UTF16 on Windows
     wxString prop_as_wxString(PropName name);

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -44,7 +44,7 @@ public:
     wxPoint as_point() const;
     wxSize as_size() const;
     wxString as_wxString() const { return m_value.wx_str(); }
-    ttlib::cview as_cview() const { return m_value.subview(); }
+    ttlib::cview as_cview() const { return ttlib::cview(m_value.c_str(), m_value.length()); }
     wxArrayString as_wxArrayString() const;
 
     auto as_vector() const -> std::vector<ttlib::cstr>;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -13,8 +13,9 @@
 #include <wx/gdicmn.h>   // Common GDI classes, types and declarations
 #include <wx/mstream.h>  // Memory stream classes
 
-#include <ttmultistr.h>  // multistr -- Breaks a single string into multiple strings
+#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
 
+#include "node.h"          // Node class
 #include "node_creator.h"  // NodeCreator class
 #include "utils.h"         // Utility functions that work with properties
 
@@ -444,9 +445,9 @@ ttlib::cstr CreateEscapedText(ttlib::cview str)
     return result;
 }
 
-std::vector<std::string> ConvertToArrayString(ttlib::cview value)
+std::vector<ttlib::cstr> ConvertToArrayString(ttlib::cview value)
 {
-    std::vector<std::string> array;
+    std::vector<ttlib::cstr> array;
     if (value.empty())
         return array;
     ttlib::cstr parse;
@@ -499,4 +500,9 @@ ttlib::cstr ConvertToCodeString(ttlib::cview text)
         }
     }
     return result;
+}
+
+ttlib::cstr ConvertToCodeString(Node* node, GenEnum::PropName prop_name)
+{
+    return ConvertToCodeString(node->prop_cview(prop_name));
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -15,6 +15,7 @@ class wxColour;
 class wxImage;
 class wxPoint;
 class wxSize;
+class Node;
 
 // Used to index fields in a bitmap property
 enum PropIndex
@@ -49,6 +50,7 @@ const char* ConvertFontFamilyToString(wxFontFamily family);
 
 // Add C++ escapes around any characters the compiler wouldn't accept as a normal part of a string.
 ttlib::cstr ConvertToCodeString(ttlib::cview text);
+ttlib::cstr ConvertToCodeString(Node* node, size_t prop_name);
 
 // Used to add escapes to a string that will be handed off to a wxWidgets property editor
 ttlib::cstr CreateEscapedText(ttlib::cview str);
@@ -59,7 +61,7 @@ wxColour ConvertToColour(ttlib::cview value);
 // Replace escape slashes with the actual character. Affects \\, \\n, \\r, and \\t
 ttlib::cstr ConvertEscapeSlashes(ttlib::cview str);
 
-std::vector<std::string> ConvertToArrayString(ttlib::cview value);
+std::vector<ttlib::cstr> ConvertToArrayString(ttlib::cview value);
 
 // Converts a GZIP unsigned char array into an image.
 wxImage LoadGzipImage(const unsigned char* data, size_t size_data);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR started out as a simple fix for the selection bug with validators (issue #212). However, in reviewing the code I uncovered two bugs that hadn't shown up yet, as well as a lot of old code that hadn't been updated with the newer property access methods in the **Node** class.

Bug fixes:

- Choices were not being converted to UTF16 on Windows when handed to the Mockup version. This would mess up any choices in a foreign language that had characters outside the standard ANSI set.
- Trying to select a string in the Mockup panel when there are no choices causes an exception in wxWidgets. The code no longer tries to do this in Mockup. It does still generate the code to do that if there is no validator -- it's up to the dev using this to create choices from their derived class if they don't provide them as part of the constructor.
