### PR TITLE
Add new custom events, remove MultiAction undo command

### DIFF
--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -16,6 +16,7 @@
 
 wxDEFINE_EVENT(EVT_ProjectUpdated, CustomEvent);
 wxDEFINE_EVENT(EVT_EventHandlerChanged, CustomEvent);
+wxDEFINE_EVENT(EVT_ParentChanged, CustomEvent);
 
 wxDEFINE_EVENT(EVT_NodeCreated, CustomEvent);
 wxDEFINE_EVENT(EVT_NodeDeleted, CustomEvent);
@@ -82,6 +83,15 @@ void MainFrame::FireProjectUpdatedEvent()
 void MainFrame::FireChangeEventHandler(NodeEvent* evt_node)
 {
     CustomEvent event(EVT_EventHandlerChanged, evt_node);
+    for (auto handler: m_custom_event_handlers)
+    {
+        handler->ProcessEvent(event);
+    }
+}
+
+void MainFrame::FireParentChangedEvent(ChangeParentAction* undo_cmd)
+{
+    CustomEvent event(EVT_ParentChanged, undo_cmd);
     for (auto handler: m_custom_event_handlers)
     {
         handler->ProcessEvent(event);

--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -17,6 +17,7 @@
 wxDEFINE_EVENT(EVT_ProjectUpdated, CustomEvent);
 wxDEFINE_EVENT(EVT_EventHandlerChanged, CustomEvent);
 wxDEFINE_EVENT(EVT_ParentChanged, CustomEvent);
+wxDEFINE_EVENT(EVT_PositionChanged, CustomEvent);
 
 wxDEFINE_EVENT(EVT_NodeCreated, CustomEvent);
 wxDEFINE_EVENT(EVT_NodeDeleted, CustomEvent);
@@ -92,6 +93,15 @@ void MainFrame::FireChangeEventHandler(NodeEvent* evt_node)
 void MainFrame::FireParentChangedEvent(ChangeParentAction* undo_cmd)
 {
     CustomEvent event(EVT_ParentChanged, undo_cmd);
+    for (auto handler: m_custom_event_handlers)
+    {
+        handler->ProcessEvent(event);
+    }
+}
+
+void MainFrame::FirePositionChangedEvent(ChangePositionAction* undo_cmd)
+{
+    CustomEvent event(EVT_PositionChanged, undo_cmd);
     for (auto handler: m_custom_event_handlers)
     {
         handler->ProcessEvent(event);

--- a/src/cstm_event.h
+++ b/src/cstm_event.h
@@ -38,6 +38,7 @@ private:
 wxDECLARE_EVENT(EVT_ProjectUpdated, CustomEvent);
 wxDECLARE_EVENT(EVT_EventHandlerChanged, CustomEvent);
 wxDECLARE_EVENT(EVT_ParentChanged, CustomEvent);
+wxDECLARE_EVENT(EVT_PositionChanged, CustomEvent);
 
 wxDECLARE_EVENT(EVT_NodeCreated, CustomEvent);
 wxDECLARE_EVENT(EVT_NodeDeleted, CustomEvent);

--- a/src/cstm_event.h
+++ b/src/cstm_event.h
@@ -11,16 +11,20 @@
 
 #include "node_classes.h"  // Forward defintions of Node classes
 
+class UndoAction;
+
 class CustomEvent : public wxEvent
 {
 public:
     CustomEvent(wxEventType commandType, Node* node) : wxEvent(0, commandType), m_node(node) {}
     CustomEvent(wxEventType commandType, NodeProperty* property) : wxEvent(0, commandType), m_property(property) {}
     CustomEvent(wxEventType commandType, NodeEvent* event) : wxEvent(0, commandType), m_event(event) {}
+    CustomEvent(wxEventType commandType, UndoAction* undo_cmd) : wxEvent(0, commandType), m_undo_cmd(undo_cmd) {}
 
     Node* GetNode() { return m_node; }
     NodeProperty* GetNodeProperty() { return m_property; }
     NodeEvent* GetEventNode() { return m_event; }
+    UndoAction* GetUndoCmd() { return m_undo_cmd; }
 
     wxEvent* Clone() const override { return new CustomEvent(*this); }  // required to instantiate wxEvent class
 
@@ -28,10 +32,12 @@ private:
     Node* m_node { nullptr };
     NodeProperty* m_property { nullptr };
     NodeEvent* m_event { nullptr };
+    UndoAction* m_undo_cmd { nullptr };
 };
 
 wxDECLARE_EVENT(EVT_ProjectUpdated, CustomEvent);
 wxDECLARE_EVENT(EVT_EventHandlerChanged, CustomEvent);
+wxDECLARE_EVENT(EVT_ParentChanged, CustomEvent);
 
 wxDECLARE_EVENT(EVT_NodeCreated, CustomEvent);
 wxDECLARE_EVENT(EVT_NodeDeleted, CustomEvent);

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1343,8 +1343,6 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
         {
             AutoFreeze freeze(this);
             PushUndoAction(std::make_shared<ChangePositionAction>(node, pos - 1));
-            FireProjectUpdatedEvent();
-            SelectNode(node, true);
             return true;
         }
         appMsgBox(_tt(strIdCantMoveUp), _tt(strIdMoveTitle));
@@ -1358,8 +1356,6 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
         {
             AutoFreeze freeze(this);
             PushUndoAction(std::make_shared<ChangePositionAction>(node, pos));
-            FireProjectUpdatedEvent();
-            SelectNode(node, true);
             return true;
         }
         appMsgBox(node->DeclName() + _tt(" cannot be moved down any lower."), _tt(strIdMoveTitle));

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1308,9 +1308,8 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
 
         if (grandparent)
         {
+            AutoFreeze freeze(this);
             PushUndoAction(std::make_shared<ChangeParentAction>(node, grandparent));
-            FireProjectUpdatedEvent();
-            SelectNode(node, true);
             return true;
         }
         appMsgBox(_tt("There is no sizer to the left of this item that it can be moved into."), _tt(strIdMoveTitle));
@@ -1327,9 +1326,8 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
 
             if (parent)
             {
+                AutoFreeze freeze(this);
                 PushUndoAction(std::make_shared<ChangeParentAction>(node, parent));
-                FireProjectUpdatedEvent();
-                SelectNode(node, true);
                 return true;
             }
         }
@@ -1343,8 +1341,8 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
             return (pos > 0);
         if (pos > 0)
         {
-            PushUndoAction(std::make_shared<ChangePositionAction>(node, pos - 1));
             AutoFreeze freeze(this);
+            PushUndoAction(std::make_shared<ChangePositionAction>(node, pos - 1));
             FireProjectUpdatedEvent();
             SelectNode(node, true);
             return true;
@@ -1358,8 +1356,8 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
             return (pos < parent->GetChildCount());
         if (pos < parent->GetChildCount())
         {
-            PushUndoAction(std::make_shared<ChangePositionAction>(node, pos));
             AutoFreeze freeze(this);
+            PushUndoAction(std::make_shared<ChangePositionAction>(node, pos));
             FireProjectUpdatedEvent();
             SelectNode(node, true);
             return true;

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -35,6 +35,8 @@ class ueStatusBar;
 class NavigationPanel;
 class RibbonPanel;
 
+class ChangeParentAction;
+
 enum class MoveDirection
 {
     Up = 1,
@@ -64,6 +66,7 @@ public:
     void FireChangeEventHandler(NodeEvent* event);
     void FireCreatedEvent(Node* node);
     void FireDeletedEvent(Node* node);
+    void FireParentChangedEvent(ChangeParentAction* undo_cmd);
     void FireProjectLoadedEvent();
     void FireProjectUpdatedEvent();
     void FirePropChangeEvent(NodeProperty* prop);

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -36,6 +36,7 @@ class NavigationPanel;
 class RibbonPanel;
 
 class ChangeParentAction;
+class ChangePositionAction;
 
 enum class MoveDirection
 {
@@ -67,6 +68,7 @@ public:
     void FireCreatedEvent(Node* node);
     void FireDeletedEvent(Node* node);
     void FireParentChangedEvent(ChangeParentAction* undo_cmd);
+    void FirePositionChangedEvent(ChangePositionAction* undo_cmd);
     void FireProjectLoadedEvent();
     void FireProjectUpdatedEvent();
     void FirePropChangeEvent(NodeProperty* prop);

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -112,6 +112,11 @@ void MockupParent::CreateContent()
         return;
     }
 
+    // Uncomment this to check whether the Mockup window is being created multiple times for a single action, or it's being recreated
+    // by a property change that doesn't need the Mockup to be recreated.
+
+    MSG_INFO("Mockup window recreated.");
+
     AutoFreeze freeze(this);
 
     // Note that we show the form even if it's property has it set to hidden

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -84,9 +84,10 @@ MockupParent::MockupParent(wxWindow* parent, MainFrame* frame) : wxScrolled<wxPa
     Bind(EVT_NodeSelected, &MockupParent::OnNodeSelected, this);
     Bind(EVT_NodePropChange, &MockupParent::OnNodePropModified, this);
 
-    Bind(EVT_ProjectUpdated, [this](CustomEvent&) { CreateContent(); });
     Bind(EVT_NodeCreated, [this](CustomEvent&) { CreateContent(); });
     Bind(EVT_NodeDeleted, [this](CustomEvent&) { CreateContent(); });
+    Bind(EVT_ParentChanged, [this](CustomEvent&) { CreateContent(); });
+    Bind(EVT_ProjectUpdated, [this](CustomEvent&) { CreateContent(); });
 
     frame->AddCustomEventHandler(GetEventHandler());
 }

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -87,6 +87,7 @@ MockupParent::MockupParent(wxWindow* parent, MainFrame* frame) : wxScrolled<wxPa
     Bind(EVT_NodeCreated, [this](CustomEvent&) { CreateContent(); });
     Bind(EVT_NodeDeleted, [this](CustomEvent&) { CreateContent(); });
     Bind(EVT_ParentChanged, [this](CustomEvent&) { CreateContent(); });
+    Bind(EVT_PositionChanged, [this](CustomEvent&) { CreateContent(); });
     Bind(EVT_ProjectUpdated, [this](CustomEvent&) { CreateContent(); });
 
     frame->AddCustomEventHandler(GetEventHandler());

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -51,6 +51,7 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, bool GenerateDerivedCod
     Bind(EVT_NodeCreated, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_NodeDeleted, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_NodePropChange, [this](wxEvent&) { GenerateBaseClass(); });
+    Bind(EVT_ParentChanged, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_ProjectUpdated, [this](wxEvent&) { GenerateBaseClass(); });
 
     Bind(EVT_NodeSelected, &BasePanel::OnNodeSelected, this);

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -52,6 +52,7 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, bool GenerateDerivedCod
     Bind(EVT_NodeDeleted, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_NodePropChange, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_ParentChanged, [this](wxEvent&) { GenerateBaseClass(); });
+    Bind(EVT_PositionChanged, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_ProjectUpdated, [this](wxEvent&) { GenerateBaseClass(); });
 
     Bind(EVT_NodeSelected, &BasePanel::OnNodeSelected, this);

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -103,6 +103,7 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
 
     Bind(EVT_NodePropChange, &NavigationPanel::OnNodePropChange, this);
     Bind(EVT_NodeSelected, &NavigationPanel::OnNodeSelected, this);
+    Bind(EVT_ParentChanged, &NavigationPanel::OnParentChange, this);
 
     Bind(EVT_ProjectUpdated, [this](CustomEvent&) { OnProjectUpdated(); });
 
@@ -257,9 +258,6 @@ void NavigationPanel::OnEndDrag(wxTreeEvent& event)
         }
 
         m_pMainFrame->PushUndoAction(std::make_shared<ChangeParentAction>(node_src, nextSizer));
-
-        m_pMainFrame->FireCreatedEvent(node_src);
-        m_pMainFrame->SelectNode(node_src, true);
     }
 }
 
@@ -375,7 +373,8 @@ void NavigationPanel::ExpandAllNodes(Node* node)
 {
     if (auto item_it = m_node_tree_map.find(node); item_it != m_node_tree_map.end())
     {
-        m_tree_ctrl->Expand(item_it->second);
+        if (m_tree_ctrl->ItemHasChildren(item_it->second))
+            m_tree_ctrl->Expand(item_it->second);
     }
 
     auto count = node->GetChildCount();
@@ -405,6 +404,16 @@ void NavigationPanel::EraseAllMaps(Node* node)
     {
         EraseAllMaps(node->GetChild(idx));
     }
+}
+
+void NavigationPanel::RecreateChildren(Node* node)
+{
+    for (size_t idx = 0; idx < node->GetChildCount(); idx++)
+    {
+        EraseAllMaps(node->GetChild(idx));
+    }
+    AddAllChildren(node);
+    ExpandAllNodes(node);
 }
 
 void NavigationPanel::OnNodeSelected(CustomEvent& event)
@@ -524,6 +533,16 @@ void NavigationPanel::OnUpdateEvent(wxUpdateUIEvent& event)
             event.Enable((node->GetParent() && node->GetParent()->GetChildCount() > 0) || node->GetChildCount() > 0);
             break;
     }
+}
+
+void NavigationPanel::OnParentChange(CustomEvent& event)
+{
+    AutoFreeze freeze(this);
+
+    auto undo_cmd = static_cast<ChangeParentAction*>(event.GetUndoCmd());
+
+    RecreateChildren(undo_cmd->GetOldParent());
+    RecreateChildren(undo_cmd->GetNewParent());
 }
 
 void NavigationPanel::ChangeExpansion(Node* node, bool include_children, bool expand)

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -104,6 +104,7 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
     Bind(EVT_NodePropChange, &NavigationPanel::OnNodePropChange, this);
     Bind(EVT_NodeSelected, &NavigationPanel::OnNodeSelected, this);
     Bind(EVT_ParentChanged, &NavigationPanel::OnParentChange, this);
