### PR TITLE
Update GetStye(), create new tab_position property

### DIFF
--- a/src/debugging/dbg_code_diff.cpp
+++ b/src/debugging/dbg_code_diff.cpp
@@ -28,7 +28,7 @@
 
 DbgCodeDiff::DbgCodeDiff(wxWindow* parent) : DbgCodeDiffBase(parent) {}
 
-DbgCodeDiffBase::~DbgCodeDiffBase()
+DbgCodeDiff::~DbgCodeDiff()
 {
     wxDir dir;
     wxArrayString files;

--- a/src/debugging/dbg_code_diff.h
+++ b/src/debugging/dbg_code_diff.h
@@ -13,6 +13,7 @@ class DbgCodeDiff : public DbgCodeDiffBase
 {
 public:
     DbgCodeDiff(wxWindow* parent = nullptr);
+    ~DbgCodeDiff();
 
 protected:
     void OnWinMerge(wxCommandEvent& event) override;

--- a/src/debugging/dbg_code_diff_base.h
+++ b/src/debugging/dbg_code_diff_base.h
@@ -19,7 +19,6 @@ class DbgCodeDiffBase : public wxDialog
 {
 public:
     DbgCodeDiffBase(wxWindow* parent);
-    ~DbgCodeDiffBase();
 
 protected:
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -284,6 +284,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_style, "style" },
     { prop_tab_behaviour, "tab_behaviour" },
     { prop_tab_indents, "tab_indents" },
+    { prop_tab_position, "tab_position" },
     { prop_tab_width, "tab_width" },
     { prop_text, "text" },
     { prop_theme, "theme" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -282,6 +282,7 @@ namespace GenEnum
         prop_style,
         prop_tab_behaviour,
         prop_tab_indents,
+        prop_tab_position,
         prop_tab_width,
         prop_text,
         prop_theme,

--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -140,9 +140,9 @@ std::optional<ttlib::cstr> BookPageGenerator::GenConstruction(Node* node)
 
 wxObject* NotebookGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    auto widget = new wxNotebook(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(prop_pos),
-                                 node->prop_as_wxSize(prop_size),
-                                 node->prop_as_int(prop_style) | node->prop_as_int(prop_window_style));
+    auto widget = new wxNotebook(
+        wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(prop_pos), node->prop_as_wxSize(prop_size),
+        node->prop_as_int(prop_tab_position) | node->prop_as_int(prop_style) | node->prop_as_int(prop_window_style));
 
     AddBookImageList(node, widget);
 
@@ -251,9 +251,11 @@ bool ChoicebookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 
 wxObject* ListbookGenerator::CreateMockup(Node* node, wxObject* parent)
 {
+    // Note the currently, wxListbook does not have a "style" property since the only thing that can be set is the label
+    // (tab) position
     auto widget = new wxListbook(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxPoint(prop_pos),
                                  node->prop_as_wxSize(prop_size),
-                                 node->prop_as_int(prop_style) | node->prop_as_int(prop_window_style));
+                                 node->prop_as_int(prop_tab_position) | node->prop_as_int(prop_window_style));
 
     AddBookImageList(node, widget);
 

--- a/src/generate/ctrl_widgets.cpp
+++ b/src/generate/ctrl_widgets.cpp
@@ -39,7 +39,7 @@ std::optional<ttlib::cstr> CalendarCtrlGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxCalendarCtrl(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", wxDefaultDateTime";
-    GeneratePosSizeFlags(node, code, false, "wxCAL_SHOW_HOLIDAYS", "wxCAL_SHOW_HOLIDAYS");
+    GeneratePosSizeFlags(node, code, false, "wxCAL_SHOW_HOLIDAYS");
 
     code.Replace(", wxDefaultDateTime);", ");");
 
@@ -170,7 +170,7 @@ std::optional<ttlib::cstr> GenericDirCtrlGenerator::GenConstruction(Node* node)
 
     if (!node->HasValue(prop_filter) && node->prop_as_int(prop_defaultfilter) == 0 && !node->HasValue(prop_window_name))
     {
-        GeneratePosSizeFlags(node, code, false, "wxDIRCTRL_DEFAULT_STYLE", "wxDIRCTRL_DEFAULT_STYLE");
+        GeneratePosSizeFlags(node, code, false, "wxDIRCTRL_DEFAULT_STYLE");
     }
     else
     {

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -379,9 +379,11 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
 
                 if (new_hdr)
                 {
-                    path = "~wxue_";
-                    path << form->prop_as_string(prop_base_file);
-                    path.make_absolute();
+                    path = base_file;
+                    if (auto pos_file = path.find_filename(); ttlib::is_found(pos_file))
+                    {
+                        path.insert(pos_file, "~wxue_");
+                    }
 
                     path.replace_extension(header_ext);
                     h_cw = std::make_unique<FileCodeWriter>(path.wx_str());
@@ -407,9 +409,11 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
 
                 if (new_src)
                 {
-                    path = "~wxue_";
-                    path << form->prop_as_string(prop_base_file);
-                    path.make_absolute();
+                    path = base_file;
+                    if (auto pos_file = path.find_filename(); ttlib::is_found(pos_file))
+                    {
+                        path.insert(pos_file, "~wxue_");
+                    }
 
                     path.replace_extension(header_ext);
                     h_cw = std::make_unique<FileCodeWriter>(path.wx_str());

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -55,8 +55,10 @@ ttlib::cstr GetParentName(Node* node);
 
 // Check for pos, size, flags, window_flags, and window name, and generate code if needed
 // starting with a comma, e.g. -- ", wxPoint(x, y), wxSize(x, y), styles, name);"
+//
+// If the only style specified is def_style, then it will not be added.
 void GeneratePosSizeFlags(Node* node, ttlib::cstr& code, bool uses_def_validator = false,
-                          ttlib::cview extra_style = tt_empty_cstr, ttlib::cview extra_def_value = tt_empty_cstr);
+                          ttlib::cview def_style = tt_empty_cstr);
 
 // Generate any non-default wxWindow settings
 void GenerateWindowSettings(Node* node, ttlib::cstr& code);
@@ -75,9 +77,8 @@ ttlib::cstr GenEventCode(NodeEvent* event, const std::string& class_name);
 void GenPos(Node* node, ttlib::cstr& code);
 void GenSize(Node* node, ttlib::cstr& code);
 
-// This will output "0" if style, win_style, and extra_style are all empty
-void GenStyle(Node* node, ttlib::cstr& code, ttlib::cview extra_style = tt_empty_cstr,
-              ttlib::cview extra_def_value = tt_empty_cstr);
+// This will output "0" if there are no styles (style, window_style, tab_position etc.)
+void GenStyle(Node* node, ttlib::cstr& code);
 
 // Version of GenAdditionalCode() specifically for forms
 ttlib::cstr GenFormCode(GenEnum::GenCodeType command, Node* node);

--- a/src/generate/grid_widgets.cpp
+++ b/src/generate/grid_widgets.cpp
@@ -141,7 +141,7 @@ std::optional<ttlib::cstr> GridGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxGrid(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, false, " wxWANTS_CHARS", " wxWANTS_CHARS");
+    GeneratePosSizeFlags(node, code, false, "wxWANTS_CHARS");
 
     return code;
 }
@@ -361,7 +361,7 @@ std::optional<ttlib::cstr> PropertyGridGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxPropertyGrid(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, false, "wxPG_DEFAULT_STYLE", "wxPG_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, false, "wxPG_DEFAULT_STYLE");
 
     code.Replace(", wxID_ANY);", ");");
 
@@ -467,7 +467,7 @@ std::optional<ttlib::cstr> PropertyGridManagerGenerator::GenConstruction(Node* n
         code << "auto ";
     code << node->get_node_name() << " = new wxPropertyGridManager(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, false, "wxPGMAN_DEFAULT_STYLE", "wxPGMAN_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, false, "wxPGMAN_DEFAULT_STYLE");
 
     code.Replace(", wxID_ANY);", ");");
 

--- a/src/generate/listctrl_widgets.cpp
+++ b/src/generate/listctrl_widgets.cpp
@@ -68,7 +68,7 @@ std::optional<ttlib::cstr> ListViewGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxListView(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, false, "wxLC_ICON", "wxLC_ICON");
+    GeneratePosSizeFlags(node, code, false, "wxLC_ICON");
 
     return code;
 }

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -456,7 +456,7 @@ std::optional<ttlib::cstr> GaugeGenerator::GenConstruction(Node* node)
         code << ", ";
     }
 
-    GeneratePosSizeFlags(node, code, true, "orientation", "wxGA_HORIZONTAL");
+    GeneratePosSizeFlags(node, code, true, "wxGA_HORIZONTAL");
 
     return code;
 }
@@ -543,7 +543,7 @@ std::optional<ttlib::cstr> SliderGenerator::GenConstruction(Node* node)
         code << ", ";
     }
 
-    GeneratePosSizeFlags(node, code, true, "orientation", "wxSL_HORIZONTAL");
+    GeneratePosSizeFlags(node, code, true, "wxSL_HORIZONTAL");
 
     return code;
 }

--- a/src/generate/panel_widgets.cpp
+++ b/src/generate/panel_widgets.cpp
@@ -105,7 +105,7 @@ std::optional<ttlib::cstr> CollapsiblePaneGenerator::GenConstruction(Node* node)
         code << "wxEmptyString";
     }
 
