### PR TITLE
Refactor and expand Windows Resource conversion

### DIFF
--- a/src/import/import_winres.cpp
+++ b/src/import/import_winres.cpp
@@ -85,7 +85,7 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
     {
         for (m_curline = 0; m_curline < m_file.size(); ++m_curline)
         {
-            auto curline = m_file[m_curline].subview();
+            auto curline = m_file[m_curline].view_nonspace();
             auto start = curline.find_nonspace();
             if (curline.empty() || curline[start] == '/')  // Ignore blank lines and comments.
                 continue;

--- a/src/import/import_winres.cpp
+++ b/src/import/import_winres.cpp
@@ -73,6 +73,7 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
 
     for (size_t idx = 0; idx < m_file.size() - 1; ++idx)
     {
+        m_file[idx].trim();
         if (m_file[idx].size() && (m_file[idx].back() == ',' || m_file[idx].back() == '|'))
         {
             m_file[idx] << m_file[idx + 1].view_nonspace();

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -24,7 +24,8 @@ class rcCtrl
 public:
     rcCtrl();
 
-    auto GetNode() const { return m_node; }
+    auto GetNode() const { return m_node.get(); }
+    auto GetNodePtr() const { return m_node; }
 
     void ParseControlCtrl(ttlib::cview line);
     void ParseEditCtrl(ttlib::cview line);
@@ -42,10 +43,22 @@ public:
 protected:
     void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
 
+    // Set prop_ to common values (disabled, hidden, scroll, etc.)
     void ParseCommonStyles(ttlib::cview line);
+
+    // Sets m_left, m_top, m_width and m_height in pixel dimensions
     void GetDimensions(ttlib::cview line);
 
+    // This will set prop_id, and return a cview to the position past the id
+    ttlib::cview GetID(ttlib::cview line);
+
+    // This will set prop_label, and return a cview to the position past the id
+    ttlib::cview GetLabel(ttlib::cview line);
+
+    // Returns a view past the closing quote, or an empty view if there was no closing quote
     ttlib::cview StepOverQuote(ttlib::cview line, ttlib::cstr& str);
+
+    // Retrieves any string between commas, returns view past the closing comma
     ttlib::cview StepOverComma(ttlib::cview line, ttlib::cstr& str);
 
 private:

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -13,10 +13,10 @@
 // version
 struct RC_RECT
 {
-    int32_t left;
-    int32_t top;
-    int32_t right;
-    int32_t bottom;
+    int left;
+    int top;
+    int right;
+    int bottom;
 };
 
 class rcCtrl
@@ -26,6 +26,7 @@ public:
 
     auto GetNode() const { return m_node; }
 
+    void ParseControlCtrl(ttlib::cview line);
     void ParseEditCtrl(ttlib::cview line);
     void ParseGroupBox(ttlib::cview line);
     void ParsePushButton(ttlib::cview line);

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -28,10 +28,6 @@ public:
     auto GetNodePtr() const { return m_node; }
 
     void ParseControlCtrl(ttlib::cview line);
-    void ParseEditCtrl(ttlib::cview line);
-    void ParseGroupBox(ttlib::cview line);
-    void ParsePushButton(ttlib::cview line);
-    void ParseStaticCtrl(ttlib::cview line);
 
     auto GetLeft() const { return m_left; }
     auto GetTop() const { return m_top; }
@@ -75,7 +71,4 @@ private:
 
     // These are in dialog coordinates
     RC_RECT m_rc { 0, 0, 0, 0 };
-
-    int m_minHeight;
-    int m_minWidth;
 };

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -315,7 +315,7 @@ void rcForm::AddSizersAndChildren()
         if (child.GetNode()->isGen(gen_wxStaticBoxSizer))
         {
             AddStaticBoxChildren(idx_child);
-            parent->Adopt(child.GetNode());
+            parent->Adopt(child.GetNodePtr());
             continue;
         }
 
@@ -335,7 +335,7 @@ void rcForm::AddSizersAndChildren()
             }
 
             // orphaned child, add to form's top level sizer
-            parent->Adopt(child.GetNode());
+            parent->Adopt(child.GetNodePtr());
             return;
         }
 
@@ -349,7 +349,7 @@ void rcForm::AddSizersAndChildren()
             while (idx_child < m_ctrls.size() && m_ctrls[idx_child].GetTop() == child.GetTop())
             {
                 // Note that we add the child we are comparing to first.
-                sizer->Adopt(m_ctrls[idx_child].GetNode());
+                sizer->Adopt(m_ctrls[idx_child].GetNodePtr());
                 ++idx_child;
             }
         }
