### PR TITLE
Enables two-step construction in wxDialog forms

### DIFF
--- a/src/debugging/dbg_code_diff_base.cpp
+++ b/src/debugging/dbg_code_diff_base.cpp
@@ -13,9 +13,11 @@
 
 #include "WinMerge.xpm"
 
-DbgCodeDiffBase::DbgCodeDiffBase(wxWindow* parent) : wxDialog()
+bool DbgCodeDiffBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Compare Code Generation"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto dlg_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -44,4 +46,6 @@ DbgCodeDiffBase::DbgCodeDiffBase(wxWindow* parent) : wxDialog()
     // Event handlers
     Bind(wxEVT_INIT_DIALOG, &DbgCodeDiffBase::OnInit, this);
     m_btn->Bind(wxEVT_BUTTON, &DbgCodeDiffBase::OnWinMerge, this);
+
+    return true;
 }

--- a/src/debugging/dbg_code_diff_base.h
+++ b/src/debugging/dbg_code_diff_base.h
@@ -18,7 +18,17 @@
 class DbgCodeDiffBase : public wxDialog
 {
 public:
-    DbgCodeDiffBase(wxWindow* parent);
+    DbgCodeDiffBase() {}
+    DbgCodeDiffBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Compare Code Generation"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Compare Code Generation"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/debugging/dbg_winres_dlg_base.cpp
+++ b/src/debugging/dbg_winres_dlg_base.cpp
@@ -12,9 +12,11 @@
 
 #include "dbg_winres_dlg_base.h"
 
-DbgWinResBase::DbgWinResBase(wxWindow* parent) : wxDialog()
+bool DbgWinResBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Resource Files"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto box_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -65,4 +67,6 @@ DbgWinResBase::DbgWinResBase(wxWindow* parent) : wxDialog()
         [this](wxCommandEvent&) { m_res_file->SetValue(m_list_files->GetString(m_list_files->GetSelection())); }
         );
     Bind(wxEVT_BUTTON, &DbgWinResBase::OnAffirmative, this, wxID_OK);
+
+    return true;
 }

--- a/src/debugging/dbg_winres_dlg_base.h
+++ b/src/debugging/dbg_winres_dlg_base.h
@@ -15,7 +15,17 @@
 class DbgWinResBase : public wxDialog
 {
 public:
-    DbgWinResBase(wxWindow* parent);
+    DbgWinResBase() {}
+    DbgWinResBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Resource Files"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Resource Files"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/debugging/nodeinfo_base.cpp
+++ b/src/debugging/nodeinfo_base.cpp
@@ -12,9 +12,11 @@
 
 #include "nodeinfo_base.h"
 
-NodeInfoBase::NodeInfoBase(wxWindow* parent) : wxDialog()
+bool NodeInfoBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Node Information"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -36,4 +38,6 @@ NodeInfoBase::NodeInfoBase(wxWindow* parent) : wxDialog()
 
     SetSizerAndFit(parent_sizer);
     Centre(wxBOTH);
+
+    return true;
 }

--- a/src/debugging/nodeinfo_base.h
+++ b/src/debugging/nodeinfo_base.h
@@ -13,7 +13,17 @@
 class NodeInfoBase : public wxDialog
 {
 public:
-    NodeInfoBase(wxWindow* parent);
+    NodeInfoBase() {}
+    NodeInfoBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Node Information"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Node Information"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1033,6 +1033,11 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
         GenSrcEventBinding(form_node, events);
     }
 
+    if (form_node->isGen(gen_wxDialog))
+    {
+        m_source->writeLine("\nreturn true;");
+    }
+
     m_source->Unindent();
     m_source->writeLine("}");
 

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -152,7 +152,8 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_TYP
         m_header->writeLine("public:");
         m_header->Indent();
 
-        m_header->writeLine(ttlib::cstr() << derived_name << "(wxWindow* parent = nullptr);");
+        m_header->writeLine(ttlib::cstr() << derived_name << "();  // If you use this constructor, you must call Create(parent)");
+        m_header->writeLine(ttlib::cstr() << derived_name << "(wxWindow* parent);");
 
         m_header->Unindent();
     }
