### PR TITLE
Don't load AUI interface if inherit specifies unknown class

### DIFF
--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -30,6 +30,10 @@ NodeCreator::~NodeCreator()
 
 NodeDeclaration* NodeCreator::GetNodeDeclaration(ttlib::cview className)
 {
+    auto result = rmap_GenNames.find(className.c_str());
+    ASSERT_MSG(result != rmap_GenNames.end(), ttlib::cstr() << "Attempt to get non-existant node declaration for " << className);
+    if (result == rmap_GenNames.end())
+        return nullptr;
     return m_a_declarations[rmap_GenNames[className.c_str()]];
 }
 

--- a/src/xml/sizers.xml
+++ b/src/xml/sizers.xml
@@ -341,7 +341,6 @@
 <gen class="wxStdDialogButtonSizer" image="stddialogbuttonsizer" type="widget">
     <inherits class="sizer_dimension" />
     <inherits class="sizer_child" />
-    <inherits class="Update Events" />
     <property name="var_name" type="string">stdBtn</property>
     <property name="class_access" type="option">
         <option name="none" />

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -1718,7 +1718,6 @@
 </gen>
 
 <gen class="wxDataViewCtrl" image="dataviewtree_ctrl" type="dataviewctrl">
-    <inherits class="wxControl" />
     <inherits class="wxWindow" />
     <inherits class="Window Events" />
     <inherits class="sizer_child" />
@@ -1785,7 +1784,6 @@
 </gen>
 
 <gen class="wxDataViewTreeCtrl" image="dataviewtree_ctrl" type="dataviewtreectrl">
-    <inherits class="wxControl" />
     <inherits class="wxWindow" />
     <inherits class="Window Events" />
     <inherits class="sizer_child" />
@@ -1852,7 +1850,6 @@
 </gen>
 
 <gen class="wxDataViewListCtrl" image="dataviewlist_ctrl" type="dataviewlistctrl">
-    <inherits class="wxControl" />
     <inherits class="wxWindow" />
     <inherits class="Window Events" />
     <inherits class="sizer_child" />


### PR DESCRIPTION
Closes #265

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes `NodeCreator::GetNodeDeclaration()` so that it checks to see if the class name actually exists before returning. If it doesn't exist, the debug build displays an assertion. Both debug and release versions then return a nullptr. During app initialization, the code that handles retrieving an inherited class already checked for a nullptr, so this just means it doesn't add the class instead of adding the first possible class (AUI).

In running the updated version, 4 instances of invalid inherited classes were found and removed.