### PR TITLE
Autocomplete

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -70,6 +70,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_aui_position, "aui_position" },
     { prop_aui_row, "aui_row" },
     { prop_auth_needed, "auth_needed" },
+    { prop_auto_complete, "auto_complete" },
     { prop_autosize_cols, "autosize_cols" },
     { prop_autosize_rows, "autosize_rows" },
     { prop_background_colour, "background_colour" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -28,11 +28,11 @@ namespace GenEnum
         type_option,
         type_path,
         type_string,
-        type_string_edit,          // this includes a button that triggers a small text editor dialog
+        type_string_edit,          // includes a button that triggers a small text editor dialog
         type_string_edit_escapes,  // includes editor dialog and also escapes characters
         type_string_edit_single,   // includes single-line text editor, does not process escapes
-        type_string_escapes,       // this doubles the backslash in escaped characters: \n, \t, \r, and "\""
-        type_stringlist,
+        type_string_escapes,       // doubles the backslash in escaped characters: \n, \t, \r, and "\""
+        type_stringlist,           // includes button to edit/move multiple choices
         type_uint,
         type_uintpairlist,
         type_wxColour,
@@ -68,6 +68,7 @@ namespace GenEnum
         prop_aui_position,
         prop_aui_row,
         prop_auth_needed,
+        prop_auto_complete,
         prop_autosize_cols,
         prop_autosize_rows,
         prop_background_colour,

--- a/src/generate/text_widgets.cpp
+++ b/src/generate/text_widgets.cpp
@@ -27,6 +27,7 @@
 
 #include "gen_common.h"  // GeneratorLibrary -- Generator classes
 #include "node.h"        // Node class
+#include "utils.h"       // Utility functions that work with properties
 
 wxObject* StaticTextGenerator::CreateMockup(Node* node, wxObject* parent)
 {
@@ -147,6 +148,12 @@ wxObject* TextCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
     widget->SetMaxLength(node->prop_as_int(prop_maxlength));
 
+    if (node->HasValue(prop_auto_complete))
+    {
+        auto array = ConvertToWxArrayString(node->prop_as_string(prop_auto_complete));
+        widget->AutoComplete(array);
+    }
+
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
 
     return widget;
@@ -215,6 +222,19 @@ std::optional<ttlib::cstr> TextCtrlGenerator::GenSettings(Node* node, size_t& au
         {
             code << node->get_node_name() << "->SetMaxLength(" << node->prop_as_string(prop_maxlength) << ");";
         }
+    }
+
+    if (node->HasValue(prop_auto_complete))
+    {
+        auto_indent = false;
+        code << "\t{\n\t\twxArrayString tmp_array;\n";
+        auto array = ConvertToArrayString(node->prop_as_string(prop_auto_complete));
+        for (auto& iter: array)
+        {
+            code << "\t\ttmp_array.push_back(wxString::FromUTF8(\"" << iter << "\"));\n";
+        }
+        code << "\t\t" << node->get_node_name() << "->AutoComplete(tmp_array);\n";
+        code << "\t}";
     }
     return code;
 }

--- a/src/ui/embedimg.cpp
+++ b/src/ui/embedimg.cpp
@@ -76,6 +76,17 @@ EmbedImage::EmbedImage(wxWindow* parent) : EmbedImageBase(parent)
     dir.make_absolute();
     m_fileOriginal->SetInitialDirectory(dir);
 
+#if defined(_WIN32)
+
+    // Windows auto-complete only works with backslashes even though forward slashes work fine for opening directories and
+    // files, and the directory name *must* end with a backslash.
+    dir.addtrailingslash();
+    dir.forwardslashestoback();
+
+    // By setting the path, the user can start typing and immediately get a drop-down list of matchning filenames.
+    m_fileOriginal->SetPath(dir);
+#endif  // _WIN32
+
     dir_property = wxGetApp().GetProject()->prop_as_string(prop_converted_art);
     if (dir_property.size())
         dir = dir_property;
@@ -131,9 +142,14 @@ void EmbedImage::OnInputChange(wxFileDirPickerEvent& WXUNUSED(event))
     if (!file.file_exists())
         return;
 
+#if !defined(_WIN32)
+    // Don't do this on Windows! If the full path is specified, the user can press CTRL+BACKSPACE to remove extension or
+    // filename and then continue to use auto-complete. If a relative path is specified, then auto-complete stops working.
+
     file.make_relative_wx(m_cwd);
     file.backslashestoforward();
     m_fileOriginal->SetPath(file);
+#endif  // _WIN32
 
     m_staticSave->SetLabelText(wxEmptyString);
     m_staticSize->SetLabelText(wxEmptyString);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -463,3 +463,22 @@ std::vector<ttlib::cstr> ConvertToArrayString(ttlib::cview value)
 
     return array;
 }
