### PR TITLE
Expanded processing of GROUPBOX importing

### DIFF
--- a/import_tests/README.md
+++ b/import_tests/README.md
@@ -1,0 +1,31 @@
+# Import Testing
+
+The files in the subfolders of this directory are used to test the ability of **wxUiEditor** to import different types of projects.
+
+## Windows Resource files
+
+The file `main_test.rc` is maintained by Visual Studio 6.0. This is the last version of Visual Studio that used property dialogs making it very easy to work with. The file will load fine with current versions of Visual Studio, but please do _not_ save over this file with a **devenv**-generated version. The older style is needed to ensure that **wxUiEditor** can pick up and convert legacy Windows projects.
+
+## Visual Studio Code launch templates
+
+If you are using Visual Studio Code for debugging, you might find the following templates useful.
+
+#### Windows Resource testing
+
+```json
+     {
+         "name": "WinTest Resource",
+         "type": "cppvsdbg",
+         "request": "launch",
+         "cwd" : "${workspaceRoot}/../import_tests/winres/",
+         "program": "${workspaceRoot}/../bin/wxUiEditorD.exe",
+         "args": [
+             "main_test.rc"
+         ],
+         "logging": {
+            "moduleLoad": false,
+         },
+         "visualizerFile": "${workspaceRoot}/wxui.natvis",
+         "stopAtEntry": false,
+     },
+```