@@ -357,7 +357,7 @@ void rcForm::AddSizersAndChildren()
         {
             sizer = g_NodeCreator.CreateNode(gen_VerticalBoxSizer, parent.get());
             parent->Adopt(sizer);
-            sizer->Adopt(child.GetNode());
+            sizer->Adopt(child.GetNodePtr());
 
             if (idx_child + 2 < m_ctrls.size())
             {
@@ -370,7 +370,7 @@ void rcForm::AddSizersAndChildren()
             while (idx_child < m_ctrls.size() && m_ctrls[idx_child].GetTop() != m_ctrls[idx_child - 1].GetTop())
             {
                 // Note that we add the child we are comparing to first.
-                sizer->Adopt(m_ctrls[idx_child].GetNode());
+                sizer->Adopt(m_ctrls[idx_child].GetNodePtr());
                 if (idx_child + 2 < m_ctrls.size())
                 {
                     // If the next two sizers have the same top, then they need to be placed in a horizontal sizer.
@@ -391,7 +391,7 @@ void rcForm::AddStaticBoxChildren(size_t& idx_child)
         const auto& child_ctrl = m_ctrls[idx_group_child];
         if (child_ctrl.GetRight() > static_box.GetRight() || child_ctrl.GetTop() > static_box.GetBottom())
             break;
-        static_box.GetNode()->Adopt(child_ctrl.GetNode());
+        static_box.GetNode()->Adopt(child_ctrl.GetNodePtr());
 
         // Update to that caller won't process this child.
         ++idx_child;

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -208,32 +208,12 @@ void rcForm::ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine)
         if (line.is_sameprefix("END"))
             break;
 
-        if (line.is_sameprefix("LTEXT") || line.is_sameprefix("CTEXT") || line.is_sameprefix("RTEXT"))
+        auto& control = m_ctrls.emplace_back();
+        control.ParseControlCtrl(line);
+        // If the control could not be converted into a node, then remove it from our list
+        if (!control.GetNode())
         {
-            auto& control = m_ctrls.emplace_back();
-            control.ParseStaticCtrl(line);
-        }
-        else if (line.is_sameprefix("EDITTEXT"))
-        {
-            auto& control = m_ctrls.emplace_back();
-            control.ParseEditCtrl(line);
-        }
-        else if (line.is_sameprefix("DEFPUSHBUTTON") || line.is_sameprefix("PUSHBUTTON"))
-        {
-            auto& control = m_ctrls.emplace_back();
-            control.ParsePushButton(line);
-        }
-        else if (line.is_sameprefix("GROUPBOX"))
-        {
-            auto& control = m_ctrls.emplace_back();
-            control.ParseGroupBox(line);
-        }
-        else if (line.is_sameprefix("CONTROL"))
-        {
-            auto& control = m_ctrls.emplace_back();
-            control.ParseControlCtrl(line);
-            if (!control.GetNode())
-                m_ctrls.pop_back();
+            m_ctrls.pop_back();
         }
     }
 }

--- a/src/import/winres/winres_form.h
+++ b/src/import/winres/winres_form.h
@@ -53,7 +53,8 @@ private:
     std::vector<rcCtrl> m_ctrls;
     size_t m_form_type;
 
-    int m_row;
-    int m_column;
-    int m_last_child_top;
+#if defined(_DEBUG)
+    // Makes it easier to know exactly which form we're looking at in the debugger
+    ttlib::cstr m_form_id;
+#endif // _DEBUG
 };

