### PR TITLE
Refactor and improve Undo Command classes

### DIFF
--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -79,15 +79,11 @@ void MainFrame::FireProjectUpdatedEvent()
     }
 }
 
-void MainFrame::ChangeEventHandler(NodeEvent* event, const ttlib::cstr& value)
+void MainFrame::FireChangeEventHandler(NodeEvent* evt_node)
 {
-    if (event && value != event->get_value())
+    CustomEvent event(EVT_EventHandlerChanged, evt_node);
+    for (auto handler: m_custom_event_handlers)
     {
-        PushUndoAction(std::make_shared<ModifyEventAction>(event, value));
-        CustomEvent evt_node(EVT_EventHandlerChanged, event);
-        for (auto handler: m_custom_event_handlers)
-        {
-            handler->ProcessEvent(evt_node);
-        }
+        handler->ProcessEvent(event);
     }
 }

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1393,6 +1393,14 @@ void MainFrame::RemoveNode(Node* node, bool isCutMode)
     }
 }
 
+void MainFrame::ChangeEventHandler(NodeEvent* event, const ttlib::cstr& value)
+{
+    if (event && value != event->get_value())
+    {
+        PushUndoAction(std::make_shared<ModifyEventAction>(event, value));
+    }
+}
+
 Node* MainFrame::FindChildSizerItem(Node* node)
 {
     if (node->GetNodeDeclaration()->isSubclassOf(gen_sizer_dimension))

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1202,7 +1202,6 @@ void MainFrame::ModifyProperty(NodeProperty* prop, ttlib::cview value)
     if (prop && value != prop->as_cview())
     {
         PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
-        FirePropChangeEvent(prop);
     }
 }
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -608,9 +608,9 @@ void MainFrame::UpdateFrame()
     menu_text = _ttwx(strIdRedo);
     if (m_undo_stack.IsRedoAvailable())
     {
-        if (m_undo_stack.GetUndoString().size())
+        if (m_undo_stack.GetRedoString().size())
         {
-            menu_text << ' ' << m_undo_stack.GetUndoString();
+            menu_text << ' ' << m_undo_stack.GetRedoString();
         }
     }
     menu_text << "\tCtrl+Y";

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1074,8 +1074,6 @@ void MainFrame::PasteNode(Node* parent)
 
     auto pos = parent->FindInsertionPos(m_selected_node);
     PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, pos));
-    new_node->FixDuplicateNodeNames();
-
     FireCreatedEvent(new_node);
     SelectNode(new_node, true, true);
 }
@@ -1092,8 +1090,6 @@ void MainFrame::DuplicateNode(Node* node)
     auto pos = parent->FindInsertionPos(m_selected_node);
     auto new_node = g_NodeCreator.MakeCopy(node);
     PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, pos));
-    new_node->FixDuplicateNodeNames();
-
     FireCreatedEvent(new_node);
     SelectNode(new_node, true, true);
 }

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1381,26 +1381,18 @@ void MainFrame::RemoveNode(Node* node, bool isCutMode)
     if (!parent)
         return;
 
-    // We need to make a copy in order to pass to FireDeletedEvent
-    auto deleted_node = node;
-    Node* node_copy = node;
-
     if (isCutMode)
     {
         ttlib::cstr undo_str;
         undo_str << "cut " << node->DeclName();
-        PushUndoAction(std::make_shared<RemoveNodeAction>(node_copy, undo_str, true));
+        PushUndoAction(std::make_shared<RemoveNodeAction>(node, undo_str, true));
     }
     else
     {
         ttlib::cstr undo_str;
         undo_str << "delete " << node->DeclName();
-        PushUndoAction(std::make_shared<RemoveNodeAction>(node_copy, undo_str, false));
+        PushUndoAction(std::make_shared<RemoveNodeAction>(node, undo_str, false));
     }
