### PR TITLE
wxPopupTransient window

### DIFF
--- a/src/ui/eventhandlerdlg.cpp
+++ b/src/ui/eventhandlerdlg.cpp
@@ -325,6 +325,7 @@ const std::unordered_map<std::string, const char*> s_EventNames = {
     { "wxEVT_DATAVIEW_ITEM_VALUE_CHANGED", "OnItemValueChanged" },
     { "wxEVT_DATAVIEW_SELECTION_CHANGED", "OnDataViewCtrlSelectionChanged" },
     { "wxEVT_DATE_CHANGED", "OnDateChanged" },
+    { "wxEVT_DESTROY", "OnDestroyed" },
     { "wxEVT_DIRCTRL_FILEACTIVATED", "OnDirctrlFileActivated" },
     { "wxEVT_DIRCTRL_SELECTIONCHANGED", "OnDirctrlSelectionChanged" },
     { "wxEVT_DIRPICKER_CHANGED", "OnDirChanged" },

--- a/src/ui/ribbon.wxui
+++ b/src/ui/ribbon.wxui
@@ -56,7 +56,7 @@
                   class="ribbonTool"
                   bitmap="Header; ..\art_headers\wxPopupTransientWindow_png.hxx; ; [-1; -1]"
                   help="wxPopupTransientWindow"
-                  id="NewPopupWin" />
+                  id="gen_wxPopupTransientWindow" />
                 <node
                   class="ribbonTool"
                   bitmap="Header; ..\art_headers\menuitem_png.hxx; ; [-1; -1]"

--- a/src/ui/ribbonpanel_base.cpp
+++ b/src/ui/ribbonpanel_base.cpp
@@ -131,7 +131,7 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
         forms_bar_windows->AddTool(CreateNewDialog, GetImgFromHdr(wxDialog_png, sizeof(wxDialog_png)), wxString::FromUTF8("wxDialog"), wxRIBBON_BUTTON_NORMAL);
         forms_bar_windows->AddTool(gen_PanelForm, GetImgFromHdr(wxPanel_png, sizeof(wxPanel_png)), wxString::FromUTF8("wxPanel"), wxRIBBON_BUTTON_NORMAL);
         forms_bar_windows->AddTool(CreateNewFrame, GetImgFromHdr(wxFrame_png, sizeof(wxFrame_png)), wxString::FromUTF8("wxFrame"), wxRIBBON_BUTTON_NORMAL);
-        forms_bar_windows->AddTool(NewPopupWin, GetImgFromHdr(wxPopupTransientWindow_png, sizeof(wxPopupTransientWindow_png)), wxString::FromUTF8("wxPopupTransientWindow"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_windows->AddTool(gen_wxPopupTransientWindow, GetImgFromHdr(wxPopupTransientWindow_png, sizeof(wxPopupTransientWindow_png)), wxString::FromUTF8("wxPopupTransientWindow"), wxRIBBON_BUTTON_NORMAL);
         forms_bar_windows->AddTool(gen_wxContextMenuEvent, GetImgFromHdr(menuitem_png, sizeof(menuitem_png)), wxString::FromUTF8("wxPopupTransientWindow"), wxRIBBON_BUTTON_NORMAL);
     }
     forms_bar_windows->Realize();

--- a/src/xml/forms.xml
+++ b/src/xml/forms.xml
@@ -494,5 +494,7 @@
             help="Sets the background colour of the window. Use &quot;Window&quot; to let wxWidgets choose the color, otherwise specify one of the system colors in the list." />
         <event name="wxEVT_CONTEXT_MENU" class="wxContextMenuEvent"
             help="Either provide your own handler function, or add a wxContextMenuEvent to create a popup menu." />
-    </gen>
+        <event name="wxEVT_DESTROY" class="wxWindowDestroyEvent"
+            help="Sent from the class destructor just before the window is destroyed." />
+        </gen>
 </GeneratorDefinitions>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Fix tool id name that prevented creating a **wxPopupTransientWindow**. Add **wxEVT_DESTROY** event in case the caller needs notification that the popup window was terminated.