### PR TITLE
Change code generation for wxPanel as a form

### DIFF
--- a/src/generate/form_widgets.h
+++ b/src/generate/form_widgets.h
@@ -36,10 +36,11 @@ public:
 class PanelFormGenerator : public BaseGenerator
 {
 public:
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    // Return true if all construction and settings code was written to src_code
+    bool GenConstruction(Node*, WriteCode* src_code) override;
+
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
-    std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };
@@ -52,7 +53,6 @@ public:
 
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
-    std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1044,7 +1044,7 @@ void BaseCodeGenerator::GenConstruction(Node* node)
 
         if (node->IsSizer())
         {
-            if (!parent->IsSizer() && !parent->isGen(gen_wxDialog))
+            if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
             {
                 // The parent node is not a sizer -- which is expected if this is the parent sizer underneath a form or
                 // wxPanel.

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -701,7 +701,7 @@ ttlib::cstr GenFormCode(GenEnum::GenCodeType command, Node* node)
 
         case code_header:
             code << node->get_node_name() << "(wxWindow* parent, wxWindowID id = " << node->prop_as_string(prop_id);
-            if (!node->isGen(gen_wxPanel) && !node->isGen(gen_wxToolBar))
+            if (!node->isGen(gen_wxPanel) && !node->isGen(gen_wxToolBar) && !node->isGen(gen_PanelForm))
             {
                 code << ",\n\tconst wxString& title = ";
                 auto& title = node->prop_as_string(prop_title);

--- a/src/panels/ribbon_tools.cpp
+++ b/src/panels/ribbon_tools.cpp
@@ -25,7 +25,7 @@
 
 // The base class specifies a larger size for the panel to make it easier to work with in the Mockup window. We switch that
 // to a default size here.
-RibbonPanel::RibbonPanel(wxWindow* parent) : RibbonPanelBase(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize) {}
+RibbonPanel::RibbonPanel(wxWindow* parent) : RibbonPanelBase(parent) {}
 
 void RibbonPanel::OnToolClick(wxRibbonToolBarEvent& event)
 {

--- a/src/ui/ribbon.wxui
+++ b/src/ui/ribbon.wxui
@@ -13,7 +13,7 @@
       base_src_includes="#include &quot;ribbon_ids.h&quot;\n#include &quot;gen_enums.h&quot;     // Enumerations for generators\n\nusing namespace GenEnum;"
       derived_class_name="RibbonPanel"
       generate_ids="false"
-      size="900,300"
+      size="-1,-1"
       window_style="wxTAB_TRAVERSAL">
       <node
         class="wxBoxSizer"

--- a/src/ui/ribbonpanel_base.cpp
+++ b/src/ui/ribbonpanel_base.cpp
@@ -106,14 +106,16 @@ static wxImage GetImgFromHdr(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
+    if (!image.FindHandler(wxBITMAP_TYPE_PNG))
+        wxImage::AddHandler(new wxPNGHandler);
     image.LoadFile(strm);
     return image;
 };
 
-RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id,
-		const wxPoint& pos, const wxSize& size, long style) :
-	wxPanel(parent, id, pos, size, style)
+RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 {
+    Create(parent, id);
+
     parent_sizer = new wxBoxSizer(wxVERTICAL);
 
     m_rbnBar = new wxRibbonBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxRIBBON_BAR_SHOW_PAGE_LABELS);
@@ -398,6 +400,8 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id,
     }
     other_bar_html->Realize();
     m_rbnBar->Realize();
+
+    SetSizerAndFit(parent_sizer);
 
     SetSizerAndFit(parent_sizer);
 

--- a/src/ui/ribbonpanel_base.h
+++ b/src/ui/ribbonpanel_base.h
@@ -22,8 +22,7 @@
 class RibbonPanelBase : public wxPanel
 {
 public:
-    RibbonPanelBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(900, 300),
-        long style = wxTAB_TRAVERSAL);
+    RibbonPanelBase(wxWindow* parent, wxWindowID id = wxID_ANY);
 
 protected:
 

--- a/src/xml/forms.xml
+++ b/src/xml/forms.xml
@@ -120,7 +120,7 @@
     <inherits class="Code Generation" />
     <inherits class="wxWindow">
         <property name="window_style">wxTAB_TRAVERSAL</property>
-        <property name="size" type="wxSize">500,300</property>
+        <property name="size" type="wxSize" />
     </inherits>
     <property name="class_name" type="string"
         help="The name of the base class.">MyPanelBase</property>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the code generation for **wxPanel** when created as a form. It's similar to the way wxDialog is created -- only the parent window and id are available to the class constructor. The default **wxPanel** is called and then `Create` is called with the rest of the panel's settings. Any size setting is called _after_ the window's sizer has been set.

Our own ribbonp anel has been updated to use the new generate code. Note that the Mockup no longer displays this panel correctly because now that the `size` parameter is correctly working, we don't want to be using that in the constructor. See issue #254 for a proposed solution to the Mockup problem.

Window settings are inherited, which means a lot of them are still bogus -- see issue #255 for a proposed solution to displaying bogus inherited properties.
