### PR TITLE
Add Debug UI for control display of panel creation messages

### DIFF
--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -56,12 +56,14 @@ public:
     ProjectSettings* GetProjectSettings() { return m_pjtSettings; };
 
     // clang-format off
-    enum
+    enum : long
     {
         PREFS_MSG_WINDOW    = 1 << 2,   // automatically create CMsgFrame window
         PREFS_MSG_INFO      = 1 << 3,   // filter AddInfoMsg
         PREFS_MSG_EVENT     = 1 << 4,   // filter AddEventMsg
         PREFS_MSG_WARNING   = 1 << 5,   // filter AddWarningMsg
+
+        PREFS_CREATION_MSG  = 1 << 6,  // Calls MSG_INFO when nav, prop, or mockup contents recreated
     };
 
     enum : long
@@ -82,6 +84,8 @@ public:
     };
 
     uiPREFERENCES& GetPrefs() { return m_prefs; }
+
+    bool isFireCreationMsgs()  const noexcept { return (m_prefs.flags & PREFS_CREATION_MSG); }
 
     bool IsPjtMemberPrefix() const noexcept { return (m_prefs.project_flags & PREFS_PJT_MEMBER_PREFIX); }
 

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -113,10 +113,12 @@ void MockupParent::CreateContent()
         return;
     }
 