--- a/src/import/winres/winres_form.h
+++ b/src/import/winres/winres_form.h
@@ -33,8 +33,9 @@ public:
     // Call this after
     void AddSizersAndChildren();
     size_t GetFormType() const { return m_form_type; }
-    Node* GetFormNode() { return m_node.get(); }
-    auto GetFormName() { return m_node->prop_as_string(prop_class_name); }
+    Node* GetFormNode() const { return m_node.get(); }
+    auto GetFormName() const { return m_node->prop_as_string(prop_class_name); }
+    int GetWidth() const { return (m_rc.right - m_rc.left); }
 
 protected:
     void AddStaticBoxChildren(size_t& idx_child);

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -161,20 +161,20 @@
         <property name="auth_needed" type="bool"
             help="Sets whether an authentication needed symbol should be displayed on the button. This method doesn't do anything if the platform is not Windows Vista or newer.">0</property>
         <property name="style" type="bitlist">
-            <option name="wxBU_LEFT"
-                help="Left-justifies the label. Windows and GTK+ only." />
-            <option name="wxBU_TOP"
-                help="Aligns the label to the top of the button. Windows and GTK+ only." />
-            <option name="wxBU_RIGHT"
-                help="Right-justifies the bitmap label. Windows and GTK+ only." />
             <option name="wxBU_BOTTOM"
                 help="Aligns the label to the bottom of the button. Windows and GTK+ only." />
+            <option name="wxBU_LEFT"
+                help="Left-justifies the label. Windows and GTK+ only." />
+                <option name="wxBU_RIGHT"
+                help="Right-justifies the bitmap label. Windows and GTK+ only." />
+            <option name="wxBU_TOP"
+                help="Aligns the label to the top of the button. Windows and GTK+ only." />
             <option name="wxBU_EXACTFIT"
                 help="By default, all buttons are made of at least the standard button size, even if their contents is small enough to fit into a smaller size. This is done for consistency as most platforms use buttons of the same size in the native dialogs, but can be overridden by specifying this flag. If it is given, the button will be made just big enough for its contents. Notice that under MSW the button will still have at least the standard height, even with this style, if it has a non-empty label." />
             <option name="wxBU_NOTEXT"
                 help="Disables the display of the text label in the button even if it has one or its id is one of the standard stock ids with an associated label: without using this style a button which is only supposed to show a bitmap but uses a standard id would display a label too." />
             <option name="wxBORDER_NONE"
-                help="Creates a button without border. This is currently implemented in MSW, GTK2 and OSX/Cocoa and OSX/Carbon ports but in the latter only applies to buttons with bitmaps and using bitmap of one of the standard sizes only, namely 128*128, 48*48, 24*24 or 16*16. In all the other cases wxBORDER_NONE is ignored under OSX/Carbon (these restrictions don't exist in OSX/Cocoa however)." />
+                help="Creates a button without border. This is currently implemented in MSW, GTK2 and OSX/Cocoa and OSX/Carbon ports. In OSX/Carbon this only applies to buttons with bitmaps and using bitmap of one of the standard sizes only, namely 128*128, 48*48, 24*24 or 16*16. In all the other cases wxBORDER_NONE is ignored under OSX/Carbon (these restrictions don't exist in OSX/Cocoa however)." />
         </property>
         <event name="wxEVT_BUTTON" class="wxCommandEvent"
             help="Generated when the button is clicked" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR switches to a single function that handles either a CONTROL directive, or one of the individual directives. The downside to this approach is that the function is quite length. The upside is that either puts all processing for either type of RC directive into the same code. Aside from styles, most of the code processing is identical between controls.

Note that with this change, all non-image resource directives that use a name or style to specify the type of control are now supported.

The second major part of the PR is switching from using a wxGridBagSizer to using box sizers. The box sizers are going to be easier for the user to manipulate once the dialog is created. Some initial code is in place to determine whether sizers should be vertical or horizontal, including make sizer vertical in order to center or right-align it's child.
