### PR TITLE
Various bug fixes from testing

### DIFF
--- a/src/import/winres/winres_form.cpp
+++ b/src/import/winres/winres_form.cpp
@@ -281,6 +281,9 @@ void rcForm::GetDimensions(ttlib::cview line)
     m_rc.right = (m_rc.right * 7) / 4;
     m_rc.top = (m_rc.top * 15) / 8;
     m_rc.bottom = (m_rc.bottom * 15) / 8;
+
+    m_width = (m_rc.right - m_rc.left);
+    m_height = (m_rc.bottom - m_rc.top);
 }
 
 void rcForm::AppendStyle(GenEnum::PropName prop_name, ttlib::cview style)
@@ -342,6 +345,7 @@ void rcForm::AddSizersAndChildren()
             sizer = g_NodeCreator.CreateNode(gen_wxBoxSizer, parent.get());
             parent->Adopt(sizer);
             sizer->prop_set_value(prop_orientation, "wxHORIZONTAL");
+
             while (idx_child < m_ctrls.size() && m_ctrls[idx_child].GetTop() == child.GetTop())
             {
                 // Note that we add the child we are comparing to first.
@@ -350,6 +354,12 @@ void rcForm::AddSizersAndChildren()
             }
             // In order to properly step through the loop
             --idx_child;
+
+            if (m_ctrls[idx_child].GetLeft() + m_ctrls[idx_child].GetWidth() > m_width - 10)
+            {
+                sizer->prop_set_value(prop_alignment, "wxALIGN_RIGHT");
+            }
+
         }
         else
         {
@@ -379,6 +389,8 @@ void rcForm::AddSizersAndChildren()
             }
         }
     }
+
+    parent->FixDuplicateNodeNames();
 }
 
 void rcForm::AddStaticBoxChildren(size_t& idx_child)

--- a/src/import/winres/winres_form.h
+++ b/src/import/winres/winres_form.h
@@ -37,7 +37,7 @@ public:
     size_t GetFormType() const { return m_form_type; }
     Node* GetFormNode() const { return m_node.get(); }
     auto GetFormName() const { return m_node->prop_as_string(prop_class_name); }
-    int GetWidth() const { return (m_rc.right - m_rc.left); }
+    int GetWidth() const { return m_width; }
 
 protected:
     void AddStaticBoxChildren(size_t& idx_child);
@@ -57,8 +57,13 @@ private:
     size_t m_form_type;
     WinResource* m_pWinResource;
 
+    // width in pixels
+    int m_width;
+    // heihgt in pixels
+    int m_height;
+
 #if defined(_DEBUG)
     // Makes it easier to know exactly which form we're looking at in the debugger
     ttlib::cstr m_form_id;
-#endif // _DEBUG
+#endif  // _DEBUG
 };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR contains bug-fixes using WinFile and NotePadPlusPlus resources as test cases. Notable changes:

- Most numeric ids <= 9 are converted to the standard Windows equivalent (e.g., 1 becomes wxID_OK).
- We can't rely on an initial quote being a label since it coulde be a #defined value
- Support BS_OWNERDRAW buttons instead of crashing (and add code to prevent crashing for other unexpected situations)
- Some icon values refer to Windows stock items -- if wxWidgets has a matching Art version, then use that
- Fix duplicate names for all the nodes added to a dialog
- Initial pass at right aligning some controls