@@ -213,8 +214,18 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_TYP
 
         {
             ttlib::cstr code;
-            code << derived_name << "::" << derived_name << "(wxWindow* parent) : ";
-            code << form->get_node_name() << "(parent) {}";
+            if (form->isGen(gen_wxDialog))
+            {
+                code << "// If this constructor is used, the caller must call Create(parent)\n";
+                code << derived_name << "::" << derived_name << "() {}\n\n";
+                code << derived_name << "::" << derived_name << "(wxWindow* parent) { Create(parent); }";
+            }
+            else
+            {
+                code << derived_name << "::" << derived_name << "(wxWindow* parent) : ";
+                code << form->get_node_name() << "(parent) {}";
+            }
+
             m_source->writeLine(code);
         }
     }

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -85,6 +85,7 @@ const auto g_lstIgnoreProps = {
     "resize",
     "show",
     "toolbar_pane",
+    "two_step_creation",
     "use_enum",
 
 };
@@ -290,6 +291,11 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
     else if (class_name.is_sameas("Panel"))
     {
         class_name = "PanelForm";
+    }
+    else if (class_name.is_sameas("CustomCode"))
+    {
+        m_errors.emplace(ttlib::cstr() << "Custom code is not supported in wxUiEditor");
+        return {};
     }
 
     if (class_name.is_sameas("wxCheckBox"))

--- a/src/ui/artpropdlg_base.cpp
+++ b/src/ui/artpropdlg_base.cpp
@@ -11,9 +11,11 @@
 
 #include "artpropdlg_base.h"
 
-ArtPropertyDlgBase::ArtPropertyDlgBase(wxWindow* parent) : wxDialog()
+bool ArtPropertyDlgBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Art Provider Image"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -53,4 +55,6 @@ ArtPropertyDlgBase::ArtPropertyDlgBase(wxWindow* parent) : wxDialog()
     // Event handlers
     m_list->Bind(wxEVT_LIST_ITEM_SELECTED, &ArtPropertyDlgBase::OnSelectItem, this);
     m_choice_client->Bind(wxEVT_CHOICE, &ArtPropertyDlgBase::OnChooseClient, this);
+
+    return true;
 }

--- a/src/ui/artpropdlg_base.h
+++ b/src/ui/artpropdlg_base.h
@@ -17,7 +17,17 @@
 class ArtPropertyDlgBase : public wxDialog
 {
 public:
-    ArtPropertyDlgBase(wxWindow* parent);
+    ArtPropertyDlgBase() {}
+    ArtPropertyDlgBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Art Provider Image"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Art Provider Image"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/debugsettingsBase.cpp
+++ b/src/ui/debugsettingsBase.cpp
@@ -14,10 +14,11 @@
 
 #include "debugsettingsBase.h"
 
-DebugSettingsBase::DebugSettingsBase(wxWindow* parent) : wxDialog()
+bool DebugSettingsBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Debug Settings"), wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -74,4 +75,6 @@ DebugSettingsBase::DebugSettingsBase(wxWindow* parent) : wxDialog()
     Bind(wxEVT_INIT_DIALOG, &DebugSettingsBase::OnInit, this);
     m_btn->Bind(wxEVT_BUTTON, &DebugSettingsBase::OnShowNow, this);
     Bind(wxEVT_BUTTON, &DebugSettingsBase::OnOK, this, wxID_OK);
+
+    return true;
 }

--- a/src/ui/debugsettingsBase.h
+++ b/src/ui/debugsettingsBase.h
@@ -15,7 +15,17 @@
 class DebugSettingsBase : public wxDialog
 {
 public:
-    DebugSettingsBase(wxWindow* parent);
+    DebugSettingsBase() {}
+    DebugSettingsBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Debug Settings"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Debug Settings"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/editstringdialog_base.cpp
+++ b/src/ui/editstringdialog_base.cpp
@@ -13,9 +13,11 @@
 
 #include "editstringdialog_base.h"
 
-EditStringDialogBase::EditStringDialogBase(wxWindow* parent) : wxDialog()
+bool EditStringDialogBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxEmptyString);
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -31,4 +33,6 @@ EditStringDialogBase::EditStringDialogBase(wxWindow* parent) : wxDialog()
 
     SetSizerAndFit(parent_sizer);
     Centre(wxBOTH);