-    // Uncomment this to check whether the Mockup window is being created multiple times for a single action, or it's being recreated
-    // by a property change that doesn't need the Mockup to be recreated.
-
-    MSG_INFO("Mockup window recreated.");
+#if defined(_DEBUG)
+    if (wxGetApp().isFireCreationMsgs())
+    {
+        MSG_INFO("Mockup window recreated.");
+    }
+#endif  // _DEBUG
 
     AutoFreeze freeze(this);
 

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -148,9 +148,12 @@ void NavigationPanel::OnProjectUpdated()
 {
     AutoFreeze freeze(this);
 
-    // Uncomment this to check whether the Navigation tree control is being recreated multiple times for a single action.
-
-    MSG_INFO("Navigation tree control recreated.");
+#if defined(_DEBUG)
+    if (wxGetApp().isFireCreationMsgs())
+    {
+        MSG_INFO("Navigation tree control recreated.");
+    }
+#endif  // _DEBUG
 
     m_tree_ctrl->DeleteAllItems();
     m_tree_node_map.clear();

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -125,10 +125,12 @@ void PropGridPanel::Create()
     {
         AutoFreeze freeze(this);
 
-        // Uncomment this to check whether the Property window is being created multiple times for a single action, or it's
-        // being recreated by a property change that doesn't need the Property to be recreated.
-
-        MSG_INFO("Property window recreated.");
+#if defined(_DEBUG)
+        if (wxGetApp().isFireCreationMsgs())
+        {
+            MSG_INFO("Property window recreated.");
+        }
+#endif  // _DEBUG
 
         wxGetApp().GetMainFrame()->SetStatusText(wxEmptyString, 2);
 

--- a/src/ui/debugsettings.cpp
+++ b/src/ui/debugsettings.cpp
@@ -22,6 +22,7 @@ void DebugSettings::OnInit(wxInitDialogEvent& event)
     m_DisplayMsgInfo = (m_orgFlags & App::PREFS_MSG_INFO);
     m_DisplayMsgEvent = (m_orgFlags & App::PREFS_MSG_EVENT);
     m_DisplayMsgWarnng = (m_orgFlags & App::PREFS_MSG_WARNING);
+    m_FireCreationMsgs = (m_orgFlags & App::PREFS_CREATION_MSG);
 
     event.Skip();  // transfer all validator data to their windows and update UI
 }
@@ -55,6 +56,11 @@ void DebugSettings::OnOK(wxCommandEvent& event)
         m_orgFlags |= App::PREFS_MSG_WARNING;
     else
         m_orgFlags &= ~App::PREFS_MSG_WARNING;
+
+    if (m_FireCreationMsgs)
+        m_orgFlags |= App::PREFS_CREATION_MSG;
+    else
+        m_orgFlags &= ~App::PREFS_CREATION_MSG;
 
     if (m_orgFlags != wxGetApp().GetPrefs().flags)
     {

--- a/src/ui/debugsettingsBase.cpp
+++ b/src/ui/debugsettingsBase.cpp
@@ -6,6 +6,7 @@
 
 #include "pch.h"
 
+#include <wx/checkbox.h>
 #include <wx/persist.h>
 #include <wx/persist/toplevel.h>
 #include <wx/statbox.h>
@@ -26,10 +27,10 @@ DebugSettingsBase::DebugSettingsBase(wxWindow* parent) : wxDialog()
     auto box_sizer = new wxBoxSizer(wxHORIZONTAL);
     static_box->Add(box_sizer, wxSizerFlags().Expand().Border(wxALL));
 
-    m_checkBox = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display MSG Window"));
-    m_checkBox->SetValidator(wxGenericValidator(&m_DisplayMsgWindow));
-    m_checkBox->SetToolTip(wxString::FromUTF8("If checked, the MSG window will be displayed the first time it receives a non-filtered MSG. If unchecked, the window is never displayed unless you go here and click the Show Now button."));
-    box_sizer->Add(m_checkBox, wxSizerFlags().Center().Border(wxALL));
+    auto checkBox = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display MSG Window"));
+    checkBox->SetValidator(wxGenericValidator(&m_DisplayMsgWindow));
+    checkBox->SetToolTip(wxString::FromUTF8("If checked, the MSG window will be displayed the first time it receives a non-filtered MSG. If unchecked, the window is never displayed unless you go here and click the Show Now button."));
+    box_sizer->Add(checkBox, wxSizerFlags().Center().Border(wxALL));
 
     box_sizer->AddSpacer(15);
 
@@ -39,17 +40,27 @@ DebugSettingsBase::DebugSettingsBase(wxWindow* parent) : wxDialog()
     auto box_sizer2 = new wxBoxSizer(wxVERTICAL);
     static_box->Add(box_sizer2, wxSizerFlags().Expand().Border(wxALL));
 
-    m_checkBox2 = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display MSG_INFO() messages"));
-    m_checkBox2->SetValidator(wxGenericValidator(&m_DisplayMsgInfo));
-    box_sizer2->Add(m_checkBox2, wxSizerFlags().Border(wxALL));
+    auto checkBox2 = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display MSG_INFO() messages"));
+    checkBox2->SetValidator(wxGenericValidator(&m_DisplayMsgInfo));
+    box_sizer2->Add(checkBox2, wxSizerFlags().Border(wxALL));
 
-    m_checkBox3 = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display MSG_EVENT() messages"));
-    m_checkBox3->SetValidator(wxGenericValidator(&m_DisplayMsgEvent));
-    box_sizer2->Add(m_checkBox3, wxSizerFlags().Border(wxALL));
+    auto checkBox3 = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display MSG_EVENT() messages"));
+    checkBox3->SetValidator(wxGenericValidator(&m_DisplayMsgEvent));
+    box_sizer2->Add(checkBox3, wxSizerFlags().Border(wxALL));
 
-    m_checkBox4 = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display MSG_WARNING() messages"));
-    m_checkBox4->SetValidator(wxGenericValidator(&m_DisplayMsgWarnng));
-    box_sizer2->Add(m_checkBox4, wxSizerFlags().Border(wxALL));
+    auto checkBox4 = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display MSG_WARNING() messages"));
+    checkBox4->SetValidator(wxGenericValidator(&m_DisplayMsgWarnng));
+    box_sizer2->Add(checkBox4, wxSizerFlags().Border(wxALL));
+
+    static_box->AddSpacer(10);
+
+    auto box_sizer_2 = new wxBoxSizer(wxVERTICAL);
+    static_box->Add(box_sizer_2, wxSizerFlags().Expand().Border(wxALL));
+
+    auto checkBox_2 = new wxCheckBox(static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("Display creation info"));
+    checkBox_2->SetValidator(wxGenericValidator(&m_FireCreationMsgs));
+    checkBox_2->SetToolTip(wxString::FromUTF8("MSG_INFO called when nav, prop, and mockup panels have their contents recreated."));
+    box_sizer_2->Add(checkBox_2, wxSizerFlags().Border(wxALL));
 
     std_button_sizer = CreateStdDialogButtonSizer(wxOK|wxCANCEL);
     parent_sizer->Add(std_button_sizer, wxSizerFlags().Expand().Border(wxALL));

--- a/src/ui/debugsettingsBase.h
+++ b/src/ui/debugsettingsBase.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <wx/button.h>
-#include <wx/checkbox.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
@@ -26,14 +25,11 @@ protected:
     bool m_DisplayMsgInfo { false };
     bool m_DisplayMsgWarnng { false };
     bool m_DisplayMsgWindow { false };
+    bool m_FireCreationMsgs { false };
 
     // Class member variables
 
     wxButton* m_btn;
-    wxCheckBox* m_checkBox2;
-    wxCheckBox* m_checkBox3;
-    wxCheckBox* m_checkBox4;
-    wxCheckBox* m_checkBox;
     wxStdDialogButtonSizer* std_button_sizer;
     wxButton* std_button_sizerOK;
     wxButton* std_button_sizerCancel;

--- a/src/ui/gridbag_item_base.cpp
+++ b/src/ui/gridbag_item_base.cpp
@@ -24,29 +24,25 @@ GridBagItemBase::GridBagItemBase(wxWindow* parent) : wxDialog()
     auto staticText = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("&Column:"));
     flex_grid_sizer->Add(staticText, wxSizerFlags().Center().Border(wxALL));
 
-    m_spin_column = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
-    wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 10, 0);
+    m_spin_column = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 10, 0);
     flex_grid_sizer->Add(m_spin_column, wxSizerFlags().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     auto staticText_2 = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("Span c&olumns:"));
     flex_grid_sizer->Add(staticText_2, wxSizerFlags().Center().Border(wxALL));
 
