### PR TITLE
Add support for hiding inherited properties

### DIFF
--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -52,12 +52,9 @@ NodeSharedPtr NodeCreator::NewNode(NodeDeclaration* node_decl)
             auto defaultValue = prop_declaration->GetDefaultValue();
             if (base > 0)
             {
-                auto defaultValueTemp =
-                    node_decl->GetBaseClassDefaultPropertyValue(base - 1, prop_declaration->DeclName().c_str());
-                if (!defaultValueTemp.empty())
-                {
-                    defaultValue = defaultValueTemp;
-                }
+                auto result = node_decl->GetOverRideDefValue(prop_declaration->get_name());
+                if (result)
+                    defaultValue = result.value();
             }
 
             auto prop = node->AddNodeProperty(prop_declaration);

--- a/src/nodes/node_decl.cpp
+++ b/src/nodes/node_decl.cpp
@@ -13,8 +13,7 @@
 #include "node.h"            // Contains the user-modifiable node
 #include "prop_decl.h"       // PropChildDeclaration and PropDeclaration classes
 
-NodeDeclaration::NodeDeclaration(ttlib::cview class_name, NodeType* type) :
-    m_type(type), m_category(class_name)
+NodeDeclaration::NodeDeclaration(ttlib::cview class_name, NodeType* type) : m_type(type), m_category(class_name)
 {
     m_gen_name = rmap_GenNames[class_name.c_str()];
     m_gen_type = type->gen_type();
@@ -68,35 +67,6 @@ const NodeEventInfo* NodeDeclaration::GetEventInfo(size_t idx) const
         return it->second.get();
 
     return nullptr;
-}
-
-void NodeDeclaration::AddBaseClassDefaultPropertyValue(size_t baseIndex, ttlib::cview propertyName,
-                                                       ttlib::cview defaultValue)
-{
-    if (auto baseClassMap = m_baseClassDefaultPropertyValues.find(baseIndex);
-        baseClassMap != m_baseClassDefaultPropertyValues.end())
-    {
-        baseClassMap->second[propertyName.c_str()] = defaultValue.c_str();
-    }
-    else
-    {
-        DblStrMap propertyDefaultValues;
-        propertyDefaultValues[propertyName.c_str()] = defaultValue;
-        m_baseClassDefaultPropertyValues[baseIndex] = propertyDefaultValues;
-    }
-}
-
-const std::string& NodeDeclaration::GetBaseClassDefaultPropertyValue(size_t baseIndex, const std::string& propertyName) const
-{
-    if (auto baseClassMap = m_baseClassDefaultPropertyValues.find(baseIndex);
-        baseClassMap != m_baseClassDefaultPropertyValues.end())
-    {
-        if (auto defaultValue = baseClassMap->second.find(propertyName); defaultValue != baseClassMap->second.end())
-        {
-            return defaultValue->second;
-        }
-    }
-    return ttlib::emptystring;
 }
 
 NodeDeclaration* NodeDeclaration::GetBaseClass(size_t idx, bool inherited) const
@@ -180,4 +150,12 @@ int_t NodeDeclaration::GetAllowableChildren(GenType child_gen_type) const
     }
 
     return m_type->GetAllowableChildren(child_gen_type);
+}
+
+std::optional<ttlib::cstr> NodeDeclaration::GetOverRideDefValue(GenEnum::PropName prop_name)
+{
+    if (auto result = m_override_def_values.find(prop_name); result != m_override_def_values.end())
+        return result->second;
+    else
+        return {};
 }

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 
 #include <wx/bitmap.h>  // wxBitmap class interface
 
@@ -45,10 +46,6 @@ public:
     const NodeEventInfo* GetEventInfo(size_t idx) const;
 
     PropDeclarationMap& GetPropInfoMap() { return m_properties; }
-
-    void AddBaseClassDefaultPropertyValue(size_t baseIndex, ttlib::cview propertyName, ttlib::cview defaultValue);
-
-    const std::string& GetBaseClassDefaultPropertyValue(size_t baseIndex, const std::string& propertyName) const;
 
     NodeType* GetNodeType() const { return m_type; }
 
@@ -88,6 +85,12 @@ public:
 
     int_t GetAllowableChildren(GenType child_gen_type) const;
 
+    void SetOverRideDefValue(GenEnum::PropName prop_name, ttlib::cview new_value)
+    {
+        m_override_def_values[prop_name] = new_value;
+    }
+    std::optional<ttlib::cstr> GetOverRideDefValue(GenEnum::PropName prop_name);
+
 private:
     ttlib::cstr m_internal_flags;
 
@@ -99,7 +102,8 @@ private:
 
     PropDeclarationMap m_properties;  // std::map<std::string, PropDeclarationPtr>
     std::map<std::string, std::unique_ptr<NodeEventInfo>> m_events;
-    std::map<size_t, DblStrMap> m_baseClassDefaultPropertyValues;
+
+    std::map<GenEnum::PropName, std::string> m_override_def_values;
 
     std::vector<NodeDeclaration*> m_base;  // base classes
 

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -9,6 +9,7 @@
 
 #include <map>
 #include <optional>
