### PR TITLE
Optimize compilation speed when major header files change

### DIFF
--- a/src/debugging/dbg_winres_dlg.h
+++ b/src/debugging/dbg_winres_dlg.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include "dbg_winres_dlg_base.h"
+#include <wx/filehistory.h>  // wxFileHistory class
 
-class wxFileHistory;
+#include "dbg_winres_dlg_base.h"
 
 class DbgWinResDlg : public DbgWinResBase
 {

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -8,6 +8,7 @@
 #include "pch.h"
 
 #include <wx/menu.h>      // wxMenu and wxMenuBar classes
+#include <wx/sizer.h>     // provide wxSizer class for layout
 #include <wx/statline.h>  // wxStaticLine class interface
 #include <wx/stattext.h>  // wxStaticText base header
 

--- a/src/generate/tree_widgets.cpp
+++ b/src/generate/tree_widgets.cpp
@@ -8,6 +8,7 @@
 #include "pch.h"
 
 #include <wx/event.h>     // Event classes
+#include <wx/sizer.h>     // provide wxSizer class for layout
 #include <wx/treectrl.h>  // wxTreeCtrl base header
 #include <wx/treelist.h>  // wxTreeListCtrl class declaration.
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -10,9 +10,12 @@
 #include <sstream>
 
 #include <wx/aboutdlg.h>          // declaration of wxAboutDialog class
+#include <wx/aui/auibook.h>       // wxaui: wx advanced user interface - notebook
 #include <wx/clipbrd.h>           // wxClipboad class and clipboard functions
 #include <wx/config.h>            // wxConfig base header
+#include <wx/fdrepdlg.h>          // wxFindReplaceDialog class
 #include <wx/filedlg.h>           // wxFileDialog base header
+#include <wx/filehistory.h>       // wxFileHistory class
 #include <wx/frame.h>             // wxFrame class interface
 #include <wx/infobar.h>           // declaration of wxInfoBarBase defining common API of wxInfoBar
 #include <wx/persist/splitter.h>  // persistence support for wxTLW

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <wx/aui/auibook.h>  // wxaui: wx advanced user interface - notebook
 #include <wx/fdrepdlg.h>     // wxFindReplaceDialog class
 #include <wx/filehistory.h>  // wxFileHistory class
 
@@ -27,9 +26,12 @@ class MockupPanel;
 class MockupParent;
 class FocusKillerEvtHandler;
 
-class ueStatusBar;
+class wxAuiNotebook;
+class wxAuiNotebookEvent;
 class wxInfoBar;
 class wxSplitterWindow;
+
+class ueStatusBar;
 class NavigationPanel;
 class RibbonPanel;
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -7,6 +7,8 @@
 
 #include "pch.h"
 
+#include <wx/sizer.h>  // provide wxSizer class for layout
+
 #include "node.h"
 
 #include "appoptions.h"    // AppOptions -- Application-wide options

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -12,10 +12,10 @@
 #include <unordered_set>
 #include <vector>
 
-#include <wx/bitmap.h>  // wxBitmap class interface
-#include <wx/sizer.h>   // provide wxSizer class for layout
-
-#include "../pugixml/pugixml.hpp"
+namespace pugi
+{
+    class xml_document;
+}
 
 #include "font_prop.h"   // FontProperty class
 #include "gen_enums.h"   // Enumerations for generators
@@ -24,6 +24,8 @@
 #include "node_prop.h"   // NodeProperty class
 #include "node_types.h"  // NodeType -- Class for storing component types and allowable child count
 #include "prop_names.h"  // Property names
+
+class wxSizerFlags;
 
 class Node;
 using NodeSharedPtr = std::shared_ptr<Node>;

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -11,8 +11,6 @@
 #include <optional>
 #include <set>
 
-#include <wx/bitmap.h>  // wxBitmap class interface
-
 #include "node_classes.h"  // Forward defintions of Node classes
 
 #include "category.h"    // NodeCategory -- Node property categories

--- a/src/pch.h
+++ b/src/pch.h
@@ -61,6 +61,19 @@
 // Without this, a huge number of #included wxWidgets header files will generate the warning
 #pragma warning(disable : 4251)  // needs to have dll-interface to be used by clients of class
 
+#include <map>
+#include <unordered_map>
+
+#include <set>
+#include <unordered_set>
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "ttlibspace.h"  // This must be included before any other ttLib header files
 
 #include "ttcstr.h"   // ttlib::cstr -- std::string with additional functions

--- a/src/pch.h
+++ b/src/pch.h
@@ -54,6 +54,9 @@
 
 #endif
 
+// This is included because mainframe.h needs it, and changing mainframe.h results in 37 files needing to read this.
+#include <wx/gdicmn.h>
+
 #ifdef _MSC_VER
     #pragma warning(pop)
 #endif

--- a/src/pch.h
+++ b/src/pch.h
@@ -159,14 +159,6 @@ bool ttAssertionMsg(const char* filename, const char* function, int line, const 
         #define ASSERT(cond)          wxASSERT(cond)
         #define ASSERT_MSG(cond, msg) wxASSERT_MSG(cond, msg)
         #define FAIL_MSG(msg)         wxFAIL_MSG(msg)
-
-        // In _DEBUG builds this will display an assertion dialog first then it will throw
-        // an excpetion. In Release builds, only the exception is thrown.
-        #define THROW(msg)         \
-            {                      \
-                wxFAIL_MSG(msg);   \
-                throw CExcept(msg) \
-            }
     #endif  // _WIN32
 
 #endif  // defined(NDEBUG)

--- a/src/project/saveproject.cpp
+++ b/src/project/saveproject.cpp
@@ -11,6 +11,8 @@
 #include "node.h"       // Node class
 #include "prop_decl.h"  // PropChildDeclaration and PropDeclaration classes
 
+#include "../pugixml/pugixml.hpp"
+
 using namespace GenEnum;
 
 void Node::CreateDoc(pugi::xml_document& doc)

--- a/src/ttLib/ttcstr.cpp
+++ b/src/ttLib/ttcstr.cpp
@@ -16,6 +16,7 @@
 #include <iomanip>
 #include <ios>
 #include <locale>
+#include <sstream>
 
 #include "ttcstr.h"
 #include "ttlibspace.h"

--- a/src/ttLib/ttcstr.h
+++ b/src/ttLib/ttcstr.h
@@ -18,8 +18,6 @@
 /// most places where std::string<char> is used. It provides additional functionality including utf8/16
 /// conversions, file name handling, etc.
 
-#include <cassert>
-#include <filesystem>
 #include <string>
 #include <string_view>
 

--- a/src/ttLib/ttcview.h
+++ b/src/ttLib/ttcview.h
@@ -29,8 +29,6 @@
 // This can be used to conditionalize code where <ttcview.h> is available or not
 #define _TTLIB_CVIEW_AVAILABLE_
 
-#include <filesystem>
-#include <sstream>
 #include <string_view>
 
 namespace ttlib

--- a/src/utils/font_prop.h
+++ b/src/utils/font_prop.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <wx/font.h>     // wxFontBase class: the interface of wxFont
-#include <wx/variant.h>  // wxVariant class, container for any type
+class wxFont;
+class wxVariant;
 
 class FontProperty
 {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
When node.h or any of the files it includes is changed, 74 files have to be rebuilt. When mainframe.h or any of the files it includes is changed, 37 files have to be rebuilt. Reducing the number of header files that are read increases compilation speed. This PR both removes unnecessary header files, and adds more files to the precompiled header file.