### PR TITLE
Switch to Node storage for Windows Resource conversion

### DIFF
--- a/src/import/import_winres.cpp
+++ b/src/import/import_winres.cpp
@@ -174,7 +174,7 @@ void WinResource::InsertDialogs(std::vector<ttlib::cstr>& dialogs)
     {
         for (auto& dlg: m_forms)
         {
-            if (dlg_name.is_sameas(dlg.m_Name))
+            if (dlg_name.is_sameas(dlg.GetFormName()))
             {
                 FormToNode(dlg);
                 break;
@@ -185,47 +185,14 @@ void WinResource::InsertDialogs(std::vector<ttlib::cstr>& dialogs)
 
 void WinResource::FormToNode(rcForm& form)
 {
-    if (form.m_Styles.contains("wxDEFAULT_DIALOG_STYLE"))
+    switch (form.GetFormType())
     {
-        auto dlg_node = g_NodeCreator.CreateNode(gen_wxDialog, m_project.get());
-        m_project->AddChild(dlg_node);
-        dlg_node->SetParent(m_project);
-
-        auto parent_sizer = g_NodeCreator.CreateNode(gen_wxBoxSizer, dlg_node.get());
-        dlg_node->AddChild(parent_sizer);
-        parent_sizer->SetParent(dlg_node);
-        parent_sizer->prop_set_value(prop_orientation, "wxVERTICAL");
-
-        if (form.m_Name.size())
-        {
-            dlg_node->prop_set_value(prop_var_name, form.m_Name);
-        }
-        if (form.m_Title.size())
-        {
-            dlg_node->prop_set_value(prop_title, form.m_Title);
-        }
-        if (form.m_Center.size() && form.m_Center.is_sameas("wxBOTH"))
-        {
-            dlg_node->prop_set_value(prop_center, form.m_Center);
-        }
-
-        if (form.m_Styles.size())
-        {
-            dlg_node->prop_set_value(prop_style, form.m_Styles);
-        }
-        if (form.m_ExStyles.size())
-        {
-            dlg_node->prop_set_value(prop_extra_style, form.m_ExStyles);
-        }
-        if (form.m_WinStyles.size())
-        {
-            dlg_node->prop_set_value(prop_window_style, form.m_WinStyles);
-        }
-        if (form.m_WinExStyles.size())
-        {
-            dlg_node->prop_set_value(prop_window_extra_style, form.m_WinExStyles);
-        }
-
-        dlg_node->prop_set_value(prop_size, ttlib::cstr() << form.m_rc.right << ',' << form.m_rc.bottom);
+        case rcForm::form_dialog:
+            {
+                auto node = g_NodeCreator.MakeCopy(form.GetFormNode());
+                m_project->AddChild(node);
+                node->SetParent(m_project);
+            }
+            return;
     }
 }

--- a/src/import/import_winres.cpp
+++ b/src/import/import_winres.cpp
@@ -67,6 +67,19 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
     m_project = g_NodeCreator.CreateNode(gen_Project, nullptr);
     m_codepage = 1252;
 
+    // Resource statements often continue onto the next line. Processing a statement is more straightforward if
+    // everything needed is on a single line, so we combine those lines here. Note that this will make error messages
+    // about parsing problems not be accurate in terms of the line number.
+
+    for (size_t idx = 0; idx < m_file.size() - 1; ++idx)
+    {
+        if (m_file[idx].size() && (m_file[idx].back() == ',' || m_file[idx].back() == '|'))
+        {
+            m_file[idx] << m_file[idx + 1].view_nonspace();
+            m_file.RemoveLine(idx + 1);
+        }
+    }
+
     try
     {
         for (m_curline = 0; m_curline < m_file.size(); ++m_curline)
@@ -185,6 +198,8 @@ void WinResource::InsertDialogs(std::vector<ttlib::cstr>& dialogs)
 
 void WinResource::FormToNode(rcForm& form)
 {
+    form.AddSizersAndChildren();
+
     switch (form.GetFormType())
     {
         case rcForm::form_dialog:

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -9,6 +9,8 @@
 
 #include "node.h"  // Node class
 
+// Same as the Windows RECT structure -- this version declared to provide a cross-platform
+// version
 struct RC_RECT
 {
     int32_t left;
@@ -31,32 +33,6 @@ public:
     auto GetLeft() const { return m_rc.left; }
     auto GetTop() const { return m_rc.top; }
 
-    // These are public so that the WinResource class can easily access them while it converts parse forms into
-    // wxUiEditor objects
-
-    ttlib::cstr m_ID;
-    ttlib::cstr m_Class;
-    ttlib::cstr m_Value;
-    ttlib::cstr m_Label;
-    ttlib::cstr m_ToolTip;
-
-    ttlib::cstr m_Styles;
-    ttlib::cstr m_WinStyles;
-    ttlib::cstr m_WinExStyles;
-
-    int m_Wrap { -1 };
-    int m_MaxLength { -1 };
-    int m_minWidth;
-    int m_minHeight;
-
-    RC_RECT m_rc { 0, 0, 0, 0 };
-
-    bool m_isMultiLine { false };
-    bool m_isDefault { false };
-    bool m_isChecked { false };
-    bool m_isEnabled { true };
-    bool m_isHidden { false };
-    bool m_isPlaced { false };
 
 protected:
     void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
@@ -67,20 +43,11 @@ protected:
     ttlib::cview StepOverQuote(ttlib::cview line, ttlib::cstr& str);
     ttlib::cview StepOverComma(ttlib::cview line, ttlib::cstr& str);
 
-    inline void AddStyle(std::string_view style)
-    {
-        if (!m_Styles.empty())
-            m_Styles.append("|");
-        m_Styles.append(style);
-    }
-
-    inline void AddWinStyle(std::string_view style)
-    {
-        if (!m_WinStyles.empty())
-            m_WinStyles.append("|");
-        m_WinStyles.append(style);
-    }
-
 private:
     NodeSharedPtr m_node;
+
+    RC_RECT m_rc { 0, 0, 0, 0 };
+
+    int m_minHeight;
+    int m_minWidth;
 };

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -7,9 +7,8 @@
 
 #pragma once
 
-#if 0
-    #include "rcData.h"
-#else
+#include "node.h"  // Node class
+
 struct RC_RECT
 {
     int32_t left;
@@ -17,7 +16,6 @@ struct RC_RECT
     int32_t right;
     int32_t bottom;
 };
-#endif
 
 class rcCtrl
 {
@@ -47,6 +45,7 @@ public:
     int m_minHeight;
 
     RC_RECT m_rc { 0, 0, 0, 0 };
+    NodeSharedPtr m_node;
 
     bool m_isMultiLine { false };
     bool m_isDefault { false };

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -22,9 +22,14 @@ class rcCtrl
 public:
     rcCtrl();
 
+    auto GetNode() { return m_node; }
+
     void ParseStaticCtrl(ttlib::cview line);
     void ParseEditCtrl(ttlib::cview line);
     void ParsePushButton(ttlib::cview line);
+
+    auto GetLeft() const { return m_rc.left; }
+    auto GetTop() const { return m_rc.top; }
 
     // These are public so that the WinResource class can easily access them while it converts parse forms into
     // wxUiEditor objects
@@ -45,7 +50,6 @@ public:
     int m_minHeight;
 
     RC_RECT m_rc { 0, 0, 0, 0 };
-    NodeSharedPtr m_node;
 
     bool m_isMultiLine { false };
     bool m_isDefault { false };
@@ -55,6 +59,8 @@ public:
     bool m_isPlaced { false };
 
 protected:
+    void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
+
     void ParseCommonStyles(ttlib::cview line);
     void GetDimensions(ttlib::cview line);
 
@@ -74,4 +80,7 @@ protected:
             m_WinStyles.append("|");
         m_WinStyles.append(style);
     }
+
+private:
+    NodeSharedPtr m_node;
 };

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -298,7 +298,7 @@ void rcForm::AddSizersAndChildren()
     for (auto& iter: m_ctrls)
     {
         auto child_node = iter.GetNode();
-        if (child_node && child_node->isGen(gen_wxStaticText))
+        if (child_node)
         {
             m_gridbag->AddChild(child_node);
             child_node->SetParent(m_gridbag);

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -7,9 +7,12 @@
 
 #include "pch.h"
 
+#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+
 #include "winres_form.h"
 
-#include "uifuncs.h"  // Miscellaneous functions for displaying UI
+#include "node_creator.h"  // NodeCreator -- Class used to create nodes
+#include "uifuncs.h"       // Miscellaneous functions for displaying UI
 
 rcForm::rcForm() {}
 
@@ -20,13 +23,53 @@ void rcForm::ParseDialog(ttlib::textfile& txtfile, size_t& curTxtLine)
     if (end == tt::npos)
         throw std::invalid_argument(_tt("Expected an ID then a DIALOG or DIALOGEX."));
 
-    // TODO: [KeyWorks - 10-18-2020] While unusual, I think it's possible the dialog is a quoted string instead of an
-    // ID.
-    m_ID = line.substr(0, end);
+    bool isDialog = true;
+
+    for (size_t idx = curTxtLine; idx < txtfile.size(); ++idx)
+    {
+        line = txtfile[curTxtLine].subview(txtfile[idx].find_nonspace());
+        if (line.is_sameprefix("STYLE"))
+        {
+            ttlib::cstr style(txtfile[curTxtLine]);
+
+            // A line ending with a , or | character means it is continued onto the next line.
+            while (style.back() == ',' || style.back() == '|')
+            {
+                std::string_view tmp("");
+                for (++curTxtLine; curTxtLine < txtfile.size(); ++curTxtLine)
+                {
+                    tmp = ttlib::find_nonspace(txtfile[curTxtLine]);
+                    if (!tmp.empty() && tmp[0] != '/')  // ignore blank lines and comments
+                        break;
+                }
+                style += tmp;
+            }
+
+            // Now that we've gathered up all the styles, check for DS_CONTROL -- if that's set, then we need to create a
+            // PanelForm not a wxDialog.
+            isDialog = style.contains("DS_CONTROL");
+            break;
+        }
+    }
+
+    m_form_type = isDialog ? form_dialog : form_panel;
+    m_node = g_NodeCreator.NewNode(isDialog ? gen_wxDialog : gen_PanelForm);
+
+    ttlib::cstr value;  // General purpose string we can use throughout this function
+    value = line.substr(0, end);
+    if (value[0] == '"')
+    {
+        value.erase(0, 1);
+        if (value.back() == '"')
+        {
+            value.erase(value.size() - 1, 1);
+        }
+    }
+    m_node->prop_set_value(prop_id, value);
 
     // Note that we can't change the name here or we won't match with the list of names saved from the dialog that got
     // the resource file.
-    m_Name = line.substr(0, end);
+    m_node->prop_set_value(prop_class_name, line.substr(0, end));
 
     line.remove_prefix(end);
     line.moveto_digit();
@@ -42,7 +85,8 @@ void rcForm::ParseDialog(ttlib::textfile& txtfile, size_t& curTxtLine)
         else if (line.is_sameprefix("CAPTION"))
         {
             line.moveto_nextword();
-            m_Title.ExtractSubString(line);
+            value.ExtractSubString(line);
+            m_node->prop_set_value(prop_caption, value);
         }
         else if (line.is_sameprefix("FONT"))
         {
@@ -80,17 +124,17 @@ void rcForm::AddStyle(ttlib::textfile& txtfile, size_t& curTxtLine)
     }
 
     if (style.contains("DS_CENTER"))
-        m_Center = "wxBOTH";
+        m_node->prop_set_value(prop_center, "wxBOTH");
     if (style.contains("WS_EX_CONTEXTHELP"))
-        m_ExStyles += "wxDIALOG_EX_CONTEXTHELP";
+        m_node->prop_set_value(prop_extra_style, "wxDIALOG_EX_CONTEXTHELP");
 
     ttlib::cstr original_styles(ttlib::stepover(style));
 
     if (original_styles.contains("DS_MODALFRAME"))
     {
-        m_Styles = "wxDEFAULT_DIALOG_STYLE";
-        // It's common for dialogs to duplicate the sytles that DS_MODALFRAM add, so we remove them here to
-        // avoid adding them.
+        m_node->prop_set_value(prop_style, "wxDEFAULT_DIALOG_STYLE");
+        // It's common for dialogs to duplicate the styles that DS_MODALFRAME add, so we remove them here to
+        // avoid adding them later.
         original_styles.Replace("WS_CAPTION", "");
         original_styles.Replace("WS_SYSMENU", "");
         original_styles.Replace("WS_POPUP", "");
@@ -98,57 +142,47 @@ void rcForm::AddStyle(ttlib::textfile& txtfile, size_t& curTxtLine)
 
     if (original_styles.contains("WS_CAPTION"))
     {
-        if (!m_Styles.empty())
-            m_Styles += "|";
-        m_Styles += "wxCAPTION";
+        AppendStyle(prop_style, "wxCAPTION");
     }
 
-    if (original_styles.find("WS_SYSMENU") != tt::npos)
+    if (original_styles.contains("WS_SYSMENU"))
     {
-        if (!m_Styles.empty())
-            m_Styles += "|";
-        m_Styles += "wxSYSTEM_MENU";
+        AppendStyle(prop_style, "wxSYSTEM_MENU");
     }
 
-    if (original_styles.find("WS_MAXIMIZEBOX") != tt::npos)
+    if (original_styles.contains("WS_MAXIMIZEBOX"))
     {
-        if (!m_Styles.empty())
-            m_Styles += "|";
-        m_Styles += "wxMAXIMIZE_BOX";
+        AppendStyle(prop_style, "wxMAXIMIZE_BOX");
     }
 
-    if (original_styles.find("WS_MINIMIZEBOX") != tt::npos)
+    if (original_styles.contains("WS_MINIMIZEBOX"))
     {
-        if (!m_Styles.empty())
-            m_Styles += "|";
-        m_Styles += "wxMINIMIZE_BOX";
+        AppendStyle(prop_style, "wxMINIMIZE_BOX");
     }
 
     if (original_styles.find("WS_THICKFRAME") != tt::npos || original_styles.find("WS_SIZEBOX") != tt::npos)
     {
-        // There is no thick frame in wxWidgets -- wxBORDER_THEME is at least a double frame
-        if (m_WinStyles.size())
-            m_WinStyles += "|";
-        m_WinStyles += "wxBORDER_THEME";
+        // In spite of what the documentation states (as of 3.1.6) there is no wxTHICK_FRAME. The closest would be
+        // wxBORDER_THEME.
+
+        // wxDialog interface (forms.xml) doesn't support this
+        // AppendStyle(prop_style, "wxBORDER_THEME");
     }
 
     if (original_styles.find("WS_CLIPCHILDREN") != tt::npos)
     {
-        if (!m_WinStyles.empty())
-            m_WinStyles += "|";
-        m_WinStyles += "wxCLIP_CHILDREN";
+        // wxDialog interface (forms.xml) doesn't support this
+        // AppendStyle(prop_style, "wxCLIP_CHILDREN");
     }
 
     if (original_styles.find("WS_CLIPSIBLINGS") != tt::npos)
     {
-        // Not supported
+        // This won't make sense for the dialog we create since we don't allow overlapping children.
     }
 
     if (original_styles.find("WS_POPUP") != tt::npos)
     {
-        if (!m_WinStyles.empty())
-            m_WinStyles += "|";
-        m_WinStyles += "wxPOPUP_WINDOW|wxBORDER_DEFAULT";
+        // There is a wxPOPUP_WINDOW, but does it work with dialogs?
     }
 
     // REVIEW: [KeyWorks - 08-24-2019] Note that we do not convert WS_HSCROLL or WS_VSCROLL.
@@ -156,9 +190,7 @@ void rcForm::AddStyle(ttlib::textfile& txtfile, size_t& curTxtLine)
 
     if (original_styles.find("WS_EX_TOPMOST") != tt::npos)
     {
-        if (!m_Styles.empty())
-            m_Styles += "|";
-        m_Styles += "wxSTAY_ON_TOP";
+        AppendStyle(prop_style, "WS_EX_TOPMOST");
     }
 }
 
@@ -261,4 +293,13 @@ void rcForm::GetDimensions(ttlib::cview line)
     m_rc.right = (m_rc.right * 6) / 4;
     m_rc.top = (m_rc.top * 13) / 8;
     m_rc.bottom = (m_rc.bottom * 13) / 8;
+}
+
+void rcForm::AppendStyle(GenEnum::PropName prop_name, ttlib::cview style)
+{
+    ttlib::cstr updated_style = m_node->prop_as_string(prop_name);
+    if (updated_style.size())
+        updated_style << '|';
+    updated_style << style;
+    m_node->prop_set_value(prop_name, updated_style);
 }

--- a/src/import/winres/winres_form.h
+++ b/src/import/winres/winres_form.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+
 #include "gen_enums.h"    // Enumerations for generators
 #include "node.h"         // Node class
 #include "winres_ctrl.h"  // rcCtrl -- Process Windows Resource control data
 
-class ttlib::textfile;
+constexpr int32_t FudgeAmount = 3;
 
 // This will either be a wxDialog or a MenuBar
 class rcForm
@@ -27,6 +29,9 @@ public:
     };
 
     void ParseDialog(ttlib::textfile& txtfile, size_t& curTxtLine);
+
+    // Call this after
+    void AddSizersAndChildren();
     size_t GetFormType() const { return m_form_type; }
     Node* GetFormNode() { return m_node.get(); }
     auto GetFormName() { return m_node->prop_as_string(prop_class_name); }
@@ -37,9 +42,13 @@ protected:
     void ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine);
     void GetDimensions(ttlib::cview line);
 
+    // Returns true if val1 is within range of val2 using a fudge value below and above val2.
+    bool isInRange(int32_t val1, int32_t val2) { return (val1 >= (val2 - FudgeAmount) && val1 <= (val2 + FudgeAmount)); }
+
 private:
     RC_RECT m_rc { 0, 0, 0, 0 };
     NodeSharedPtr m_node;
+    NodeSharedPtr m_gridbag;
     std::vector<rcCtrl> m_ctrls;
     size_t m_form_type;
 };

--- a/src/import/winres/winres_form.h
+++ b/src/import/winres/winres_form.h
@@ -7,41 +7,39 @@
 
 #pragma once
 
-#include <tttextfile.h>  // ttTextFile -- Similar to wxTextFile, but uses UTF8 strings
+#include "gen_enums.h"    // Enumerations for generators
+#include "node.h"         // Node class
+#include "winres_ctrl.h"  // rcCtrl -- Process Windows Resource control data
 
-#include "winres_ctrl.h"
+class ttlib::textfile;
 
+// This will either be a wxDialog or a MenuBar
 class rcForm
 {
 public:
     rcForm();
 
+    enum : size_t
+    {
+        form_dialog,
+        form_panel,
+        form_menu,
+    };
+
     void ParseDialog(ttlib::textfile& txtfile, size_t& curTxtLine);
-
-    // These are public so that the WinResource class can easily access them while it converts parse forms into
-    // wxUiEditor objects
-
-    ttlib::cstr m_Name;
-    ttlib::cstr m_Title;
-    ttlib::cstr m_Font;
-    ttlib::cstr m_ID;
-
-    ttlib::cstr m_BaseName;     // Generated filename
-    ttlib::cstr m_DerivedName;  // Derived filename
-
-    ttlib::cstr m_Styles;
-    ttlib::cstr m_ExStyles;
-    ttlib::cstr m_WinStyles;
-    ttlib::cstr m_WinExStyles;
-
-    ttlib::cstr m_Center;  // wxBOTH, wxHORIZONTAL, or wxVERTICAL
-
-    std::vector<rcCtrl> m_ctrls;
-
-    RC_RECT m_rc { 0, 0, 0, 0 };
+    size_t GetFormType() const { return m_form_type; }
+    Node* GetFormNode() { return m_node.get(); }
+    auto GetFormName() { return m_node->prop_as_string(prop_class_name); }
 
 protected:
+    void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
     void AddStyle(ttlib::textfile& txtfile, size_t& curTxtLine);
     void ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine);
     void GetDimensions(ttlib::cview line);
+
+private:
+    RC_RECT m_rc { 0, 0, 0, 0 };
+    NodeSharedPtr m_node;
+    std::vector<rcCtrl> m_ctrls;
+    size_t m_form_type;
 };

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -197,7 +197,7 @@ protected:
     void OnEmbedImageConverter(wxCommandEvent& event) override;
     void OnGenInhertedClass(wxCommandEvent& event) override;
     void OnGenerateCode(wxCommandEvent& event) override;
-    void OnImportWindowsResource(wxCommandEvent& event);
+    void OnImportWindowsResource(wxCommandEvent& event) override;
     void OnInsertWidget(wxCommandEvent&) override;
     void OnNewProject(wxCommandEvent& event);
     void OnOpenProject(wxCommandEvent& event) override;

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -59,8 +59,6 @@
                 help="Highlight the URLs and generate the wxTextUrlEvents when mouse events occur over them. This style is only supported for wxTE_RICH Win32 and multi-line wxGTK2 text controls." />
             <option name="wxTE_NOHIDESEL"
                 help="By default, the Windows text control doesn't show the selection when it doesn't have focus - use this style to force it to always show it. This style is ignored under other platforms." />
-            <option name="wxHSCROLL"
-                help="A horizontal scrollbar will be created and used, so that text won't be wrapped. No effect under wxGTK1." />
             <option name="wxTE_NO_VSCROLL"
                 help="For multiline controls only: a vertical scrollbar will never be created. This limits the amount of text which can be entered into the control to what can be displayed in it under MSW but not under GTK2. Currently not implemented for the other platforms." />
             <option name="wxTE_LEFT"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR converts Windows Resource conversion to use Nodes for storing forms and controls. This makes it easy to hook up the controls to sizers once all of the initial processing is done. It also means we use the same mechanism for editing properties in this conversion code as we do all the other conversion classes.

There are a couple of miscellaneous simple bug fixes that were uncovered while working on this code.