### PR TITLE
Refactor tool creation functions

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -349,7 +349,11 @@ void MainFrame::OnInsertWidget(wxCommandEvent&)
     InsertDialog dlg(this);
     if (dlg.ShowModal() == wxID_OK)
     {
-        CreateToolNode(dlg.GetWidget());
+        if (auto result = rmap_GenNames.find(dlg.GetWidget()); result != rmap_GenNames.end())
+        {
+            return CreateToolNode(result->second);
+        }
+        FAIL_MSG(ttlib::cstr() << "No property enum type exists for dlg.GetWidget()! This should be impossible...");
     }
 }
 
@@ -971,21 +975,8 @@ void MainFrame::CreateToolNode(GenName name)
 
     if (!m_selected_node->CreateToolNode(name))
     {
-        appMsgBox(ttlib::cstr() << "Unable to create " << map_GenNames[name] << " as a child of " << m_selected_node->DeclName());
-    }
-}
-
-void MainFrame::CreateToolNode(const ttlib::cstr& name)
-{
-    if (!m_selected_node)
-    {
-        appMsgBox("You need to select something first in order to properly place this widget.");
-        return;
-    }
-
-    if (!m_selected_node->CreateToolNode(name))
-    {
-        appMsgBox(ttlib::cstr() << "Unable to create " << name << " as a child of " << m_selected_node->DeclName());
+        appMsgBox(ttlib::cstr() << "Unable to create " << map_GenNames[name] << " as a child of "
+                                << m_selected_node->DeclName());
     }
 }
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -128,8 +128,7 @@ public:
 
     // If there is a selection, this will create a new child node with special handling for
     // specific components.
-    void CreateToolNode(const ttlib::cstr& name);
-    void CreateToolNode(GenName name);
+    void CreateToolNode(GenEnum::GenName name);
 
     wxFileHistory& GetFileHistory() { return m_FileHistory; }
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -653,6 +653,16 @@ bool Node::CreateToolNode(GenName name)
     {
         new_node->CreateChildNode(gen_VerticalBoxSizer);
     }
+    else if (name == gen_wxMenuBar || name == gen_MenuBar)
+    {
+        auto node_menu = new_node->CreateChildNode(gen_wxMenu);
+        if (node_menu)
+            node_menu->CreateChildNode(gen_wxMenuItem);
+    }
+    else if (name == gen_wxToolBar || name == gen_ToolBar)
+    {
+        new_node->CreateChildNode(gen_tool);
+    }
     else if (name == gen_wxBoxSizer || name == gen_VerticalBoxSizer || name == gen_wxWrapSizer || name == gen_wxGridSizer ||
              name == gen_wxFlexGridSizer || name == gen_wxGridBagSizer || name == gen_wxStaticBoxSizer ||
              name == gen_StaticCheckboxBoxSizer || name == gen_StaticRadioBtnBoxSizer)

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -475,7 +475,7 @@ wxSizerFlags Node::GetSizerFlags() const
     return flags;
 }
 
-Node* Node::CreateChildNode(ttlib::cview name)
+Node* Node::CreateChildNode(GenName name)
 {
     auto& frame = wxGetFrame();
 
@@ -492,7 +492,7 @@ Node* Node::CreateChildNode(ttlib::cview name)
         // currently exists, if the Windows version of wxUiEditor is used, then ALL versions of the app the user creates will
         // use this background color.
 
-        if (name.is_sameas("BookPage"))
+        if (name == gen_BookPage)
         {
             if (auto prop = new_node->get_prop_ptr(prop_background_colour); prop)
             {
@@ -502,14 +502,15 @@ Node* Node::CreateChildNode(ttlib::cview name)
         }
 #endif  // _WIN32
 
-        ttlib::cstr undo_str = "insert " + name;
+        ttlib::cstr undo_str;
+        undo_str << "insert " << map_GenNames[name];
         frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), this, undo_str));
         new_node->FixDuplicateName();
     }
 
     // A "ribbonButton" component is used for both wxRibbonButtonBar and wxRibbonToolBar. If creating the node failed,
     // then assume the parent is wxRibbonToolBar and retry with "ribbonTool"
