### PR TITLE
Fix RisohEditor and hand-edited resource file problems

### DIFF
--- a/src/import/import_winres.cpp
+++ b/src/import/import_winres.cpp
@@ -38,7 +38,8 @@ bool WinResource::Import(const ttString& filename, bool write_doc)
         {
             auto pos_end = iter.find(' ');
             auto name = iter.substr(0, pos_end);
-            if (ttlib::is_alpha(name[0]))
+            // Normally a dialog starts with a alphabetical char, but there a few occasions where a digit is used instead.
+            if (ttlib::is_alnum(name[0]))
             {
                 dialogs.emplace_back(name);
             }

--- a/src/import/winres/winres_ctrl.cpp
+++ b/src/import/winres/winres_ctrl.cpp
@@ -30,6 +30,8 @@ void rcCtrl::ParseCommonStyles(ttlib::cview line)
 
 void rcCtrl::GetDimensions(ttlib::cview line)
 {
+    line.moveto_nonspace();
+
     if (line.empty())
     {
         MSG_ERROR(ttlib::cstr() << "Missing dimensions :" << m_original_line);
@@ -95,6 +97,8 @@ void rcCtrl::GetDimensions(ttlib::cview line)
 
 ttlib::cview rcCtrl::GetID(ttlib::cview line)
 {
+    line.moveto_nonspace();
+
     if (line.empty())
     {
         MSG_ERROR(ttlib::cstr() << "Missing ID :" << m_original_line);
@@ -105,6 +109,15 @@ ttlib::cview rcCtrl::GetID(ttlib::cview line)
     if (line[0] == ',')
     {
         line = StepOverComma(line, id);
+        id.LeftTrim();
+        if (id.is_sameas("-1"))
+        {
+            id = "wxID_ANY";
+        }
+        else if (ttlib::is_digit(id[0]))
+        {
+            id.insert(0, "id_");
+        }
     }
     else
     {
@@ -137,11 +150,14 @@ ttlib::cview rcCtrl::GetID(ttlib::cview line)
     else
         m_node->prop_set_value(prop_id, id);
 
+    line.moveto_nonspace();
     return line;
 }
 
 ttlib::cview rcCtrl::GetLabel(ttlib::cview line)
 {
+    line.moveto_nonspace();
+
     if (line.empty())
     {
         MSG_ERROR(ttlib::cstr() << "Missing label :" << m_original_line);
@@ -160,6 +176,7 @@ ttlib::cview rcCtrl::GetLabel(ttlib::cview line)
         throw std::invalid_argument("Expected a quoted label.");
     }
 
+    line.moveto_nonspace();
     return line;
 }
 
@@ -178,7 +195,9 @@ ttlib::cview rcCtrl::StepOverComma(ttlib::cview line, ttlib::cstr& str)
     if (pos == std::string::npos)
         return ttlib::emptystring;
 
-    return line.subview(pos + 1);
+    line.remove_prefix(pos + 1);
+    line.moveto_nonspace();
+    return line;
 }
 
 void rcCtrl::AppendStyle(GenEnum::PropName prop_name, ttlib::cview style)
@@ -464,7 +483,9 @@ void rcCtrl::ParseDirective(WinResource* pWinResource, ttlib::cview line)
     }
 
     if (line[0] == '"')
+    {
         line = GetLabel(line);
+    }
     line = GetID(line);
 
     if (is_control)


### PR DESCRIPTION
Closes #292

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR supports numeric ids by add a `id_` prefix. It supports `{` and `}` as alternatives to `BEGIN` and `END` statements. It handles additional white-space around parameters.

Note that numeric dialog class names are _not_ changed since may have been presented to the user as a list, and we can't map them to that list if we change the name.