+
+    return true;
 }

--- a/src/ui/editstringdialog_base.h
+++ b/src/ui/editstringdialog_base.h
@@ -13,7 +13,17 @@
 class EditStringDialogBase : public wxDialog
 {
 public:
-    EditStringDialogBase(wxWindow* parent);
+    EditStringDialogBase() {}
+    EditStringDialogBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString,
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString,
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
     const wxString& GetResults() const { return m_value; }
 

--- a/src/ui/embedimg_base.cpp
+++ b/src/ui/embedimg_base.cpp
@@ -15,9 +15,11 @@
 
 #include "embedimg_base.h"
 
-EmbedImageBase::EmbedImageBase(wxWindow* parent) : wxDialog()
+bool EmbedImageBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Convert Image"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -208,4 +210,6 @@ EmbedImageBase::EmbedImageBase(wxWindow* parent) : wxDialog()
     m_ForceXpmMask->Bind(wxEVT_CHECKBOX, &EmbedImageBase::OnForceXpmMask, this);
     m_comboXpmMask->Bind(wxEVT_COMBOBOX, &EmbedImageBase::OnComboXpmMask, this);
     m_btnConvert->Bind(wxEVT_BUTTON, &EmbedImageBase::OnConvert, this);
+
+    return true;
 }

--- a/src/ui/embedimg_base.h
+++ b/src/ui/embedimg_base.h
@@ -20,7 +20,17 @@
 class EmbedImageBase : public wxDialog
 {
 public:
-    EmbedImageBase(wxWindow* parent);
+    EmbedImageBase() {}
+    EmbedImageBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Convert Image"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Convert Image"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/eventhandlerdlg_base.cpp
+++ b/src/ui/eventhandlerdlg_base.cpp
@@ -10,9 +10,11 @@
 
 #include "eventhandlerdlg_base.h"
 
-EventHandlerDlgBase::EventHandlerDlgBase(wxWindow* parent) : wxDialog()
+bool EventHandlerDlgBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Event Handler"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -83,4 +85,6 @@ EventHandlerDlgBase::EventHandlerDlgBase(wxWindow* parent) : wxDialog()
     m_check_include_event->Bind(wxEVT_CHECKBOX, &EventHandlerDlgBase::OnIncludeEvent, this);
     m_stc->Bind(wxEVT_STC_CHANGE, &EventHandlerDlgBase::OnChange, this);
     Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnOK, this, wxID_OK);
+
+    return true;
 }

--- a/src/ui/eventhandlerdlg_base.h
+++ b/src/ui/eventhandlerdlg_base.h
@@ -20,7 +20,17 @@
 class EventHandlerDlgBase : public wxDialog
 {
 public:
-    EventHandlerDlgBase(wxWindow* parent);
+    EventHandlerDlgBase() {}
+    EventHandlerDlgBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Event Handler"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Event Handler"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/gridbag_item_base.cpp
+++ b/src/ui/gridbag_item_base.cpp
@@ -12,9 +12,11 @@
 
 #include "gridbag_item_base.h"
 
-GridBagItemBase::GridBagItemBase(wxWindow* parent) : wxDialog()
+bool GridBagItemBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Append or Insert into wxGridBagSizer"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto dlg_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -72,4 +74,6 @@ GridBagItemBase::GridBagItemBase(wxWindow* parent) : wxDialog()
     m_spin_column->Bind(wxEVT_SPINCTRL, &GridBagItemBase::OnColumn, this);
     m_spin_row->Bind(wxEVT_SPINCTRL, &GridBagItemBase::OnRow, this);
     Bind(wxEVT_BUTTON, &GridBagItemBase::OnOK, this, wxID_OK);
+
+    return true;
 }

