### PR TITLE
Handle wxListView modes without creating style conflicts

### DIFF
--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -301,6 +301,13 @@ void GenStyle(Node* node, ttlib::cstr& code)
         all_styles << node->prop_as_string(prop_window_style);
     }
 
+    if (node->isGen(gen_wxListView))
+    {
+        if (all_styles.size())
+            all_styles << '|';
+        all_styles << node->prop_as_string(prop_mode);
+    }
+
     if (all_styles.empty())
     {
         code << "0";

--- a/src/generate/listctrl_widgets.cpp
+++ b/src/generate/listctrl_widgets.cpp
@@ -67,7 +67,11 @@ std::optional<ttlib::cstr> ListViewGenerator::GenConstruction(Node* node)
         code << "auto ";
     code << node->get_node_name() << GenerateNewAssignment(node);
     code << GetParentName(node) << ", " << node->prop_as_string(prop_id);
-    GeneratePosSizeFlags(node, code, false, "wxLC_ICON");
+
+    // Note that the default style is not specified, so that it will always be generated. That makes the generated code
+    // easier to understand since you know exactly which type of list view is being created instead of having to know what
+    // the default it.
+    GeneratePosSizeFlags(node, code);
 
     return code;
 }

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -302,6 +302,30 @@ void ImportXML::ProcessStyle(pugi::xml_node& xml_prop, Node* node, NodeProperty*
             node->prop_set_value(prop_style, "wxFNTP_FONTDESC_AS_LABEL|wxFNTP_USEFONT_FOR_LABEL");
         }
     }
+    else if (node->isGen(gen_wxListView))
+    {
+        ttlib::cstr style(xml_prop.text().as_string());
+        ttlib::multistr mstr(style, '|');
+        style.clear();
+        for (auto& iter: mstr)
+        {
+            if (iter.is_sameprefix("wxLC_ICON") || iter.is_sameprefix("wxLC_SMALL_ICON") ||
+                iter.is_sameprefix("wxLC_LIST") || iter.is_sameprefix("wxLC_REPORT"))
+            {
+                node->prop_set_value(prop_mode, iter);
+            }
+            else
+            {
+                if (style.size())
+                {
+                    style << '|';
+                }
+                style << iter;
+            }
+        }
+        if (style.size())
+            prop->set_value(style);
+    }
 
     else
     {

--- a/src/winres/winres_styles.cpp
+++ b/src/winres/winres_styles.cpp
@@ -119,8 +119,17 @@ void resCtrl::ParseButtonStyles(ttlib::cview line)
 
 void resCtrl::ParseListViewStyles(ttlib::cview line)
 {
-    // Clear the default style (wxLC_ICON)
     m_node->prop_set_value(prop_style, "");
+
+    if (line.contains("LVS_ICON"))
+        m_node->prop_set_value(prop_mode, "wxLC_ICON");
+    else if (line.contains("LVS_SMALLICON"))
+        m_node->prop_set_value(prop_mode, "wxLC_SMALL_ICON");
+    else if (line.contains("LVS_LIST"))
+        m_node->prop_set_value(prop_mode, "wxLC_LIST");
+    else if (line.contains("LVS_REPORT"))
+        m_node->prop_set_value(prop_mode, "wxLC_REPORT");
+    AppendStyle(prop_style, "wxLC_REPORT");
 
     if (line.contains("LVS_ALIGNLEFT"))
         AppendStyle(prop_style, "wxLC_ALIGN_LEFT");
@@ -131,14 +140,6 @@ void resCtrl::ParseListViewStyles(ttlib::cview line)
         AppendStyle(prop_style, "wxLC_AUTOARRANGE");
     if (line.contains("LVS_EDITLABELS"))
         AppendStyle(prop_style, "wxLC_EDIT_LABELS");
-    if (line.contains("LVS_ICON"))
-        AppendStyle(prop_style, "wxLC_ICON");
-    if (line.contains("LVS_SMALLICON"))
-        AppendStyle(prop_style, "wxLC_SMALL_ICON");
-    if (line.contains("LVS_LIST"))
-        AppendStyle(prop_style, "wxLC_LIST");
-    if (line.contains("LVS_REPORT"))
-        AppendStyle(prop_style, "wxLC_REPORT");
     if (line.contains("LVS_NOCOLUMNHEADER"))
         AppendStyle(prop_style, "wxLC_NO_HEADER");
     if (line.contains("LVS_SINGLESEL"))

--- a/src/xml/widgets.xml
+++ b/src/xml/widgets.xml
@@ -411,17 +411,20 @@
         <inherits class="Window Events" />
         <inherits class="sizer_child" />
         <property name="var_name" type="string">m_lstview</property>
-        <property name="style" type="bitlist">
-            <option name="wxLC_LIST"
-                help="Multicolumn list view, with optional small icons. Columns are computed automatically, i.e. you don't set columns as in wxLC_REPORT. In other words, the list wraps, unlike a wxListBox." />
-            <option name="wxLC_REPORT"
-                help="Single or multicolumn report view, with optional header." />
-            <option name="wxLC_VIRTUAL"
-                help="The application provides items text on demand. May only be used with wxLC_REPORT." />
+        <property name="mode" type="option">
             <option name="wxLC_ICON"
                 help="Large icon view, with optional labels." />
             <option name="wxLC_SMALL_ICON"
                 help="Small icon view, with optional labels." />
+            <option name="wxLC_LIST"
+                help="Multicolumn list view, with optional small icons. Columns are computed automatically, i.e. you don't set columns as in wxLC_REPORT. In other words, the list wraps, unlike a wxListBox." />
+            <option name="wxLC_REPORT"
+                help="Single or multicolumn report view, with optional header." />
+                wxLC_REPORT
+        </property>
+        <property name="style" type="bitlist">
+            <option name="wxLC_VIRTUAL"
+                help="The application provides items text on demand. May only be used with wxLC_REPORT." />
             <option name="wxLC_ALIGN_TOP"
                 help="Icons align to the top. Win32 default, Win32 only." />
             <option name="wxLC_ALIGN_LEFT"
@@ -442,7 +445,6 @@
                 help="Draws light horizontal rules between rows in report mode." />
             <option name="wxLC_VRULES"
                 help="Draws light vertical rules between columns in report mode." />
-            wxLC_ICON
         </property>
         <event name="wxEVT_LIST_BEGIN_DRAG" class="wxListEvent"
             help="Begin dragging with the left mouse button." />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This splits out the 4 wxListView styles which cannot be combined, and puts them in a `mode` dropdown property so that only one can be chosen.

This updates `ImportXML::ProcessStyle()` class to that any importer based on XML will automatically pick up the change. `resCtrl::ParseListViewStyles()` was updated to support the change when importing Windows Resource projects.

Closes #286