### PR TITLE
Correctly handles a spacer in a wxGridBagSizer

### DIFF
--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -109,20 +109,32 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
     {
         if (node->IsSpacer() && parentNode)
         {
-            if (node->prop_as_int(prop_proportion) != 0)
+            if (node->GetParent()->isGen(gen_wxGridBagSizer))
             {
-                wxStaticCast(parentNode, wxSizer)->AddStretchSpacer(node->prop_as_int(prop_proportion));
+                auto flags = node->GetSizerFlags();
+                wxStaticCast(parentNode, wxGridBagSizer)
+                    ->Add(node->prop_as_int(prop_width), node->prop_as_int(prop_height),
+                          wxGBPosition(node->prop_as_int(prop_row), node->prop_as_int(prop_column)),
+                          wxGBSpan(node->prop_as_int(prop_rowspan), node->prop_as_int(prop_colspan)), flags.GetFlags(),
+                          node->prop_as_int(prop_border_size));
             }
             else
             {
-                auto width = node->prop_as_int(prop_width);
-                auto height = node->prop_as_int(prop_height);
-                if (node->prop_as_bool(prop_add_default_border))
+                if (node->prop_as_int(prop_proportion) != 0)
                 {
-                    width += wxSizerFlags::GetDefaultBorder();
-                    height += wxSizerFlags::GetDefaultBorder();
+                    wxStaticCast(parentNode, wxSizer)->AddStretchSpacer(node->prop_as_int(prop_proportion));
                 }
-                wxStaticCast(parentNode, wxSizer)->Add(width, height);
+                else
+                {
+                    auto width = node->prop_as_int(prop_width);
+                    auto height = node->prop_as_int(prop_height);
+                    if (node->prop_as_bool(prop_add_default_border))
+                    {
+                        width += wxSizerFlags::GetDefaultBorder();
+                        height += wxSizerFlags::GetDefaultBorder();
+                    }
+                    wxStaticCast(parentNode, wxSizer)->Add(width, height);
+                }
             }
         }
         return;  // means the component doesn't create any UI element, and cannot have children

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -173,7 +173,12 @@ void PropGridPanel::Create()
                 CreateEventCategory(info_base->DeclName(), node, info_base, event_set);
             }
 
-            if (node->GetParent() && node->GetParent()->IsSizer() && !node->IsSpacer())
+            if (node->IsSpacer())
+            {
+                if (node->isParent(gen_wxGridBagSizer))
+                    CreateLayoutCategory(node);
+            }
+            else if (node->GetParent() && node->GetParent()->IsSizer())
             {
                 CreateLayoutCategory(node);
             }
@@ -1444,11 +1449,19 @@ static constexpr std::initializer_list<PropName> lst_LayoutProps = {
 
 };
 
+// clang-format off
 static constexpr std::initializer_list<PropName> lst_GridBagProps = {
 
-    prop_row, prop_column, prop_rowspan, prop_colspan
+    prop_borders,
+    prop_border_size,
+    prop_flags,
+    prop_row,
+    prop_column,
+    prop_rowspan,
+    prop_colspan
 
 };
+// clang-format on
 
 void PropGridPanel::CreateLayoutCategory(Node* node)
 {
@@ -1456,22 +1469,22 @@ void PropGridPanel::CreateLayoutCategory(Node* node)
 
     auto id = m_prop_grid->Append(new wxPropertyCategory("Layout"));
 
-    for (auto iter: lst_LayoutProps)
-    {
-        auto prop = node->get_prop_ptr(iter);
-        if (!prop)
-            continue;
-
-        auto id_prop = m_prop_grid->Append(GetProperty(prop));
-
-        auto propInfo = prop->GetPropDeclaration();
-        m_prop_grid->SetPropertyHelpString(id_prop, propInfo->GetDescription());
-
-        m_property_map[id_prop] = prop;
-    }
-
     if (!node->isParent(gen_wxGridBagSizer))
     {
+        for (auto iter: lst_LayoutProps)
+        {
+            auto prop = node->get_prop_ptr(iter);
+            if (!prop)
+                continue;
+
+            auto id_prop = m_prop_grid->Append(GetProperty(prop));
+
+            auto propInfo = prop->GetPropDeclaration();
+            m_prop_grid->SetPropertyHelpString(id_prop, propInfo->GetDescription());
+
+            m_property_map[id_prop] = prop;
+        }
+
         if (auto prop = node->get_prop_ptr(prop_proportion); prop)
         {
             auto id_prop = m_prop_grid->Append(GetProperty(prop));


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This fixes spacers when used within a **wxGridBagSizer**. It displays the properties needed by the parent sizer, correctly displays the spacer in the Mockup panel, and generates the correct code for the base source file.

Closes #347