### PR TITLE
Complete outer code for importing dialogs from Windows Resource files.

### DIFF
--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -89,10 +89,11 @@ Files:
     generate/wizard_form.cpp       # Wizard form class
 
     import/import_formblder.cpp    # Import a wxFormBuider project
-    import/import_winres.cpp       # Import a Windows resource file
     import/import_wxglade.cpp      # Import a Import a wxGlade file
     import/import_wxsmith.cpp      # Process XRC files
     import/import_xml.cpp          # Base class for XML importing
+
+    import/import_winres.cpp       # Import a Windows resource file
     import/winres/winres_ctrl.cpp  # Process Windows Resource control data
     import/winres/winres_form.cpp  # Process a Windows Resource form (usually a dialog)
 

--- a/src/import/import_winres.h
+++ b/src/import/import_winres.h
@@ -22,7 +22,6 @@ public:
     WinResource();
 
     bool Import(const ttString& filename, bool write_doc) override;
-
     bool ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>& m_dialogs);
     void InsertDialogs(std::vector<ttlib::cstr>& dialogs);
 
@@ -35,8 +34,6 @@ private:
     ttlib::cstr m_OutDirectory;
     ttlib::cstr m_outProjectName;
 
-    pugi::xml_document m_docOut;
-
     wxString m_strErrorMsg;
 
     std::string strLanguage;
@@ -44,7 +41,6 @@ private:
     ttlib::textfile m_file;
 
     std::vector<rcForm> m_forms;
-    Node* m_project;
 
     size_t m_curline;
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -182,7 +182,12 @@ public:
     void ToggleBorderFlag(Node* node, int border);
 
 protected:
+
     void OnAbout(wxCommandEvent& event) override;
+    void OnAppendFormBuilder(wxCommandEvent& event) override;
+    void OnAppendGlade(wxCommandEvent& event) override;
+    void OnAppendSmith(wxCommandEvent& event) override;
+    void OnAppendXRC(wxCommandEvent& event) override;
     void OnChangeAlignment(wxCommandEvent& event) override;
     void OnChangeBorder(wxCommandEvent& event) override;
     void OnClose(wxCloseEvent& event) override;
@@ -192,11 +197,8 @@ protected:
     void OnEmbedImageConverter(wxCommandEvent& event) override;
     void OnGenInhertedClass(wxCommandEvent& event) override;
     void OnGenerateCode(wxCommandEvent& event) override;
-    void OnAppendFormBuilder(wxCommandEvent& event) override;
-    void OnAppendGlade(wxCommandEvent& event) override;
-    void OnAppendSmith(wxCommandEvent& event) override;
-    void OnAppendXRC(wxCommandEvent& event) override;
     void OnImportWindowsResource(wxCommandEvent& event);
+    void OnInsertWidget(wxCommandEvent&) override;
     void OnNewProject(wxCommandEvent& event);
     void OnOpenProject(wxCommandEvent& event) override;
     void OnOpenRecentProject(wxCommandEvent& event);
@@ -205,7 +207,6 @@ protected:
     void OnSaveAsProject(wxCommandEvent& event) override;
     void OnSaveProject(wxCommandEvent& event) override;
     void OnToggleExpandLayout(wxCommandEvent&) override;
-    void OnInsertWidget(wxCommandEvent&) override;
 
     void OnFindDialog(wxCommandEvent& event) override;
     void OnFind(wxFindDialogEvent& event);

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -369,7 +369,7 @@ void MockupContent::OnNodeSelected(Node* node)
             break;
 
         node = node->GetParent();
