### PR TITLE
Add support for ICON control

### DIFF
--- a/src/import/import_winres.h
+++ b/src/import/import_winres.h
@@ -5,6 +5,8 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
+#include <optional>
+
 #pragma once
 
 #include <ttcvector.h>
@@ -25,6 +27,9 @@ public:
     bool ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>& m_dialogs);
     void InsertDialogs(std::vector<ttlib::cstr>& dialogs);
 
+    std::optional<ttlib::cstr> FindIcon(const std::string& id);
+    std::optional<ttlib::cstr> FindBitmap(const std::string& id);
+
 protected:
     void FormToNode(rcForm& form);
     void ParseDialog();
@@ -41,6 +46,9 @@ private:
     ttlib::textfile m_file;
 
     std::vector<rcForm> m_forms;
+
+    std::map<std::string, ttlib::cstr> m_map_icons;
+    std::map<std::string, ttlib::cstr> m_map_bitmaps;
 
     size_t m_curline;
 

--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -9,6 +9,8 @@
 
 #include "node.h"  // Node class
 
+class WinResource;
+
 // Same as the Windows RECT structure -- this version declared to provide a cross-platform
 // version
 struct RC_RECT
@@ -27,7 +29,7 @@ public:
     auto GetNode() const { return m_node.get(); }
     auto GetNodePtr() const { return m_node; }
 
-    void ParseControlCtrl(ttlib::cview line);
+    void ParseDirective(WinResource* pWinResource, ttlib::cview line);
 
     auto GetLeft() const { return m_left; }
     auto GetTop() const { return m_top; }
@@ -57,8 +59,13 @@ protected:
     // Retrieves any string between commas, returns view past the closing comma
     ttlib::cview StepOverComma(ttlib::cview line, ttlib::cstr& str);
 
+    // Icon controls require too much special processing to be inside the ParseDirective()
+    // function.
+    void ParseIconControl(ttlib::cview line);
+
 private:
     NodeSharedPtr m_node;
+    WinResource* m_pWinResource;
 
     // left position in pixel coordinate
     int m_left;

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -16,8 +16,9 @@
 
 rcForm::rcForm() {}
 
-void rcForm::ParseDialog(ttlib::textfile& txtfile, size_t& curTxtLine)
+void rcForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, size_t& curTxtLine)
 {
+    m_pWinResource = pWinResource;
     auto line = txtfile[curTxtLine].subview();
     auto end = line.find_space();
     if (end == tt::npos)
@@ -209,7 +210,7 @@ void rcForm::ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine)
             break;
 
         auto& control = m_ctrls.emplace_back();
-        control.ParseControlCtrl(line);
+        control.ParseDirective(m_pWinResource, line);
         // If the control could not be converted into a node, then remove it from our list
         if (!control.GetNode())
         {

--- a/src/import/winres/winres_form.h
+++ b/src/import/winres/winres_form.h
@@ -13,6 +13,8 @@
 #include "node.h"         // Node class
 #include "winres_ctrl.h"  // rcCtrl -- Process Windows Resource control data
 
+class WinResource;
+
 constexpr int32_t FudgeAmount = 3;
 
 // This will either be a wxDialog or a MenuBar
@@ -28,7 +30,7 @@ public:
         form_menu,
     };
 
-    void ParseDialog(ttlib::textfile& txtfile, size_t& curTxtLine);
+    void ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, size_t& curTxtLine);
 
     // Call this after
     void AddSizersAndChildren();
@@ -53,6 +55,7 @@ private:
     NodeSharedPtr m_gridbag;
     std::vector<rcCtrl> m_ctrls;
     size_t m_form_type;
+    WinResource* m_pWinResource;
 
 #if defined(_DEBUG)
     // Makes it easier to know exactly which form we're looking at in the debugger


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds support for the ICON dialog control, as well as gathinging up maps of any BITMAP and ICON resources that were specified.

The `rcCtrl` class now contains a pointer to the `WinResource` class which has two new functions: `FindIcon()` and `FindBitmap()` which can be used to retrieve the original filename as specified in the resource file.