### PR TITLE
Update Dialog ID name conversion

### DIFF
--- a/src/ui/importwinresdlg.cpp
+++ b/src/ui/importwinresdlg.cpp
@@ -57,7 +57,7 @@ void ImportWinResDlg::ReadRcFile()
         {
             auto pos_end = iter.find(' ');
             auto name = iter.substr(0, pos_end);
-            if (ttlib::is_alpha(name[0]))
+            if (ttlib::is_alnum(name[0]) || name[0] == '"')
             {
                 auto sel = m_checkListResUI->Append(name);
                 m_checkListResUI->Check(sel);

--- a/src/winres/import_winres.cpp
+++ b/src/winres/import_winres.cpp
@@ -297,7 +297,7 @@ void WinResource::InsertDialogs(std::vector<ttlib::cstr>& dialogs)
         {
             for (auto& dlg: m_forms)
             {
-                if (dlg_name.is_sameas(dlg.GetFormName()))
+                if (dlg.ConvertDialogId(dlg_name).is_sameas(dlg.GetFormName()))
                 {
                     FormToNode(dlg);
                     break;

--- a/src/winres/winres_form.cpp
+++ b/src/winres/winres_form.cpp
@@ -293,5 +293,25 @@ ttlib::cstr rcForm::ConvertDialogId(ttlib::cview id)
         value << "id_" << id;
     }
     value.RightTrim();
+
+    if (value.is_sameprefix("IDD_"))
+        value.erase(0, sizeof("IDD_") - 1);
+
+    if (value.size() > 1 && std::isupper(value[1]))
+    {
+        auto utf8locale = std::locale("en_US.utf8");
+        for (size_t idx = 1; idx < value.size(); ++idx)
+        {
+            if (value[idx] == '_')
+            {
+                value.erase(idx, 1);
+                value[idx] = std::toupper(value[idx], utf8locale);
+            }
+            else
+            {
+                value[idx] = std::tolower(value[idx], utf8locale);
+            }
+        }
+    }
     return value;
 }

--- a/src/winres/winres_form.cpp
+++ b/src/winres/winres_form.cpp
@@ -44,26 +44,11 @@ void rcForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, si
 
     ttlib::cstr value;  // General purpose string we can use throughout this function
     value = line.substr(0, end);
-    if (value[0] == '"')
-    {
-        value.erase(0, 1);
-        if (value.back() == '"')
-        {
-            value.erase(value.size() - 1, 1);
-        }
-    }
-    else if (ttlib::is_digit(value[0]))
-    {
-        value.insert(0, "id_");
-    }
-    m_node->prop_set_value(prop_id, value);
-#if defined(_DEBUG)
-    m_form_id = value;
-#endif  // _DEBUG
+    m_node->prop_set_value(prop_class_name, ConvertDialogId(value));
 
-    // Note that we can't change the name here or we won't match with the list of names saved from the dialog that got
-    // the resource file.
-    m_node->prop_set_value(prop_class_name, line.substr(0, end));
+#if defined(_DEBUG)
+    m_form_id = m_node->prop_as_string(prop_class_name);
+#endif  // _DEBUG
 
     line.remove_prefix(end);
     line.moveto_digit();
@@ -293,4 +278,20 @@ void rcForm::AppendStyle(GenEnum::PropName prop_name, ttlib::cview style)
         updated_style << '|';
     updated_style << style;
     m_node->prop_set_value(prop_name, updated_style);
+}
+
+ttlib::cstr rcForm::ConvertDialogId(ttlib::cview id)
+{
+    id.moveto_nonspace();
+    ttlib::cstr value;
+    if (id[0] == '"')
+    {
+        value.AssignSubString(id);
+    }
+    else if (ttlib::is_digit(value[0]))
+    {
+        value << "id_" << id;
+    }
+    value.RightTrim();
+    return value;
 }

--- a/src/winres/winres_form.h
+++ b/src/winres/winres_form.h
@@ -32,6 +32,10 @@ public:
 
     void ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, size_t& curTxtLine);
 
+    // Remove outer quotes, prefix a digit with id_ -- this is how the id gets stored in the
+    // dialog.
+    ttlib::cstr ConvertDialogId(ttlib::cview id);
+
     // Call this after
     void AddSizersAndChildren();
     size_t GetFormType() const { return m_form_type; }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a function to the `rcForm` class that converts a dialog id into the name that will be used as the class name. The function removes outer quotes, and if the id is a number, it prefixes the name with "id_". If the id begins with `IDD_` then the prefix is removed.

If the second letter of the id is capitalized, then special processing is done to convert all but leading letters to lowercase. If a `_` is encountered, then it is removed, and the following letter is capitalized.

```
    "IDD_MY_DIALOG"

becomes

    MyDialog
```