-    else if (name.is_sameas("ribbonButton"))
+    else if (name == gen_ribbonButton)
     {
         new_node = g_NodeCreator.CreateNode(gen_ribbonTool, this);
         if (new_node)
@@ -538,14 +539,15 @@ Node* Node::CreateChildNode(ttlib::cview name)
             if (new_node)
             {
                 auto pos = parent->FindInsertionPos(this);
-                ttlib::cstr undo_str = "insert " + name;
+                ttlib::cstr undo_str;
+                undo_str << "insert " << map_GenNames[name];
                 frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, pos));
                 new_node->FixDuplicateName();
             }
         }
         else
         {
-            appMsgBox(ttlib::cstr() << "You cannot add " << name << " as a child of " << DeclName());
+            appMsgBox(ttlib::cstr() << "You cannot add " << map_GenNames[name] << " as a child of " << DeclName());
             return nullptr;
         }
     }
@@ -558,7 +560,7 @@ Node* Node::CreateChildNode(ttlib::cview name)
     return new_node.get();
 }
 
-Node* Node::CreateNode(ttlib::cview name)
+Node* Node::CreateNode(GenName name)
 {
     auto& frame = wxGetFrame();
     auto cur_selection = frame.GetSelectedNode();
@@ -572,23 +574,15 @@ Node* Node::CreateNode(ttlib::cview name)
 
 bool Node::CreateToolNode(GenName name)
 {
-    // TODO: [KeyWorks - 04-15-2021] Currently we convert the name into a string and call CreateToolNode with that string.
-    // Ultimately, we should reverse that and convert the string into a GenName and make this the primary function.
-
-    return CreateToolNode(map_GenNames[name]);
-}
-
-bool Node::CreateToolNode(const ttlib::cstr& name)
-{
     auto new_node = CreateChildNode(name);
     if (!new_node)
         return false;
 
     auto& frame = wxGetFrame();
 
-    if (name == "wxDialog" || name == "PanelForm" || name == "wxPanel" || name == "wxPopupTransientWindow")
+    if (name == gen_wxDialog || name == gen_PanelForm || name == gen_wxPanel || name == gen_wxPopupTransientWindow)
     {
-        auto child_node = new_node->CreateChildNode("VerticalBoxSizer");
+        auto child_node = new_node->CreateChildNode(gen_VerticalBoxSizer);
         if (child_node)
         {
             if (auto prop = child_node->get_prop_ptr(prop_orientation); prop)
@@ -608,12 +602,11 @@ bool Node::CreateToolNode(const ttlib::cstr& name)
             frame.SelectNode(new_node);
         }
     }
-    else if (name == "wxNotebook" || name == "wxSimplebook" || name == "wxChoicebook" || name == "wxListbook" ||
-             name == "wxAuiNotebook")
+    else if (name == gen_wxNotebook || name == gen_wxSimplebook || name == gen_wxChoicebook || name == gen_wxListbook)
     {
-        new_node = new_node->CreateChildNode("BookPage");
+        new_node = new_node->CreateChildNode(gen_BookPage);
 
-        new_node = new_node->CreateChildNode("VerticalBoxSizer");
+        new_node = new_node->CreateChildNode(gen_VerticalBoxSizer);
         if (new_node)
         {
             if (auto prop = new_node->get_prop_ptr(prop_orientation); prop)
@@ -631,9 +624,9 @@ bool Node::CreateToolNode(const ttlib::cstr& name)
             }
         }
     }
-    else if (name == "BookPage")
+    else if (name == gen_BookPage)
     {
-        new_node = new_node->CreateChildNode("VerticalBoxSizer");
+        new_node = new_node->CreateChildNode(gen_VerticalBoxSizer);
         if (new_node)
         {
             if (auto prop = new_node->get_prop_ptr(prop_orientation); prop)
@@ -651,18 +644,18 @@ bool Node::CreateToolNode(const ttlib::cstr& name)
             }
         }
     }
-    else if (name == "wxWizard")
+    else if (name == gen_wxWizard)
     {
-        new_node = new_node->CreateChildNode("wxWizardPageSimple");
-        new_node->CreateChildNode("VerticalBoxSizer");
+        new_node = new_node->CreateChildNode(gen_wxWizardPageSimple);
+        new_node->CreateChildNode(gen_VerticalBoxSizer);
     }
-    else if (name == "wxWizardPageSimple")
+    else if (name == gen_wxWizardPageSimple)
     {
-        new_node->CreateChildNode("VerticalBoxSizer");
+        new_node->CreateChildNode(gen_VerticalBoxSizer);
     }
