### PR TITLE
Expand support for buttons

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -390,6 +390,7 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_Check3State, "Check3State" },
     { gen_Choice_Validator, "Choice Validator" },
     { gen_Code_Generation, "Code Generation" },
+    { gen_Command_Bitmaps, "Command Bitmaps" },
     { gen_Integer_Validator, "Integer Validator" },
     { gen_List_Validator, "List Validator" },
     { gen_MenuBar, "MenuBar" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -400,6 +400,7 @@ namespace GenEnum
         gen_Check3State,
         gen_Choice_Validator,
         gen_Code_Generation,
+        gen_Command_Bitmaps,
         gen_Integer_Validator,
         gen_List_Validator,
         gen_MenuBar,

--- a/src/generate/btn_widgets.cpp
+++ b/src/generate/btn_widgets.cpp
@@ -39,25 +39,27 @@ wxObject* ButtonGenerator::CreateMockup(Node* node, wxObject* parent)
         widget->SetAuthNeeded();
 
     if (node->HasValue(prop_bitmap))
+    {
         widget->SetBitmap(node->prop_as_wxBitmap(prop_bitmap));
 
-    if (node->HasValue(prop_disabled_bmp))
-        widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));
+        if (node->HasValue(prop_disabled_bmp))
+            widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));
 
-    if (node->HasValue(prop_pressed_bmp))
-        widget->SetBitmapPressed(node->prop_as_wxBitmap(prop_pressed_bmp));
+        if (node->HasValue(prop_pressed_bmp))
+            widget->SetBitmapPressed(node->prop_as_wxBitmap(prop_pressed_bmp));
 
-    if (node->HasValue(prop_focus))
-        widget->SetBitmapFocus(node->prop_as_wxBitmap(prop_focus));
+        if (node->HasValue(prop_focus))
+            widget->SetBitmapFocus(node->prop_as_wxBitmap(prop_focus));
 
-    if (node->HasValue(prop_current))
-        widget->SetBitmapCurrent(node->prop_as_wxBitmap(prop_current));
+        if (node->HasValue(prop_current))
+            widget->SetBitmapCurrent(node->prop_as_wxBitmap(prop_current));
 
-    if (node->HasValue(prop_position))
-        widget->SetBitmapPosition(static_cast<wxDirection>(node->prop_as_int(prop_position)));
+        if (node->HasValue(prop_position))
+            widget->SetBitmapPosition(static_cast<wxDirection>(node->prop_as_int(prop_position)));
 