-
-    FireDeletedEvent(deleted_node);
-    ASSERT(GetSelectedNodePtr());  // RemoveNodeAction should have selected something
-    SelectNode(GetSelectedNode(), true, true);
 }
 
 Node* MainFrame::FindChildSizerItem(Node* node)

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1110,9 +1110,10 @@ void MainFrame::Undo()
 
     m_undo_stack.Undo();
     m_isProject_modified = (m_undo_stack_size != m_undo_stack.size());
-    FireProjectUpdatedEvent();
-    ASSERT(m_selected_node)
-    FireSelectedEvent(m_selected_node.get());
+    if (!m_undo_stack.wasUndoEventGenerated())
+        FireProjectUpdatedEvent();
+    if (!m_undo_stack.wasUndoSelectEventGenerated())
+        FireSelectedEvent(m_selected_node.get());
 }
 
 void MainFrame::Redo()
@@ -1121,8 +1122,10 @@ void MainFrame::Redo()
 
     m_undo_stack.Redo();
     m_isProject_modified = (m_undo_stack_size != m_undo_stack.size());
-    FireProjectUpdatedEvent();
-    FireSelectedEvent(GetSelectedNode());
+    if (!m_undo_stack.wasRedoEventGenerated())
+        FireProjectUpdatedEvent();
+    if (!m_undo_stack.wasRedoSelectEventGenerated())
+        FireSelectedEvent(GetSelectedNode());
 }
 
 void MainFrame::OnToggleExpandLayout(wxCommandEvent&)

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -61,6 +61,7 @@ public:
 
     void AddCustomEventHandler(wxEvtHandler* handler) { m_custom_event_handlers.push_back(handler); }
 
+    void FireChangeEventHandler(NodeEvent* event);
     void FireCreatedEvent(Node* node);
     void FireDeletedEvent(Node* node);
     void FireProjectLoadedEvent();

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -508,7 +508,6 @@ Node* Node::CreateChildNode(GenName name)
         ttlib::cstr undo_str;
         undo_str << "insert " << map_GenNames[name];
         frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), this, undo_str));
-        new_node->FixDuplicateName();
     }
 
     // A "ribbonButton" component is used for both wxRibbonButtonBar and wxRibbonToolBar. If creating the node failed,
@@ -520,7 +519,6 @@ Node* Node::CreateChildNode(GenName name)
         {
             ttlib::cstr undo_str = "insert ribbon tool";
             frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), this, undo_str));
-            new_node->FixDuplicateName();
         }
         else
         {
@@ -556,7 +554,6 @@ Node* Node::CreateChildNode(GenName name)
                 ttlib::cstr undo_str;
                 undo_str << "insert " << map_GenNames[name];
                 frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, pos));
-                new_node->FixDuplicateName();
             }
         }
         else

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -589,7 +589,6 @@ void Node::ModifyProperty(PropName name, ttlib::cview value)
     if (prop && value != prop->as_cview())
     {
         wxGetFrame().PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
-        wxGetFrame().FirePropChangeEvent(prop);
     }
 }
 
@@ -602,7 +601,6 @@ void Node::ModifyProperty(ttlib::cview name, int value)
     if (prop && value != prop->as_int())
     {
         wxGetFrame().PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
-        wxGetFrame().FirePropChangeEvent(prop);
     }
 }
 
@@ -615,7 +613,6 @@ void Node::ModifyProperty(ttlib::cview name, ttlib::cview value)
     if (prop && value != prop->as_cview())
     {
         wxGetFrame().PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
-        wxGetFrame().FirePropChangeEvent(prop);
     }
 }
 
@@ -624,7 +621,6 @@ void Node::ModifyProperty(NodeProperty* prop, int value)
     if (prop && value != prop->as_int())
     {
         wxGetFrame().PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
-        wxGetFrame().FirePropChangeEvent(prop);
     }
 }
 
@@ -633,7 +629,6 @@ void Node::ModifyProperty(NodeProperty* prop, ttlib::cview value)
     if (prop && value != prop->as_cview())
     {
         wxGetFrame().PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
-        wxGetFrame().FirePropChangeEvent(prop);
     }
 }
 

