### PR TITLE
Support additional styles and properties in wxPopupTransientWindow

### DIFF
--- a/src/xml/forms.xml
+++ b/src/xml/forms.xml
@@ -349,10 +349,27 @@
         help="The name of the base class.">MyPopupBase</property>
     <property name="border" type="option"
         help="Specifies the type of border to use for the window.">
-        <option name="wxBORDER_NONE" />
+        <option name="wxBORDER_NONE"
+            help="No border will be displayed." />
         <option name="wxBORDER_RAISED"
             help="Displays a raised border." />
+        <option name="wxBORDER_SIMPLE"
+            help="Displays a thin border around the window." />
+        <option name="wxBORDER_SUNKEN"
+            help="Displays a sunken border." />
+        <option name="wxBORDER_THEME"
+            help="Displays a native border suitable for a control, on the current platform. On Windows, this will be a themed border; on most other platforms a sunken border will be used." />
       wxBORDER_NONE
       </property>
+    <property name="style" type="bitlist">
+        <option name="wxPU_CONTAINS_CONTROLS"
+            help="By default in wxMSW, a popup window will not take focus from its parent window. However many standard controls, including common ones such as wxTextCtrl, need focus to function correctly and will not work when placed on a default popup. This flag can be used to make the popup take focus and let all controls work but at the price of not allowing the parent window to keep focus while the popup is shown, which can also be sometimes desirable. This style is currently only implemented in MSW and simply does nothing under the other platforms. Requires wxWidgets 3.1.3" />
+        </property>
+    <property name="font" type="wxFont"
+        help="Sets the font for this window. This should not be use for a parent window if you don't want its font to be inherited by its children" />
+    <property name="foreground_colour" type="wxColour"
+        help="Sets the foreground colour of the window. Use &quot;Window&quot; to let wxWidgets choose the color, otherwise specify one of the system colors in the list." />
+    <property name="background_colour" type="wxColour"
+        help="Sets the background colour of the window. Use &quot;Window&quot; to let wxWidgets choose the color, otherwise specify one of the system colors in the list." />
 </gen>
 </GeneratorDefinitions>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds additional properties to the **wxPopupTransientWindow** generator. It now supports additional borders and the `wxPU_CONTAINS_CONTROLS` style. Font, foreground_colour and bakcground_colour are also now supported.