+    Bind(EVT_PositionChanged, &NavigationPanel::OnPositionChange, this);
 
     Bind(EVT_ProjectUpdated, [this](CustomEvent&) { OnProjectUpdated(); });
 
@@ -543,6 +544,15 @@ void NavigationPanel::OnParentChange(CustomEvent& event)
 
     RecreateChildren(undo_cmd->GetOldParent());
     RecreateChildren(undo_cmd->GetNewParent());
+}
+
+void NavigationPanel::OnPositionChange(CustomEvent& event)
+{
+    AutoFreeze freeze(this);
+
+    auto undo_cmd = static_cast<ChangePositionAction*>(event.GetUndoCmd());
+
+    RecreateChildren(undo_cmd->GetParent());
 }
 
 void NavigationPanel::ChangeExpansion(Node* node, bool include_children, bool expand)

--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -35,6 +35,7 @@ protected:
     void InsertNode(Node* node);
     void DeleteNode(Node* item);
     void EraseAllMaps(Node* node);
+    void RecreateChildren(Node* node);
 
     void ExpandAllNodes(Node* node);
     Node* GetNode(wxTreeItemId item);
@@ -64,6 +65,7 @@ protected:
     void OnNodeCreated(CustomEvent& event);
     void OnNodeSelected(CustomEvent& event);
     void OnNodePropChange(CustomEvent& event);