--- a/src/nodes/node_gridbag.cpp
+++ b/src/nodes/node_gridbag.cpp
@@ -60,12 +60,7 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
 
     if (dlg.GetRow() > m_max_row)
     {
-        ttlib::cstr undo_str;
-        undo_str << "Append " << map_GenNames[new_node->gen_name()];
-        wxGetFrame().PushUndoAction(std::make_shared<AppendGridBagAction>(new_node, gbsizer, undo_str));
-        new_node->FixDuplicateName();
-        wxGetFrame().FireCreatedEvent(new_node);
-        wxGetFrame().SelectNode(new_node, true, true);
+        wxGetFrame().PushUndoAction(std::make_shared<AppendGridBagAction>(new_node, gbsizer));
         return true;
     }
 
@@ -96,12 +91,7 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
         if (pos_append >= static_cast<int_t>(gbsizer->GetChildCount()))
             pos_append = -1;  // Append the child at the very end
 
-        ttlib::cstr undo_str;
-        undo_str << "Append " << map_GenNames[new_node->gen_name()];
-        wxGetFrame().PushUndoAction(std::make_shared<AppendGridBagAction>(new_node, gbsizer, undo_str, pos_append));
-        new_node->FixDuplicateName();
-        wxGetFrame().FireCreatedEvent(new_node);
-        wxGetFrame().SelectNode(new_node, true, true);
+        wxGetFrame().PushUndoAction(std::make_shared<AppendGridBagAction>(new_node, gbsizer, pos_append));
         return true;
     }
 

--- a/src/nodes/node_gridbag.cpp
+++ b/src/nodes/node_gridbag.cpp
@@ -15,7 +15,7 @@
 #include "mainapp.h"       // App -- Main application class
 #include "mainframe.h"     // Main window frame
 #include "node.h"          // Node class
-#include "undo_cmds.h"     // InsertNodeAction -- Undoable command classes derived from UndoAction
+#include "undo_cmds.h"     // Undoable command classes derived from UndoAction
 
 GridBag::GridBag(Node* node_gridbag) : m_gridbag(node_gridbag)
 {

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -407,25 +407,24 @@ void NavigationPanel::AddNode(Node* node, Node* parent)
 
 void NavigationPanel::DeleteNode(Node* node)
 {
-    if (auto it = m_node_tree_map.find(node); it != m_node_tree_map.end() && it->second.IsOk())
-    {
-        m_tree_ctrl->Delete(it->second);
-        EraseAllMaps(it->first);
-    }
+    EraseAllMaps(node);
 }
 
 void NavigationPanel::EraseAllMaps(Node* node)
 {
-    if (auto it = m_node_tree_map.find(node); it != m_node_tree_map.end() && it->second.IsOk())
+    if (auto iter = m_node_tree_map.find(node); iter != m_node_tree_map.end())
     {
-        m_tree_node_map.erase(it->second);
+        m_tree_node_map.erase(iter->second);
+        if (iter->second.IsOk())
+            m_tree_ctrl->Delete(iter->second);
+
+        // Don't erase this until the iterator is no longer needed
+        m_node_tree_map.erase(node);
     }
 
-    m_node_tree_map.erase(node);
-
-    for (size_t i = 0; i < node->GetChildCount(); i++)
+    for (size_t idx = 0; idx < node->GetChildCount(); idx++)
     {
-        EraseAllMaps(node->GetChild(i));
+        EraseAllMaps(node->GetChild(idx));
     }
 }
 

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -22,7 +22,7 @@
 #include "node_creator.h"  // NodeCreator class
 #include "node_decl.h"     // NodeDeclaration class
 #include "uifuncs.h"       // Miscellaneous functions for displaying UI
-#include "undo_cmds.h"     // InsertNodeAction -- Undoable command classes derived from UndoAction
+#include "undo_cmds.h"     // Undoable command classes derived from UndoAction
 
 #include "../utils/auto_freeze.h"  // AutoFreeze -- Automatically Freeze/Thaw a window
 

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -311,7 +311,6 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
         multi_cmd->Add(insert_cmd);
 
         wxGetFrame().PushUndoAction(multi_cmd);
-        new_sizer->FixDuplicateName();
 
         // REVIEW: [KeyWorks - 03-30-2021] See issue #94 about the problem this causes.
         wxGetFrame().FireProjectUpdatedEvent();

--- a/src/ui/newdialog.cpp
+++ b/src/ui/newdialog.cpp
@@ -99,8 +99,6 @@ void NewDialog::CreateNode()
 
     auto pos = parent->FindInsertionPos(parent);
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), parent, undo_str, pos));
-    form_node->FixDuplicateNodeNames();
-
     wxGetFrame().FireCreatedEvent(form_node);
     wxGetFrame().SelectNode(form_node, true, true);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);