-    if (node->HasValue(prop_margins))
-        widget->SetBitmapMargins(node->prop_as_wxSize(prop_margins));
+        if (node->HasValue(prop_margins))
+            widget->SetBitmapMargins(node->prop_as_wxSize(prop_margins));
+    }
 
     if (!node->isPropValue(prop_variant, "normal"))
     {
@@ -175,40 +177,56 @@ std::optional<ttlib::cstr> ButtonGenerator::GenSettings(Node* node, size_t& /* a
     {
         if (code.size())
             code << '\n';
+
         code << node->get_node_name() << "->SetBitmap(" << GenerateBitmapCode(node->prop_as_string(prop_bitmap)) << ");";
-    }
 
-    if (node->HasValue(prop_disabled_bmp))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapDisabled("
-             << GenerateBitmapCode(node->prop_as_string(prop_disabled_bmp)) << ");";
-    }
+        if (node->HasValue(prop_position))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapPosition(" << node->prop_as_int(prop_position) << ");";
+        }
 
-    if (node->HasValue(prop_pressed_bmp))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapPressed(" << GenerateBitmapCode(node->prop_as_string(prop_pressed_bmp))
-             << ");";
-    }
+        if (node->HasValue(prop_margins))
+        {
+            if (code.size())
+                code << '\n';
+            auto size = node->prop_as_wxSize(prop_margins);
+            code << node->get_node_name() << "->SetBitmapMargins(" << size.GetWidth() << ", " << size.GetHeight() << ");";
+        }
 
-    if (node->HasValue(prop_focus))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string(prop_focus)) << ");";
-    }
+        if (node->HasValue(prop_disabled_bmp))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapDisabled("
+                 << GenerateBitmapCode(node->prop_as_string(prop_disabled_bmp)) << ");";
+        }
 
-    if (node->HasValue(prop_current))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string(prop_current))
-             << ");";
-    }
+        if (node->HasValue(prop_pressed_bmp))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapPressed("
+                 << GenerateBitmapCode(node->prop_as_string(prop_pressed_bmp)) << ");";
+        }
 
+        if (node->HasValue(prop_focus))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string(prop_focus))
+                 << ");";
+        }
+
+        if (node->HasValue(prop_current))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string(prop_current))
+                 << ");";
+        }
+    }
     return code;
 }
 
@@ -349,37 +367,53 @@ std::optional<ttlib::cstr> ToggleButtonGenerator::GenSettings(Node* node, size_t
         if (code.size())
             code << '\n';
         code << node->get_node_name() << "->SetBitmap(" << GenerateBitmapCode(node->prop_as_string(prop_bitmap)) << ");";
-    }
 
-    if (node->HasValue(prop_disabled_bmp))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapDisabled("
-             << GenerateBitmapCode(node->prop_as_string(prop_disabled_bmp)) << ");";
-    }
+        if (node->HasValue(prop_position))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapPosition(" << node->prop_as_int(prop_position) << ");";
+        }
 
-    if (node->HasValue(prop_pressed_bmp))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapPressed(" << GenerateBitmapCode(node->prop_as_string(prop_pressed_bmp))
-             << ");";
-    }
+        if (node->HasValue(prop_margins))
+        {
+            if (code.size())
+                code << '\n';
+            auto size = node->prop_as_wxSize(prop_margins);
+            code << node->get_node_name() << "->SetBitmapMargins(" << size.GetWidth() << ", " << size.GetHeight() << ");";
+        }
 
-    if (node->HasValue(prop_focus))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string(prop_focus)) << ");";
-    }
+        if (node->HasValue(prop_disabled_bmp))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapDisabled("
+                 << GenerateBitmapCode(node->prop_as_string(prop_disabled_bmp)) << ");";
+        }
 
-    if (node->HasValue(prop_current))
-    {
-        if (code.size())
-            code << '\n';
-        code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string(prop_current))
-             << ");";
+        if (node->HasValue(prop_pressed_bmp))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapPressed("
+                 << GenerateBitmapCode(node->prop_as_string(prop_pressed_bmp)) << ");";
+        }
+
+        if (node->HasValue(prop_focus))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string(prop_focus))
+                 << ");";
+        }
+
+        if (node->HasValue(prop_current))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string(prop_current))
+                 << ");";
+        }
     }
 
     return code;
@@ -401,6 +435,26 @@ wxObject* CommandLinkBtnGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->prop_as_bool(prop_default))
         widget->SetDefault();
+
+    if (node->prop_as_bool(prop_auth_needed))
+        widget->SetAuthNeeded();
+
+    if (node->HasValue(prop_bitmap))
+    {
+        widget->SetBitmap(node->prop_as_wxBitmap(prop_bitmap));
+
+        if (node->HasValue(prop_disabled_bmp))
+            widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));
+
+        if (node->HasValue(prop_pressed_bmp))
+            widget->SetBitmapPressed(node->prop_as_wxBitmap(prop_pressed_bmp));
+
+        if (node->HasValue(prop_focus))
+            widget->SetBitmapFocus(node->prop_as_wxBitmap(prop_focus));
+
+        if (node->HasValue(prop_current))
+            widget->SetBitmapCurrent(node->prop_as_wxBitmap(prop_current));
+    }
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
@@ -432,6 +486,52 @@ std::optional<ttlib::cstr> CommandLinkBtnGenerator::GenSettings(Node* node, size
             code << '\n';
 
         code << node->get_node_name() << "->SetDefault();";
+    }
+
+    if (node->prop_as_bool(prop_auth_needed))
+    {
+        if (code.size())
+            code << '\n';
+        code << node->get_node_name() << "->SetAuthNeeded();";
+    }
+
+    if (node->HasValue(prop_bitmap))
+    {
+        if (code.size())
+            code << '\n';
+        code << node->get_node_name() << "->SetBitmap(" << GenerateBitmapCode(node->prop_as_string(prop_bitmap)) << ");";
+
+        if (node->HasValue(prop_disabled_bmp))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapDisabled("
+                 << GenerateBitmapCode(node->prop_as_string(prop_disabled_bmp)) << ");";
+        }
+
+        if (node->HasValue(prop_pressed_bmp))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapPressed("
+                 << GenerateBitmapCode(node->prop_as_string(prop_pressed_bmp)) << ");";
+        }
+
+        if (node->HasValue(prop_focus))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapFocus(" << GenerateBitmapCode(node->prop_as_string(prop_focus))
+                 << ");";
+        }
+
+        if (node->HasValue(prop_current))
+        {
+            if (code.size())
+                code << '\n';
+            code << node->get_node_name() << "->SetBitmapCurrent(" << GenerateBitmapCode(node->prop_as_string(prop_current))
+                 << ");";
+        }
     }
 
     return code;

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1440,7 +1440,7 @@ void PropGridPanel::CreatePropCategory(ttlib::cview name, Node* node, NodeDeclar
         // TODO: [KeyWorks - 07-25-2020] Need to see if parent is using AUI, and if so, don't collapse this
         m_prop_grid->Collapse(id);
     }
-    else if (name.is_sameas("Bitmaps"))
+    else if (name.is_sameas("Bitmaps") || name.is_sameas("Command Bitmaps"))
     {
         m_prop_grid->Collapse(id);
         m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#dce4ef"));

--- a/src/xml/interface.xml
+++ b/src/xml/interface.xml
@@ -200,7 +200,7 @@
 
 <gen class="Bitmaps" type="interface">
     <property name="bitmap" type="image"
-        help="This is the bitmap shown in the default state, it must be always valid while all the other bitmaps are optional and don't have to be set." />
+        help="This is the bitmap shown in the default state. It will also be used for all other bitmaps if they are not explicitly set." />
     <property name="disabled_bmp" type="image"
         help="Bitmap shown when the button is disabled." />
     <property name="pressed_bmp" type="image"
@@ -221,7 +221,21 @@
             help="Positions the bitmap at the bottom" />
       </property>
     <property name="margins" type="wxSize"
-        help="The margins between the bitmap and the text of the button. This is currently only implemented under MSW. If it is not specified, default margin is used around the bitmap." />
+        help="The margins between the bitmap and the text of the button. This is currently only implemented under MSW. If it is not specified, a default margin is used around the bitmap." />
+</gen>
+
+<!-- wxCommandLink needs a special version because position and margins are not used. -->
+<gen class="Command Bitmaps" type="interface">
+    <property name="bitmap" type="image"
+        help="This is the bitmap shown in the default state. It will also be used for all other bitmaps if they are not explicitly set." />
+    <property name="disabled_bmp" type="image"
+        help="Bitmap shown when the button is disabled." />
+    <property name="pressed_bmp" type="image"
+        help="Bitmap shown when the button is pushed (e.g. while the user keeps the mouse button pressed on it)." />
+    <property name="focus" type="image"
+        help="Bitmap shown when the button has keyboard focus but is not pressed." />
+    <property name="current" type="image"
+        help="Bitmap shown when the mouse is over the button (but it is not pressed). Notice that if hover bitmap is not specified but the current platform UI uses hover images for the buttons (such as Windows XP or GTK+), then the focus bitmap is used for hover state as well. This makes it possible to set focus bitmap only to get reasonably good behaviour on all platforms." />
 </gen>
 
 <gen class="AUI" type="interface">

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -196,6 +196,7 @@
 </gen>
 
 <gen class="wxCommandLinkButton" image="wxCommandLinkButton" type="widget">
+    <inherits class="Command Bitmaps" />
     <inherits class="wxWindow" />
     <inherits class="Window Events" />
     <inherits class="sizer_child" />
@@ -204,6 +205,10 @@
     <property name="note" type="string_edit_escapes" />
     <property name="default" type="bool"
         help="If true, this will be the default button (it will be depressed when the return key is pressed)">0</property>
+    <property name="auth_needed" type="bool"
+        help="Sets whether an authentication needed symbol should be displayed on the button. This method doesn't do anything if the platform is not Windows Vista or newer.">
+      0
+      </property>
     <event name="wxEVT_BUTTON" class="wxCommandEvent"
         help="Generated when the button is clicked" />
 </gen>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates **wxCommandLinkButton**, adding support for authorization and bitmaps. The PR also updates **wxButton** and **wxToggleButton** to add code generation for bitmap position and margins. In both cases, the Mockup panel already displayed these settings, but there was no code generation for them.

For all three buttons, the primary bitmap must be set or any other bitmap or bitmap setting will be ignored.