+#include <set>
 
 #include <wx/bitmap.h>  // wxBitmap class interface
 
@@ -91,6 +92,9 @@ public:
     }
     std::optional<ttlib::cstr> GetOverRideDefValue(GenEnum::PropName prop_name);
 
+    void HideProperty(GenEnum::PropName prop_name) { m_hide_properties.emplace(prop_name); }
+    bool IsPropHidden(GenEnum::PropName prop_name) { return (m_hide_properties.find(prop_name) != m_hide_properties.end()); }
+
 private:
     ttlib::cstr m_internal_flags;
 
@@ -104,6 +108,7 @@ private:
     std::map<std::string, std::unique_ptr<NodeEventInfo>> m_events;
 
     std::map<GenEnum::PropName, std::string> m_override_def_values;
+    std::set<GenEnum::PropName> m_hide_properties;
 
     std::vector<NodeDeclaration*> m_base;  // base classes
 

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -334,6 +334,20 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview name)
                         class_info->SetOverRideDefValue(lookup_name->second, inheritedProperty.text().as_cview());
                         inheritedProperty = inheritedProperty.next_sibling("property");
                     }
+
+                    inheritedProperty = elem_base.child("hide");
+                    while (inheritedProperty)
+                    {
+                        auto lookup_name = rmap_PropNames.find(inheritedProperty.attribute("name").as_string());
+                        if (lookup_name == rmap_PropNames.end())
+                        {
+                            MSG_ERROR(ttlib::cstr("Unrecognized inherited property name -- ")
+                                      << inheritedProperty.attribute("name").as_string());
+                            continue;
+                        }
+                        class_info->HideProperty(lookup_name->second);
+                        inheritedProperty = inheritedProperty.next_sibling("hide");
+                    }
                 }
                 elem_base = elem_base.next_sibling("inherits");
             }

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -319,14 +319,19 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview name)
                 auto base_info = GetNodeDeclaration(base_name);
                 if (class_info && base_info)
                 {
-                    size_t baseIndex = class_info->AddBaseClass(base_info);
+                    class_info->AddBaseClass(base_info);
 
                     auto inheritedProperty = elem_base.child("property");
                     while (inheritedProperty)
                     {
-                        auto prop_name = inheritedProperty.attribute("name").as_cview();
-                        auto value = inheritedProperty.text().as_string();
-                        class_info->AddBaseClassDefaultPropertyValue(baseIndex, prop_name, value);
+                        auto lookup_name = rmap_PropNames.find(inheritedProperty.attribute("name").as_string());
+                        if (lookup_name == rmap_PropNames.end())
+                        {
+                            MSG_ERROR(ttlib::cstr("Unrecognized inherited property name -- ")
+                                      << inheritedProperty.attribute("name").as_string());
+                            continue;
+                        }
+                        class_info->SetOverRideDefValue(lookup_name->second, inheritedProperty.text().as_cview());
                         inheritedProperty = inheritedProperty.next_sibling("property");
                     }
                 }

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -483,6 +483,9 @@ void PropGridPanel::AddProperties(ttlib::cview name, Node* node, NodeCategory& c
         if (!prop)
             continue;
 
+        if (node->GetNodeDeclaration()->IsPropHidden(prop_name))
+            continue;
+
         if (prop_set.find(prop_name) == prop_set.end())
         {
             if (!IsPropAllowed(node, prop))

--- a/src/xml/README.md
+++ b/src/xml/README.md
@@ -11,6 +11,18 @@ Declarations which inherit from the **Window Events** base class will have all o
 - no_mouse_events: all wxMouseEvent events are hidden
 - no_focus_events: all wxFocusEvent events are hidden
 
+## Limiting inherited properties
+
+When an interface is inherited (`<inherits class=`) you can add child nodes called `<hide name=` where the name specifies the property you do not want inherited. This will typically be used when inheriting from the `wxWindow` interface. For example, to prevent a tooltip property, you could encode the following in the XML file:
+
+```xml
+    <inherits class="wxWindow">
+        <!-- Indicate which properties should not be shown in the Property Panel -->
+        <hide name="tooltip" />
+    </inherits>
+```
+
+
 ## Adding a declaration or property
 
 The files `gen_enums.h` and `gen_enums.cpp` _must_ be updated any time you add a new component or a property, or if you change an existing class name or property type. In a DEBUG build you will get warnings if you forget to update one or more of the enumeration lists and there's a fairly good chance the program will not work correctly or even crash if you try to use a component with the missing enumeration.


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds support for child XML nodes called `<hide>` which have a single `name=` attribute that specifies the name of an inherited property to hide. These nodes will be processed during app startup and must be placed within a parent `<inherits>` node.

The PR also replaces the way overriden default values are stored and retrieved. Instead of a map of indexes with a value being another map of property names and values, a single map of `GenEnum::PropName` keys is stored with a map to the overridden default value.