--- a/src/ui/newframe.cpp
+++ b/src/ui/newframe.cpp
@@ -87,8 +87,6 @@ void NewFrame::CreateNode()
 
     auto pos = parent->FindInsertionPos(parent);
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), parent, undo_str, pos));
-    form_node->FixDuplicateNodeNames();
-
     wxGetFrame().FireCreatedEvent(form_node);
     wxGetFrame().SelectNode(form_node, true, true);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);

--- a/src/ui/newribbon.cpp
+++ b/src/ui/newribbon.cpp
@@ -82,8 +82,6 @@ void NewRibbon::CreateNode()
     auto parent = wxGetFrame().GetSelectedNode();
     auto pos = parent->FindInsertionPos(parent);
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(bar_node.get(), parent, undo_str, pos));
-    bar_node->FixDuplicateNodeNames();
-
     wxGetFrame().FireCreatedEvent(bar_node);
     wxGetFrame().SelectNode(bar_node, true, true);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(bar_node.get(), true, true);

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -112,7 +112,7 @@ void RemoveNodeAction::Revert()
 
 ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, ttlib::cview value) : m_property(prop)
 {
-    SetUndoString(ttlib::cstr() << "change " << prop->DeclName());
+    m_undo_string << "change " << prop->DeclName();
 
     m_change_value << value;
     m_revert_value = prop->as_string();
@@ -120,7 +120,7 @@ ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, ttlib::cview valu
 
 ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, int value) : m_property(prop)
 {
-    SetUndoString(ttlib::cstr() << "change " << prop->DeclName());
+    m_undo_string << "change " << prop->DeclName();
 
     m_change_value << value;
     m_revert_value = prop->as_string();
@@ -140,7 +140,7 @@ void ModifyPropertyAction::Revert()
 
 ModifyEventAction::ModifyEventAction(NodeEvent* event, ttlib::cview value) : m_event(event)
 {
-    SetUndoString(ttlib::cstr() << "change " << event->get_name() << " handler");
+    m_undo_string << "change " << event->get_name() << " handler";
 
     m_change_value << value;
     m_revert_value = event->get_value();
@@ -160,7 +160,7 @@ void ModifyEventAction::Revert()
 
 ChangePositionAction::ChangePositionAction(Node* node, size_t position)
 {
-    SetUndoString(ttlib::cstr() << "change " << node->DeclName() << " position");
+    m_undo_string << "change " << node->DeclName() << " position";
 
     m_node = node->GetSharedPtr();
     m_parent = node->GetParentPtr();
@@ -183,7 +183,7 @@ void ChangePositionAction::Revert()
 
 ChangeParentAction::ChangeParentAction(Node* node, Node* parent)
 {
-    SetUndoString(ttlib::cstr() << "change " << node->DeclName() << " parent");
+    m_undo_string << "change " << node->DeclName() << " parent";
 
     m_node = node->GetSharedPtr();
     m_change_parent = parent->GetSharedPtr();

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -119,6 +119,8 @@ ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, ttlib::cview valu
 
     m_change_value << value;
     m_revert_value = prop->as_string();
+    m_RedoEventGenerated = true;
+    m_UndoEventGenerated = true;
 }
 
 ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, int value) : m_property(prop)
@@ -132,31 +134,39 @@ ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, int value) : m_pr
 void ModifyPropertyAction::Change()
 {
     m_property->set_value(m_change_value);
+
+    wxGetFrame().FirePropChangeEvent(m_property);
 }
 
 void ModifyPropertyAction::Revert()
 {
     m_property->set_value(m_revert_value);
+
+    wxGetFrame().FirePropChangeEvent(m_property);
 }
 
 ///////////////////////////////// ModifyEventAction ////////////////////////////////////
 
-ModifyEventAction::ModifyEventAction(NodeEvent* event, ttlib::cview value) : m_event(event)
+ModifyEventAction::ModifyEventAction(NodeEvent* event, ttlib::cview value) : m_event(event), m_change_value(value)
 {
     m_undo_string << "change " << event->get_name() << " handler";
 
-    m_change_value << value;
     m_revert_value = event->get_value();
+
+    m_RedoEventGenerated = true;
+    m_UndoEventGenerated = true;
 }
 
 void ModifyEventAction::Change()
 {
     m_event->set_value(m_change_value);
+    wxGetFrame().FireChangeEventHandler(m_event);
 }
 
 void ModifyEventAction::Revert()
 {
     m_event->set_value(m_revert_value);
+    wxGetFrame().FireChangeEventHandler(m_event);
 }
 
 ///////////////////////////////// ChangePositionAction ////////////////////////////////////

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -137,6 +137,8 @@ void RemoveNodeAction::Change()
     m_parent->RemoveChild(m_node);
     m_node->SetParent(NodeSharedPtr());
 
+    wxGetFrame().FireDeletedEvent(m_node.get());
+
     if (m_parent->GetChildCount())
     {
         auto pos = (m_old_pos < m_parent->GetChildCount() ? m_old_pos : m_parent->GetChildCount() - 1);

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -76,6 +76,9 @@ RemoveNodeAction::RemoveNodeAction(Node* node, const ttlib::cstr& undo_str, bool
     m_parent = node->GetParentPtr();
     m_old_pos = m_parent->GetChildPosition(node);
     m_old_selected = wxGetFrame().GetSelectedNodePtr();
+
+    m_RedoEventGenerated = true;
+    m_RedoSelectEventGenerated = true;
 }
 
 void RemoveNodeAction::Change()

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -22,6 +22,7 @@ private:
     NodeSharedPtr m_node;
     NodeSharedPtr m_old_selected;
     int m_pos;
+    bool m_fix_duplicate_names { true };
 };
 
 class RemoveNodeAction : public UndoAction

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -14,7 +14,11 @@ class InsertNodeAction : public UndoAction
 {
 public:
     InsertNodeAction(Node* node, Node* parent, const ttlib::cstr& undo_str, int pos = -1);
+
+    // Called when pushed to the Undo stack and when Redo is called
     void Change() override;
+
+    // Called when Undo is requested
     void Revert() override;
 
 private:
@@ -29,7 +33,11 @@ class RemoveNodeAction : public UndoAction
 {
 public:
     RemoveNodeAction(Node* node, const ttlib::cstr& undo_str, bool AddToClipboard = false);
+
+    // Called when pushed to the Undo stack and when Redo is called
     void Change() override;
+
+    // Called when Undo is requested
     void Revert() override;
 
 private:

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -124,7 +124,7 @@ private:
 class AppendGridBagAction : public UndoAction
 {
 public:
-    AppendGridBagAction(Node* node, Node* parent, const ttlib::cstr& undo_str, int pos = -1);
+    AppendGridBagAction(Node* node, Node* parent, int pos = -1);
     void Change() override;
     void Revert() override;
 
@@ -132,7 +132,10 @@ private:
     NodeSharedPtr m_parent;
     NodeSharedPtr m_node;
     NodeSharedPtr m_old_selected;
+    size_t m_old_pos;
+
     int m_pos;
+    bool m_fix_duplicate_names { true };
 };
 
 // Use this when the entire wxGridBagSizer node needs to be saved.

--- a/src/undo_stack.cpp
+++ b/src/undo_stack.cpp
@@ -11,12 +11,12 @@
 
 void UndoStack::Push(UndoActionPtr ptr)
 {
-    ptr->Change();
     if (!m_locked)
     {
         m_undo.push_back(ptr);
         m_redo.clear();
     }
+    ptr->Change();
 }
 
 void UndoStack::Undo()
@@ -25,8 +25,8 @@ void UndoStack::Undo()
     {
         auto command = m_undo.back();  // make a copy of the share_ptr to increase the reference count
         m_undo.pop_back();
-        command->Revert();
         m_redo.push_back(command);
+        command->Revert();
     }
 }
 
@@ -36,8 +36,8 @@ void UndoStack::Redo()
     {
         auto command = m_redo.back();  // make a copy of the share_ptr to increase the reference count
         m_redo.pop_back();
-        command->Change();
         m_undo.push_back(command);
+        command->Change();
     }
 }
 

--- a/src/undo_stack.h
+++ b/src/undo_stack.h
@@ -24,7 +24,7 @@ public:
     ttlib::cstr GetUndoString() { return m_undo_string; }
     void SetUndoString(ttlib::cview str) { m_undo_string = str; }
 
-private:
+protected:
     ttlib::cstr m_undo_string;
 };
 