--- a/import_tests/winres/main_test.rc
+++ b/import_tests/winres/main_test.rc
@@ -1,0 +1,180 @@
+//Microsoft Developer Studio generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "afxres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (U.S.) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+#ifdef _WIN32
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+#endif //_WIN32
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE DISCARDABLE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE DISCARDABLE 
+BEGIN
+    "#include ""afxres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE DISCARDABLE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_MAINTEST DIALOG DISCARDABLE  0, 0, 286, 180
+STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Main Dialog Test"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    DEFPUSHBUTTON   "OK",IDOK,169,160,50,14
+    LTEXT           "My static text.",IDC_STATIC,6,66,50,13
+    CONTROL         "Check 1",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | 
+                    WS_TABSTOP,84,66,43,10
+    CONTROL         "Check 2",IDC_CHECK2,"Button",BS_AUTOCHECKBOX | 
+                    WS_TABSTOP,144,66,43,10
+    CONTROL         "Check 3",IDC_CHECK3,"Button",BS_AUTOCHECKBOX | 
+                    WS_TABSTOP,84,94,43,10
+    CONTROL         "Check 4",IDC_CHECK4,"Button",BS_AUTOCHECKBOX | 
+                    WS_TABSTOP,144,94,43,10
+    COMBOBOX        IDC_COMBO1,207,66,73,30,CBS_DROPDOWN | CBS_SORT | 
+                    WS_VSCROLL | WS_TABSTOP
+    PUSHBUTTON      "Cancel",IDCANCEL,230,160,50,14
+    GROUPBOX        "Checks",IDC_STATIC,71,52,126,60
+    LTEXT           "Group box in center with vertically aligned controls on either side.",
+                    IDC_STATIC,6,6,274,13
+END
+
+IDD_MAINDLG DIALOG DISCARDABLE  0, 0, 359, 292
+STYLE DS_NOIDLEMSG | DS_CENTER | WS_MINIMIZEBOX | WS_CAPTION | WS_SYSMENU
+CAPTION "DlgWiz"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Folder:",IDC_STATIC,6,6,22,8
+    EDITTEXT        IDTXT_CUR_DIR,46,6,154,14,ES_AUTOHSCROLL | ES_READONLY
+    LTEXT           "Class name:",IDC_STATIC,6,30,38,8
+    EDITTEXT        IDEDIT_CLASS,46,27,154,14,ES_AUTOHSCROLL
+    LTEXT           "Filename:",IDC_STATIC,6,55,31,8
+    EDITTEXT        IDEDIT_FILE,46,51,154,14,ES_AUTOHSCROLL
+    GROUPBOX        "Dialog Type",IDC_STATIC,223,79,130,128,WS_GROUP
+    CONTROL         "&ttCDlg",IDRADIO_TYPE_CTTDLG,"Button",
+                    BS_AUTORADIOBUTTON | WS_TABSTOP,236,97,107,10
+    CONTROL         "C&DialogImpl",IDRADIO_TYPE_CDIALOGIMPL,"Button",
+                    BS_AUTORADIOBUTTON | WS_TABSTOP,236,113,107,10
+    CONTROL         "Resizable",IDCHECK_RESIZABLE_CDIALOG,"Button",
+                    BS_AUTOCHECKBOX,250,125,84,10
+    CONTROL         "CA&xDialogImpl (ActiveX)",IDRADIO_TYPE_CAXDIALOGIMPL,
+                    "Button",BS_AUTORADIOBUTTON | WS_TABSTOP,236,144,107,10
+    CONTROL         "Resizable",IDCHECK_RESIZABLE_CAXDIALOG,"Button",
+                    BS_AUTOCHECKBOX,250,156,84,10
+    CONTROL         "Event handler",IDCHECK_DISP_EVENT,"Button",
+                    BS_AUTOCHECKBOX,250,168,57,10
+    CONTROL         "C&PropertyPageImpl",IDRADIO_TYPE_PROPERTY,"Button",
+                    BS_AUTORADIOBUTTON | WS_TABSTOP,236,188,107,10
+    DEFPUSHBUTTON   "Create",IDOK,227,270,60,14
+    PUSHBUTTON      "Cancel",IDCANCEL,293,270,60,14
+    LTEXT           "Resource File:",IDC_STATIC,224,6,87,8
+    COMBOBOX        IDCOMBO_RC_FILES,224,18,130,187,CBS_DROPDOWN | CBS_SORT | 
+                    WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Dialog ID:",IDC_STATIC,224,43,38,8
+    COMBOBOX        IDCOMBO_DLG_IDS,223,53,130,187,CBS_DROPDOWN | CBS_SORT | 
+                    WS_VSCROLL | WS_TABSTOP
+    GROUPBOX        "Members",IDC_STATIC,6,79,195,90
+    LISTBOX         IDLIST_MEMBERS,19,94,114,67,LBS_SORT | 
+                    LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
+    PUSHBUTTON      "&Add...",IDBTN_ADD,142,94,50,14
+    PUSHBUTTON      "&Edit...",IDBTN_EDIT,142,114,50,14
+    PUSHBUTTON      "&Remove",IDBTN_REMOVE,142,134,50,14
+    CONTROL         "Constructor (in code)",IDCHECK_CONSTRUCTOR,"Button",
+                    BS_AUTOCHECKBOX | WS_TABSTOP,14,196,77,10
+    CONTROL         "Destructor",IDCHECK_DESTRUCTOR,"Button",BS_AUTOCHECKBOX | 
+                    WS_TABSTOP,14,208,77,10
+    CONTROL         "OnBegin",IDCHECK_METHOD_INITIALIZE,"Button",
+                    BS_AUTOCHECKBOX | WS_TABSTOP,14,223,77,10
+    CONTROL         "OnOK",IDCHECK_METHOD_CLOSE,"Button",BS_AUTOCHECKBOX | 
+                    WS_TABSTOP,14,234,77,10
+    CONTROL         "OnCancel",IDCHECK_METHOD_CANCEL,"Button",
+                    BS_AUTOCHECKBOX | WS_TABSTOP,14,245,77,10
+    CONTROL         "Center window",IDCHECK_CENTER_WINDOW,"Button",
+                    BS_AUTOCHECKBOX | WS_TABSTOP,128,196,59,10
+    CONTROL         "Shaded buttons",IDCHECK_SHADED_BUTTONS,"Button",
+                    BS_AUTOCHECKBOX | WS_TABSTOP,128,208,63,10
+    CONTROL         "Button icons",IDCHECK_ICONS,"Button",BS_AUTOCHECKBOX | 
+                    WS_TABSTOP,128,220,52,10
+    GROUPBOX        "Methods",IDC_STATIC,6,182,99,80
+    GROUPBOX        "Options",IDC_STATIC,117,182,84,80
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO DISCARDABLE 
+BEGIN
+    IDD_MAINTEST, DIALOG
+    BEGIN
+        LEFTMARGIN, 6
+        RIGHTMARGIN, 280
+        TOPMARGIN, 6
+        BOTTOMMARGIN, 174
+    END
+
+    IDD_MAINDLG, DIALOG
+    BEGIN
+        LEFTMARGIN, 6
+        RIGHTMARGIN, 353
+        TOPMARGIN, 6
+        BOTTOMMARGIN, 284
+        BOTTOMMARGIN, 255
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+#endif    // English (U.S.) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/import_tests/winres/resource.h
+++ b/import_tests/winres/resource.h
@@ -1,0 +1,46 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Developer Studio generated include file.
+// Used by main_test.rc
+//
+#define IDD_MAINTEST                    102
+#define IDD_MAINDLG                     127
+#define IDEDIT_CLASS                    1000
+#define IDEDIT_FILE                     1001
+#define IDLIST_MEMBERS                  1004
+#define IDBTN_ADD                       1005
+#define IDBTN_REMOVE                    1006
+#define IDCHECK_ICONS                   1007
+#define IDCHECK_METHOD_INITIALIZE       1008
+#define IDCHECK_METHOD_CLOSE            1009
+#define IDRADIO_TYPE_CTTDLG             1010
+#define IDRADIO_TYPE_CAXDIALOGIMPL      1011
+#define IDRADIO_TYPE_CDIALOGIMPL        1012
+#define IDCHECK_DISP_EVENT              1013
+#define IDCHECK_CENTER_WINDOW           1014
+#define IDCHECK_SHADED_BUTTONS          1015
+#define IDRADIO_TYPE_PROPERTY           1016
+#define IDCHECK_METHOD_CANCEL           1017
+#define IDCHECK_CONSTRUCTOR             1020
+#define IDCHECK_DESTRUCTOR              1021
+#define IDBTN_EDIT                      1033
+#define IDTXT_CUR_DIR                   1034
+#define IDC_CHECK1                      1038
+#define IDC_CHECK2                      1039
+#define IDC_CHECK3                      1040
+#define IDC_CHECK4                      1041
+#define IDC_COMBO1                      1042
+#define IDCOMBO_DLG_IDS                 1042
+#define IDCOMBO_RC_FILES                1043
+#define IDCHECK_RESIZABLE_CDIALOG       1045
+#define IDCHECK_RESIZABLE_CAXDIALOG     1046
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1000
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/winres/winres_ctrl.h
+++ b/src/winres/winres_ctrl.h
@@ -37,8 +37,12 @@ public:
     auto GetBottom() const { return (m_top + m_height); }
     auto GetWidth() const { return m_width; }
     auto GetHeight() const { return m_height; }
