### PR TITLE
Update Nav Panel context menu

### DIFF
--- a/src/panels/navpopupmenu.h
+++ b/src/panels/navpopupmenu.h
@@ -26,6 +26,7 @@ protected:
     void OnMenuEvent(wxCommandEvent& event);
     void OnUpdateEvent(wxUpdateUIEvent& event);
 
+    void CreateNormalMenu(Node* node);
     void CreateBarMenu(Node* node);
     void CreateBookMenu(Node* node);
     void CreateContainerMenu(Node* node);
@@ -38,11 +39,7 @@ protected:
 
     enum
     {
-        MenuCUT = wxID_HIGHEST + 2000,
-        MenuCOPY,
-        MenuPASTE,
-        MenuDUPLICATE,
-        MenuDELETE,
+        MenuDUPLICATE = wxID_HIGHEST + 2000,
 
         MenuMOVE_UP,
         MenuMOVE_DOWN,


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates the Navigation Panel context menu:

- All 4 move commands added to OnUpdateEvent() and the Enable() command removed from the individual menus.
- Paste, Move Up and Move Down added to most menus
- Cut, Copy, Paste and Delete now use standard IDs (which means text/shortcut provided by wxWidgets) and all use wxArtProvider for their image
- All move menus now include their normal icon
- The constructor now calls `CreateNormalMenu()` if no other menu function is called rather than having all of that creation code in the construction.