-    else if (name == "wxBoxSizer" || name == "VerticalBoxSizer" || name == "wxWrapSizer" || name == "wxGridSizer" ||
-             name == "wxFlexGridSizer" || name == "wxGridBagSizer" || name == "wxStaticBoxSizer" ||
-             name == "StaticCheckboxBoxSizer" || name == "StaticRadioBtnBoxSizer")
+    else if (name == gen_wxBoxSizer || name == gen_VerticalBoxSizer || name == gen_wxWrapSizer || name == gen_wxGridSizer ||
+             name == gen_wxFlexGridSizer || name == gen_wxGridBagSizer || name == gen_wxStaticBoxSizer ||
+             name == gen_StaticCheckboxBoxSizer || name == gen_StaticRadioBtnBoxSizer)
     {
         auto node = new_node->GetParent();
         ASSERT(node);
@@ -679,7 +672,7 @@ bool Node::CreateToolNode(const ttlib::cstr& name)
                 prop->set_value("wxEXPAND");
         }
     }
-    else if (name == "wxStdDialogButtonSizer" || name == "wxStaticLine")
+    else if (name == gen_wxStdDialogButtonSizer || name == gen_wxStaticLine)
     {
         if (auto prop = new_node->get_prop_ptr(prop_flags); prop)
         {

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -194,10 +194,14 @@ public:
 
     // This creates an orphaned node -- it is the caller's responsibility to hook it up with
     // a parent.
-    Node* CreateChildNode(ttlib::cview name);
+    Node* CreateChildNode(GenName name);
 
-    Node* CreateNode(ttlib::cview name);
-    bool CreateToolNode(const ttlib::cstr& name);
+    // Gets the current selected node and uses that to call CreateChildNode().
+    Node* CreateNode(GenName name);
+
+    // This is the preferred way to create a new node when requested by the user (tool, menu,
+    // or dialog). Besides creating the node, some nodes will get special processing to
+    // automatically create additional child nodes.
     bool CreateToolNode(GenName name);
 
     // This will modify the property and fire a EVT_NodePropChange event if the property

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -115,7 +115,7 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
     switch (event.GetId())
     {
         case MenuNEW_ITEM:
-            if (m_tool_name.size())
+            if (m_tool_name < gen_name_array_size)
             {
                 if (m_child)
                     m_child->CreateToolNode(m_tool_name);
@@ -203,15 +203,15 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
         case MenuADD_PAGE:
             if (m_node->isGen(gen_BookPage))
             {
-                m_node->GetParent()->CreateToolNode("BookPage");
+                m_node->GetParent()->CreateToolNode(gen_BookPage);
             }
             if (m_node->isGen(gen_wxWizardPageSimple))
             {
-                m_node->GetParent()->CreateToolNode("wxWizardPageSimple");
+                m_node->GetParent()->CreateToolNode(gen_wxWizardPageSimple);
             }
             else
             {
-                wxGetFrame().CreateToolNode("wxPanel");
+                wxGetFrame().CreateToolNode(gen_wxPanel);
             }
             break;
 
@@ -517,7 +517,7 @@ void NavPopupMenu::CreateProjectMenu(Node* WXUNUSED(node))
     Bind(
         wxEVT_MENU,
         [](wxCommandEvent&) {
-            wxGetFrame().CreateToolNode("wxWizard");
+            wxGetFrame().CreateToolNode(gen_wxWizard);
             ;
         },
         MenuPROJECT_ADD_WIZARD);
@@ -525,7 +525,7 @@ void NavPopupMenu::CreateProjectMenu(Node* WXUNUSED(node))
 
 void NavPopupMenu::OnAddNew(wxCommandEvent& event)
 {
-    if (m_tool_name.size())
+    if (m_tool_name < gen_name_array_size)
     {
         if (m_child)
             m_child->CreateToolNode(m_tool_name);
@@ -537,31 +537,31 @@ void NavPopupMenu::OnAddNew(wxCommandEvent& event)
     switch (event.GetId())
     {
         case MenuNEW_SIBLING_BOX_SIZER:
-            m_child->CreateToolNode("wxBoxSizer");
+            m_child->CreateToolNode(gen_wxBoxSizer);
             break;
 
         case MenuNEW_SIBLING_STATIC_SIZER:
-            m_child->CreateToolNode("wxStaticBoxSizer");
+            m_child->CreateToolNode(gen_wxStaticBoxSizer);
             break;
 
         case MenuNEW_SIBLING_WRAP_SIZER:
-            m_child->CreateToolNode("wxWrapSizer");
+            m_child->CreateToolNode(gen_wxWrapSizer);
             break;
 
         case MenuNEW_SIBLING_GRID_SIZER:
-            m_child->CreateToolNode("wxGridSizer");
+            m_child->CreateToolNode(gen_wxGridSizer);
             break;
 
         case MenuNEW_SIBLING_FLEX_GRID_SIZER:
-            m_child->CreateToolNode("wxFlexGridSizer");
+            m_child->CreateToolNode(gen_wxFlexGridSizer);
             break;
 
         case MenuNEW_SIBLING_GRIDBAG_SIZER:
-            m_child->CreateToolNode("wxGridBagSizer");
+            m_child->CreateToolNode(gen_wxGridBagSizer);
             break;
 
         case MenuNEW_SIBLING_STD_DIALG_BTNS:
-            m_child->CreateToolNode("wxStdDialogButtonSizer");
+            m_child->CreateToolNode(gen_wxStdDialogButtonSizer);
             break;
 
 #if 0
@@ -575,47 +575,47 @@ void NavPopupMenu::OnAddNew(wxCommandEvent& event)
 #endif
 
         case MenuNEW_CHILD_BOX_SIZER:
-            wxGetFrame().CreateToolNode("wxBoxSizer");
+            wxGetFrame().CreateToolNode(gen_wxBoxSizer);
             break;
 
         case MenuNEW_CHILD_STATIC_SIZER:
-            wxGetFrame().CreateToolNode("wxStaticBoxSizer");
+            wxGetFrame().CreateToolNode(gen_wxStaticBoxSizer);
             break;
 
         case MenuNEW_CHILD_WRAP_SIZER:
-            wxGetFrame().CreateToolNode("wxWrapSizer");
+            wxGetFrame().CreateToolNode(gen_wxWrapSizer);
             break;
 
         case MenuNEW_CHILD_GRID_SIZER:
-            wxGetFrame().CreateToolNode("wxGridSizer");
+            wxGetFrame().CreateToolNode(gen_wxGridSizer);
             break;
 
         case MenuNEW_CHILD_FLEX_GRID_SIZER:
-            wxGetFrame().CreateToolNode("wxFlexGridSizer");
+            wxGetFrame().CreateToolNode(gen_wxFlexGridSizer);
             break;
 
         case MenuNEW_CHILD_GRIDBAG_SIZER:
-            wxGetFrame().CreateToolNode("wxGridBagSizer");
+            wxGetFrame().CreateToolNode(gen_wxGridBagSizer);
             break;
 
         case MenuNEW_CHILD_STD_DIALG_BTNS:
-            wxGetFrame().CreateToolNode("wxStdDialogButtonSizer");
+            wxGetFrame().CreateToolNode(gen_wxStdDialogButtonSizer);
             break;
 
         case MenuNEW_CHILD_SPACER:
-            wxGetFrame().CreateToolNode("spacer");
+            wxGetFrame().CreateToolNode(gen_spacer);
             break;
 
         case MenuNEW_TOOLBAR:
-            wxGetFrame().CreateToolNode("wxToolBar");
+            wxGetFrame().CreateToolNode(gen_wxToolBar);
             break;
 
         case MenuNEW_INFOBAR:
-            wxGetFrame().CreateToolNode("wxInfoBar");
+            wxGetFrame().CreateToolNode(gen_wxInfoBar);
             break;
 
         case MenuADD_MENU:
-            wxGetFrame().CreateToolNode("wxMenu");
+            wxGetFrame().CreateToolNode(gen_wxMenu);
             break;
 
         default:
@@ -829,7 +829,7 @@ void NavPopupMenu::CreateMenuMenu(Node* /* node */)
     Bind(
         wxEVT_MENU,
         [](wxCommandEvent&) {
-            wxGetFrame().CreateToolNode("wxmenu_item");
+            wxGetFrame().CreateToolNode(gen_wxMenuItem);
             ;
             ;
         },
@@ -838,7 +838,7 @@ void NavPopupMenu::CreateMenuMenu(Node* /* node */)
     Bind(
         wxEVT_MENU,
         [](wxCommandEvent&) {
-            wxGetFrame().CreateToolNode("submenu");
+            wxGetFrame().CreateToolNode(gen_submenu);
             ;
         },
         MenuADD_SUBMENU);
@@ -846,7 +846,7 @@ void NavPopupMenu::CreateMenuMenu(Node* /* node */)
     Bind(
         wxEVT_MENU,
         [](wxCommandEvent&) {
-            wxGetFrame().CreateToolNode("separator");
+            wxGetFrame().CreateToolNode(gen_separator);
             ;
         },
         MenuADD_SEPARATOR);
@@ -876,26 +876,26 @@ void NavPopupMenu::CreateBarMenu(Node* node)
     else if (node->isGen(gen_wxRibbonBar))
     {
         AppendSeparator();
-        m_tool_name = "wxRibbonPage";
+        m_tool_name = gen_wxRibbonPage;
         Append(MenuNEW_ITEM, "Add Page");
     }
     else if (node->isGen(gen_wxRibbonPage))
     {
         AppendSeparator();
-        m_tool_name = "wxRibbonPanel";
+        m_tool_name = gen_wxRibbonPanel;
         Append(MenuNEW_ITEM, "Add Panel");
     }
     else if (node->isGen(gen_wxRibbonToolBar))
     {
         AppendSeparator();
-        m_tool_name = "ribbonTool";
+        m_tool_name = gen_ribbonTool;
         Append(MenuNEW_ITEM, "Add Tool");
     }
     else if (node->isGen(gen_ribbonTool))
     {
         m_child = node->GetParent();
         AppendSeparator();
-        m_tool_name = "ribbonTool";
+        m_tool_name = gen_ribbonTool;
         Append(MenuNEW_ITEM, "Add Tool");
     }
 
@@ -921,7 +921,7 @@ void NavPopupMenu::CreateWizardMenu(Node* /* node */)
     menu_item->SetBitmap(GetInternalImage("nav_movedown"));
 
     AppendSeparator();
-    m_tool_name = "wxWizardPageSimple";
+    m_tool_name = gen_wxWizardPageSimple;
     Append(MenuNEW_ITEM, "Add Page\tCtrl+P");
 
     Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
@@ -941,7 +941,7 @@ void NavPopupMenu::CreateBookMenu(Node* /* node */)
     menu_item->SetBitmap(GetInternalImage("nav_movedown"));
 
     AppendSeparator();
-    m_tool_name = "BookPage";
+    m_tool_name = gen_BookPage;
     Append(MenuNEW_ITEM, "Add Page");
     AppendSeparator();
 

--- a/src/panels/navpopupmenu.h
+++ b/src/panels/navpopupmenu.h
@@ -10,6 +10,7 @@
 #include <wx/event.h>  // Event classes
 #include <wx/menu.h>   // wxMenu and wxMenuBar classes
 
+#include "gen_enums.h"     // Enumerations for generators
 #include "node_classes.h"  // Forward defintions of Node classes
 
 // Creates a context-menu for the specified object
@@ -108,5 +109,5 @@ protected:
 private:
     Node* m_node;
     Node* m_child { nullptr };
-    ttlib::cstr m_tool_name;  // used by MenuNEW_ITEM -> wxGetApp().CreateToolNode(m_tool_name);
+    GenEnum::GenName m_tool_name { GenEnum::GenName::gen_name_array_size };  // used by MenuNEW_ITEM -> wxGetApp().CreateToolNode(m_tool_name)
 };

--- a/src/panels/ribbon_tools.cpp
+++ b/src/panels/ribbon_tools.cpp
@@ -79,8 +79,10 @@ void RibbonPanel::OnToolClick(wxRibbonToolBarEvent& event)
 
         // For release build, we'll at least attempt to create it in case the help string specifies a widget.
         auto name = event.GetBar()->GetToolHelpString(event.GetId());
-        if (name.size())
-            wxGetFrame().CreateToolNode(ttlib::cstr() << name.wx_str());
+        if (auto result = rmap_GenNames.find(name.utf8_string()); result != rmap_GenNames.end())
+        {
+            wxGetFrame().CreateToolNode(result->second);
+        }
     }
 }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR has two parts. The first is to refactor the tool creation functions so that they take one of the GenName enums instead of the class name string. The second part is to automatically create a **wxMenu** node when a **wxMenuBar** is created, and a tool node when a **wxToolBar** is created.

Closes #257