--- a/src/ui/gridbag_item_base.h
+++ b/src/ui/gridbag_item_base.h
@@ -16,7 +16,17 @@
 class GridBagItemBase : public wxDialog
 {
 public:
-    GridBagItemBase(wxWindow* parent);
+    GridBagItemBase() {}
+    GridBagItemBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Append or Insert into wxGridBagSizer"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Append or Insert into wxGridBagSizer"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/import_base.cpp
+++ b/src/ui/import_base.cpp
@@ -8,9 +8,11 @@
 
 #include "import_base.h"
 
-ImportBase::ImportBase(wxWindow* parent) : wxDialog()
+bool ImportBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("New Imported Project"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -84,4 +86,6 @@ ImportBase::ImportBase(wxWindow* parent) : wxDialog()
     btn_2->Bind(wxEVT_BUTTON, &ImportBase::OnSelectAll, this);
     btn__2->Bind(wxEVT_BUTTON, &ImportBase::OnSelectNone, this);
     Bind(wxEVT_BUTTON, &ImportBase::OnOK, this, wxID_OK);
+
+    return true;
 }

--- a/src/ui/import_base.h
+++ b/src/ui/import_base.h
@@ -19,7 +19,17 @@
 class ImportBase : public wxDialog
 {
 public:
-    ImportBase(wxWindow* parent);
+    ImportBase() {}
+    ImportBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("New Imported Project"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("New Imported Project"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/importwinres_base.cpp
+++ b/src/ui/importwinres_base.cpp
@@ -10,9 +10,11 @@
 
 #include "importwinres_base.h"
 
-ImportWinResBase::ImportWinResBase(wxWindow* parent) : wxDialog()
+bool ImportWinResBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Import Windows Resource Dialogs"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -60,4 +62,6 @@ ImportWinResBase::ImportWinResBase(wxWindow* parent) : wxDialog()
     m_btnSelectAll->Bind(wxEVT_BUTTON, &ImportWinResBase::OnSelectAll, this);
     m_btnClearAll->Bind(wxEVT_BUTTON, &ImportWinResBase::OnClearAll, this);
     Bind(wxEVT_BUTTON, &ImportWinResBase::OnOk, this, wxID_OK);
+
+    return true;
 }

--- a/src/ui/importwinres_base.h
+++ b/src/ui/importwinres_base.h
@@ -17,7 +17,17 @@
 class ImportWinResBase : public wxDialog
 {
 public:
-    ImportWinResBase(wxWindow* parent);
+    ImportWinResBase() {}
+    ImportWinResBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Import Windows Resource Dialogs"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Import Windows Resource Dialogs"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/insertdialog_base.cpp
+++ b/src/ui/insertdialog_base.cpp
@@ -10,9 +10,11 @@
 
 #include "insertdialog_base.h"
 
-InsertDialogBase::InsertDialogBase(wxWindow* parent) : wxDialog()
+bool InsertDialogBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Insert widget"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto box_sizer = new wxBoxSizer(wxVERTICAL);
     box_sizer->SetMinSize(300, 400);
@@ -46,4 +48,6 @@ InsertDialogBase::InsertDialogBase(wxWindow* parent) : wxDialog()
         );
     m_listBox->Bind(wxEVT_LISTBOX_DCLICK, &InsertDialogBase::OnListBoxDblClick, this);
     Bind(wxEVT_BUTTON, &InsertDialogBase::OnOK, this, wxID_OK);
+
+    return true;
 }

--- a/src/ui/insertdialog_base.h
+++ b/src/ui/insertdialog_base.h
@@ -17,7 +17,17 @@
 class InsertDialogBase : public wxDialog
 {
 public:
-    InsertDialogBase(wxWindow* parent);
+    InsertDialogBase() {}
+    InsertDialogBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Insert widget"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Insert widget"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/newdialog_base.cpp
+++ b/src/ui/newdialog_base.cpp
@@ -14,9 +14,11 @@
 
 #include "newdialog_base.h"
 
-NewDialogBase::NewDialogBase(wxWindow* parent) : wxDialog()
+bool NewDialogBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("New Dialog"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -81,4 +83,6 @@ NewDialogBase::NewDialogBase(wxWindow* parent) : wxDialog()
     m_check_tabs->Bind(wxEVT_CHECKBOX,
         [this](wxCommandEvent&) { m_spinCtrlTabs->Enable(m_check_tabs->GetValue()); }
         );
+
+    return true;
 }

--- a/src/ui/newdialog_base.h
+++ b/src/ui/newdialog_base.h
@@ -16,7 +16,17 @@
 class NewDialogBase : public wxDialog
 {
 public:
-    NewDialogBase(wxWindow* parent);
+    NewDialogBase() {}
+    NewDialogBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("New Dialog"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("New Dialog"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/newframe_base.cpp
+++ b/src/ui/newframe_base.cpp
@@ -15,9 +15,11 @@
 
 #include "newframe_base.h"
 
-NewFrameBase::NewFrameBase(wxWindow* parent) : wxDialog()
+bool NewFrameBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("New wxFrame window"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto box_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -72,4 +74,6 @@ NewFrameBase::NewFrameBase(wxWindow* parent) : wxDialog()
         [this](wxInitDialogEvent& event) { m_classname->SetFocus();  event.Skip(); }
         );
     m_checkBox_mainframe->Bind(wxEVT_CHECKBOX, &NewFrameBase::OnCheckMainFrame, this);
+
+    return true;
 }

--- a/src/ui/newframe_base.h
+++ b/src/ui/newframe_base.h
@@ -15,7 +15,17 @@
 class NewFrameBase : public wxDialog
 {
 public:
-    NewFrameBase(wxWindow* parent);
+    NewFrameBase() {}
+    NewFrameBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("New wxFrame window"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("New wxFrame window"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/newribbon_base.cpp
+++ b/src/ui/newribbon_base.cpp
@@ -12,9 +12,11 @@
 
 #include "newribbon_base.h"
 
-NewRibbonBase::NewRibbonBase(wxWindow* parent) : wxDialog()
+bool NewRibbonBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("New Ribbon Bar"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto box_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -55,4 +57,6 @@ NewRibbonBase::NewRibbonBase(wxWindow* parent) : wxDialog()
 
     SetSizerAndFit(box_sizer);
     Centre(wxBOTH);
+
+    return true;
 }

--- a/src/ui/newribbon_base.h
+++ b/src/ui/newribbon_base.h
@@ -15,7 +15,17 @@
 class NewRibbonBase : public wxDialog
 {
 public:
-    NewRibbonBase(wxWindow* parent);
+    NewRibbonBase() {}
+    NewRibbonBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("New Ribbon Bar"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("New Ribbon Bar"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/optionsdlg_base.cpp
+++ b/src/ui/optionsdlg_base.cpp
@@ -16,9 +16,11 @@
 
 #include "optionsdlg_base.h"
 
-OptionsDlgBase::OptionsDlgBase(wxWindow* parent) : wxDialog()
+bool OptionsDlgBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Options"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -77,4 +79,6 @@ OptionsDlgBase::OptionsDlgBase(wxWindow* parent) : wxDialog()
     // Event handlers
     Bind(wxEVT_INIT_DIALOG, &OptionsDlgBase::OnInit, this);
     Bind(wxEVT_BUTTON, &OptionsDlgBase::OnAffirmative, this, wxID_OK);
+
+    return true;
 }

--- a/src/ui/optionsdlg_base.h
+++ b/src/ui/optionsdlg_base.h
@@ -13,7 +13,17 @@
 class OptionsDlgBase : public wxDialog
 {
 public:
-    OptionsDlgBase(wxWindow* parent);
+    OptionsDlgBase() {}
+    OptionsDlgBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Options"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Options"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This implements two-step construction for wxDialogs. Both base and derived code generation has been updated.

Existing code does not need to change as the standard constructor is still supported.

Closes #366