### PR TITLE
Update Parent/Child types in generator interface initialization

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -334,7 +334,6 @@ std::map<GenType, const char*> GenEnum::map_GenTypes = {
     { type_dataviewlistcolumn, "dataviewlistcolumn" },
     { type_dataviewlistctrl, "dataviewlistctrl" },
     { type_dataviewtreectrl, "dataviewtreectrl" },
-    { type_expanded_widget, "expanded_widget" },
     { type_form, "form" },
     { type_gbsizer, "gbsizer" },
     { type_gbsizeritem, "gbsizeritem" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -338,7 +338,6 @@ namespace GenEnum
         type_dataviewlistcolumn,
         type_dataviewlistctrl,
         type_dataviewtreectrl,
-        type_expanded_widget,
         type_form,
         type_gbsizer,
         type_gbsizeritem,

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -227,48 +227,6 @@ NodeSharedPtr NodeCreator::MakeCopy(Node* node)
     return copyObj;
 }
 
-// TODO: [KeyWorks - 04-13-2021] This function isn't being called, and mostly duplicates the code in Node::CreateToolNode.
-// This should become the preferred method, but first we need to merge in the code from CreateToolNode() since that is up to
-// date and does things like call FirePropChangeEvent.
-
-void NodeCreator::SetDefaultLayoutProperties(Node* node)
-{
-    auto node_decl = node->GetNodeDeclaration();
-
-    // Caution: Do NOT place spaces around the | that combines flags. Other parts of the codebase rely on there being no
-    // spaces...
-
-    if (node_decl->isGen(gen_wxStdDialogButtonSizer) || node_decl->isGen(gen_wxStaticLine))
-    {
-        node->prop_set_value(prop_borders, "wxALL");
-        node->prop_set_value(prop_flags, "wxEXPAND");
-        return;
-    }
-
-    if (node->IsSizer() || node->isType(type_splitter) || node_decl->isGen(gen_spacer))
-    {
-        node->prop_set_value(prop_proportion, "1");
-        node->prop_set_value(prop_flags, "wxEXPAND");
-    }
-    else if (node_decl->isGen(gen_wxToolBar))
-    {
-        node->prop_set_value(prop_flags, "wxEXPAND");
-    }
-    else if (node->isType(type_widget) || node->isType(type_statusbar))
-    {
-        node->prop_set_value(prop_proportion, "0");
-        node->prop_set_value(prop_borders, "wxALL");
-    }
-    else if (node->isType(type_notebook) || node->isType(type_listbook) || node->isType(type_simplebook) ||
-             node->isType(type_choicebook) || node->isType(type_auinotebook) || node->isType(type_treelistctrl) ||
-             node->isType(type_expanded_widget) || node->isType(type_container))
-    {
-        node->prop_set_value(prop_proportion, "1");
-        node->prop_set_value(prop_borders, "wxALL");
-        node->prop_set_value(prop_flags, "wxEXPAND");
-    }
-}
-
 int NodeCreator::GetConstantAsInt(const std::string& name, int defValue) const
 {
     if (auto iter = m_map_constants.find(name); iter != m_map_constants.end())

--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -76,8 +76,6 @@ protected:
 
     size_t CountChildrenWithSameType(Node* parent, GenType type);
 
-    void SetDefaultLayoutProperties(Node* node);
-
     void AddAllConstants();
 
 private:

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -89,7 +89,6 @@ static const ParentChild lstParentChild[] = {
     { type_sizer, type_dataviewctrl, infinite },
     { type_sizer, type_dataviewlistctrl, infinite },
     { type_sizer, type_dataviewtreectrl, infinite },
-    { type_sizer, type_expanded_widget, infinite },
     { type_sizer, type_gbsizer, infinite },
     { type_sizer, type_listbook, infinite },
     { type_sizer, type_notebook, infinite },
@@ -110,21 +109,17 @@ static const ParentChild lstParentChild[] = {
 
     { type_tool, type_menu, one },
 
-    { type_toolbar, type_expanded_widget, infinite },
     { type_toolbar, type_tool, infinite },
     { type_toolbar, type_widget, infinite },
-    { type_toolbar_form, type_expanded_widget, infinite },
     { type_toolbar_form, type_tool, infinite },
     { type_toolbar_form, type_widget, infinite },
 
     { type_aui_toolbar, type_aui_tool, infinite },
     { type_aui_toolbar, type_widget, infinite },
 
-    { type_treelistctrl, type_expanded_widget, infinite },
     { type_treelistctrl, type_menu, one },
     { type_treelistctrl, type_treelistctrlcolumn, infinite },
 
-    { type_widget, type_expanded_widget, one },
     { type_widget, type_menu, one },
 
     { type_wizard, type_menu, one },

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -34,14 +34,18 @@ struct ParentChild
 // A child node can only be created if it is listed below as valid for the current parent.
 static const ParentChild lstParentChild[] = {
 
+    // Books
+
     { type_bookpage, type_gbsizer, one },
     { type_bookpage, type_sizer, one },
 
     { type_choicebook, type_bookpage, infinite },
-    { type_choicebook, type_widget, infinite },
+    { type_choicebook, type_widget, infinite },  // The only book that allows adding a widget
+    { type_listbook, type_bookpage, infinite },
+    { type_notebook, type_bookpage, infinite },
+    { type_simplebook, type_bookpage, infinite },
 
     { type_container, type_gbsizer, one },
-    { type_container, type_menu, one },
     { type_container, type_sizer, one },
 
     { type_dataviewctrl, type_dataviewcolumn, infinite },
@@ -50,24 +54,18 @@ static const ParentChild lstParentChild[] = {
     { type_form, type_sizer, one },
     { type_form, type_gbsizer, one },
 
-    { type_listbook, type_bookpage, infinite },
-
     { type_menu, type_menuitem, infinite },
     { type_menu, type_submenu, infinite },
     { type_menubar, type_menu, infinite },
     { type_menubar_form, type_menu, infinite },
-
-    { type_notebook, type_bookpage, infinite },
 
     { type_project, type_form, infinite },
     { type_project, type_menubar_form, infinite },
     { type_project, type_toolbar_form, infinite },
     { type_project, type_wizard, infinite },
 
-    { type_propgrid, type_menu, one },
     { type_propgrid, type_propgriditem, infinite },
     { type_propgriditem, type_propgridpage, infinite },
-    { type_propgridman, type_menu, one },
     { type_propgridman, type_propgridpage, infinite },
     { type_propgridpage, type_propgriditem, infinite },
 
@@ -79,8 +77,6 @@ static const ParentChild lstParentChild[] = {
     { type_ribbonpanel, type_ribbongallery, one },
     { type_ribbonpanel, type_ribbontoolbar, one },
     { type_ribbontoolbar, type_ribbontool, infinite },
-
-    { type_simplebook, type_bookpage, infinite },
 
     { type_sizer, type_auinotebook, infinite },
     { type_sizer, type_aui_toolbar, infinite },
@@ -107,8 +103,6 @@ static const ParentChild lstParentChild[] = {
     { type_submenu, type_menuitem, infinite },
     { type_submenu, type_submenu, infinite },
 
-    { type_tool, type_menu, one },
-
     { type_toolbar, type_tool, infinite },
     { type_toolbar, type_widget, infinite },
     { type_toolbar_form, type_tool, infinite },
@@ -117,16 +111,11 @@ static const ParentChild lstParentChild[] = {
     { type_aui_toolbar, type_aui_tool, infinite },
     { type_aui_toolbar, type_widget, infinite },
 
-    { type_treelistctrl, type_menu, one },
     { type_treelistctrl, type_treelistctrlcolumn, infinite },
 
-    { type_widget, type_menu, one },
-
-    { type_wizard, type_menu, one },
     { type_wizard, type_wizardpagesimple, infinite },
 
     { type_wizardpagesimple, type_gbsizer, one },
-    { type_wizardpagesimple, type_menu, one },
     { type_wizardpagesimple, type_sizer, one },
 
 };

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -1138,7 +1138,7 @@
         help="" />
 </gen>
 
-<gen class="wxRichTextCtrl" image="richtextctrl" type="expanded_widget">
+<gen class="wxRichTextCtrl" image="richtextctrl" type="widget">
     <inherits class="wxWindow">
         <property name="window_style">wxVSCROLL | wxHSCROLL | wxNO_BORDER | wxWANTS_CHARS</property>
     </inherits>
@@ -1182,7 +1182,7 @@
         help="Generated when content has been deleted from the control. Valid event functions: GetPosition, GetRange." />
 </gen>
 
-<gen class="wxStyledTextCtrl" image="scintilla" type="expanded_widget">
+<gen class="wxStyledTextCtrl" image="scintilla" type="widget">
     <inherits class="wxWindow" />
     <inherits class="Window Events" />
     <inherits class="sizer_child" />
@@ -1320,7 +1320,7 @@
         help="User clicked on the week of the year number (only generic)." />
 </gen>
 
-<gen class="wxGenericDirCtrl" image="genericdir_ctrl" type="expanded_widget">
+<gen class="wxGenericDirCtrl" image="genericdir_ctrl" type="widget">
     <inherits class="wxWindow" />
     <inherits class="Window Events" />
     <inherits class="sizer_child" />
@@ -1358,7 +1358,7 @@
         help="The user activated a file by double-clicking or pressing Enter." />
 </gen>
 
-<gen class="wxFileCtrl" image="wxFileCtrl" type="expanded_widget">
+<gen class="wxFileCtrl" image="wxFileCtrl" type="widget">
     <inherits class="wxWindow" />
     <inherits class="Window Events" />
     <inherits class="sizer_child" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Closes #209

This PR removes type_expanded_widget -- all interfaces that used that type are now declared as type_widget.

The PR also removes type_menu as a child for non-menus. See #211 for more information. Note that we don't currently have any special processing for **wxFormBuilder** imports that used child menus. That will need to wait until we come up with a better solution for providing popup menu support.