-    m_spin_span_column = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
-    wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 10, 1);
+    m_spin_span_column = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 10, 1);
     flex_grid_sizer->Add(m_spin_span_column, wxSizerFlags().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     auto staticText_3 = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("&Row:"));
     flex_grid_sizer->Add(staticText_3, wxSizerFlags().Center().Border(wxALL));
 
-    m_spin_row = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
-    wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 10, 0);
+    m_spin_row = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 10, 0);
     flex_grid_sizer->Add(m_spin_row, wxSizerFlags().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     auto staticText_4 = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("Span ro&ws:"));
     flex_grid_sizer->Add(staticText_4, wxSizerFlags().Center().Border(wxALL));
 
-    m_spin_span_row = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
-    wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 10, 1);
+    m_spin_span_row = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 10, 1);
     flex_grid_sizer->Add(m_spin_span_row, wxSizerFlags().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     m_infoBar = new wxInfoBar(this);

--- a/src/ui/newdialog_base.cpp
+++ b/src/ui/newdialog_base.cpp
@@ -60,8 +60,7 @@ NewDialogBase::NewDialogBase(wxWindow* parent) : wxDialog()
     auto staticText_4 = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("Tab&s:"));
     box_sizer_4->Add(staticText_4, wxSizerFlags().Center().Border(wxLEFT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
-    m_spinCtrlTabs = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
-    wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 7, 3);
+    m_spinCtrlTabs = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 7, 3);
     m_spinCtrlTabs->SetValidator(wxGenericValidator(&m_num_tabs));
     m_spinCtrlTabs->Enable(false);
     box_sizer_4->Add(m_spinCtrlTabs, wxSizerFlags().Border(wxALL));

--- a/src/ui/newribbon_base.cpp
+++ b/src/ui/newribbon_base.cpp
@@ -45,8 +45,7 @@ NewRibbonBase::NewRibbonBase(wxWindow* parent) : wxDialog()
     auto staticText_4 = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("&Pages:"));
     box_sizer_4->Add(staticText_4, wxSizerFlags().Center().Border(wxLEFT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
-    m_spinCtrlPages = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
-    wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 7, 3);
+    m_spinCtrlPages = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 7, 3);
     m_spinCtrlPages->SetValidator(wxGenericValidator(&m_num_pages));
     m_spinCtrlPages->Enable(false);
     box_sizer_4->Add(m_spinCtrlPages, wxSizerFlags().Border(wxALL));

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -894,73 +894,6 @@
     </node>
     <node
       class="wxDialog"
-      base_file="debugsettingsBase"
-      class_name="DebugSettingsBase"
-      derived_class_name="DebugSettings"
-      derived_file="debugsettings"
-      persist="true"
-      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
-      title="Debug Settings"
-      wxEVT_INIT_DIALOG="OnInit">
-      <node
-        class="wxBoxSizer"
-        orientation="wxVERTICAL"
-        var_name="parent_sizer">
-        <node
-          class="wxStaticBoxSizer"
-          label="MSG Window Settings"
-          flags="wxEXPAND">
-          <node
-            class="wxBoxSizer"
-            flags="wxEXPAND">
-            <node
-              class="wxCheckBox"
-              label="Display MSG Window"
-              validator_variable="m_DisplayMsgWindow"
-              tooltip="If checked, the MSG window will be displayed the first time it receives a non-filtered MSG. If unchecked, the window is never displayed unless you go here and click the Show Now button."
-              alignment="wxALIGN_CENTER" />
-            <node
-              class="spacer"
-              width="15"
-              flags="wxEXPAND" />
-            <node
-              class="wxButton"
-              label="Show Now"
-              wxEVT_BUTTON="OnShowNow" />
-          </node>
-          <node
-            class="wxBoxSizer"
-            orientation="wxVERTICAL"
-            var_name="box_sizer2"
-            flags="wxEXPAND">
-            <node
-              class="wxCheckBox"
-              label="Display MSG_INFO() messages"
-              var_name="m_checkBox2"
-              validator_variable="m_DisplayMsgInfo" />
-            <node
-              class="wxCheckBox"
-              label="Display MSG_EVENT() messages"
-              var_name="m_checkBox3"
-              validator_variable="m_DisplayMsgEvent" />
-            <node
-              class="wxCheckBox"
-              label="Display MSG_WARNING() messages"
-              var_name="m_checkBox4"
-              validator_variable="m_DisplayMsgWarnng" />
-          </node>
-        </node>
-        <node
-          class="wxStdDialogButtonSizer"
-          class_access="protected:"
-          static_line="false"
-          var_name="std_button_sizer"
-          flags="wxEXPAND"
-          OKButtonClicked="OnOK" />
-      </node>
-    </node>
-    <node
-      class="wxDialog"
       base_file="newproject_base"
       class_name="NewProjectBase"
       derived_class_name="NewProjectDlg"