-    GeneratePosSizeFlags(node, code, true, "wxCP_DEFAULT_STYLE", "wxCP_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, true, "wxCP_DEFAULT_STYLE");
 
     return code;
 }

--- a/src/generate/picker_widgets.cpp
+++ b/src/generate/picker_widgets.cpp
@@ -40,7 +40,7 @@ std::optional<ttlib::cstr> DatePickerCtrlGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxDatePickerCtrl(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", wxDefaultDateTime";
-    GeneratePosSizeFlags(node, code, true, "wxDP_DEFAULT|wxDP_SHOWCENTURY", "wxDP_DEFAULT|wxDP_SHOWCENTURY");
+    GeneratePosSizeFlags(node, code, true, "wxDP_DEFAULT|wxDP_SHOWCENTURY");
 
     return code;
 }
@@ -77,7 +77,7 @@ std::optional<ttlib::cstr> TimePickerCtrlGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxTimePickerCtrl(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", wxDefaultDateTime";
-    GeneratePosSizeFlags(node, code, true, "wxTP_DEFAULT", "wxTP_DEFAULT");
+    GeneratePosSizeFlags(node, code, true, "wxTP_DEFAULT");
 
     return code;
 }
@@ -158,7 +158,7 @@ std::optional<ttlib::cstr> FilePickerGenerator::GenConstruction(Node* node)
 
     // Note that wxFLP_DEFAULT_STYLE cannot be specified by the user. We use this to force writing 0 if the user doesn't
     // select any options.
