### PR TITLE
Update wxUiTesting app

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1435,6 +1435,7 @@ void BaseCodeGenerator::GenCtxConstruction(Node* node)
         {
             m_source->writeLine();
             result->Replace("(menu", "(&menu");
+            result->Replace("menu->AppendSeparator(", "menu.AppendSeparator(");
             m_source->writeLine(result.value(), indent::auto_no_whitespace);
         }
         size_t auto_indent = indent::auto_no_whitespace;

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -326,6 +326,9 @@ void NavigationPanel::UpdateDisplayName(wxTreeItemId id, Node* node)
 {
     ttlib::cstr text;
     auto prop = node->get_prop_ptr(prop_label);
+    if (!prop && node->HasValue(prop_main_label))
+        prop = node->get_prop_ptr(prop_main_label);  // used by wxCommandLinkButton
+
     if (prop && prop->get_value().size())
     {
         text = prop->get_value();

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -188,8 +188,11 @@
         <inherits class="Window Events" />
         <inherits class="sizer_child" />
         <property name="var_name" type="string">m_btn</property>
-        <property name="main_label" type="string_edit">MyButton</property>
-        <property name="note" type="string_edit_escapes" />
+        <property name="main_label" type="string_edit"
+            help="First line of text on the button, typically the label of an action that will be made when the button is pressed.">MyButton</property>
+        <property name="note" type="string_edit_escapes"
+            help="Second line of text describing the action performed when the button is pressed."
+        />
         <property name="default" type="bool"
             help="If true, this will be the default button (it will be depressed when the return key is pressed)">0</property>
         <property name="auth_needed" type="bool"

--- a/testing/ui/commonctrls_base.cpp
+++ b/testing/ui/commonctrls_base.cpp
@@ -7,11 +7,13 @@
 #include "pch.h"
 
 #include <wx/artprov.h>
+#include <wx/event.h>
 #include <wx/sizer.h>
 #include <wx/statbmp.h>
 #include <wx/statbox.h>
 #include <wx/valgen.h>
 #include <wx/valtext.h>
+#include <wx/window.h>
 
 #include "commonctrls_base.h"
 
@@ -224,7 +226,7 @@ CommonCtrlsBase::CommonCtrlsBase(wxWindow* parent) : wxDialog()
     m_slider->SetValue(50);
     box_sizer5->Add(m_slider, wxSizerFlags().Border(wxALL));
 
-    m_staticText13 = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("Guage:"));
+    m_staticText13 = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("Gauge:"));
     box_sizer5->Add(m_staticText13, wxSizerFlags().Center().Border(wxLEFT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     m_gauge = new wxGauge(this, wxID_ANY, 100);
@@ -238,6 +240,7 @@ CommonCtrlsBase::CommonCtrlsBase(wxWindow* parent) : wxDialog()
     Centre(wxBOTH);
 
     // Event handlers
+    Bind(wxEVT_CONTEXT_MENU, &CommonCtrlsBase::OnContextMenu, this);
     m_textCtrl->Bind(wxEVT_TEXT_ENTER, &CommonCtrlsBase::OnProcessEnter, this);
     m_checkBox->Bind(wxEVT_CHECKBOX, &CommonCtrlsBase::OnCheckBox, this);
     m_btn->Bind(wxEVT_BUTTON, &CommonCtrlsBase::OnFirstBtn, this);
@@ -257,4 +260,50 @@ CommonCtrlsBase::CommonCtrlsBase(wxWindow* parent) : wxDialog()
         [this](wxCommandEvent&) { if (m_toggleBtn->GetValue())  m_animation_ctrl->Play();  else  m_animation_ctrl->Stop(); }
         );
     m_slider->Bind(wxEVT_SLIDER, &CommonCtrlsBase::OnSlider, this);
+}
+
+void CommonCtrlsBase::OnContextMenu(wxContextMenuEvent& event)
+{
+    wxMenu menu;
+
+    auto menu_item = new wxMenuItem(&menu, wxID_ANY, wxString::FromUTF8("Play Animation"));
+    menu.Append(menu_item);
+
+    auto menu_item_2 = new wxMenuItem(&menu, wxID_ANY, wxString::FromUTF8("Stop Animation"));
+    menu.Append(menu_item_2);
+
+    menu.AppendSeparator();
+
+    auto menu_item_3 = new wxMenuItem(&menu, wxID_ANY, wxString::FromUTF8("Set Slider to 25"));
+    menu.Append(menu_item_3);
+
+    auto menu_item_4 = new wxMenuItem(&menu, wxID_ANY, wxString::FromUTF8("Set Slider to 75"));
+    menu.Append(menu_item_4);
+
+    auto menu_item_5 = new wxMenuItem(&menu, wxID_ANY, wxString::FromUTF8("Set Gauge to 25"));
+    menu.Append(menu_item_5);
+
+    auto menu_item_6 = new wxMenuItem(&menu, wxID_ANY, wxString::FromUTF8("Set Gauge to 75"));
+    menu.Append(menu_item_6);
+
+    menu.Bind(wxEVT_MENU,
+        [this](wxCommandEvent&) { m_animation_ctrl->Play(); },
+        menu_item->GetId());
+    menu.Bind(wxEVT_MENU,
+        [this](wxCommandEvent&) { m_animation_ctrl->Stop(); },
+        menu_item_2->GetId());
+    menu.Bind(wxEVT_MENU,
+        [this](wxCommandEvent&) { m_slider->SetValue(25); },
+        menu_item_3->GetId());
+    menu.Bind(wxEVT_MENU,
+        [this](wxCommandEvent&) { m_slider->SetValue(75); },
+        menu_item_4->GetId());
+    menu.Bind(wxEVT_MENU,
+        [this](wxCommandEvent&) { m_gauge->SetValue(25); },
+        menu_item_5->GetId());
+    menu.Bind(wxEVT_MENU,
+        [this](wxCommandEvent&) { m_gauge->SetValue(75); },
+        menu_item_6->GetId());
+
+    wxStaticCast(event.GetEventObject(), wxWindow)->PopupMenu(&menu);
 }

