### PR TITLE
Support wxFormBuilder subclass property

### DIFF
--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -449,7 +449,8 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
     auto xml_event = xml_obj.child("event");
     while (xml_event)
     {
-        if (auto event_name = xml_event.attribute("name").as_cview(); event_name.size() && xml_event.text().as_cview().size())
+        if (auto event_name = xml_event.attribute("name").as_cview();
+            event_name.size() && xml_event.text().as_cview().size())
         {
             if (auto result = m_mapEventNames.find(event_name.c_str()); result != m_mapEventNames.end())
             {
@@ -712,10 +713,18 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
     {
         return;
     }
-
+    else if (prop_name.is_sameas("subclass") && (xml_prop.text().as_cview().is_sameas("; ; forward_declare") ||
+                                                 xml_prop.text().as_cview().is_sameas("; forward_declare")))
+    {
+        return;
+    }
     else
     {
-        MSG_INFO(ttlib::cstr() << prop_name << " property in " << class_name << " class not supported");
+        if (xml_prop.text().as_cview().size())
+        {
+            MSG_INFO(ttlib::cstr() << prop_name << "(" << xml_prop.text().as_string() << ") property in " << class_name
+                                   << " class not supported");
+        }
     }
 }
 

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -713,10 +713,25 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
     {
         return;
     }
-    else if (prop_name.is_sameas("subclass") && (xml_prop.text().as_cview().is_sameas("; ; forward_declare") ||
-                                                 xml_prop.text().as_cview().is_sameas("; forward_declare")))
+    else if (prop_name.is_sameas("subclass"))
     {
-        return;
+        ttlib::multistr parts(xml_prop.text().as_string());
+        parts[0].BothTrim();
+        if (parts[0].empty())
+            return;
+        if (auto prop = newobject->get_prop_ptr(prop_derived_class); prop)
+        {
+            prop->set_value(parts[0]);
+            if (parts.size() > 0 && !parts[1].contains("forward_declare"))
+            {
+                parts[1].BothTrim();
+                prop = newobject->get_prop_ptr(prop_derived_header);
+                if (prop)
+                {
+                    prop->set_value(parts[1]);
+                }
+            }
+        }
     }
     else
     {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
In addition to now supporting the subclass property, non-supported properties that don't have a value are silently ignored.