+    auto& GetDialogRect() const { return m_rc; }
 
-    auto GetPostProcessStyle() { return m_non_processed_style; }
+    auto GetPostProcessStyle() const { return m_non_processed_style; }
+
+    bool isAdded() const { return m_added; }
+    void setAdded() { m_added = true; }
 
 protected:
     // This will map window styles to wxWidgets styles and append them to prop_style
@@ -99,8 +103,10 @@ private:
     int m_height;
 
     // These are in dialog coordinates
-    RC_RECT m_rc { 0, 0, 0, 0 };
+    wxRect m_rc { 0, 0, 0, 0 };
+    // wxRect m_rect;
 
     bool m_add_min_width_property;
     bool m_add_wrap_property;
+    bool m_added { false };
 };

--- a/src/winres/winres_form.h
+++ b/src/winres/winres_form.h
@@ -44,7 +44,21 @@ public:
     int GetWidth() const { return m_width; }
 
 protected:
-    void AddStaticBoxChildren(size_t& idx_child);
+    // Adopts child node and sets child flag to indicate it has been added
+    void Adopt(const NodeSharedPtr& node, rcCtrl& child);
+
+    // Fills in m_group_ctrls with every control within the boundaries of the group box
+    void CollectGroupControls(size_t idx_parent);
+
+    // -1 if no horizontal alignment needed
+    // 0 if box sizer needed
+    // > 0 number of columns required for wxFlexGridSizer
+    int GridSizerNeeded(size_t idx_start, size_t idx_end, const rcCtrl* p_static_box);
+
+    // Similar to GridSizerNeeded(), but only processes m_group_ctrls
+    int GroupGridSizerNeeded(size_t idx_start) const;
+
+    void AddStaticBoxChildren(const rcCtrl& box, size_t idx_group_box);
     void AddStyle(ttlib::textfile& txtfile, size_t& curTxtLine);
     void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
     void GetDimensions(ttlib::cview line);