-        if (node->IsForm())
+        if (!node || node->IsForm())
             return;
     }
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -510,7 +510,14 @@ void App::AppendWinRes(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>& dia
     WinResource winres;
     if (winres.ImportRc(rc_file, dialogs))
     {
-        winres.InsertDialogs(dialogs);
+        auto project = winres.GetProjectPtr();
+        for (size_t idx_child = 0; idx_child < project->GetChildCount(); ++idx_child)
+        {
+            auto new_node = g_NodeCreator.MakeCopy(project->GetChildPtr(idx_child));
+            m_project->AddChild(new_node);
+            new_node->SetParent(m_project);
+        }
+
         wxGetFrame().FireProjectUpdatedEvent();
         wxGetFrame().SetModified();
     }

--- a/src/ui/importwinresdlg.cpp
+++ b/src/ui/importwinresdlg.cpp
@@ -9,29 +9,41 @@
 
 #include <wx/dir.h>
 
-#include <tttextfile.h>  // textfile -- Classes for reading and writing line-oriented files
+#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
 
 #include "importwinresdlg.h"  // auto-generated: importwinres_base.h and importwinres_base.cpp
 
 #include "mainapp.h"  // App -- App class
 #include "uifuncs.h"  // Miscellaneous functions for displaying UI
 
-ImportWinResDlg::ImportWinResDlg(wxWindow* parent) : ImportWinResBase(parent) {}
+ImportWinResDlg::ImportWinResDlg(wxWindow* parent, ttString filename) : ImportWinResBase(parent)
+{
+    if (filename.size())
+        m_rcFilename.utf(filename.wx_str());
+}
 
 void ImportWinResDlg::OnInit(wxInitDialogEvent& WXUNUSED(event))
 {
-    wxDir dir(wxGetCwd());
-    wxString filename;
-    if (dir.GetFirst(&filename, "*.rc"))
+    if (m_rcFilename.empty())
     {
-        m_fileResource->SetPath(filename);
+        wxDir dir(wxGetCwd());
+        wxString filename;
+        if (dir.GetFirst(&filename, "*.rc"))
+        {
+            m_fileResource->SetPath(filename);
+            ReadRcFile();
+        }
+    }
+    else
+    {
+        m_fileResource->SetPath(m_rcFilename.wx_str());
         ReadRcFile();
     }
 }
 
 void ImportWinResDlg::ReadRcFile()
 {
-    m_rcFilename << m_fileResource->GetPath().wx_str();
+    m_rcFilename.utf(m_fileResource->GetPath().wx_str());
     ttlib::textfile rc_file;
     if (!rc_file.ReadFile(m_rcFilename))
     {
@@ -88,5 +100,7 @@ void ImportWinResDlg::OnOk(wxCommandEvent& event)
             name << m_checkListResUI->GetString(pos).wx_str();
         }
     }
+
+    m_rcFilename.utf(m_fileResource->GetTextCtrlValue().wx_str());
     event.Skip();
 }

--- a/src/ui/importwinresdlg.h
+++ b/src/ui/importwinresdlg.h
@@ -12,7 +12,8 @@
 class ImportWinResDlg : public ImportWinResBase
 {
 public:
-	ImportWinResDlg(wxWindow* parent);
+	ImportWinResDlg(wxWindow* parent, ttString filename = wxEmptyString);
+
 
 	const ttlib::cstr& GetRcFilename() { return m_rcFilename; }
 	std::vector<ttlib::cstr>& GetDlgNames() { return m_dialogs; }

--- a/src/ui/mainframe_base.cpp
+++ b/src/ui/mainframe_base.cpp
@@ -88,6 +88,10 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto submenu = new wxMenu();
 
+    auto menu_item_5 = new wxMenuItem(submenu, id_AppendWinRes, wxString::FromUTF8("Windows Resource..."),
+    wxString::FromUTF8("Append Windows Resource into current project"), wxITEM_NORMAL);
+    submenu->Append(menu_item_5);
+
     auto menu_item_1 = new wxMenuItem(submenu, id_AppendFormBuilder, wxString::FromUTF8("wxFormBuilder Project..."),
     wxString::FromUTF8("Append wxFormBuilder project into current project"), wxITEM_NORMAL);
     submenu->Append(menu_item_1);
@@ -376,6 +380,7 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
         [](wxUpdateUIEvent& event) { event.Enable(wxGetFrame().IsModified()); },
         wxID_SAVE);
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveAsProject, this, id_SaveProjectAs);
+    Bind(wxEVT_MENU, &MainFrameBase::OnImportWindowsResource, this, id_AppendWinRes);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendFormBuilder, this, id_AppendFormBuilder);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendGlade, this, id_AppendGlade);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendSmith, this, id_AppendSmith);

--- a/src/ui/mainframe_base.h
+++ b/src/ui/mainframe_base.h
@@ -31,6 +31,7 @@ public:
         id_AppendFormBuilder,
         id_AppendGlade,
         id_AppendSmith,
+        id_AppendWinRes,
         id_AppendXRC,
         id_BorderBottom,
         id_BorderLeft,
