### PR TITLE
Windows Resource conversion additions

### DIFF
--- a/src/import/winres/winres_ctrl.cpp
+++ b/src/import/winres/winres_ctrl.cpp
@@ -292,7 +292,7 @@ void rcCtrl::ParsePushButton(ttlib::cview line)
     {
         ttlib::cstr label;
         line = StepOverQuote(line, label);
-        m_node->prop_set_value(prop_label, ConvertEscapeSlashes(label));
+        m_node->prop_set_value(prop_label, label);
     }
     else
     {
@@ -327,6 +327,45 @@ void rcCtrl::ParsePushButton(ttlib::cview line)
     {
         throw std::invalid_argument("Expected edit control ID to be followed with a comma and dimensions.");
     }
+}
+
+void rcCtrl::ParseGroupBox(ttlib::cview line)
+{
+    m_node = g_NodeCreator.NewNode(gen_wxStaticBoxSizer);
+
+    line.moveto_nextword();
+    // This should be the label (can be empty but must be quoted).
+    if (line[0] == '"')
+    {
+        ttlib::cstr label;
+        line = StepOverQuote(line, label);
+        m_node->prop_set_value(prop_label, label);
+    }
+
+    // This should be the id (typically IDC_STATIC).
+    if (line[0] == ',')
+    {
+        ttlib::cstr id;
+        line = StepOverComma(line, id);
+        if (!id.is_sameas("IDC_STATIC"))
+            m_node->prop_set_value(prop_id, id);
+    }
+    else
+    {
+        throw std::invalid_argument("Expected GROUPBOX label to be followed with a comma and an ID.");
+    }
+
+    // This should be the dimensions.
+    if (ttlib::is_digit(line[0]) || line[0] == ',')
+    {
+        GetDimensions(line);
+    }
+    else
+    {
+        throw std::invalid_argument("Expected GROUPBOX ID to be followed with a comma and dimensions.");
+    }
+
+    ParseCommonStyles(line);
 }
 
 void rcCtrl::AppendStyle(GenEnum::PropName prop_name, ttlib::cview style)

--- a/src/import/winres/winres_ctrl.cpp
+++ b/src/import/winres/winres_ctrl.cpp
@@ -10,6 +10,7 @@
 #include "winres_ctrl.h"
 
 #include "node_creator.h"  // NodeCreator -- Class used to create nodes
+#include "utils.h"         // Utility functions that work with properties
 
 rcCtrl::rcCtrl() {}
 
