### PR TITLE
Change AssignSubString to step over escaped backslahes

### DIFF
--- a/ttLib/ttcstr.cpp
+++ b/ttLib/ttcstr.cpp
@@ -165,7 +165,8 @@ std::string_view cstr::view_substr(size_t offset, char chBegin, char chEnd)
             // is unnecessary. Should we support it?
 
             // only check quotes -- a slash is valid before other character pairs.
-            if (at(offset) == '\\' && (chBegin == '"' || chBegin == '\'') && offset + 1 < size() && (at(offset + 1) == chEnd))
+            if (at(offset) == '\\' && (chBegin == '"' || chBegin == '\'') && offset + 1 < size() &&
+                (at(offset + 1) == chEnd))
             {
                 // step over an escaped quote if the string to fetch is within a quote
                 offset += 2;
@@ -215,12 +216,15 @@ size_t cstr::AssignSubString(std::string_view src, char chBegin, char chEnd)
             // REVIEW: [KeyWorks - 01-26-2020] '\"' is also valid for the C compiler, though the slash
             // is unnecessary. Should we support it?
 
-            // only check quotes -- a slash is valid before other character pairs.
-            if (src[pos] == '\\' && (chBegin == '"' || chBegin == '\'') && pos + 1 < src.length() && (src[pos + 1] == chEnd))
+            // only check quotes and backslashes -- a slash is ignored before other character pairs.
+            if (src[pos] == '\\' && pos + 1 < src.length())
             {
-                // step over an escaped quote if the string to fetch is within a quote
-                pos += 2;
-                continue;
+                if (src[pos + 1] == '\\' || ((chBegin == '"' || chBegin == '\'') && src[pos + 1] == chEnd))
+                {
+                    // step over an escaped quote if the string to fetch is within a quote
+                    pos += 2;
+                    continue;
+                }
             }
             ++pos;
         }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a bug in ttlib::cstr::AssignSubString()

See https://github.com/KeyWorksRW/ttLib/issues/221

`ttlib::cstr::AssignSubString()` fails if last portion of a string is an escaped backslash.

The problem occurs when a Windows-style directory is passed in. For example,

```c++
    "d:\\aa\\bb\\......\\xx\\yy\\zz\\",342
```

Parsing that string would continue past the closing quote because of the trailing `\\` returning the length of the entire string.