+
+wxArrayString ConvertToWxArrayString(ttlib::cview value)
+{
+    wxArrayString array;
+    if (value.empty())
+        return array;
+    ttlib::cstr parse;
+    auto pos = parse.ExtractSubString(value);
+    array.push_back(parse.wx_str());
+
+    for (auto tmp_value = ttlib::stepover(value.data() + pos); tmp_value.size();
+         tmp_value = ttlib::stepover(tmp_value.data() + pos))
+    {
+        pos = parse.ExtractSubString(tmp_value);
+        array.push_back(parse.wx_str());
+    }
+
+    return array;
+}

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -59,6 +59,9 @@ ttlib::cstr ConvertEscapeSlashes(ttlib::cview str);
 
 std::vector<ttlib::cstr> ConvertToArrayString(ttlib::cview value);
 
+// Use ConvertToArrayString() to get a vector, this function to get a wxArrayString
+wxArrayString ConvertToWxArrayString(ttlib::cview value);
+
 // Converts a GZIP unsigned char array into an image.
 wxImage LoadGzipImage(const unsigned char* data, size_t size_data);
 

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -76,6 +76,8 @@
             <option name="wxTE_BESTWRAP"
                 help="Wrap the lines at word boundaries or at any other character if there are words longer than the window width (this is the default)." />
         </property>
+        <property name="auto_complete" type="stringlist"
+            help="If one or more strings are entered, they will be used to initialized autocomplete (" />
         <event name="wxEVT_TEXT" class="wxCommandEvent"
             help="Generated when the text changes. Notice that this event will always be generated when the text controls contents changes - whether this is due to user input or comes from the program itself (for example, if SetValue() is called.)" />
         <event name="wxEVT_TEXT_ENTER" class="wxCommandEvent"

--- a/ttLib/ttstr.cpp
+++ b/ttLib/ttstr.cpp
@@ -395,6 +395,19 @@ ttString& ttString::backslashestoforward()
     return *this;
 }
 
+#if defined(_WIN32)
+
+ttString& ttString::forwardslashestoback()
+{
+    for (auto pos = find('/'); pos != wxString::npos; pos = find('/'))
+    {
+        replace(pos, 1, L"\\");
+    }
+    return *this;
+}
+
+#endif  // _WIN32
+
 ttString ttString::extension() const
 {
     if (empty())

--- a/ttLib/ttstr.h
+++ b/ttLib/ttstr.h
@@ -211,6 +211,13 @@ public:
     /// Note: Windows API functions work fine with forward slashes instead of backslashes.
     ttString& backslashestoforward();
 
+#if defined(_WIN32)
+    /// Converts all forward slashes in the string to backward slashes.
+    ///
+    /// Note: Windows API functions work fine with forward slashes instead of backslashes.
+    ttString& forwardslashestoback();
+#endif  // _WIN32
+
     /// ext param should begin with a period (e.g., ".cpp")
     bool has_extension(std::string_view ext, tt::CASE checkcase = tt::CASE::either) { return extension().is_sameas(ext, checkcase); }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a auto_complete property to **wxTextCtrl**. 

The PR also changes the `EmbedImage` dialog to use conditionalized Windows sections to enable autocomplete in the Input field. This meant converting forward slashes to back slashes, and making certin the directory ends with a trailing backslash. Unlike other Windows functions, the autocomplete will not work with a forward slash. It also doesn't work with relative paths -- so the full path is used for the input filename. 

Closes #28

I did not add this to the other 7 controls because all the other controls are likely to need a large matching array of strings, and it's impractical to enter those one by one in a property grid just to generate the strings in the class constructor.