--- a/testing/ui/commonctrls_base.h
+++ b/testing/ui/commonctrls_base.h
@@ -22,6 +22,7 @@
 #include <wx/image.h>
 #include <wx/infobar.h>
 #include <wx/listbox.h>
+#include <wx/menu.h>
 #include <wx/radiobox.h>
 #include <wx/radiobut.h>
 #include <wx/slider.h>
@@ -93,4 +94,5 @@ protected:
     virtual void OnRadio(wxCommandEvent& event) { event.Skip(); }
     virtual void OnRadioBox(wxCommandEvent& event) { event.Skip(); }
     virtual void OnSlider(wxCommandEvent& event) { event.Skip(); }
+    void OnContextMenu(wxContextMenuEvent& event);
 };

--- a/testing/ui/dlgmultitest_base.cpp
+++ b/testing/ui/dlgmultitest_base.cpp
@@ -33,7 +33,7 @@ static wxImage GetImgFromHdr(const unsigned char* data, size_t size_data)
 
 DlgMultiTestBase::DlgMultiTestBase(wxWindow* parent) : wxDialog()
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Widgets Testing"), wxPoint(600, 800), wxDefaultSize,
+    Create(parent, wxID_ANY, wxString::FromUTF8("Widgets Testing"), wxDefaultPosition, wxDefaultSize,
         wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
     auto box_sizer_2 = new wxBoxSizer(wxVERTICAL);

--- a/testing/ui/dlgmultitest_base.cpp
+++ b/testing/ui/dlgmultitest_base.cpp
@@ -138,7 +138,6 @@ DlgMultiTestBase::DlgMultiTestBase(wxWindow* parent) : wxDialog()
     box_sizer_2->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));
 
     SetSizerAndFit(box_sizer_2);
-    SetSize(wxSize(600, 800));
     Centre(wxBOTH);
 
     // Event handlers

--- a/testing/ui/popupwin_base.cpp
+++ b/testing/ui/popupwin_base.cpp
@@ -10,11 +10,13 @@
 
 #include "popupwin_base.h"
 
-PopupWinBase::PopupWinBase(wxWindow* parent, int border) : wxPopupTransientWindow(parent, border)
+PopupWinBase::PopupWinBase(wxWindow* parent, int style) : wxPopupTransientWindow(parent, style)
 {
+    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOBK));
+
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
-    m_staticText = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("This is a wxPopupTransientWindow set to use a raised border around it. Note that the default is to not have a border at all.\n\nClick outside this window to dismiss it."));
+    m_staticText = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("This is a wxPopupTransientWindow set to use a raised border around it. Note that the default is to not have a border at all.\n\nBTW, right-click anywhere in the dialog to get a popup menu for changing some of the control values.\n\nClick outside this window to dismiss it."));
     m_staticText->Wrap(250);
     parent_sizer->Add(m_staticText, wxSizerFlags().Border(wxALL));
 

