### PR TITLE
Move commands in wxGridBagSizer change column and row number as well as position

### DIFF
--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -25,6 +25,8 @@ wxDEFINE_EVENT(EVT_NodeSelected, CustomEvent);
 
 wxDEFINE_EVENT(EVT_NodePropChange, CustomEvent);
 
+wxDEFINE_EVENT(EVT_GridBagAction, CustomEvent);
+
 void MainFrame::FireProjectLoadedEvent()
 {
     ProjectLoaded();
@@ -102,6 +104,15 @@ void MainFrame::FireParentChangedEvent(ChangeParentAction* undo_cmd)
 void MainFrame::FirePositionChangedEvent(ChangePositionAction* undo_cmd)
 {
     CustomEvent event(EVT_PositionChanged, undo_cmd);
+    for (auto handler: m_custom_event_handlers)
+    {
+        handler->ProcessEvent(event);
+    }
+}
+
+void MainFrame::FireGridBagActionEvent(GridBagAction* undo_cmd)
+{
+    CustomEvent event(EVT_GridBagAction, undo_cmd);
     for (auto handler: m_custom_event_handlers)
     {
         handler->ProcessEvent(event);

--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -9,7 +9,7 @@
 
 #include "cstm_event.h"
 
-#include "mainapp.h"     // MoveDirection -- Main application class
+#include "mainapp.h"     // App -- Main application class
 #include "mainframe.h"   // MainFrame -- Main window frame
 #include "node_event.h"  // NodeEventInfo -- NodeEvent and NodeEventInfo classes
 #include "undo_cmds.h"   // Undoable command classes derived from UndoAction

--- a/src/cstm_event.h
+++ b/src/cstm_event.h
@@ -45,3 +45,5 @@ wxDECLARE_EVENT(EVT_NodeDeleted, CustomEvent);
 wxDECLARE_EVENT(EVT_NodeSelected, CustomEvent);
 
 wxDECLARE_EVENT(EVT_NodePropChange, CustomEvent);
+
+wxDECLARE_EVENT(EVT_GridBagAction, CustomEvent);

--- a/src/customprops/anim_props.cpp
+++ b/src/customprops/anim_props.cpp
@@ -10,7 +10,7 @@
 #include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
 
 #include "anim_props.h"  // AnimationProperties
-#include "mainapp.h"     // MoveDirection -- Main application class
+#include "mainapp.h"     // App -- Main application class
 #include "node.h"        // Node -- Node class
 #include "utils.h"       // Utility functions that work with properties
 

--- a/src/customprops/anim_string_prop.cpp
+++ b/src/customprops/anim_string_prop.cpp
@@ -14,9 +14,9 @@
 
 #include "anim_string_prop.h"
 
-#include "mainapp.h"       // MoveDirection -- Main application class
-#include "node.h"          // Node -- Node class
-#include "uifuncs.h"       // Miscellaneous functions for displaying UI
+#include "mainapp.h"  // App -- Main application class
+#include "node.h"     // Node -- Node class
+#include "uifuncs.h"  // Miscellaneous functions for displaying UI
 
 bool AnimDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGProperty* WXUNUSED(property))
 {

--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -10,7 +10,7 @@
 #include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
 
 #include "img_props.h"  // ImageProperties
-#include "mainapp.h"    // MoveDirection -- Main application class
+#include "mainapp.h"    // App -- Main application class
 #include "node.h"       // Node -- Node class
 #include "utils.h"      // Utility functions that work with properties
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -38,14 +38,6 @@ class RibbonPanel;
 class ChangeParentAction;
 class ChangePositionAction;
 
-enum class MoveDirection
-{
-    Up = 1,
-    Down,
-    Left,
-    Right
-};
-
 // Warning! This MUST be at least 3!
 constexpr const size_t StatusPanels = 3;
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -25,6 +25,7 @@ class PropGridPanel;
 class MockupPanel;
 class MockupParent;
 class FocusKillerEvtHandler;
+class GridBagAction;
 
 class wxAuiNotebook;
 class wxAuiNotebookEvent;
@@ -59,6 +60,7 @@ public:
     void FireChangeEventHandler(NodeEvent* event);
     void FireCreatedEvent(Node* node);
     void FireDeletedEvent(Node* node);
+    void FireGridBagActionEvent(GridBagAction* undo_cmd);
     void FireParentChangedEvent(ChangeParentAction* undo_cmd);
     void FirePositionChangedEvent(ChangePositionAction* undo_cmd);
     void FireProjectLoadedEvent();

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -84,6 +84,7 @@ MockupParent::MockupParent(wxWindow* parent, MainFrame* frame) : wxScrolled<wxPa
     Bind(EVT_NodeSelected, &MockupParent::OnNodeSelected, this);
     Bind(EVT_NodePropChange, &MockupParent::OnNodePropModified, this);
 
+    Bind(EVT_GridBagAction, [this](CustomEvent&) { CreateContent(); });
     Bind(EVT_NodeCreated, [this](CustomEvent&) { CreateContent(); });
     Bind(EVT_NodeDeleted, [this](CustomEvent&) { CreateContent(); });
     Bind(EVT_ParentChanged, [this](CustomEvent&) { CreateContent(); });

--- a/src/nodes/node_gridbag.cpp
+++ b/src/nodes/node_gridbag.cpp
@@ -164,3 +164,41 @@ size_t GridBag::IncrementColumns(int row, int column, Node* gbsizer)
 
     return result;
 }
+
+static bool CompareRowNodes(NodeSharedPtr a, NodeSharedPtr b)
+{
+    return (a->prop_as_int(prop_row) < b->prop_as_int(prop_row));
+}
+
+static bool CompareColumnNodes(NodeSharedPtr a, NodeSharedPtr b)
+{
+    return (a->prop_as_int(prop_column) < b->prop_as_int(prop_column));
+}
+
+void GridBag::GridBagSort(Node* gridbag)
+{
+    if (!gridbag->GetChildCount())
+        return;  // no children, so nothing to do
+
+    auto& grid_vector = gridbag->GetChildNodePtrs();
+
+    // First sort the rows
+    std::sort(grid_vector.begin(), grid_vector.end(), CompareRowNodes);
+
+    // Now sort the columns within each row
+    for (size_t idx = 0; idx < grid_vector.size() - 1;)
+    {
+        auto row = grid_vector[idx]->prop_as_int(prop_row);
+        auto end = idx + 1;
+        while (grid_vector[end]->prop_as_int(prop_row) == row)
+        {
+            ++end;
+            if (end >= grid_vector.size())
+                break;
+        }
+
+        std::sort(grid_vector.begin() + idx, grid_vector.begin() + end, CompareColumnNodes);
+
+        idx = end;
+    }
+}

--- a/src/nodes/node_gridbag.cpp
+++ b/src/nodes/node_gridbag.cpp
@@ -117,8 +117,8 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
 
     gbsizer->AddChild(insert_pos, new_node);
     new_node->SetParent(gbsizer);
-    undo_cmd->Update(gbsizer, new_node);
-    wxGetFrame().FireCreatedEvent(new_node);
+    undo_cmd->Update();
+    wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
     wxGetFrame().SelectNode(new_node, true, true);
 
     return true;
@@ -201,4 +201,121 @@ void GridBag::GridBagSort(Node* gridbag)
 
         idx = end;
     }
+}
+
+static void SwapNodes(Node* gbSizer, size_t first_pos, size_t second_pos)
+{
+    auto& vector = gbSizer->GetChildNodePtrs();
+    auto temp = std::move(vector[first_pos]);
+    vector[first_pos] = std::move(vector[second_pos]);
+    vector[second_pos] = std::move(temp);
+}
+
+bool GridBag::MoveNode(Node* node, MoveDirection where, bool check_only)
+{
+    // This function is completely reliant on the children of the wxGridBagSizer being sorted. That means unless we are just
+    // doing a check or know that no action can be taken, then we always resort the entire gridbagsizer.
+
+    auto gbsizer = node->GetParent();
+    ASSERT(gbsizer->isGen(gen_wxGridBagSizer));
+
+    if (where == MoveDirection::Left)
+    {
+        if (check_only || node->prop_as_int(prop_column) == 0)
+        {
+            return (node->prop_as_int(prop_column) > 0);
+        }
+
+        ttlib::cstr undo_str;
+        undo_str << "Change column of " << map_GenNames[node->gen_name()];
+
+        // Unlike a normal undo command, this one will make a copy of the current gbsizer rather than the current node.
+        auto undo_cmd = std::make_shared<GridBagAction>(gbsizer, undo_str);
+        wxGetFrame().PushUndoAction(undo_cmd);
+
+        GridBagSort(gbsizer);
+
+        auto cur_position = gbsizer->GetChildPosition(node);
+        auto cur_row = node->prop_as_int(prop_row);
+        auto cur_column = node->prop_as_int(prop_column);
+
+        auto previous_node = gbsizer->GetChild(cur_position - 1);
+        bool isColumnChangeOnly { false };
+        if (previous_node->prop_as_int(prop_row) != cur_row)
+        {
+            isColumnChangeOnly = true;
+        }
+        else
+        {
+            auto previous_column = previous_node->prop_as_int(prop_column) + (previous_node->prop_as_int(prop_colspan) - 1);
+            if (cur_column - 1 > previous_column)
+                isColumnChangeOnly = true;
+        }
+
+        if (isColumnChangeOnly)
+        {
+            node->prop_set_value(prop_column, cur_column - 1);
+        }
+        else
+        {
+            node->prop_set_value(prop_column, previous_node->prop_as_int(prop_column));
+            previous_node->prop_set_value(prop_column, cur_column);
+
+            SwapNodes(gbsizer, cur_position - 1, cur_position);
+        }
+
+        // This needs to be called once the gbsizer has been modified
+        undo_cmd->Update();
+        wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
+        wxGetFrame().SelectNode(node, true, true);
+    }
+    else if (where == MoveDirection::Right)
+    {
+        // Unless we decide to enforce a limit, the user can always increase the column number
+        if (check_only)
+            return true;
+
+        ttlib::cstr undo_str;
+        undo_str << "Change column of " << map_GenNames[node->gen_name()];
+        // Unlike a normal undo command, this one will make a copy of the current gbsizer rather than the current node.
+        auto undo_cmd = std::make_shared<GridBagAction>(gbsizer, undo_str);
+        wxGetFrame().PushUndoAction(undo_cmd);
+
+        GridBagSort(gbsizer);
+
+        auto cur_position = gbsizer->GetChildPosition(node);
+        auto cur_row = node->prop_as_int(prop_row);
+        auto cur_column = node->prop_as_int(prop_column);
+
+        auto next_node = (cur_position + 1 < gbsizer->GetChildCount()) ? gbsizer->GetChild(cur_position + 1) : nullptr;
+
+        bool isColumnChangeOnly { false };
+        if (!next_node || next_node->prop_as_int(prop_row) != cur_row)
+        {
+            isColumnChangeOnly = true;
+        }
+        else if (cur_column + node->prop_as_int(prop_colspan) < next_node->prop_as_int(prop_column))
+        {
+            isColumnChangeOnly = true;
+        }
+
+        if (isColumnChangeOnly)
+        {
+            node->prop_set_value(prop_column, cur_column + 1);
+        }
+        else
+        {
+            // prop_colspan is always at least 1
+            node->prop_set_value(prop_column, cur_column + next_node->prop_as_int(prop_colspan));
+            next_node->prop_set_value(prop_column, cur_column);
+
+            SwapNodes(gbsizer, cur_position + 1, cur_position);
+        }
+
+        undo_cmd->Update();
+        wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
+        wxGetFrame().SelectNode(node, true, true);
+    }
+
+    return false;
 }