--- a/src/undo_stack.h
+++ b/src/undo_stack.h
@@ -18,14 +18,27 @@ public:
 
     virtual ~UndoAction() = default;
 
+    // Called when pushed to the Undo stack and when Redo is called
     virtual void Change() = 0;
+
+    // Called when Undo is requested
     virtual void Revert() = 0;
 
     ttlib::cstr GetUndoString() { return m_undo_string; }
     void SetUndoString(ttlib::cview str) { m_undo_string = str; }
 
+    bool wasUndoEventGenerated() { return m_UndoEventGenerated; }
+    bool wasRedoEventGenerated() { return m_RedoEventGenerated; }
+    bool wasUndoSelectEventGenerated() { return m_UndoSelectEventGenerated; }
+    bool wasRedoSelectEventGenerated() { return m_RedoSelectEventGenerated; }
+
 protected:
     ttlib::cstr m_undo_string;
+
+    bool m_UndoEventGenerated { false };
+    bool m_RedoEventGenerated { false };
+    bool m_UndoSelectEventGenerated { false };
+    bool m_RedoSelectEventGenerated { false };
 };
 
 using UndoActionPtr = std::shared_ptr<UndoAction>;
@@ -64,6 +77,15 @@ public:
         m_redo.clear();
         m_undo.clear();
     }
+
+    // When undo is called, the command is popped and pushed onto the redo stack. So to get at the last undo command, you
+    // have to get the last item in the redo stack. Redo works just the opposite, pushing it's command to the last of the
+    // undo stack.
+
+    bool wasUndoEventGenerated() { return m_redo.back()->wasUndoEventGenerated(); }
+    bool wasRedoEventGenerated() { return m_undo.back()->wasRedoEventGenerated(); }
+    bool wasUndoSelectEventGenerated() { return m_redo.back()->wasUndoSelectEventGenerated(); }
+    bool wasRedoSelectEventGenerated() { return m_undo.back()->wasRedoSelectEventGenerated(); }
 
 private:
     std::vector<UndoActionPtr> m_undo;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The main focus of this PR is to move event firing into the undo command classes and by doing so, to make it possible to prevent calling `FireProjectUpdatedEvent()` if it's not needed. That particular event forces the Navigation Panel to completely recreate it's tree control which can have a significant performance impact when working with a large project.

The `NavigationPanel::EraseAllMaps()` function has been refactored to ensure both maps and tree items get deleted correctly. Currently, this is only called when a node is deleted, but will ultimately be used by the gridbag change events.