--- a/testing/ui/popupwin_base.h
+++ b/testing/ui/popupwin_base.h
@@ -6,14 +6,16 @@
 
 #pragma once
 
+#include <wx/colour.h>
 #include <wx/gdicmn.h>
 #include <wx/popupwin.h>
+#include <wx/settings.h>
 #include <wx/stattext.h>
 
 class PopupWinBase : public wxPopupTransientWindow
 {
 public:
-    PopupWinBase(wxWindow* parent, int border_flag = wxBORDER_RAISED);
+    PopupWinBase(wxWindow* parent, int style = wxBORDER_RAISED);
 protected:
 
     // Class member variables

--- a/testing/ui/ribbondlg_base.cpp
+++ b/testing/ui/ribbondlg_base.cpp
@@ -14,7 +14,7 @@
 
 RibbonDlgBase::RibbonDlgBase(wxWindow* parent) : wxDialog()
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Ribbon Dialog"), wxPoint(500, 300), wxDefaultSize,
+    Create(parent, wxID_ANY, wxString::FromUTF8("Ribbon Dialog"), wxDefaultPosition, wxDefaultSize,
         wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);

--- a/testing/ui/wxUiTesting.wxui
+++ b/testing/ui/wxUiTesting.wxui
@@ -1121,7 +1121,7 @@
       derived_class_name="DlgMultiTest"
       derived_file="dlgmultitest"
       minimum_size="-1,-1"
-      size="600,800"
+      size="-1,-1"
       style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
       title="Widgets Testing">
       <node

--- a/testing/ui/wxUiTesting.wxui
+++ b/testing/ui/wxUiTesting.wxui
@@ -95,12 +95,13 @@
     </node>
     <node
       class="wxDialog"
+      base_file="commonctrls_base"
       class_name="CommonCtrlsBase"
+      derived_class_name="CommonCtrls"
+      derived_file="commonctrls"
       style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
       title="Common controls"
-      base_file="commonctrls_base"
-      derived_class_name="CommonCtrls"
-      derived_file="commonctrls">
+      wxEVT_CONTEXT_MENU="OnContextMenu">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -342,7 +343,7 @@
             wxEVT_SLIDER="OnSlider" />
           <node
             class="wxStaticText"
-            label="Guage:"
+            label="Gauge:"
             var_name="m_staticText13"
             alignment="wxALIGN_CENTER"
             borders="wxLEFT|wxTOP|wxBOTTOM" />
@@ -355,16 +356,50 @@
           Help="true"
           flags="wxEXPAND" />
       </node>
+      <node
+        class="wxContextMenuEvent">
+        <node
+          class="wxMenuItem"
+          label="Play Animation"
+          wxEVT_MENU="[this](wxCommandEvent&amp;) { m_animation_ctrl->Play(); }" />
+        <node
+          class="wxMenuItem"
+          label="Stop Animation"
+          var_name="menu_item_2"
+          wxEVT_MENU="[this](wxCommandEvent&amp;) { m_animation_ctrl->Stop(); }" />
+        <node
+          class="separator" />
+        <node
+          class="wxMenuItem"
+          label="Set Slider to 25"
+          var_name="menu_item_3"
+          wxEVT_MENU="[this](wxCommandEvent&amp;) { m_slider->SetValue(25); }" />
+        <node
+          class="wxMenuItem"
+          label="Set Slider to 75"
+          var_name="menu_item_4"
+          wxEVT_MENU="[this](wxCommandEvent&amp;) { m_slider->SetValue(75); }" />
+        <node
+          class="wxMenuItem"
+          label="Set Gauge to 25"
+          var_name="menu_item_5"
+          wxEVT_MENU="[this](wxCommandEvent&amp;) { m_gauge->SetValue(25); }" />
+        <node
+          class="wxMenuItem"
+          label="Set Gauge to 75"
+          var_name="menu_item_6"
+          wxEVT_MENU="[this](wxCommandEvent&amp;) { m_gauge->SetValue(75); }" />
+      </node>
     </node>
     <node
       class="wxDialog"
-      class_name="RibbonDlgBase"
-      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
-      title="Ribbon Dialog"
       base_file="ribbondlg_base"
+      class_name="RibbonDlgBase"
       derived_class_name="RibbonDlg"
       derived_file="ribbondlg"
-      size="500,300">
+      size="500,300"
+      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
+      title="Ribbon Dialog">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -397,8 +432,7 @@
     </node>
     <node
       class="PanelForm"
-      size="500,300"
-      window_style="wxTAB_TRAVERSAL">
+      size="500,300">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -497,10 +531,10 @@
     </node>
     <node
       class="wxDialog"
-      class_name="ChoiceBookBase"
-      title="Choicebook"
       base_file="choicebook_base"
-      derived_class_name="ChoiceBook">
+      class_name="ChoiceBookBase"
+      derived_class_name="ChoiceBook"
+      title="Choicebook">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -612,12 +646,12 @@
     </node>
     <node
       class="wxDialog"
-      class_name="NotebookBase"
-      title="Notebook"
       base_file="notebook_base"
+      class_name="NotebookBase"
       derived_class_name="Notebook"
       minimum_size="-1,-1"
-      size="-1,-1">
+      size="-1,-1"
+      title="Notebook">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL">
@@ -686,10 +720,10 @@
     </node>
     <node
       class="wxDialog"
-      class_name="ListbookBase"
-      title="Listbook"
       base_file="listbook_base"
-      derived_class_name="Listbook">
+      class_name="ListbookBase"
+      derived_class_name="Listbook"
+      title="Listbook">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL">
@@ -757,10 +791,10 @@
     </node>
     <node
       class="wxDialog"
-      class_name="TreebookBase"
-      title="Treebook"
       base_file="treebook_base"
-      derived_class_name="Treebook">
+      class_name="TreebookBase"
+      derived_class_name="Treebook"
+      title="Treebook">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL">
@@ -827,10 +861,10 @@
     </node>
     <node
       class="wxDialog"
-      class_name="ToolbookBase"
-      title="wxToolbook"
       base_file="toolbook_base"
-      derived_class_name="Toolbook">
+      class_name="ToolbookBase"
+      derived_class_name="Toolbook"
+      title="wxToolbook">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL">
@@ -896,6 +930,7 @@
     </node>
     <node
       class="wxPopupTransientWindow"
+      background_colour="wxSYS_COLOUR_INFOBK"
       border="wxBORDER_RAISED"
       class_name="PopupWinBase"
       base_file="popupwin_base"
@@ -907,21 +942,21 @@
         var_name="parent_sizer">
         <node
           class="wxStaticText"
-          label="This is a wxPopupTransientWindow set to use a raised border around it. Note that the default is to not have a border at all.&#10;&#10;Click outside this window to dismiss it."
+          label="This is a wxPopupTransientWindow set to use a raised border around it. Note that the default is to not have a border at all.&#10;&#10;BTW, right-click anywhere in the dialog to get a popup menu for changing some of the control values.&#10;&#10;Click outside this window to dismiss it."
           wrap="250" />
       </node>
     </node>
     <node
       class="wxDialog"
-      class_name="OtherCtrlsBase"
-      persist="true"
-      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
-      title="NoteBook Dialog"
       base_file="other_ctrls_base"
+      class_name="OtherCtrlsBase"
       derived_class_name="OtherCtrlsDlg"
       derived_file="other_ctrls"
       minimum_size="-1,-1"
-      size="-1,-1">
+      persist="true"
+      size="-1,-1"
+      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
+      title="NoteBook Dialog">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -1081,14 +1116,14 @@
     </node>
     <node
       class="wxDialog"
-      class_name="DlgMultiTestBase"
-      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
-      title="Widgets Testing"
       base_file="dlgmultitest_base"
+      class_name="DlgMultiTestBase"
       derived_class_name="DlgMultiTest"
       derived_file="dlgmultitest"
       minimum_size="-1,-1"
-      size="600,800">
+      size="600,800"
+      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
+      title="Widgets Testing">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates the **wxUiTesting** app, along with fixing some minor bugs in **wxUiEditor** uncovered by changes to the testing app.

Buf fixes:

- Adding a menu separator to a wxContextMenuEvent menu used `menu->AppendSeparator` instead of `menu.AppendSeparator`.
- Prop panel wasn't displaying the label name for wxCommandLinkButton.
- Add help description for main_label and note in wxCommandLinkButton.
