### PR TITLE
Improve property categories

### DIFF
--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -18,6 +18,8 @@
 
 #include "node_classes.h"  // Forward defintions of Node classes
 
+#include "../pugixml/pugixml.hpp"
+
 #include "gen_enums.h"  // Enumerations for generators
 using namespace GenEnum;
 
@@ -25,11 +27,6 @@ class NodeCategory;
 
 using NodeDeclarationArray = std::array<NodeDeclaration*, gen_name_array_size>;
 
-namespace pugi
-{
-    class xml_document;
-    class xml_node;
-}  // namespace pugi
 
 // Contains definitions of all components
 class NodeCreator
@@ -90,6 +87,13 @@ private:
     std::unordered_set<std::string> m_setOldHostTypes;
 
     std::unordered_map<std::string, int> m_map_constants;
+
+    // Contains the nodes that m_interfaces maps to -- valid only during Initialize()
+    pugi::xml_document* m_pdoc_interface { nullptr };
+
+    // Contains a map to every interface class -- valid only during Initialize()
+    std::map<std::string, pugi::xml_node> m_interfaces;
+    bool m_is_interface;  // true means an interface file is being processed
 };
 
 extern NodeCreator g_NodeCreator;

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -471,7 +471,8 @@ wxPGProperty* PropGridPanel::GetProperty(NodeProperty* prop)
     return new_pg_property;
 }
 