@@ -107,7 +108,8 @@ void rcCtrl::ParseStaticCtrl(ttlib::cview line)
     {
         ttlib::cstr label;
         line = StepOverQuote(line, label);
-        m_node->prop_set_value(prop_label, label);
+
+        m_node->prop_set_value(prop_label, ConvertEscapeSlashes(label));
     }
     else
     {
@@ -290,7 +292,7 @@ void rcCtrl::ParsePushButton(ttlib::cview line)
     {
         ttlib::cstr label;
         line = StepOverQuote(line, label);
-        m_node->prop_set_value(prop_label, label);
+        m_node->prop_set_value(prop_label, ConvertEscapeSlashes(label));
     }
     else
     {
@@ -310,7 +312,6 @@ void rcCtrl::ParsePushButton(ttlib::cview line)
             m_node->prop_set_value(prop_id, "wxID_CANCEL");
         else
             m_node->prop_set_value(prop_id, id);
-
     }
     else
     {

--- a/src/import/winres/winres_ctrl.cpp
+++ b/src/import/winres/winres_ctrl.cpp
@@ -65,6 +65,25 @@ void rcCtrl::GetDimensions(ttlib::cview line)
     if (line.empty() || !ttlib::is_digit(line[0]))
         throw std::invalid_argument("Expected a numeric dimension value");
     m_rc.bottom = ttlib::atoi(line);
+
+    /*
+
+        On Windows 10, dialogs are supposed to use Segoe UI, 9pt font. However, a lot of dialogs are going to be using
+        "MS Shell Dlg" or "MS Shell Dlg2" using an 8pt size. Those coordinates will end up being wrong when displayed by
+        wxWidgets because wxWidgets follows the Windows 10 guidelines which normally uses a 9pt font.
+
+        The following code converts dialog coordinates into pixels assuming a 9pt font.
+
+        For the most part, these values are simply used to determine which sizer to place the control in. However, it will
+        change things like the wrapping width of a wxStaticText -- it will be larger if the dialog used an 8pt font, smaller
+        if it used a 10pt font.
+
+    */
+
+    m_left = static_cast<int>((static_cast<int64_t>(m_rc.left) * 7 / 4));
+    m_width = static_cast<int>((static_cast<int64_t>(m_rc.right) * 7 / 4));
+    m_top = static_cast<int>((static_cast<int64_t>(m_rc.top) * 15 / 4));
+    m_height = static_cast<int>((static_cast<int64_t>(m_rc.bottom) * 15 / 4));
 }
 
 ttlib::cview rcCtrl::StepOverQuote(ttlib::cview line, ttlib::cstr& str)

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -24,15 +24,17 @@ class rcCtrl
 public:
     rcCtrl();
 
-    auto GetNode() { return m_node; }
+    auto GetNode() const { return m_node; }
 
     void ParseEditCtrl(ttlib::cview line);
     void ParseGroupBox(ttlib::cview line);
     void ParsePushButton(ttlib::cview line);
     void ParseStaticCtrl(ttlib::cview line);
 
-    auto GetLeft() const { return m_rc.left; }
-    auto GetTop() const { return m_rc.top; }
+    auto GetLeft() const { return m_left; }
+    auto GetTop() const { return m_top; }
+    auto GetRight() const { return (m_left + m_width); }
+    auto GetBottom() const { return (m_top + m_height); }
     auto GetWidth() const { return m_width; }
     auto GetHeight() const { return m_height; }
 

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -33,6 +33,8 @@ public:
 
     auto GetLeft() const { return m_rc.left; }
     auto GetTop() const { return m_rc.top; }
+    auto GetWidth() const { return m_width; }
+    auto GetHeight() const { return m_height; }
 
 protected:
     void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
@@ -46,6 +48,16 @@ protected:
 private:
     NodeSharedPtr m_node;
 
+    // left position in pixel coordinate
+    int m_left;
+    // top position in pixel coordinate
+    int m_top;
+    // width in pixels
+    int m_width;
+    // heihgt in pixels
+    int m_height;
+
+    // These are in dialog coordinates
     RC_RECT m_rc { 0, 0, 0, 0 };
 
     int m_minHeight;

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -26,13 +26,13 @@ public:
 
     auto GetNode() { return m_node; }
 
-    void ParseStaticCtrl(ttlib::cview line);
     void ParseEditCtrl(ttlib::cview line);
+    void ParseGroupBox(ttlib::cview line);
     void ParsePushButton(ttlib::cview line);
+    void ParseStaticCtrl(ttlib::cview line);
 
     auto GetLeft() const { return m_rc.left; }
     auto GetTop() const { return m_rc.top; }
-
 
 protected:
     void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -86,7 +86,7 @@ void rcForm::ParseDialog(ttlib::textfile& txtfile, size_t& curTxtLine)
         {
             line.moveto_nextword();
             value.ExtractSubString(line);
-            m_node->prop_set_value(prop_caption, value);
+            m_node->prop_set_value(prop_title, value);
         }
         else if (line.is_sameprefix("FONT"))
         {

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -288,6 +288,10 @@ void rcForm::AddSizersAndChildren()
     m_gridbag = g_NodeCreator.CreateNode(gen_wxGridBagSizer, parent.get());
     parent->Adopt(m_gridbag);
 
+    // First sort horizontally
+    std::sort(std::begin(m_ctrls), std::end(m_ctrls), [](rcCtrl a, rcCtrl b) { return a.GetLeft() < b.GetLeft(); });
+
+    // Now sort vertically
     std::sort(std::begin(m_ctrls), std::end(m_ctrls), [](rcCtrl a, rcCtrl b) { return a.GetTop() < b.GetTop(); });
 
     int row = -1;
@@ -295,17 +299,18 @@ void rcForm::AddSizersAndChildren()
 
     int32_t top = 0;
 
-    for (auto& iter: m_ctrls)
+    for (size_t idx_child = 0; idx_child < m_ctrls.size(); ++idx_child)
     {
-        auto child_node = iter.GetNode();
+        auto child_node = m_ctrls[idx_child].GetNode();
         if (child_node)
         {
             m_gridbag->Adopt(child_node);
-            if (!isInRange(iter.GetTop(), top))
+
+            if (!isInRange(m_ctrls[idx_child].GetTop(), top))
             {
                 ++row;
                 column = 0;
-                top = iter.GetTop();
+                top = m_ctrls[idx_child].GetTop();
             }
             else
             {

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -219,6 +219,13 @@ void rcForm::ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine)
             auto& control = m_ctrls.emplace_back();
             control.ParsePushButton(line);
         }
+#if 0
+        else if (line.is_sameprefix("GROUPBOX"))
+        {
+            auto& control = m_ctrls.emplace_back();
+            control.ParseGroupBox(line);
+        }
+#endif
     }
 }
 
@@ -294,10 +301,9 @@ void rcForm::AddSizersAndChildren()
     // Now sort vertically
     std::sort(std::begin(m_ctrls), std::end(m_ctrls), [](rcCtrl a, rcCtrl b) { return a.GetTop() < b.GetTop(); });
 
-    int row = -1;
-    int column = 0;
+    m_row = -1;
 
-    int32_t top = 0;
+    m_last_child_top = 0;
 
     for (size_t idx_child = 0; idx_child < m_ctrls.size(); ++idx_child)
     {
@@ -306,19 +312,40 @@ void rcForm::AddSizersAndChildren()
         {
             m_gridbag->Adopt(child_node);
 
-            if (!isInRange(m_ctrls[idx_child].GetTop(), top))
+            if (!isInRange(m_ctrls[idx_child].GetTop(), m_last_child_top))
             {
-                ++row;
-                column = 0;
-                top = m_ctrls[idx_child].GetTop();
+                ++m_row;
+                m_column = 0;
+                m_last_child_top = m_ctrls[idx_child].GetTop();
             }
             else
             {
-                ++column;
+                ++m_column;
             }
 
-            child_node->prop_set_value(prop_row, row);
-            child_node->prop_set_value(prop_column, column);
+            child_node->prop_set_value(prop_row, m_row);
+            child_node->prop_set_value(prop_column, m_column);
+
+            if (child_node->isGen(gen_wxStaticBoxSizer))
+                AddStaticBoxChildren(idx_child);
         }
     }
+}
+
+void rcForm::AddStaticBoxChildren(size_t& idx_child)
+{
+    const auto& static_box = m_ctrls[idx_child];
+    for (size_t idx_group_child = idx_child + 1; idx_group_child < m_ctrls.size(); ++idx_group_child)
+    {
+        const auto& child_ctrl = m_ctrls[idx_group_child];
+        if (child_ctrl.GetRight() > static_box.GetRight() || child_ctrl.GetTop() > static_box.GetBottom())
+            break;
+        static_box.GetNode()->Adopt(child_ctrl.GetNode());
+
+        // Update to that caller won't process this child.
+        ++idx_child;
+    }
+
+    // TODO: [KeyWorks - 05-31-2021] Depending on the number and position of the children, we may need to change the
+    // orientation as well as spanning more than one column or row.
 }

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -288,6 +288,8 @@ void rcForm::AddSizersAndChildren()
     m_gridbag = g_NodeCreator.CreateNode(gen_wxGridBagSizer, parent.get());
     parent->Adopt(m_gridbag);
 