-    GeneratePosSizeFlags(node, code, true, "wxFLP_DEFAULT_STYLE", "wxFLP_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, true, "wxFLP_DEFAULT_STYLE");
 
     return code;
 }
@@ -221,7 +221,7 @@ std::optional<ttlib::cstr> DirPickerGenerator::GenConstruction(Node* node)
         }
     }
 
-    GeneratePosSizeFlags(node, code, true, "wxDIRP_DEFAULT_STYLE", "wxDIRP_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, true, "wxDIRP_DEFAULT_STYLE");
 
     return code;
 }
@@ -261,7 +261,7 @@ std::optional<ttlib::cstr> ColourPickerGenerator::GenConstruction(Node* node)
         code << node->prop_as_string(prop_colour);
     else
         code << "*wxBLACK";
-    GeneratePosSizeFlags(node, code, true, "wxCLRP_DEFAULT_STYLE", "wxCLRP_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, true, "wxCLRP_DEFAULT_STYLE");
 
     return code;
 }
@@ -329,7 +329,7 @@ std::optional<ttlib::cstr> FontPickerGenerator::GenConstruction(Node* node)
         code << "wxNullFont";
     }
 
-    GeneratePosSizeFlags(node, code, true, "wxFNTP_DEFAULT_STYLE", "wxFNTP_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, true, "wxFNTP_DEFAULT_STYLE");
 
     return code;
 }