-void PropGridPanel::AddProperties(ttlib::cview name, Node* node, NodeCategory& category, PropNameSet& prop_set)
+void PropGridPanel::AddProperties(ttlib::cview name, Node* node, NodeCategory& category, PropNameSet& prop_set,
+                                  bool is_child_cat)
 {
     size_t propCount = category.GetPropNameCount();
     for (size_t i = 0; i < propCount; i++)
@@ -597,10 +598,18 @@ void PropGridPanel::AddProperties(ttlib::cview name, Node* node, NodeCategory& c
             continue;
         }
 
-        wxPGProperty* catId =
-            m_prop_grid->AppendIn(GetCategoryDisplayName(category.GetName()), new wxPropertyCategory(nextCat.GetName()));
+        wxPGProperty* catId;
+        if (is_child_cat)
+        {
+            catId =
+                m_prop_grid->AppendIn(GetCategoryDisplayName(category.GetName()), new wxPropertyCategory(nextCat.GetName()));
+        }
+        else
+        {
+            catId = m_prop_grid->Append(new wxPropertyCategory(nextCat.GetName()));
+        }
 
-        AddProperties(name, node, nextCat, prop_set);
+        AddProperties(name, node, nextCat, prop_set, true);
 
         if (auto it = m_expansion_map.find(nextCat.getName()); it != m_expansion_map.end())
         {

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -47,7 +47,8 @@ protected:
     void CreateLayoutCategory(Node* node);
 
     void AddEvents(ttlib::cview name, Node* node, NodeCategory& category, EventSet& event_set);
-    void AddProperties(ttlib::cview name, Node* node, NodeCategory& category, PropNameSet& prop_set);
+    void AddProperties(ttlib::cview name, Node* node, NodeCategory& category, PropNameSet& prop_set,
+                       bool is_child_cat = false);
 
     void ReplaceDrvName(const wxString& formName, NodeProperty* propType);
     void ReplaceBaseFile(const wxString& formName, NodeProperty* propType);

--- a/src/utils/loadxml.cpp
+++ b/src/utils/loadxml.cpp
@@ -40,7 +40,7 @@ static const GZIP_PAIR gzip_pairs[] = {
 };
 // clang-format on
 
-bool LoadInternalXmlDocFile(ttlib::cview file, pugi::xml_document& doc)
+bool LoadInternalXmlDocFile(ttlib::cview file, pugi::xml_document* doc)
 {
     for (auto& iter: gzip_pairs)
     {
@@ -49,7 +49,7 @@ bool LoadInternalXmlDocFile(ttlib::cview file, pugi::xml_document& doc)
             auto str = LoadGzipString(iter.gzip_data, iter.gzip_size);
             if (str.size())
             {
-                if (auto result = doc.load_string(str.c_str()); result)
+                if (auto result = doc->load_string(str.c_str()); result)
                 {
                     return true;
                 }

--- a/src/xml/aui.xml
+++ b/src/xml/aui.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<GeneratorDefitions>
+<GeneratorDefinitions>
 <!-- <gen class="AUI Events" type="interface">
 
   <gen class="AUI Events" type="interface">
@@ -161,4 +161,4 @@
     <event name="wxEVT_AUITOOLBAR_BEGIN_DRAG" class="wxAuiToolBarEvent"
         help="" />
 </gen>
-</GeneratorDefitions>
+</GeneratorDefinitions>

--- a/src/xml/bars.xml
+++ b/src/xml/bars.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<GeneratorDefitions>
+<GeneratorDefinitions>
 
 <gen class="wxMenuBar" image="wxMenuBar" type="menubar">
     <inherits class="wxWindow" />
@@ -497,4 +497,4 @@
     <property name="bitmap" type="image"
         help="The bitmap to display for the item. Note that all items must have equally sized bitmaps. " />
 </gen>
-</GeneratorDefitions>
+</GeneratorDefinitions>

--- a/src/xml/containers.xml
+++ b/src/xml/containers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<GeneratorDefitions>
+<GeneratorDefinitions>
 
 <gen class="wxPanel" image="wxPanel" type="container">
     <inherits class="Window Events" />
@@ -361,4 +361,4 @@
     <property name="bitmap" type="image" />
     <property name="select" type="bool" />
 </gen>
-</GeneratorDefitions>
+</GeneratorDefinitions>

--- a/src/xml/forms.xml
+++ b/src/xml/forms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<GeneratorDefitions>
+<GeneratorDefinitions>
 
 <gen class="Project" type="project" image="project">
     <property name="source_ext" type="option"
@@ -93,6 +93,7 @@
       </property>
     <property name="icon" type="image"
         help="Specifies the image to display in the title bar of the dialog." />
+
     <event name="wxEVT_INIT_DIALOG" class="wxInitDialogEvent"
         help="Generated when the dialog is being initialized." />
 </gen>
@@ -336,4 +337,4 @@
       wxBORDER_NONE
       </property>
 </gen>
-</GeneratorDefitions>
+</GeneratorDefinitions>

--- a/src/xml/interface.xml
+++ b/src/xml/interface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<GeneratorDefitions>
+<GeneratorDefinitions>
 
 <gen class="wxTopLevelWindow" type="interface">
     <event name="wxEVT_ACTIVATE" class="wxActivateEvent"
@@ -571,4 +571,4 @@
     <property name="set_function" type="string"
         help="Function name to set the value of the variable." />
 </gen>
-</GeneratorDefitions>
+</GeneratorDefinitions>

--- a/src/xml/sizers.xml
+++ b/src/xml/sizers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<GeneratorDefitions>
+<GeneratorDefinitions>
 
 <gen class="sizer_dimension" type="interface">
     <property name="minimum_size" type="wxSize"
@@ -469,4 +469,4 @@
       0
       </property>
 </gen>
-</GeneratorDefitions>
+</GeneratorDefinitions>

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<GeneratorDefitions>
+<GeneratorDefinitions>
 
 <gen class="wxStaticText" image="wxStaticText" type="widget">
     <inherits class="wxWindow" />
@@ -2341,4 +2341,4 @@
       wxTOP
       </property>
 </gen>
-</GeneratorDefitions>
+</GeneratorDefinitions>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability for a generator to specify a category with an attribute of "base_name" that will first include all the properties of the base_name class (specified in interface.xml). This can be used in cases where a common set of properties is needed with additional properties for the generator's category. It's a prerequisite to fixing issue #247.

With the new code, when interface.xml is processed, a map is temporarily created pointing to each top level class. During the rest of the `NodeCreator::Initialize()` function, the other files can reparse any of the classes. To resolve issue #247, an interface containing a limited set of properties can be created, and a generator can start with those properties before adding it's own:

```xml
    <category name="Dialog Settings" base_class="Settings">
        <property name = "foo">
    <category>
```

In the above example, a Category would be created called "Dialog Settings" and it would first include all the properties specified by the "Settings" interface class, followed byt the "foo" property.

The other part of this PR fixes a problem in the Property Panel where any category specified by a generator was always indented by one.