+    std::sort(std::begin(m_ctrls), std::end(m_ctrls), [](rcCtrl a, rcCtrl b) { return a.GetTop() < b.GetTop(); });
+
     int row = -1;
     int column = 0;
 

--- a/src/import/winres/winres_form.h
+++ b/src/import/winres/winres_form.h
@@ -37,10 +37,11 @@ public:
     auto GetFormName() { return m_node->prop_as_string(prop_class_name); }
 
 protected:
-    void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
+    void AddStaticBoxChildren(size_t& idx_child);
     void AddStyle(ttlib::textfile& txtfile, size_t& curTxtLine);
-    void ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine);
+    void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
     void GetDimensions(ttlib::cview line);
+    void ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine);
 
     // Returns true if val1 is within range of val2 using a fudge value below and above val2.
     bool isInRange(int32_t val1, int32_t val2) { return (val1 >= (val2 - FudgeAmount) && val1 <= (val2 + FudgeAmount)); }
@@ -51,4 +52,8 @@ private:
     NodeSharedPtr m_gridbag;
     std::vector<rcCtrl> m_ctrls;
     size_t m_form_type;
+
+    int m_row;
+    int m_column;
+    int m_last_child_top;
 };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR sorts controls horizontally then vertically, adds conversion of Dialog coordinates into pixels, and adds initial code for converting GROUPBOX into **wxStaticBoxSizer**.