--- a/src/nodes/node_gridbag.h
+++ b/src/nodes/node_gridbag.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-class Node;
+#include "node_classes.h"  // Forward defintions of Node classes
 
 class GridBag
 {
@@ -17,6 +17,8 @@ public:
     auto GetMaxColumn() { return m_max_column; }
     auto GetMaxRow() { return m_max_row; }
     bool InsertNode(Node* gbsizer, Node* new_node);
+
+    static void GridBagSort(Node* gridbag);
 
 protected:
     size_t IncrementColumns(int row, int column, Node* gbsizer);

--- a/src/nodes/node_gridbag.h
+++ b/src/nodes/node_gridbag.h
@@ -14,10 +14,12 @@ class GridBag
 public:
     GridBag(Node* node_gridbag);
 
+
     auto GetMaxColumn() { return m_max_column; }
     auto GetMaxRow() { return m_max_row; }
     bool InsertNode(Node* gbsizer, Node* new_node);
 
+    static bool MoveNode(Node* node, MoveDirection where, bool check_only);
     static void GridBagSort(Node* gridbag);
 
 protected:

--- a/src/nodes/node_gridbag.h
+++ b/src/nodes/node_gridbag.h
@@ -27,6 +27,11 @@ protected:
     size_t IncrementRows(int row, Node* gbsizer);
     void Initialize();
 
+    static void MoveLeft(Node* node);
+    static void MoveRight(Node* node);
+    static void MoveUp(Node* node);
+    static void MoveDown(Node* node);
+
 private:
     Node* m_gridbag;
 

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -48,6 +48,7 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, bool GenerateDerivedCod
     Bind(wxEVT_FIND_NEXT, &BasePanel::OnFind, this);
 
     Bind(EVT_EventHandlerChanged, [this](wxEvent&) { GenerateBaseClass(); });
+    Bind(EVT_GridBagAction, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_NodeCreated, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_NodeDeleted, [this](wxEvent&) { GenerateBaseClass(); });
     Bind(EVT_NodePropChange, [this](wxEvent&) { GenerateBaseClass(); });

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -108,6 +108,8 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
 
     Bind(EVT_ProjectUpdated, [this](CustomEvent&) { OnProjectUpdated(); });
 
+    Bind(EVT_GridBagAction, &NavigationPanel::OnGridBagAction, this);
+
     Bind(EVT_NodeCreated, &NavigationPanel::OnNodeCreated, this);
     Bind(EVT_NodeDeleted, [this](CustomEvent& event) { DeleteNode(event.GetNode()); });
 
@@ -276,6 +278,14 @@ void NavigationPanel::OnNodeCreated(CustomEvent& event)
 {
     AutoFreeze freeze(this);
     InsertNode(event.GetNode());
+}
+
+void NavigationPanel::OnGridBagAction(CustomEvent& event)
+{
+    AutoFreeze freeze(this);
+
+    auto gb_action = static_cast<GridBagAction*>(event.GetUndoCmd());
+    RecreateChildren(gb_action->GetSizerNode());
 }
 
 void NavigationPanel::InsertNode(Node* node)

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -1,4 +1,4 @@
-/////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
 // Purpose:   Navigation Panel
 // Author:    Ralph Walden
 // Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
@@ -107,8 +107,6 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
     Bind(EVT_PositionChanged, &NavigationPanel::OnPositionChange, this);
 
     Bind(EVT_ProjectUpdated, [this](CustomEvent&) { OnProjectUpdated(); });
-
-    Bind(EVT_GridBagAction, &NavigationPanel::OnGridBagAction, this);
 
     Bind(EVT_NodeCreated, &NavigationPanel::OnNodeCreated, this);
     Bind(EVT_NodeDeleted, [this](CustomEvent& event) { DeleteNode(event.GetNode()); });
@@ -278,14 +276,6 @@ void NavigationPanel::OnNodeCreated(CustomEvent& event)
 {
     AutoFreeze freeze(this);
     InsertNode(event.GetNode());
-}
-
-void NavigationPanel::OnGridBagAction(CustomEvent& event)
-{
-    AutoFreeze freeze(this);
-
-    auto gb_action = static_cast<GridBagAction*>(event.GetUndoCmd());
-    RecreateChildren(gb_action->GetSizerNode());
 }
 
 void NavigationPanel::InsertNode(Node* node)

--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -62,6 +62,7 @@ protected:
     void OnCollapse(wxCommandEvent& event);
     void OnExpand(wxCommandEvent& event);
 
+    void OnGridBagAction(CustomEvent& event);
     void OnNodeCreated(CustomEvent& event);
     void OnNodeSelected(CustomEvent& event);
     void OnNodePropChange(CustomEvent& event);

--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -29,15 +29,16 @@ public:
     NavigationPanel(wxWindow* parent, MainFrame* frame);
     void ChangeExpansion(Node* node, bool include_children, bool expand);
 
-protected:
+    void EraseAllMaps(Node* node);
     void AddAllChildren(Node* node_parent);
+    void ExpandAllNodes(Node* node);
+
+protected:
 
     void InsertNode(Node* node);
     void DeleteNode(Node* item);
-    void EraseAllMaps(Node* node);
     void RecreateChildren(Node* node);
 
-    void ExpandAllNodes(Node* node);
     Node* GetNode(wxTreeItemId item);
 
     int GetImageIndex(Node* node);
@@ -62,7 +63,6 @@ protected:
     void OnCollapse(wxCommandEvent& event);
     void OnExpand(wxCommandEvent& event);
 
-    void OnGridBagAction(CustomEvent& event);
     void OnNodeCreated(CustomEvent& event);
     void OnNodeSelected(CustomEvent& event);
     void OnNodePropChange(CustomEvent& event);

--- a/src/pch.h
+++ b/src/pch.h
@@ -91,7 +91,15 @@
 // signed integer type with width determined by platform
 typedef ptrdiff_t int_t;
 
-#endif
+#endif  // not !defined(int_t)
+
+enum class MoveDirection
+{
+    Up = 1,
+    Down,
+    Left,
+    Right
+};
 
 constexpr const char* txtVersion = "wxUiEditor 1.0.0";
 constexpr const char* txtCopyRight = "Copyright (c) 2019-2021 KeyWorks Software";

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -25,6 +25,7 @@ using namespace GenEnum;
 #include "../import/import_wxsmith.h"    // WxSmith -- Import a wxSmith file
 #include "../ui/newproject.h"            // NewProjectDlg -- Dialog to create a new project
 #include "../winres/import_winres.h"     // WinResource -- Parse a Windows resource file
+#include "node_gridbag.h"                // GridBag -- Create and modify a node containing a wxGridBagSizer
 #include "oldproject.h"                  // Load older version of wxUiEditor project
 
 using namespace GenEnum;
@@ -366,6 +367,11 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
     for (auto child = xml_obj.child("node"); child; child = child.next_sibling("node"))
     {
         CreateNode(child, new_node.get());
+    }
+
+    if (new_node->isGen(gen_wxGridBagSizer))
+    {
+        GridBag::GridBagSort(new_node.get());
     }
 
     return new_node;

--- a/src/ui/gridbag_item.cpp
+++ b/src/ui/gridbag_item.cpp
@@ -11,7 +11,7 @@
 
 #include "gridbag_item.h"  // auto-generated: gridbag_item_base.h and gridbag_item_base.cpp
 
-#include "mainframe.h"     // MoveDirection -- Main window frame
+#include "mainframe.h"     // MainFrame -- Main window frame
 #include "node.h"          // Node class
 #include "node_gridbag.h"  // GridBag -- Create and modify a node containing a wxGridBagSizer
 

--- a/src/ui/newdialog.cpp
+++ b/src/ui/newdialog.cpp
@@ -10,7 +10,7 @@
 #include "newdialog.h"  // auto-generated: newdialog_base.h and newdialog_base.cpp
 
 #include "../panels/nav_panel.h"  // NavigationPanel -- Navigation Panel
-#include "mainframe.h"            // MoveDirection -- Main window frame
+#include "mainframe.h"            // MainFrame -- Main window frame
 #include "node.h"                 // Node class
 #include "node_creator.h"         // NodeCreator -- Class used to create nodes
 #include "undo_cmds.h"            // InsertNodeAction -- Undoable command classes derived from UndoAction

--- a/src/ui/newribbon.cpp
+++ b/src/ui/newribbon.cpp
@@ -11,7 +11,7 @@
 
 #include "../panels/nav_panel.h"     // NavigationPanel -- Navigation Panel
 #include "../panels/ribbon_tools.h"  // RibbonPanel -- Displays component tools in a wxRibbonBar
-#include "mainframe.h"               // MoveDirection -- Main window frame
+#include "mainframe.h"               // MainFrame -- Main window frame
 #include "node.h"                    // Node class
 #include "node_creator.h"            // NodeCreator -- Class used to create nodes
 #include "uifuncs.h"                 // Miscellaneous functions for displaying UI

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -130,7 +130,8 @@ private:
     bool m_fix_duplicate_names { true };
 };
 
