### PR TITLE
Toggle Expand on turns off wxALIGN_RIGHT

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1137,8 +1137,18 @@ void MainFrame::OnToggleExpandLayout(wxCommandEvent&)
     }
 
     auto currentValue = propFlag->as_string();
-    auto value = (isPropFlagSet("wxEXPAND", currentValue) ? ClearPropFlag("wxEXPAND", currentValue) :
-                                                            SetPropFlag("wxEXPAND", currentValue));
+    auto wasExpanded = isPropFlagSet("wxEXPAND", currentValue);
+    auto value = (wasExpanded ? ClearPropFlag("wxEXPAND", currentValue) : SetPropFlag("wxEXPAND", currentValue));
+
+    if (!wasExpanded)
+    {
+        auto alignment = m_selected_node->get_prop_ptr(prop_alignment);
+        if (alignment && isPropFlagSet("wxALIGN_RIGHT", alignment->as_cview()))
+        {
+            auto new_value = ClearPropFlag("wxALIGN_RIGHT", alignment->as_cview());
+            ModifyProperty(alignment, new_value);
+        }
+    }
 
     ModifyProperty(propFlag, value);
 }


### PR DESCRIPTION
It's invalid to use both, so this avoids the assertion error that will occur if the user compilers a _DEBUG version of their program.

Related to #73

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