--- a/src/generate/ribbon_widgets.cpp
+++ b/src/generate/ribbon_widgets.cpp
@@ -157,7 +157,7 @@ std::optional<ttlib::cstr> RibbonBarGenerator::GenConstruction(Node* node)
     code << node->get_node_name() << " = new wxRibbonBar(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
 
-    GeneratePosSizeFlags(node, code, false, "wxRIBBON_BAR_DEFAULT_STYLE", "wxRIBBON_BAR_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, false, "wxRIBBON_BAR_DEFAULT_STYLE");
 
     return code;
 }
@@ -294,7 +294,7 @@ std::optional<ttlib::cstr> RibbonPanelGenerator::GenConstruction(Node* node)
     else
         code << ", wxNullBitmap";
 
-    GeneratePosSizeFlags(node, code, false, "wxRIBBON_PANEL_DEFAULT_STYLE", "wxRIBBON_PANEL_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, false, "wxRIBBON_PANEL_DEFAULT_STYLE");
 
     code.Replace(", wxNullBitmap);", ");");
     code.Replace(", wxNullBitmap,", ",\n\t\twxNullBitmap,");

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -288,8 +288,7 @@ std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenConstruction(Node
         code << "wxEmptyString";
     }
 
-    GeneratePosSizeFlags(node, code);
-    code << '\n';
+    code << ");\n";
 
     if (auto result = GenInheritSettings(node); result)
     {

--- a/src/generate/spin_widgets.cpp
+++ b/src/generate/spin_widgets.cpp
@@ -165,7 +165,7 @@ std::optional<ttlib::cstr> SpinButtonGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxSpinButton(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, false, "wxSP_VERTICAL", "wxSP_VERTICAL");
+    GeneratePosSizeFlags(node, code, false, "wxSP_VERTICAL");
 
     code.Replace(", wxID_ANY);", ");");
 

--- a/src/generate/toolbar_widgets.cpp
+++ b/src/generate/toolbar_widgets.cpp
@@ -278,7 +278,7 @@ std::optional<ttlib::cstr> ToolBarGenerator::GenConstruction(Node* node)
     else
     {
         code << " = new wxToolBar(" << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-        GeneratePosSizeFlags(node, code, false, "", "wxTB_HORIZONTAL");
+        GeneratePosSizeFlags(node, code, false, "wxTB_HORIZONTAL");
     }
 
     return code;
@@ -460,7 +460,7 @@ std::optional<ttlib::cstr> AuiToolBarGenerator::GenConstruction(Node* node)
     code << node->prop_as_string(prop_var_name);
 
     code << " = new wxAuiToolBar(" << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, false, "", "wxAUI_TB_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, false, "wxAUI_TB_DEFAULT_STYLE");
 
     return code;
 }

--- a/src/generate/tree_widgets.cpp
+++ b/src/generate/tree_widgets.cpp
@@ -54,7 +54,7 @@ std::optional<ttlib::cstr> TreeCtrlGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxTreeCtrl(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, true, "wxTR_DEFAULT_STYLE", "wxTR_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, true, "wxTR_DEFAULT_STYLE");
 
     code.Replace(", wxID_ANY);", ");");
 
@@ -92,7 +92,7 @@ std::optional<ttlib::cstr> TreeListViewGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << " = new wxTreeListCtrl(";
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, true, "wxTL_DEFAULT_STYLE", "wxTL_DEFAULT_STYLE");
+    GeneratePosSizeFlags(node, code, true, "wxTL_DEFAULT_STYLE");
 
     return code;
 }

