### PR TITLE
Prevent unnecessary event firing and processing

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -131,10 +131,12 @@ MainFrame::MainFrame() : MainFrameBase(nullptr), m_findData(wxFR_DOWN)
 
     Bind(EVT_NodeSelected, &MainFrame::OnNodeSelected, this);
 
-    Bind(EVT_NodeCreated, [this](CustomEvent&) { UpdateFrame(); });
     Bind(EVT_EventHandlerChanged, [this](CustomEvent&) { UpdateFrame(); });
+    Bind(EVT_NodeCreated, [this](CustomEvent&) { UpdateFrame(); });
     Bind(EVT_NodeDeleted, [this](CustomEvent&) { UpdateFrame(); });
     Bind(EVT_NodePropChange, [this](CustomEvent&) { UpdateFrame(); });
+    Bind(EVT_ParentChanged, [this](CustomEvent&) { UpdateFrame(); });
+    Bind(EVT_PositionChanged, [this](CustomEvent&) { UpdateFrame(); });
 
     Bind(
         wxEVT_MENU, [this](wxCommandEvent&) { Close(); }, wxID_EXIT);

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -148,6 +148,10 @@ void NavigationPanel::OnProjectUpdated()
 {
     AutoFreeze freeze(this);
 
+    // Uncomment this to check whether the Navigation tree control is being recreated multiple times for a single action.
+
+    MSG_INFO("Navigation tree control recreated.");
+
     m_tree_ctrl->DeleteAllItems();
     m_tree_node_map.clear();
     m_node_tree_map.clear();

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -127,6 +127,11 @@ void PropGridPanel::Create()
     {
         AutoFreeze freeze(this);
 
+        // Uncomment this to check whether the Property window is being created multiple times for a single action, or it's
+        // being recreated by a property change that doesn't need the Property to be recreated.
+
+        MSG_INFO("Property window recreated.");
+
         wxGetApp().GetMainFrame()->SetStatusText(wxEmptyString, 2);
 
         m_currentSel = node;

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -92,8 +92,6 @@ PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(paren
     Bind(EVT_NodePropChange, &PropGridPanel::OnNodePropChange, this);
 
     Bind(EVT_NodeSelected, [this](CustomEvent&) { Create(); });
-    Bind(EVT_ParentChanged, [this](CustomEvent&) { Create(); });
-    Bind(EVT_PositionChanged, [this](CustomEvent&) { Create(); });
     Bind(EVT_ProjectUpdated, [this](CustomEvent&) { Create(); });
 
     frame->AddCustomEventHandler(GetEventHandler());

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -191,14 +191,14 @@ void ChangePositionAction::Change()
 {
     m_parent->ChangeChildPosition(m_node, m_change_pos);
     wxGetFrame().FirePositionChangedEvent(this);
-    wxGetFrame().FireSelectedEvent(m_node);
+    wxGetFrame().SelectNode(m_node);
 }
 
 void ChangePositionAction::Revert()
 {
     m_parent->ChangeChildPosition(m_node, m_revert_pos);
     wxGetFrame().FirePositionChangedEvent(this);
-    wxGetFrame().FireSelectedEvent(m_node);
+    wxGetFrame().SelectNode(m_node);
 }
 
 ///////////////////////////////// ChangeParentAction ////////////////////////////////////
@@ -229,7 +229,7 @@ void ChangeParentAction::Change()
         m_node->SetParent(m_change_parent);
 
         wxGetFrame().FireParentChangedEvent(this);
-        wxGetFrame().FireSelectedEvent(m_node);
+        wxGetFrame().SelectNode(m_node);
 
         // TODO: [KeyWorks - 11-18-2020] If we got moved into a gridbag sizer, then things are a bit complicated since row
         // and column aren't going to be right. We need to make some intelligent guess and change the node's property
@@ -250,7 +250,7 @@ void ChangeParentAction::Revert()
         prop->set_value(m_revert_col);
 
     wxGetFrame().FireParentChangedEvent(this);
-    wxGetFrame().FireSelectedEvent(m_node);
+    wxGetFrame().SelectNode(m_node);
 }
 
 ///////////////////////////////// AppendGridBagAction ////////////////////////////////////


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR prevents events from firing that aren't needed, prevents the Property Panel from being recreated when the selected node hasn't changed, and fixes problems with the UI for the Move commands not being updated after a previous Move command.