@@ -1821,6 +1754,94 @@
     </node>
     <node
       class="wxDialog"
+      base_file="debugsettingsBase"
+      class_name="DebugSettingsBase"
+      derived_class_name="DebugSettings"
+      derived_file="debugsettings"
+      persist="true"
+      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
+      title="Debug Settings"
+      wxEVT_INIT_DIALOG="OnInit">
+      <node
+        class="wxBoxSizer"
+        orientation="wxVERTICAL"
+        var_name="parent_sizer">
+        <node
+          class="wxStaticBoxSizer"
+          label="MSG Window Settings"
+          flags="wxEXPAND">
+          <node
+            class="wxBoxSizer"
+            flags="wxEXPAND">
+            <node
+              class="wxCheckBox"
+              class_access="none"
+              label="Display MSG Window"
+              var_name="checkBox"
+              validator_variable="m_DisplayMsgWindow"
+              tooltip="If checked, the MSG window will be displayed the first time it receives a non-filtered MSG. If unchecked, the window is never displayed unless you go here and click the Show Now button."
+              alignment="wxALIGN_CENTER" />
+            <node
+              class="spacer"
+              width="15"
+              flags="wxEXPAND" />
+            <node
+              class="wxButton"
+              label="Show Now"
+              wxEVT_BUTTON="OnShowNow" />
+          </node>
+          <node
+            class="wxBoxSizer"
+            orientation="wxVERTICAL"
+            var_name="box_sizer2"
+            flags="wxEXPAND">
+            <node
+              class="wxCheckBox"
+              class_access="none"
+              label="Display MSG_INFO() messages"
+              var_name="checkBox2"
+              validator_variable="m_DisplayMsgInfo" />
+            <node
+              class="wxCheckBox"
+              class_access="none"
+              label="Display MSG_EVENT() messages"
+              var_name="checkBox3"
+              validator_variable="m_DisplayMsgEvent" />
+            <node
+              class="wxCheckBox"
+              class_access="none"
+              label="Display MSG_WARNING() messages"
+              var_name="checkBox4"
+              validator_variable="m_DisplayMsgWarnng" />
+          </node>
+          <node
+            class="spacer"
+            height="10" />
+          <node
+            class="wxBoxSizer"
+            orientation="wxVERTICAL"
+            var_name="box_sizer_2"
+            flags="wxEXPAND">
+            <node
+              class="wxCheckBox"
+              class_access="none"
+              label="Display creation info"
+              var_name="checkBox_2"
+              validator_variable="m_FireCreationMsgs"
+              tooltip="MSG_INFO called when nav, prop, and mockup panels have their contents recreated." />
+          </node>
+        </node>
+        <node
+          class="wxStdDialogButtonSizer"
+          class_access="protected:"
+          static_line="false"
+          var_name="std_button_sizer"
+          flags="wxEXPAND"
+          OKButtonClicked="OnOK" />
+      </node>
+    </node>
+    <node
+      class="wxDialog"
       base_file="..\debugging\dbg_winres_dlg_base"
       class_name="DbgWinResBase"
       derived_class_name="DbgWinResDlg"
@@ -1997,7 +2018,6 @@
         </node>
         <node
           class="wxInfoBar"
-          var_name="m_infoBar"
           flags="wxEXPAND"
           proportion="1" />
         <node


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The Navigation, Property, and Mockup panels all have a call to MSG_INFO() when the contents of the panel is created (or recreated). This is used to check that we aren't accidentally recreating the contents when we don't need to.

This PR adds UI to the Debug Settings dialog that controls whether or not to call MSG_INFO(). That makes it easy to test without having to recompile.