--- a/src/nodes/node_constants.cpp
+++ b/src/nodes/node_constants.cpp
@@ -441,6 +441,13 @@ void NodeCreator::AddAllConstants()
     ADD_CONSTANT(wxHSCROLL);
     ADD_CONSTANT(wxVSCROLL);
 
+    // Books
+    ADD_CONSTANT(wxBK_DEFAULT)
+    ADD_CONSTANT(wxBK_TOP)
+    ADD_CONSTANT(wxBK_BOTTOM)
+    ADD_CONSTANT(wxBK_LEFT)
+    ADD_CONSTANT(wxBK_RIGHT)
+
     // wxNotebook
     ADD_CONSTANT(wxNB_TOP)
     ADD_CONSTANT(wxNB_LEFT)

--- a/src/xml/containers.xml
+++ b/src/xml/containers.xml
@@ -177,18 +177,18 @@
             help="All tab images will be scaled to this size.">16, 16</property>
         <property name="persist_name" type="string"
             help="If a name is specified, wxPersistenceManager will be used to save/restore the currently selected page." />
-        <property name="style" type="bitlist">
-            <option name="wxLB_DEFAULT"
-                help="Choose the default location for the labels depending on the current platform (left everywhere except Mac where it is top)." />
-            <option name="wxLB_TOP"
+        <property name="tab_position" type="option">
+            <option name="wxBK_DEFAULT"
+                help="Default location for the labels depending on the current platform (left everywhere except Mac where it is top)." />
+            <option name="wxBK_TOP"
                 help="Place labels above the page area." />
-            <option name="wxLB_LEFT"
+            <option name="wxBK_LEFT"
                 help="Place labels on the left side." />
-            <option name="wxLB_RIGHT"
+            <option name="wxBK_RIGHT"
                 help="Place labels on the right side." />
-            <option name="wxLB_BOTTOM"
+            <option name="wxBK_BOTTOM"
                 help="Place labels below the page area." />
-            wxLB_DEFAULT
+            wxBK_DEFAULT
         </property>
         <event name="wxEVT_LISTBOOK_PAGE_CHANGED" class="wxBookCtrlEvent"
             help="The page selection was changed." />
@@ -213,15 +213,20 @@
             help="All tab images will be scaled to this size.">16, 16</property>
         <property name="persist_name" type="string"
             help="If a name is specified, wxPersistenceManager will be used to save/restore the currently selected page." />
-        <property name="style" type="bitlist">
-            <option name="wxNB_TOP"
+        <property name="tab_position" type="option">
+            <option name="wxBK_DEFAULT"
+                help="Default placement of tabs (currently top on all platforms)." />
+            <option name="wxBK_TOP"
                 help="Place tabs on the top side." />
-            <option name="wxNB_LEFT"
+            <option name="wxBK_BOTTOM"
+                help="Place tabs under instead of above the book pages." />
+            <option name="wxBK_LEFT"
                 help="Place tabs on the left side." />
-            <option name="wxNB_RIGHT"
+            <option name="wxBK_RIGHT"
                 help="Place tabs on the right side." />
-            <option name="wxNB_BOTTOM"
-                help="Place tabs under instead of above the notebook pages." />
+            wxBK_DEFAULT
+        </property>
+        <property name="style" type="bitlist">
             <option name="wxNB_FIXEDWIDTH"
                 help="All tabs will have same width. (Windows only)" />
             <option name="wxNB_MULTILINE"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The changes to `GetStyle()` were needed so that other properties like the new `tab_position` could be used to split apart styles into multiple properties.

Closes #287
