### PR TITLE
Convert Windows Stock IDS

### DIFF
--- a/src/import/winres/winres_ctrl.cpp
+++ b/src/import/winres/winres_ctrl.cpp
@@ -7,6 +7,8 @@
 
 #include "pch.h"
 
+#include <map>
+
 #include "winres_ctrl.h"
 
 #include "../import_winres.h"  // WinResource -- Parse a Windows resource file
@@ -14,6 +16,50 @@
 #include "utils.h"             // Utility functions that work with properties
 
 rcCtrl::rcCtrl() {}
+
+static std::map<int, const char*> map_win_stock_cursors = {
+
+    { 32512, "IDC_ARROW" },        // Standard arrow cursor.
+    { 32513, "IDC_IBEAM" },        // I-beam cursor.
+    { 32514, "IDC_WAIT" },         // Hourglass cursor.
+    { 32515, "IDC_CROSS" },        // Crosshair cursor.
+    { 32516, "IDC_UPARROW" },      // Vertical arrow cursor.
+    { 32642, "IDC_SIZENWSE" },     // Double-pointed arrow cursor pointing northwest and southeast.
+    { 32643, "IDC_SIZENESW" },     // Double-pointed arrow cursor pointing northeast and southwest.
+    { 32644, "IDC_SIZEWE" },       // Double-pointed arrow cursor pointing west and east.
+    { 32645, "IDC_SIZENS" },       // Double-pointed arrow cursor pointing north and south.
+    { 32646, "IDC_SIZEALL" },      // Four-pointed arrow cursor pointing north, south, east, and west.
+    { 32648, "IDC_NO" },           // Slashed circle cursor.
+    { 32649, "IDC_HAND" },         // Hand cursor.
+    { 32650, "IDC_APPSTARTING" },  // Standard arrow and small hourglass cursor.
+    { 32651, "IDC_HELP" },         // Arrow and question mark cursor.
+
+};
+
+// Note that the first 5 numbers are identical to the map_win_stock_cursors numbers, even
+// though the images are different.
+static std::map<int, const char*> map_win_stock_icons = {
+
+    { 32512, "IDI_APPLICATION" },  // Application icon.
+    { 32513, "IDI_HAND" },         // Stop sign icon.
+    { 32514, "IDI_QUESTION" },     // Question-mark icon.
+    { 32515, "IDI_EXCLAMATION" },  // Exclamation point icon.
+    { 32516, "IDI_ASTERISK" },     // Asterisk icon.
+    { 32517, "IDI_WINLOGO" },
+
+};
+
+// clang-format off
+
+static std::map<std::string, const char*> map_win_wx_stock = {
+
+    {"IDI_EXCLAMATION", "wxART_INFORMATION"},
+    {"IDI_HAND", "wxART_ERROR"},
+    {"IDI_QUESTION", "wxART_HELP"},
+
+};
+
+// clang-format on
 
 void rcCtrl::ParseCommonStyles(ttlib::cview line)
 {
@@ -821,55 +867,77 @@ void rcCtrl::ParseImageControl(ttlib::cview line)
         }
         image_name = line.subview(0, pos_comma);
         line.remove_prefix(pos_comma);
+
+        if (ttlib::is_digit(image_name[0]))
+        {
+            if (auto icon = map_win_stock_icons.find(ttlib::atoi(image_name)); icon != map_win_stock_icons.end())
+            {
+                image_name = icon->second;
+            }
+            else if (auto cursor = map_win_stock_cursors.find(ttlib::atoi(image_name));
+                     cursor != map_win_stock_cursors.end())
+            {
+                image_name = cursor->second;
+            }
+        }
     }
 
-    ttlib::cstr final_name;
-    std::optional<ttlib::cstr> result;
-
-    if (line.contains("SS_ICON"))
+    if (auto stock_image = map_win_wx_stock.find(image_name); stock_image != map_win_wx_stock.end())
     {
-        result = m_pWinResource->FindIcon(image_name);
-        if (!result)
-        {
-            MSG_ERROR(ttlib::cstr() << "Image not found :" << m_original_line);
-            return;
-        }
-        final_name = result.value();
+        ttlib::cstr prop;
+        prop << "Art; " << stock_image->second << "; wxART_TOOLBAR; [-1; -1]";
+        m_node->prop_set_value(prop_bitmap, prop);
     }
     else
     {
-        result = m_pWinResource->FindBitmap(image_name);
+        ttlib::cstr final_name;
+        std::optional<ttlib::cstr> result;
 
-        /*
-            Visual Studio (as if version 16.09) won't necessarily use the correct name if and ICON and BITMAP resource
-            both have the same numerical value. The resource compiler will convert the id name to it's value, and get
-            the correct bitmap, but we don't have that capability.
-
-        */
-
-        if (result)
+        if (line.contains("SS_ICON"))
         {
+            result = m_pWinResource->FindIcon(image_name);
+            if (!result)
+            {
+                MSG_ERROR(ttlib::cstr() << "Image not found :" << m_original_line);
+                return;
+            }
             final_name = result.value();
         }
         else
         {
-            MSG_ERROR(ttlib::cstr() << "Image not found :" << m_original_line);
+            result = m_pWinResource->FindBitmap(image_name);
+
+            /*
+                Visual Studio (as if version 16.09) won't necessarily use the correct name if and ICON and BITMAP resource
+                both have the same numerical value. The resource compiler will convert the id name to it's value, and get
+                the correct bitmap, but we don't have that capability.
+
+            */
+
+            if (result)
+            {
+                final_name = result.value();
+            }
+            else
+            {
+                MSG_ERROR(ttlib::cstr() << "Image not found :" << m_original_line);
+            }
         }
-    }
 
-    if (final_name.size())
-    {
-        final_name.remove_extension();
-        if (line.contains("SS_ICON"))
-            final_name << "_ico.h";
-        else
-            final_name << "_png.h";
-        ttlib::cstr prop;
-        prop << "Header; " << final_name << "; " << result.value() << "; [-1; -1]";
+        if (final_name.size())
+        {
+            final_name.remove_extension();
+            if (line.contains("SS_ICON"))
+                final_name << "_ico.h";
+            else
+                final_name << "_png.h";
+            ttlib::cstr prop;
+            prop << "Header; " << final_name << "; " << result.value() << "; [-1; -1]";
 
-        // Note that this sets up the filename to convert, but doesn't actually do the conversion -- that will require the
-        // code to be generated.
-        m_node->prop_set_value(prop_bitmap, prop);
+            // Note that this sets up the filename to convert, but doesn't actually do the conversion -- that will require
+            // the code to be generated.
+            m_node->prop_set_value(prop_bitmap, prop);
+        }
     }
 
     line = GetID(line);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds mappings to convert digit cursor and icon values into the Windows constant, and for the `IDI_` constants that have art provider equivalents, it sets the image to the Art equivalent.