### PR TITLE
Support #include in Windows Resource files

### DIFF
--- a/src/import/import_winres.h
+++ b/src/import/import_winres.h
@@ -24,11 +24,15 @@ public:
     WinResource();
 
     bool Import(const ttString& filename, bool write_doc) override;
-    bool ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>& m_dialogs);
+
+    // If forms is empty, then all forms will be parsed
+    bool ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>& forms);
     void InsertDialogs(std::vector<ttlib::cstr>& dialogs);
 
     std::optional<ttlib::cstr> FindIcon(const std::string& id);
     std::optional<ttlib::cstr> FindBitmap(const std::string& id);
+
+    auto& GetIncludeLines() { return m_include_lines; }
 
 protected:
     void FormToNode(rcForm& form);
@@ -46,6 +50,7 @@ private:
     ttlib::textfile m_file;
 
     std::vector<rcForm> m_forms;
+    std::set<ttlib::cstr> m_include_lines;
 
     std::map<std::string, ttlib::cstr> m_map_icons;
     std::map<std::string, ttlib::cstr> m_map_bitmaps;

--- a/src/import/winres/winres_ctrl.cpp
+++ b/src/import/winres/winres_ctrl.cpp
@@ -283,6 +283,13 @@ void rcCtrl::ParseDirective(WinResource* pWinResource, ttlib::cview line)
 
     // First copy the diretive name without the leading whitespace
     temp_view.moveto_nonspace();
+    auto pos_space = temp_view.find_space();
+    if (ttlib::is_error(pos_space))
+    {
+        MSG_ERROR(ttlib::cstr() << "Invalid directive: " << line);
+        return;
+    }
+
     m_original_line.assign(temp_view, temp_view.find_space());
 
     // Now copy the rest of the line after skipping over all the alignment whitespace used after the directive


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds processing for #include commands within a Windows Resource file. WinFile was used as the test case, and getting the #includes to work correctly also required fixing some other bugs -- details below.

If the include file contains a `.h` extension and is not `afxres.h`, `windows.h` or `winres.h` then the entire include line is added to each dialog's `base_src_includes` property (multiple #inclues are handled).

If the `#include` line specifies a file with a `.rc*` extension or a `.dlg` extension, then the entire file is processed as if it was part of the original resource file. The sub-resource will also have it's `#include` lines processed.

The `WinResource` class now supports processing all forms when directly importing, versus a subset when appending. This avoids the double read.

Closes #291

Hand-edited resource files (such as the WinFile files) can contain #ifdef/#else/#endif conditionals that aren't related to being appstudio invoked. There isn't any way to know what the definition is set to, so the code just assumes that the `#ifdef` is true and adds it, and ignores anything in a `#else` section.

WinFile can break lines after a `NOT` directive, so the code node adds that to the trailing `,` and `|` that it already supports.