+    void OnParentChange(CustomEvent& event);
 
 private:
     MainFrame* m_pMainFrame;

--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -66,6 +66,7 @@ protected:
     void OnNodeSelected(CustomEvent& event);
     void OnNodePropChange(CustomEvent& event);
     void OnParentChange(CustomEvent& event);
+    void OnPositionChange(CustomEvent& event);
 
 private:
     MainFrame* m_pMainFrame;

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -310,12 +310,9 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
         auto insert_cmd = std::make_shared<InsertNodeAction>(new_sizer.get(), parent, tt_empty_cstr, childPos);
         multi_cmd->Add(insert_cmd);
 
+        wxGetFrame().Freeze();
         wxGetFrame().PushUndoAction(multi_cmd);
-
-        // REVIEW: [KeyWorks - 03-30-2021] See issue #94 about the problem this causes.
-        wxGetFrame().FireProjectUpdatedEvent();
-
-        wxGetFrame().SelectNode(new_sizer->GetChild(0), true, true);
+        wxGetFrame().Thaw();
     }
 }
 

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -296,22 +296,15 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
     }
 
     // Avoid the temptation to set new_sizer to the raw pointer so that .get() doesn't have to be called below. Doing so will
-    // result in the reference count being decremented before we are done hooking it up, and you end up crashing (see issue
-    // #93).
+    // result in the reference count being decremented before we are done hooking it up, and you end up crashing.
 
     auto new_sizer = g_NodeCreator.CreateNode(widget, parent);
     if (new_sizer)
     {
-        auto multi_cmd = std::make_shared<MultiAction>(ttlib::cstr() << "new sizer for " << node->DeclName());
-
-        auto reparent_cmd = std::make_shared<ChangeParentAction>(node, new_sizer.get());
-        multi_cmd->Add(reparent_cmd);
-
-        auto insert_cmd = std::make_shared<InsertNodeAction>(new_sizer.get(), parent, tt_empty_cstr, childPos);
-        multi_cmd->Add(insert_cmd);
-
         wxGetFrame().Freeze();
-        wxGetFrame().PushUndoAction(multi_cmd);
+        wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(new_sizer.get(), parent, "Insert new sizer", childPos));
+        wxGetFrame().PushUndoAction(std::make_shared<ChangeParentAction>(node, new_sizer.get()));
+        wxGetFrame().SelectNode(node, true, true);
         wxGetFrame().Thaw();
     }
 }

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -91,8 +91,9 @@ PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(paren
 
     Bind(EVT_NodePropChange, &PropGridPanel::OnNodePropChange, this);
 
-    Bind(EVT_ProjectUpdated, [this](CustomEvent&) { Create(); });
     Bind(EVT_NodeSelected, [this](CustomEvent&) { Create(); });
+    Bind(EVT_ParentChanged, [this](CustomEvent&) { Create(); });
+    Bind(EVT_ProjectUpdated, [this](CustomEvent&) { Create(); });
 
     frame->AddCustomEventHandler(GetEventHandler());
 }

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -93,6 +93,7 @@ PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(paren
 
     Bind(EVT_NodeSelected, [this](CustomEvent&) { Create(); });
     Bind(EVT_ParentChanged, [this](CustomEvent&) { Create(); });
+    Bind(EVT_PositionChanged, [this](CustomEvent&) { Create(); });
     Bind(EVT_ProjectUpdated, [this](CustomEvent&) { Create(); });
 
     frame->AddCustomEventHandler(GetEventHandler());

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -205,6 +205,11 @@ ChangeParentAction::ChangeParentAction(Node* node, Node* parent)
     m_revert_position = m_revert_parent->GetChildPosition(node);
     m_revert_row = node->prop_as_int(prop_row);
     m_revert_col = node->prop_as_int(prop_column);
+
+    m_UndoEventGenerated = true;
+    m_RedoEventGenerated = true;
+    m_UndoSelectEventGenerated = true;
+    m_RedoSelectEventGenerated = true;
 }
 
 void ChangeParentAction::Change()
