### PR TITLE
Pragma

### DIFF
--- a/src/frame_status_bar.cpp
+++ b/src/frame_status_bar.cpp
@@ -51,7 +51,7 @@ public:
         wxStatusBar::DoUpdateStatusText(number);
     }
 
-    void setText(const ttlib::cstr& txt, size_t pane = 1) { SetStatusText(txt.wx_str(), pane); }
+    void setText(const ttlib::cstr& txt, int pane = 1) { SetStatusText(txt.wx_str(), pane); }
 };
 
 wxStatusBar* MainFrame::OnCreateStatusBar(int number, long style, wxWindowID id, const wxString& name)
@@ -66,7 +66,7 @@ wxStatusBar* MainFrame::OnCreateStatusBar(int number, long style, wxWindowID id,
     return m_statBar;
 }
 
-void MainFrame::setStatusText(const ttlib::cstr& txt, size_t pane)
+void MainFrame::setStatusText(const ttlib::cstr& txt, int pane)
 {
     if (m_statBar)
         m_statBar->setText(txt, pane);

--- a/src/generate/text_widgets.cpp
+++ b/src/generate/text_widgets.cpp
@@ -7,11 +7,21 @@
 
 #include "pch.h"
 
+#ifdef _MSC_VER
+    #pragma warning(push)
+
+    #pragma warning(disable : 4267)  // conversion from 'size_t' to 'int', possible loss of data
+#endif
+
 #include <wx/event.h>                  // Event classes
 #include <wx/html/htmlwin.h>           // wxHtmlWindow class for parsing & displaying HTML
 #include <wx/richtext/richtextctrl.h>  // A rich edit control
 #include <wx/stattext.h>               // wxStaticText base header
 #include <wx/stc/stc.h>                // A wxWidgets implementation of Scintilla.
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
 
 #include "text_widgets.h"
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -156,7 +156,7 @@ public:
 
     void FindItemName(Node* node);
 
-    void setStatusText(const ttlib::cstr& txt, size_t pane = 1);
+    void setStatusText(const ttlib::cstr& txt, int pane = 1);
     wxStatusBar* OnCreateStatusBar(int number, long style, wxWindowID id, const wxString& name) override;
 
     bool SaveWarning();

--- a/src/mockup/mockup_wizard.cpp
+++ b/src/mockup/mockup_wizard.cpp
@@ -252,7 +252,7 @@ bool MockupWizard::ResizeBitmap(wxBitmap& bmp)
     auto bmp_width = wxMax(bmp.GetScaledWidth(), m_wizard_node->prop_as_int(prop_bmp_min_width));
     auto bmp_height = wxMax(m_largest_nonbmp_page.y, bmp.GetScaledHeight());
 
-    wxBitmap bitmap(bmp_width, bmp_height);
+    wxBitmap bitmap(static_cast<int>(bmp_width), static_cast<int>(bmp_height));
     wxMemoryDC dc;
     dc.SelectObject(bitmap);
     if (m_wizard_node->HasValue(prop_bmp_background_colour))
@@ -263,7 +263,7 @@ bool MockupWizard::ResizeBitmap(wxBitmap& bmp)
 
     if (m_bmp_placement & wxWIZARD_TILE)
     {
-        wxWizard::TileBitmap(wxRect(0, 0, bmp_width, bmp_height), dc, bmp);
+        wxWizard::TileBitmap(wxRect(0, 0, static_cast<int>(bmp_width), static_cast<int>(bmp_height)), dc, bmp);
     }
     else
     {
@@ -272,16 +272,16 @@ bool MockupWizard::ResizeBitmap(wxBitmap& bmp)
         if (m_bmp_placement & wxWIZARD_HALIGN_LEFT)
             x = 0;
         else if (m_bmp_placement & wxWIZARD_HALIGN_RIGHT)
-            x = bmp_width - bmp.GetScaledWidth();
+            x = static_cast<int>(bmp_width - bmp.GetScaledWidth());
         else
-            x = (bmp_width - bmp.GetScaledWidth()) / 2;
+            x = static_cast<int>((bmp_width - bmp.GetScaledWidth()) / 2);
 
         if (m_bmp_placement & wxWIZARD_VALIGN_TOP)
             y = 0;
         else if (m_bmp_placement & wxWIZARD_VALIGN_BOTTOM)
-            y = bmp_height - bmp.GetScaledHeight();
+            y = static_cast<int>(bmp_height - bmp.GetScaledHeight());
         else
-            y = (bmp_height - bmp.GetScaledHeight()) / 2;
+            y = static_cast<int>((bmp_height - bmp.GetScaledHeight()) / 2);
 
         dc.DrawBitmap(bmp, x, y, true);
         dc.SelectObject(wxNullBitmap);

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -308,7 +308,7 @@ wxPGProperty* PropGridPanel::GetProperty(NodeProperty* prop)
         {
             for (size_t i = 0; i < flagsProp->GetItemCount(); i++)
             {
-                auto id = flagsProp->Item(i);
+                auto id = flagsProp->Item(static_cast<unsigned int>(i));
                 auto& label = id->GetLabel();
                 for (auto& iter: propInfo->GetOptions())
                 {

--- a/src/pch.h
+++ b/src/pch.h
@@ -13,6 +13,21 @@
 #define wxUSE_GUI         1
 #define wxUSE_NO_MANIFEST 1  // This is required for compiling using CLANG 9 and earlier
 
+// This *IS* a legitimate warning, however while wxWidgets 3.1.15 has made some progress, there are still header files that
+// do this, and of course we can't assume the user is compiling with a version of wxWidgets where it has been fixed.
+
+#if (wxMAJOR_VERSION < 4) && (wxMINOR_VERSION < 2) && (wxRELEASE_NUMBER < 16)
+    #if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
+        #ifdef _MSC_VER
+            #pragma warning(disable : 5054)  // operator '|': deprecated between enumerations of different types
+        #endif
+    #endif
+#endif
+
+#ifdef _MSC_VER
+    #pragma warning(push)
+#endif
+
 #include <wx/defs.h>  // Declarations/definitions common to all wx source files
 
 #if defined(__WINDOWS__)
@@ -29,6 +44,22 @@
 #endif
 
 #include <wx/debug.h>  // Misc debug functions and macros
+
+#if (wxMAJOR_VERSION < 4) && (wxMINOR_VERSION < 2) && (wxRELEASE_NUMBER < 16)
+
+    // We include these here so that C4244 and C4267 get disabled
+    #include <wx/choicebk.h>                 // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
+    #include <wx/htmllbox.h>                 // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
+    #include <wx/richtext/richtextbuffer.h>  // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
+
+#endif
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
+
+// Without this, a huge number of #included wxWidgets header files will generate the warning
+#pragma warning(disable : 4251)  // needs to have dll-interface to be used by clients of class
 
 #include <ttlibspace.h>  // This must be included before any other ttLib header files
 
@@ -69,20 +100,20 @@ constexpr const char BMP_PROP_SEPARATOR = ';';
 
     #include "debugging/msg_logging.h"  // MsgLogging -- Message logging class
 
-    #define MSG_INFO(msg)                  \
-        {                                  \
+    #define MSG_INFO(msg)                   \
+        {                                   \
             g_pMsgLogging->AddInfoMsg(msg); \
         }
-    #define MSG_EVENT(msg)                  \
-        {                                   \
+    #define MSG_EVENT(msg)                   \
+        {                                    \
             g_pMsgLogging->AddEventMsg(msg); \
         }
-    #define MSG_WARNING(msg)                  \
-        {                                     \
+    #define MSG_WARNING(msg)                   \
+        {                                      \
             g_pMsgLogging->AddWarningMsg(msg); \
         }
-    #define MSG_ERROR(msg)                  \
-        {                                   \
+    #define MSG_ERROR(msg)                   \
+        {                                    \
             g_pMsgLogging->AddErrorMsg(msg); \
         }
 

--- a/src/ui/importwinresdlg.cpp
+++ b/src/ui/importwinresdlg.cpp
@@ -74,7 +74,7 @@ void ImportWinResDlg::OnResourceFile(wxFileDirPickerEvent& WXUNUSED(event))
 void ImportWinResDlg::OnSelectAll(wxCommandEvent& WXUNUSED(event))
 {
     auto count = m_checkListResUI->GetCount();
-    for (size_t pos = 0; pos < count; ++pos)
+    for (unsigned int pos = 0; pos < count; ++pos)
     {
         m_checkListResUI->Check(pos);
     }
@@ -83,7 +83,7 @@ void ImportWinResDlg::OnSelectAll(wxCommandEvent& WXUNUSED(event))
 void ImportWinResDlg::OnClearAll(wxCommandEvent& WXUNUSED(event))
 {
     auto count = m_checkListResUI->GetCount();
-    for (size_t pos = 0; pos < count; ++pos)
+    for (unsigned int pos = 0; pos < count; ++pos)
     {
         m_checkListResUI->Check(pos, false);
     }
@@ -92,7 +92,7 @@ void ImportWinResDlg::OnClearAll(wxCommandEvent& WXUNUSED(event))
 void ImportWinResDlg::OnOk(wxCommandEvent& event)
 {
     auto count = m_checkListResUI->GetCount();
-    for (size_t pos = 0; pos < count; ++pos)
+    for (unsigned int pos = 0; pos < count; ++pos)
     {
         if (m_checkListResUI->IsChecked(pos))
         {

--- a/src/ui/newproject.cpp
+++ b/src/ui/newproject.cpp
@@ -33,7 +33,7 @@ void NewProjectDlg::OnOK(wxCommandEvent& event)
 {
     if (!m_checkBoxEmptyProject->IsChecked())
     {
-        for (size_t pos = 0; pos < m_checkListProjects->GetCount(); ++pos)
+        for (unsigned int pos = 0; pos < m_checkListProjects->GetCount(); ++pos)
         {
             if (m_checkListProjects->IsChecked(pos))
             {
@@ -151,7 +151,7 @@ void NewProjectDlg::OnWxGlade(wxCommandEvent& WXUNUSED(event))
 
 void NewProjectDlg::OnSelectAll(wxCommandEvent& WXUNUSED(event))
 {
-    for (size_t pos = 0; pos < m_checkListProjects->GetCount(); ++pos)
+    for (unsigned int pos = 0; pos < m_checkListProjects->GetCount(); ++pos)
     {
         m_checkListProjects->Check(pos, true);
     }
@@ -159,7 +159,7 @@ void NewProjectDlg::OnSelectAll(wxCommandEvent& WXUNUSED(event))
 
 void NewProjectDlg::OnSelectNone(wxCommandEvent& WXUNUSED(event))
 {
-    for (size_t pos = 0; pos < m_checkListProjects->GetCount(); ++pos)
+    for (unsigned int pos = 0; pos < m_checkListProjects->GetCount(); ++pos)
     {
         m_checkListProjects->Check(pos, false);
     }

--- a/testing/.srcfiles.yaml
+++ b/testing/.srcfiles.yaml
@@ -1,4 +1,4 @@
-# Requires ttBld.exe version 1.4.0 or higher to process -- see https://github.com/KeyWorksRW/ttBld
+# Requires ttBld.exe version 1.8.0 or higher to process -- see https://github.com/KeyWorksRW/ttBld
 
 Options:
     Project:      wxUiTesting  # project name
@@ -11,10 +11,10 @@ Options:
     Crt_dbg:      dll          # [static | dll] type of CRT to link to in debug builds
     Ms_linker:    true         # true means use link.exe even when compiling with clang
 
-    # Note that if your compiler can generate c++20 code, a lot of deprecated warnings will be generated
-    # CFlags_cmn:   -std:c++latest /Zc:__cplusplus /utf-8 # common compiler flags
-    CFlags_cmn:   -std:c++17 /Zc:__cplusplus /utf-8 # common compiler flags
+    CFlags_cmn:   /Zc:__cplusplus /utf-8 # common compiler flags
 
+    msvc_cmn:     -std:c++latest
+    Clang_cmn:    -std:c++17
 
     CFlags_rel:  /DNDEBUG       # static wxWidgets libraries in release build
     CFlags_dbg:  -DWXUSINGDLL   # dll wxWidgets libraries in debug build

--- a/testing/pch.h
+++ b/testing/pch.h
@@ -6,6 +6,21 @@
 #define wxUSE_GUI         1
 #define wxUSE_NO_MANIFEST 1  // This is required for compiling using CLANG 9 and earlier
 
+// This *IS* a legitimate warning, however while wxWidgets 3.1.15 has made some progress, there are still header files that
+// do this, and of course we can't assume the user is compiling with a version of wxWidgets where it has been fixed.
+
+#if (wxMAJOR_VERSION < 4) && (wxMINOR_VERSION < 2) && (wxRELEASE_NUMBER < 16)
+    #if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
+        #ifdef _MSC_VER
+            #pragma warning(disable : 5054)  // operator '|': deprecated between enumerations of different types
+        #endif
+    #endif
+#endif
+
+#ifdef _MSC_VER
+    #pragma warning(push)
+#endif
+
 #include <wx/defs.h>
 
 #if defined(__WINDOWS__)
@@ -27,6 +42,22 @@
 #include <wx/msgdlg.h>
 #include <wx/string.h>
 
+#if (wxMAJOR_VERSION < 4) && (wxMINOR_VERSION < 2) && (wxRELEASE_NUMBER < 16)
+
+    // We include these here so that C4244 and C4267 get disabled
+    #include <wx/richtext/richtextbuffer.h>  // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
+    #include <wx/richtext/richtextctrl.h>  // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
+    #include <wx/choicebk.h>  // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
+
+#endif
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
+
+// Without this, a huge number of #included wxWidgets header files will generate the warning
+#pragma warning(disable : 4251)  // needs to have dll-interface to be used by clients of class
+
 constexpr const auto txtVersion = "wxUiTesting 1.0.0";
-constexpr const auto txtCopyRight = "Copyright (c) 2020 KeyWorks Software (Ralph Walden)";
+constexpr const auto txtCopyRight = "Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)";
 constexpr const auto txtAppname = "wxUiTesting";


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR uses pragma warning(push/pop) around the wxWidgets header files in the precompiled header so that non of the warnings disabled by `wx/defs.h` are disabled in the rest of our code. A few additional wxWidgets header files were added to the precompiled header just to cut down on the number of warnings that still cropped up.

Once the warnings were enabled, I fixed the cases where warnings were now showing up in our code -- most of these just needed a `static_cast` but a few needed a type change.

For wxUiTesting, I went ahead and turned on the -std:c++latest flag for MSVC-only to start checking for c++20 compilation. That requires ttBld 1.8.0 or later which is available if built, but not currently in our binary version (waiting for additional ttBld changes before copying it).