@@ -82,6 +83,7 @@ protected:
     virtual void OnFindDialog(wxCommandEvent& event) { event.Skip(); }
     virtual void OnGenInhertedClass(wxCommandEvent& event) { event.Skip(); }
     virtual void OnGenerateCode(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnImportWindowsResource(wxCommandEvent& event) { event.Skip(); }
     virtual void OnInsertWidget(wxCommandEvent& event) { event.Skip(); }
     virtual void OnOpenProject(wxCommandEvent& event) { event.Skip(); }
     virtual void OnOptionsDlg(wxCommandEvent& event) { event.Skip(); }

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -69,6 +69,13 @@
             label="&amp;Append">
             <node
               class="wxMenuItem"
+              help="Append Windows Resource into current project"
+              id="id_AppendWinRes"
+              label="Windows Resource..."
+              var_name="menu_item_5"
+              wxEVT_MENU="OnImportWindowsResource" />
+            <node
+              class="wxMenuItem"
               help="Append wxFormBuilder project into current project"
               id="id_AppendFormBuilder"
               label="wxFormBuilder Project..."
@@ -595,12 +602,12 @@
     </node>
     <node
       class="wxDialog"
-      class_name="EmbedImageBase"
-      title="Convert Image"
       base_file="embedimg_base"
+      class_name="EmbedImageBase"
       derived_class_name="EmbedImage"
       minimum_size="-1,-1"
-      size="-1,-1">
+      size="-1,-1"
+      title="Convert Image">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -887,13 +894,13 @@
     </node>
     <node
       class="wxDialog"
+      base_file="debugsettingsBase"
       class_name="DebugSettingsBase"
+      derived_class_name="DebugSettings"
+      derived_file="debugsettings"
       persist="true"
       style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
       title="Debug Settings"
-      base_file="debugsettingsBase"
-      derived_class_name="DebugSettings"
-      derived_file="debugsettings"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -954,10 +961,10 @@
     </node>
     <node
       class="wxDialog"
-      class_name="NewProjectBase"
-      title="New Project"
       base_file="newproject_base"
+      class_name="NewProjectBase"
       derived_class_name="NewProjectDlg"
+      title="New Project"
       wxEVT_INIT_DIALOG="OnInitDialog">
       <node
         class="wxBoxSizer"
@@ -1075,10 +1082,10 @@
     </node>
     <node
       class="wxDialog"
-      class_name="ImportWinResBase"
-      title="Import Windows Resource Dialogs"
       base_file="importwinres_base"
+      class_name="ImportWinResBase"
       derived_class_name="ImportWinResDlg"
+      title="Import Windows Resource Dialogs"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -1142,11 +1149,11 @@
     </node>
     <node
       class="wxDialog"
-      class_name="OptionsDlgBase"
-      title="Options"
       base_file="optionsdlg_base"
+      class_name="OptionsDlgBase"
       derived_class_name="OptionsDlg"
       derived_file="optionsdlg"
+      title="Options"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -1221,10 +1228,10 @@
     </node>
     <node
       class="wxDialog"
-      class_name="ArtPropertyDlgBase"
-      title="Art Provider Image"
       base_file="artpropdlg_base"
-      derived_class_name="ArtPropertyDlg">
+      class_name="ArtPropertyDlgBase"
+      derived_class_name="ArtPropertyDlg"
+      title="Art Provider Image">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -1282,8 +1289,8 @@
     </node>
     <node
       class="wxDialog"
-      class_name="EditStringDialogBase"
       base_file="editstringdialog_base"
+      class_name="EditStringDialogBase"
       derived_class_name="EditStringDialog">
       <node
         class="wxBoxSizer"
@@ -1306,10 +1313,10 @@
     </node>
     <node
       class="wxDialog"
-      class_name="EventHandlerDlgBase"
-      title="Event Handler"
       base_file="eventhandlerdlg_base"
+      class_name="EventHandlerDlgBase"
       derived_class_name="EventHandlerDlg"
+      title="Event Handler"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -1396,12 +1403,12 @@
     </node>
     <node
       class="wxDialog"
-      class_name="InsertDialogBase"
-      title="Insert widget"
       base_file="insertdialog_base"
+      class_name="InsertDialogBase"
       derived_class_name="InsertDialog"
       derived_file="insertdialog"
       minimum_size="-1,-1"
+      title="Insert widget"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -1448,11 +1455,11 @@
     </node>
     <node
       class="wxDialog"
-      class_name="NodeInfoBase"
-      title="Node Information"
       base_file="..\debugging\nodeinfo_base"
+      class_name="NodeInfoBase"
       derived_class_name="NodeInfo"
-      derived_file="../debugging/nodeinfo">
+      derived_file="../debugging/nodeinfo"
+      title="Node Information">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -1576,11 +1583,11 @@
     </node>
     <node
       class="wxDialog"
-      class_name="NewDialogBase"
-      title="New Dialog"
       base_file="newdialog_base"
+      class_name="NewDialogBase"
       derived_class_name="NewDialog"
       derived_file="newdialog"
+      title="New Dialog"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -1675,11 +1682,11 @@
     </node>
     <node
       class="wxDialog"
-      class_name="NewFrameBase"
-      title="New wxFrame window"
       base_file="newframe_base"
+      class_name="NewFrameBase"
       derived_class_name="NewFrame"
       derived_file="newframe"
+      title="New wxFrame window"
       wxEVT_INIT_DIALOG="[this](wxInitDialogEvent&amp; event) { m_classname->SetFocus();  event.Skip(); }">
       <node
         class="wxBoxSizer"
@@ -1756,11 +1763,11 @@
     </node>
     <node
       class="wxDialog"
-      class_name="NewRibbonBase"
-      title="New Ribbon Bar"
       base_file="newribbon_base"
+      class_name="NewRibbonBase"
       derived_class_name="NewRibbon"
-      derived_file="newribbon">
+      derived_file="newribbon"
+      title="New Ribbon Bar">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR hooks up and fixes the outlying problems with importing or appending dialogs from a Windows Resource file. Everything works through the calls to either `WinResource::Import()` or `WinResource::ImportRc()`. It should now be possible to have a long-running branch as the import functionality gets flushed out without any need to change the main branch outside of syncing.

Note that so far, only empty dialogs can be imported -- everything else in the DIALOG template is ignored (though it is parsed).