-// Use this when the entire wxGridBagSizer node needs to be saved.
+// Use this when the entire wxGridBagSizer node needs to be saved. You *MUST* call Update()
+// or the Navigation Panel will be frozen!
 class GridBagAction : public UndoAction
 {
 public:
@@ -139,14 +140,13 @@ public:
     void Revert() override;
 
     // Call this after making all changes to the gbsizer children
-    void Update(Node* cur_gbsizer, Node* selected);
-    Node* GetSizerNode() const { return m_cur_gbsizer.get(); }
+    void Update();
+    Node* GetOldSizerNode() const { return m_old_gbsizer.get(); }
+    Node* GetCurSizerNode() const { return m_cur_gbsizer.get(); }
 
 private:
     NodeSharedPtr m_cur_gbsizer;
-    NodeSharedPtr m_old_cur_gbsizer;  // Set when Update() is called
     NodeSharedPtr m_old_gbsizer;
 
-    size_t m_idx_old_selected { 0 };
-    size_t m_idx_cur_selected { 0 };
+    bool m_isReverted { false };
 };

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -140,6 +140,7 @@ public:
 
     // Call this after making all changes to the gbsizer children
     void Update(Node* cur_gbsizer, Node* selected);
+    Node* GetSizerNode() const { return m_cur_gbsizer.get(); }
 
 private:
     NodeSharedPtr m_cur_gbsizer;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Closes #342

This PR now sorts all children of every **wxGridBagSizer** whenever a project is loaded. All move commands now also sort the current **wxGridBagSizer**. It's still possible for the positions to be unsorted if the user modifies row or column directly -- but only until a move command or the project is reloaded.

Each move command can affect multiple children, so the Undo command stores a copy of the entire **wxGridBagSizer**.

Moving a column will take into account the span size of either the current column if moving right, or the previous column's span if moving left. Both horizontal moves take into account empty columns.

Moving up or down moves every column in the row. Currently, rowspan is not taken into account.