### PR TITLE
Mockup

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -219,6 +219,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_min_size, "min_size" },
     { prop_minimize_button, "minimize_button" },
     { prop_minimum_size, "minimum_size" },
+    { prop_mockup_size, "mockup_size" },
     { prop_mode, "mode" },
     { prop_model_column, "model_column" },
     { prop_moveable, "moveable" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -219,6 +219,7 @@ namespace GenEnum
         prop_min_size,
         prop_minimize_button,
         prop_minimum_size,
+        prop_mockup_size,
         prop_mode,
         prop_model_column,
         prop_moveable,

--- a/src/mockup/mockup_content.h
+++ b/src/mockup/mockup_content.h
@@ -25,8 +25,6 @@ public:
 
     void CreateAllGenerators();
 
-    void CreateWizard();
-
     void OnNodeSelected(Node* node);
 
     void RemoveNodes();

--- a/src/mockup/mockup_parent.h
+++ b/src/mockup/mockup_parent.h
@@ -24,6 +24,7 @@ public:
 
     Node* GetSelectedForm() { return m_form; }
     bool IsShowingHidden() { return m_ShowHiddenControls; }
+    bool IsMagnified() { return m_IsMagnifyWindow; }
     void ShowHiddenControls(bool show);
     void MagnifyWindow(bool show);
     void CreateContent();

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -308,11 +308,13 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
         if (auto find_prop = rmap_PropNames.find(iter.name()); find_prop != rmap_PropNames.end())
         {
             prop = new_node->get_prop_ptr(find_prop->second);
-
-            if (prop->type() == type_bool)
-                prop->set_value(iter.as_bool());
-            else
-                prop->set_value(iter.value());
+            if (prop)
+            {
+                if (prop->type() == type_bool)
+                    prop->set_value(iter.as_bool());
+                else
+                    prop->set_value(iter.value());
+            }
         }
         else
         {

--- a/src/ui/ribbon.wxui
+++ b/src/ui/ribbon.wxui
@@ -9,6 +9,7 @@
     <node
       class="PanelForm"
       class_name="RibbonPanelBase"
+      mockup_size="600,100"
       base_file="ribbonpanel_base"
       base_src_includes="#include &quot;ribbon_ids.h&quot;\n#include &quot;gen_enums.h&quot;     // Enumerations for generators\n\nusing namespace GenEnum;"
       derived_class_name="RibbonPanel"

--- a/src/xml/forms.xml
+++ b/src/xml/forms.xml
@@ -124,6 +124,8 @@
     </inherits>
     <property name="class_name" type="string"
         help="The name of the base class.">MyPanelBase</property>
+    <property name="mockup_size" type="wxSize"
+        help="This is the minimum size to display the panel in the Mockup Panel. It does not affect the actual size of the panel in your compiled code.">200, 200</property>
     <event name="wxEVT_INIT_DIALOG" class="wxInitDialogEvent"
         help="generated when the panel is being initialised." />
 </gen>
@@ -131,9 +133,7 @@
 <gen class="wxFrame" image="wxFrame" type="form">
     <inherits class="Code Generation" />
     <inherits class="wxTopLevelWindow" />
-    <inherits class="wxWindow">
-        <property name="size" type="wxSize">500,300</property>
-    </inherits>
+    <inherits class="wxWindow" />
     <property name="class_name" type="string"
         help="The name of the base class.">MyFrameBase</property>
     <property name="title" type="string_escapes"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors the sizing code in the Mockup Panel. The new code is both simpler and more accurate, particularly when the Magnify command is used, and it adds support for a `mockup_size` property (currently only used by FormPanel).

This removes the prop_size check as per issue #259.

Note that the Magnify command for a **wxDialog** is correct even if it results in standard buttons being placed quite a ways up from the bottom of the window. The reason is that unless a dialog contains a main sizer or spacer with a proportion of 1, then all items will be only the minimum size they need starting from the top. That's by design -- a dialog that can be resized needs to handle the kind of resizing that the Magnify command displays.