@@ -213,6 +218,9 @@ void ChangeParentAction::Change()
     {
         m_revert_parent->RemoveChild(m_node);
         m_node->SetParent(m_change_parent);
+
+        wxGetFrame().FireParentChangedEvent(this);
+        wxGetFrame().FireSelectedEvent(m_node);
 
         // TODO: [KeyWorks - 11-18-2020] If we got moved into a gridbag sizer, then things are a bit complicated since row
         // and column aren't going to be right. We need to make some intelligent guess and change the node's property
@@ -231,6 +239,9 @@ void ChangeParentAction::Revert()
         prop->set_value(m_revert_row);
     if (auto prop = m_node->get_prop_ptr(prop_column); prop)
         prop->set_value(m_revert_col);
+
+    wxGetFrame().FireParentChangedEvent(this);
+    wxGetFrame().FireSelectedEvent(m_node);
 }
 
 ///////////////////////////////// MultiAction ////////////////////////////////////

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -253,29 +253,6 @@ void ChangeParentAction::Revert()
     wxGetFrame().FireSelectedEvent(m_node);
 }
 
-///////////////////////////////// MultiAction ////////////////////////////////////
-
-void MultiAction::Add(UndoActionPtr command)
-{
-    m_cmds.emplace_back(command);
-}
-
-void MultiAction::Change()
-{
-    for (auto& cmd: m_cmds)
-    {
-        cmd->Change();
-    }
-}
-
-void MultiAction::Revert()
-{
-    for (auto cmd = m_cmds.rbegin(); cmd != m_cmds.rend(); ++cmd)
-    {
-        cmd->get()->Revert();
-    }
-}
-
 ///////////////////////////////// AppendGridBagAction ////////////////////////////////////
 
 AppendGridBagAction::AppendGridBagAction(Node* node, Node* parent, int pos) : m_pos(pos)

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -180,16 +180,25 @@ ChangePositionAction::ChangePositionAction(Node* node, size_t position)
 
     m_change_pos = position;
     m_revert_pos = m_parent->GetChildPosition(node);
