### PR TITLE
Support more Windows Resource controls

### DIFF
--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -38,8 +38,14 @@ public:
     auto GetWidth() const { return m_width; }
     auto GetHeight() const { return m_height; }
 
+    auto GetPostProcessStyle() { return m_non_processed_style; }
+
 protected:
-    void ParseTrackBarStyles(ttlib::cview line);
+    // This will map window styles to wxWidgets styles and append them to prop_style
+    void ParseStyles(ttlib::cview line);
+
+    void ParseListViewStyles(ttlib::cview line);
+    void ParseButtonStyles(ttlib::cview line);
 
     void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
 
@@ -74,6 +80,9 @@ protected:
 private:
     NodeSharedPtr m_node;
     WinResource* m_pWinResource;
+
+    // Some styles like UDS_AUTOBUDDY have to be post-processed during actual layout.
+    ttlib::cstr m_non_processed_style;
 
     // left position in pixel coordinate
     int m_left;

--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -216,6 +216,15 @@ void rcForm::ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine)
         {
             m_ctrls.pop_back();
         }
+        else if (control.GetNode()->isGen(gen_wxSpinCtrl) && control.GetPostProcessStyle().contains("UDS_AUTOBUDDY"))
+        {
+            auto cur_pos = m_ctrls.size() - 1;
+            if (cur_pos > 0 && m_ctrls[cur_pos - 1].GetNode()->isGen(gen_wxTextCtrl))
+            {
+                control.GetNode()->prop_set_value(prop_id, m_ctrls[cur_pos - 1].GetNode()->prop_as_string(prop_id));
+                m_ctrls.erase(m_ctrls.begin() + (cur_pos - 1));
+            }
+        }
     }
 }
 

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -141,6 +141,8 @@
                 help="Marks the beginning of a new group of radio buttons." />
             <option name="wxRB_SINGLE"
                 help="Creates a radio button which is not part of any radio button group. When this style is used, no other radio buttons will be turned off automatically then this button is checked." />
+            <option name="wxALIGN_RIGHT"
+                help="Aligns the radio button to the right of the text instead of the left." />
         </property>
         <event name="wxEVT_RADIOBUTTON" class="wxCommandEvent"
             help="Generated when the radio button is clicked." />
@@ -165,7 +167,7 @@
                 help="Aligns the label to the bottom of the button. Windows and GTK+ only." />
             <option name="wxBU_LEFT"
                 help="Left-justifies the label. Windows and GTK+ only." />
-                <option name="wxBU_RIGHT"
+            <option name="wxBU_RIGHT"
                 help="Right-justifies the bitmap label. Windows and GTK+ only." />
             <option name="wxBU_TOP"
                 help="Aligns the label to the top of the button. Windows and GTK+ only." />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR completes support for controls that Visual Studio version 16.09 can create that have a wxWidgets equivalent.

To increase code readability, many of the control names and styles have been placed in static lists that be handled by a general purpose function that uses an iteration loop. This can't always be used, since sometimes a style might determine which wxWidget class to use, or a style needs special processing.