@@ -57,14 +71,17 @@ private:
     RC_RECT m_rc { 0, 0, 0, 0 };
     NodeSharedPtr m_node;
     NodeSharedPtr m_gridbag;
-    std::vector<rcCtrl> m_ctrls;
     size_t m_form_type;
     WinResource* m_pWinResource;
 
-    // width in pixels
-    int m_width;
-    // heihgt in pixels
-    int m_height;
+    std::vector<rcCtrl> m_ctrls;
+
+    // This will contain pointers to every control within a wxStaticBoxSizer. It gets reset
+    // every time a new wxStaticBoxSizer needs to be processed (see CollectGroupControls()).
+    std::vector<rcCtrl*> m_group_ctrls;
+
+    int m_width;   // width in pixels
+    int m_height;  // height in pixels
 
 #if defined(_DEBUG)
     // Makes it easier to know exactly which form we're looking at in the debugger

--- a/src/winres/winres_layout.cpp
+++ b/src/winres/winres_layout.cpp
@@ -11,28 +11,55 @@
 
 #include "winres_form.h"
 
-#include "node_creator.h"   // NodeCreator -- Class used to create nodes
+#include "node_creator.h"  // NodeCreator -- Class used to create nodes
 
 void rcForm::AddSizersAndChildren()
 {
     // First sort all children horizontally
-    std::sort(std::begin(m_ctrls), std::end(m_ctrls), [](rcCtrl a, rcCtrl b) { return a.GetLeft() < b.GetLeft(); });
+    // std::sort(std::begin(m_ctrls), std::end(m_ctrls), [](rcCtrl a, rcCtrl b) { return a.GetLeft() < b.GetLeft(); });
 
     // Now sort vertically
-    std::sort(std::begin(m_ctrls), std::end(m_ctrls), [](rcCtrl a, rcCtrl b) { return a.GetTop() < b.GetTop(); });
+    // std::sort(std::begin(m_ctrls), std::end(m_ctrls), [](rcCtrl a, rcCtrl b) { return a.GetTop() < b.GetTop(); });
+    std::sort(m_ctrls.begin(), m_ctrls.end(), [](rcCtrl a, rcCtrl b) { return a.GetTop() < b.GetTop(); });
+
+    for (size_t begin = 0; begin < m_ctrls.size() - 1; ++begin)
+    {
+        auto end = begin + 1;
+        while (m_ctrls[end].GetTop() == m_ctrls[begin].GetTop())
+        {
+            ++end;
+            if (end >= m_ctrls.size())
+                break;
+        }
+
+        if (end > begin + 1)
+        {
+            std::sort(m_ctrls.begin() + begin, m_ctrls.begin() + end,
+                      [](rcCtrl a, rcCtrl b) { return a.GetLeft() < b.GetLeft(); });
+        }
+    }
 
     auto parent = g_NodeCreator.CreateNode(gen_VerticalBoxSizer, m_node.get());
+    parent->prop_set_value(prop_var_name, "parent_sizer");
     m_node->Adopt(parent);
-
-    NodeSharedPtr sizer;
 
     for (size_t idx_child = 0; idx_child < m_ctrls.size(); ++idx_child)
     {
-        const auto& child = m_ctrls[idx_child];
+        auto& child = m_ctrls[idx_child];
+        // A group box will have added a bunch of children, so if the current child has been added already then ignore it.
+        // Note that children can appear to the left or right of a group box, which is why we can't just step over a group of
+        // children when a group box is encountered.
+        if (child.isAdded())
+            continue;
+
         if (child.GetNode()->isGen(gen_wxStaticBoxSizer))
         {
-            AddStaticBoxChildren(idx_child);
+            if (child.GetWidth() > GetWidth() - 30)
+                child.GetNode()->prop_set_value(prop_flags, "wxEXPAND");
+
+            AddStaticBoxChildren(child, idx_child);
             parent->Adopt(child.GetNodePtr());
+            child.setAdded();
             continue;
         }
 
@@ -60,16 +87,22 @@ void rcForm::AddSizersAndChildren()
         {
             // If there is more than one child with the same top position, then create a horizontal box sizer
             // and add all children with the same top position.
-            sizer = g_NodeCreator.CreateNode(gen_wxBoxSizer, parent.get());
+            auto sizer = g_NodeCreator.CreateNode(gen_wxBoxSizer, parent.get());
             parent->Adopt(sizer);
             sizer->prop_set_value(prop_orientation, "wxHORIZONTAL");
 
             while (idx_child < m_ctrls.size() && m_ctrls[idx_child].GetTop() == child.GetTop())
             {
+                if (m_ctrls[idx_child].isAdded())
+                    break;  // means there was a static box to the right
+
                 // Note that we add the child we are comparing to first.
                 sizer->Adopt(m_ctrls[idx_child].GetNodePtr());
                 ++idx_child;
             }
+            if (idx_child < m_ctrls.size() && m_ctrls[idx_child].isAdded())
+                continue;
+
             // In order to properly step through the loop
             --idx_child;
 
@@ -80,20 +113,17 @@ void rcForm::AddSizersAndChildren()
         }
         else
         {
-            sizer = g_NodeCreator.CreateNode(gen_VerticalBoxSizer, parent.get());
+            auto sizer = g_NodeCreator.CreateNode(gen_VerticalBoxSizer, parent.get());
             parent->Adopt(sizer);
             sizer->Adopt(child.GetNodePtr());
-
-            if (idx_child + 2 < m_ctrls.size())
-            {
-                // If the next two sizers have the same top, then they need to be placed in a horizontal sizer.
-                if (m_ctrls[idx_child + 1].GetTop() == m_ctrls[idx_child + 2].GetTop())
-                    continue;
-            }
-            ++idx_child;
+            if (idx_child == 0)
+                continue;
 
             while (idx_child < m_ctrls.size() && m_ctrls[idx_child].GetTop() != m_ctrls[idx_child - 1].GetTop())
             {
+                if (m_ctrls[idx_child].isAdded())
+                    break;  // means there was a static box to the right
+
                 // Note that we add the child we are comparing to first.
                 sizer->Adopt(m_ctrls[idx_child].GetNodePtr());
                 if (idx_child + 2 < m_ctrls.size())
@@ -110,20 +140,194 @@ void rcForm::AddSizersAndChildren()
     parent->FixDuplicateNodeNames();
 }
 
-void rcForm::AddStaticBoxChildren(size_t& idx_child)
+void rcForm::AddStaticBoxChildren(const rcCtrl& box, size_t idx_group_box)
 {
-    const auto& static_box = m_ctrls[idx_child];
-    for (size_t idx_group_child = idx_child + 1; idx_group_child < m_ctrls.size(); ++idx_group_child)
-    {
-        const auto& child_ctrl = m_ctrls[idx_group_child];
-        if (child_ctrl.GetRight() > static_box.GetRight() || child_ctrl.GetTop() > static_box.GetBottom())
-            break;
-        static_box.GetNode()->Adopt(child_ctrl.GetNodePtr());
+    CollectGroupControls(idx_group_box);
 
-        // Update to that caller won't process this child.
-        ++idx_child;
+    const auto& static_box = m_ctrls[idx_group_box];
+    for (size_t idx_child = 0; idx_child < m_group_ctrls.size(); ++idx_child)
+    {
+        auto result = GroupGridSizerNeeded(idx_child);
+        if (result < 0)
+        {
+            // No vertical alignment with the next control, so just add it normally
+            auto& child = reinterpret_cast<rcCtrl&>(*m_group_ctrls[idx_child]);
+            Adopt(static_box.GetNodePtr(), child);
+
+            // REVIEW: [KeyWorks - 06-16-2021] Does this actually happen in a group box?
+            int dlg_margin = (box.GetWidth() / 2) - child.GetWidth();
+            if (child.GetRight() < (box.GetWidth() - dlg_margin))
+                child.GetNode()->prop_set_value(prop_alignment, "wxALIGN_CENTER_HORIZONTAL");
+            continue;
+        }
+        else if (result == 0)
+        {
+            // Single row vertical alignment with now horizontal alignment in the next row, so use a horizontal box sizer
+            auto sizer = g_NodeCreator.CreateNode(gen_wxBoxSizer, box.GetNode());
+            sizer->prop_set_value(prop_orientation, "wxHORIZONTAL");
+            static_box.GetNodePtr()->Adopt(sizer);
+
+            auto& child = reinterpret_cast<rcCtrl&>(*m_group_ctrls[idx_child]);
+
+            while (idx_child < m_group_ctrls.size() && m_group_ctrls[idx_child]->GetTop() == child.GetTop())
+            {
+                // Note that we add the child we are comparing to first.
+                Adopt(sizer, *m_group_ctrls[idx_child]);
+                ++idx_child;
+            }
+            // In order to properly step through the loop
+            --idx_child;
+        }
+        else
+        {
+            // There's more than one row with vertical alignment, and at least one of those rows has a column with horizontal
+            // alignment, so use a wxFlexGridSizer.
+
+            auto total_columns = result;  // This is just for readability
+            auto sizer = g_NodeCreator.CreateNode(gen_wxFlexGridSizer, box.GetNode());
+            sizer->prop_set_value(prop_cols, ttlib::itoa(total_columns));
+            static_box.GetNodePtr()->Adopt(sizer);
+
+            auto& child = reinterpret_cast<rcCtrl&>(*m_group_ctrls[idx_child]);
+            std::vector<int> positions;
+            positions.reserve(total_columns);
+            for (size_t idx = 0; idx < total_columns; ++idx)
+            {
+                if (m_group_ctrls[idx_child + idx]->GetTop() == child.GetTop())
+                    positions.emplace_back(m_group_ctrls[idx_child + idx]->GetLeft());
+                else
+                    positions.emplace_back(-1);
+            }
+
+            // It's possible that there's an initial group of aligned controls followed by some randomly positioned control.
+            // However, that should be a rare case, so we assume that if we're using a grid, then all the rest of the
+            // controls in the group box should be placed into that grid.
+
+            // There may be gaps in the columns, so cur_column is used to track which column is being added.
+            int cur_column = 0;
+            for (; idx_child < m_group_ctrls.size(); ++idx_child)
+            {
+                // This covers the case where the previous rows had gaps in the columns
+                if (positions[cur_column] == -1)
+                    positions[cur_column] = m_group_ctrls[idx_child]->GetLeft();
+
+                while (m_group_ctrls[idx_child]->GetLeft() > positions[cur_column])
+                {
+                    auto spacer = g_NodeCreator.CreateNode(gen_spacer, sizer.get());
+                    sizer->Adopt(spacer);
+                    ++cur_column;
+                    if (cur_column >= total_columns)
+                    {
+                        break;
+                    }
+                }
+                Adopt(sizer, *m_group_ctrls[idx_child]);
+                ++cur_column;
+                if (cur_column >= total_columns)
+                    cur_column = 0;
+            }
+            return;
+        }
     }
 
     // TODO: [KeyWorks - 05-31-2021] Depending on the number and position of the children, we may need to change the
     // orientation as well as spanning more than one column or row.
+}
+
+int rcForm::GridSizerNeeded(size_t idx_start, size_t idx_end, const rcCtrl* /* p_static_box */)
+{
+    ASSERT(idx_end < m_ctrls.size());
+
+    if (idx_start + 1 > idx_end || m_ctrls[idx_start + 1].GetTop() != m_ctrls[idx_start].GetTop())
+        return -1;
+
+    size_t row_children = 2;
+    while (idx_start + row_children < idx_end && m_ctrls[idx_start + row_children].GetTop() != m_ctrls[idx_start].GetTop())
+        ++row_children;
+
+    size_t idx_next_row = idx_start + row_children;
+    if (idx_next_row >= idx_end)
+        return 0;  // only one aligned row, so a box sizer is needed
+
+    size_t max_columns = row_children;
+
+    while (idx_next_row < idx_end && m_ctrls[idx_next_row + 1].GetTop() != m_ctrls[idx_next_row].GetTop())
+    {
+        row_children = 2;
+        while (idx_next_row + row_children < idx_end &&
+               m_ctrls[idx_next_row + row_children].GetTop() != m_ctrls[idx_next_row].GetTop())
+            ++row_children;
+        if (row_children > max_columns)
+            max_columns = row_children;
+
+        idx_next_row = idx_next_row + row_children;
+        if (idx_next_row >= idx_end)
+            break;
+    }
+
+    return static_cast<int>(max_columns);
+}
+
+int rcForm::GroupGridSizerNeeded(size_t idx_start) const
+{
+    if (idx_start + 1 >= m_group_ctrls.size() || m_group_ctrls[idx_start + 1]->GetTop() != m_group_ctrls[idx_start]->GetTop())
+        return -1;
+
+    size_t row_children = 2;
+    while (idx_start + row_children < m_group_ctrls.size() &&
+           m_group_ctrls[idx_start + row_children]->GetTop() == m_group_ctrls[idx_start]->GetTop())
+        ++row_children;
+
+    size_t idx_next_row = idx_start + row_children;
+    if (idx_next_row + 1 >= m_group_ctrls.size() ||
+        m_group_ctrls[idx_next_row + +1]->GetTop() != m_group_ctrls[idx_next_row]->GetTop())
+        return 0;  // only one aligned row, so a box sizer is needed
+
+    size_t max_columns = row_children;
+
+    while (idx_next_row + 1 < m_group_ctrls.size() &&
+           m_group_ctrls[idx_next_row + 1]->GetTop() == m_group_ctrls[idx_next_row]->GetTop())
+    {
+        row_children = 2;
+        while (idx_next_row + row_children < m_group_ctrls.size() &&
+               m_group_ctrls[idx_next_row + row_children]->GetTop() == m_group_ctrls[idx_next_row]->GetTop())
+            ++row_children;
+        if (row_children > max_columns)
+            max_columns = row_children;
+
+        idx_next_row = idx_next_row + row_children;
+    }
+
+    return static_cast<int>(max_columns);
+}
+
+void rcForm::CollectGroupControls(size_t idx_parent)
+{
+    m_group_ctrls.clear();
+    auto& rc_parent = m_ctrls[idx_parent].GetDialogRect();
+
+    for (size_t idx = idx_parent + 1; idx < m_ctrls.size(); ++idx)
+    {
+        auto& child_rc = m_ctrls[idx].GetDialogRect();
+        if (rc_parent.Contains(m_ctrls[idx].GetDialogRect()))
+        {
+            m_group_ctrls.emplace_back(&m_ctrls[idx]);
+            continue;
+        }
+        else
+        {
+            // It's possible the control is to the left or right of the group box in which case we keep looking. However, if
+            // it's below it, then we're done.
+            if (child_rc.GetTop() >= (rc_parent.GetTop() + rc_parent.GetHeight()))
+                return;
+        }
+    }
+}
+
+void rcForm::Adopt(const NodeSharedPtr& node, rcCtrl& child)
+{
+    ASSERT_MSG(!child.isAdded(), "Logic problem, child has already been added.");
+
+    node->Adopt(child.GetNodePtr());
+    child.setAdded();
 }

--- a/src/winres/winres_utils.cpp
+++ b/src/winres/winres_utils.cpp
@@ -39,7 +39,7 @@ void rcCtrl::GetDimensions(ttlib::cview line)
 
     if (line.empty() || !ttlib::is_digit(line[0]))
         throw std::invalid_argument("Expected a numeric dimension value");
-    m_rc.left = ttlib::atoi(line);
+    m_rc.SetLeft(ttlib::atoi(line));
 
     auto pos = line.find_first_of(',');
     if (pos == std::string::npos)
@@ -49,7 +49,7 @@ void rcCtrl::GetDimensions(ttlib::cview line)
     line.moveto_digit();
     if (line.empty() || !ttlib::is_digit(line[0]))
         throw std::invalid_argument("Expected a numeric dimension value");
-    m_rc.top = ttlib::atoi(line);
+    m_rc.SetTop(ttlib::atoi(line));
 
     pos = line.find_first_of(',');
     if (pos == std::string::npos)
@@ -59,7 +59,7 @@ void rcCtrl::GetDimensions(ttlib::cview line)
     line.moveto_digit();
     if (line.empty() || !ttlib::is_digit(line[0]))
         throw std::invalid_argument("Expected a numeric dimension value");
-    m_rc.right = ttlib::atoi(line);
+    m_rc.SetWidth(ttlib::atoi(line));
 
     pos = line.find_first_of(',');
     if (pos == std::string::npos)
@@ -69,7 +69,7 @@ void rcCtrl::GetDimensions(ttlib::cview line)
     line.moveto_digit();
     if (line.empty() || !ttlib::is_digit(line[0]))
         throw std::invalid_argument("Expected a numeric dimension value");
-    m_rc.bottom = ttlib::atoi(line);
+    m_rc.SetHeight(ttlib::atoi(line));
 
     /*
 
@@ -85,10 +85,10 @@ void rcCtrl::GetDimensions(ttlib::cview line)
 
     */
 
-    m_left = static_cast<int>((static_cast<int64_t>(m_rc.left) * 7 / 4));
-    m_width = static_cast<int>((static_cast<int64_t>(m_rc.right) * 7 / 4));
-    m_top = static_cast<int>((static_cast<int64_t>(m_rc.top) * 15 / 4));
-    m_height = static_cast<int>((static_cast<int64_t>(m_rc.bottom) * 15 / 4));
+    m_left = static_cast<int>((static_cast<int64_t>(m_rc.GetLeft()) * 7 / 4));
+    m_width = static_cast<int>((static_cast<int64_t>(m_rc.GetWidth()) * 7 / 4));
+    m_top = static_cast<int>((static_cast<int64_t>(m_rc.GetTop()) * 15 / 4));
+    m_height = static_cast<int>((static_cast<int64_t>(m_rc.GetHeight()) * 15 / 4));
 }
 
 ttlib::cview rcCtrl::GetID(ttlib::cview line)


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds several functions for working with **GROUPBOX** controls, including trying to determine whether it's children should be in a **wxFlexGridSizer**.

In cases where there are controls outside of the GROUPBOX on the left or right which are vertically aligned with the controls within the GROUPBOX, the code will now correctly place the children under the **wxStaticBoxSizer**. However, currently it will _not_ correctly place the **wxStaticBoxSizer** or the children to the left or right of it.

The file `main_test.rc` has been added to the repository so that there is a consistent place to go for problematic dialogs. Currently, the `IDD_MAINTEST` dialog is created purely for testing, and the other dialogs are real-world dialogs copied from other projects.
