### PR TITLE
Correctly display a page based on current selection of any node

### DIFF
--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -330,8 +330,49 @@ wxObject* MockupContent::Get_wxObject(Node* node)
         return nullptr;
 }
 
+// clang-format off
+
+// List of classes that will have multiple pages -- we want to select the correct page based
+// on it's children.
+static const GenEnum::GenName lst_select_nodes[] = {
+
+    gen_wxWizardPageSimple,
+    gen_BookPage,
+    gen_wxRibbonPage,
+    gen_wxRibbonPanel,
+    gen_wxRibbonButtonBar,
+    gen_wxRibbonToolBar,
+    gen_ribbonButton,
+    gen_ribbonTool,
+
+};
+// clang-format on
+
 void MockupContent::OnNodeSelected(Node* node)
 {
+    if (node->IsForm())
+        return;
+
+    bool HavePageNode = false;
+    for (;;)
+    {
+        for (auto& iter: lst_select_nodes)
+        {
+            if (node->isGen(iter))
+            {
+                HavePageNode = true;
+                break;
+            }
+        }
+
+        if (HavePageNode)
+            break;
+
+        node = node->GetParent();
+        if (node->IsForm())
+            return;
+    }
+
     if (m_wizard && node->isGen(gen_wxWizardPageSimple))
     {
         auto parent = node->GetParent();

--- a/src/mockup/mockup_content.h
+++ b/src/mockup/mockup_content.h
@@ -25,6 +25,7 @@ public:
 
     void CreateAllGenerators();
 
+    // Call this to switch to the correct page in a wizard, book, or ribbon
     void OnNodeSelected(Node* node);
 
     void RemoveNodes();

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -410,5 +410,6 @@ void MockupParent::OnNodePropModified(CustomEvent& event)
     if (!is_updated)
     {
         CreateContent();
+        m_panelContent->OnNodeSelected(wxGetFrame().GetSelectedNode());
     }
 }


### PR DESCRIPTION
Closes #241

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a call to `MockupContent::OnNodeSelected()` when a property is changed that requires rebuilding the content panel. The `OnNodeSelected()` has been updated to walk up the node parent heirarchy and if at any point a wizard, book, or ribbon page is found, the matching page is selected and displayed. With this change, the user can select any child (widget, sizer, etc.) underneath a page in the Navigation panel, and the containing page will be displayed in the Mockup panel.
