### PR TITLE
Change from ASSERT_MSG to MSG_ reporting

### DIFF
--- a/src/import/winres/winres_ctrl.h
+++ b/src/import/winres/winres_ctrl.h
@@ -84,6 +84,10 @@ private:
     // Some styles like UDS_AUTOBUDDY have to be post-processed during actual layout.
     ttlib::cstr m_non_processed_style;
 
+#if defined(_DEBUG)
+    ttlib::cstr m_original_line;
+#endif  // _DEBUG
+
     // left position in pixel coordinate
     int m_left;
     // top position in pixel coordinate


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how parsing problems are reported in the Windows Resource conversion code. Instead of generating an assert every time a problem occurs, a msg is sent to the log window. The reason for the change is that we sometimes need to work through multiple problems with parsing a specific resource file, and we need to see all of them in a way that we can save them to a file and then work through them one by one.