+
+    m_UndoEventGenerated = true;
+    m_RedoEventGenerated = true;
+    m_UndoSelectEventGenerated = true;
+    m_RedoSelectEventGenerated = true;
 }
 
 void ChangePositionAction::Change()
 {
     m_parent->ChangeChildPosition(m_node, m_change_pos);
+    wxGetFrame().FirePositionChangedEvent(this);
+    wxGetFrame().FireSelectedEvent(m_node);
 }
 
 void ChangePositionAction::Revert()
 {
     m_parent->ChangeChildPosition(m_node, m_revert_pos);
+    wxGetFrame().FirePositionChangedEvent(this);
+    wxGetFrame().FireSelectedEvent(m_node);
 }
 
 ///////////////////////////////// ChangeParentAction ////////////////////////////////////

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -96,6 +96,10 @@ public:
     void Change() override;
     void Revert() override;
 
+    Node* GetOldParent() { return m_revert_parent.get(); }
+    Node* GetNewParent() { return m_change_parent.get(); }
+    Node* GetNode() { return m_node.get(); }
+
 private:
     NodeSharedPtr m_node;
     NodeSharedPtr m_change_parent;

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -113,21 +113,6 @@ private:
     int m_revert_col;
 };
 
-class MultiAction : public UndoAction
-{
-public:
-    MultiAction(const ttlib::cstr& undo_str) : UndoAction(undo_str.c_str()) {};
-
-    void Add(UndoActionPtr command);
-
-protected:
-    void Change() override;
-    void Revert() override;
-
-private:
-    std::vector<UndoActionPtr> m_cmds;
-};
-
 class AppendGridBagAction : public UndoAction
 {
 public:

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -82,6 +82,9 @@ public:
     void Change() override;
     void Revert() override;
 
+    Node* GetParent() { return m_parent.get(); }
+    Node* GetNode() { return m_node.get(); }
+
 private:
     NodeSharedPtr m_parent;
     NodeSharedPtr m_node;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new type of custom event which stores a pointer to an one of the derived undo commands. That gives more flexability to the event handler since it can query for additional information that the undo command is storing.

The new `EVT_ParentChanged` and `EVT_PositionChanged` custom events use the new undo command. That allows the navigation panel to just recreate the affected parent node(s) instead of having to recreate the entire tree control.