### PR TITLE
Fixes Mockup redraw of wxBannerWindow, adds banner to testing app

### DIFF
--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -367,7 +367,12 @@ void MockupParent::OnNodePropModified(CustomEvent& event)
     for (auto iter: NonUiProps)
     {
         if (prop->isProp(iter))
-            return;
+        {
+            if (prop->isProp(prop_message) && prop->GetNode()->isGen(gen_wxBannerWindow))
+                break;  // In this case, Mockup does need to be redrawn
+            else
+                return;
+        }
     }
 
     // Some properties can be changed after the widget is created. We call the component to update the widget, and if returns

--- a/testing/ui/dlgmultitest_base.cpp
+++ b/testing/ui/dlgmultitest_base.cpp
@@ -17,6 +17,7 @@
 #include "../art/disabled_png.h"
 #include "../art/focus_png.h"
 #include "../art/normal_png.h"
+#include "../art/wiztest_png.h"
 
 #include <wx/mstream.h>  // Memory stream classes
 
@@ -91,13 +92,38 @@ bool DlgMultiTestBase::Create(wxWindow *parent, wxWindowID id, const wxString &t
     page_2->SetSizerAndFit(box_sizer_3);
 
     auto page_3 = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(page_3, wxString::FromUTF8("Tab 2"));
+    m_notebook->AddPage(page_3, wxString::FromUTF8("Banners"));
 
     auto box_sizer_4 = new wxBoxSizer(wxVERTICAL);
 
-    m_staticText_3 = new wxStaticText(page_3, wxID_ANY, wxString::FromUTF8("TODO: replace this control with something more useful..."));
-    m_staticText_3->Wrap(200);
-    box_sizer_4->Add(m_staticText_3, wxSizerFlags().Border(wxALL));
+    auto box_sizer_8 = new wxBoxSizer(wxHORIZONTAL);
+    box_sizer_4->Add(box_sizer_8, wxSizerFlags(1).Border(wxALL));
+
+    m_banner_left = new wxBannerWindow(page_3, wxLEFT);
+    m_banner_left->SetText(wxString::FromUTF8("Left Banner"),
+        wxEmptyString);
+    box_sizer_8->Add(m_banner_left, wxSizerFlags().Border(wxALL));
+
+    m_banner_top = new wxBannerWindow(page_3, wxTOP);
+    m_banner_top->SetGradient(wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTION),
+        wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
+    m_banner_top->SetText(wxString::FromUTF8("Top Banner"),
+        wxString::FromUTF8("This is the top banner message"));
+    box_sizer_8->Add(m_banner_top, wxSizerFlags().Border(wxALL));
+
+    m_banner_right = new wxBannerWindow(page_3, wxRIGHT);
+    m_banner_right->SetText(wxString::FromUTF8("Right Banner"),
+        wxEmptyString);
+    box_sizer_8->Add(m_banner_right, wxSizerFlags().Border(wxALL));
+
+    auto box_sizer_9 = new wxBoxSizer(wxHORIZONTAL);
+    box_sizer_4->Add(box_sizer_9, wxSizerFlags().Border(wxALL));
+
+    m_banner = new wxBannerWindow(page_3, wxLEFT);
+    m_banner->SetBitmap(GetImgFromHdr(wiztest_png, sizeof(wiztest_png)));
+    m_banner->SetText(wxString::FromUTF8("This is a long title"),
+        wxEmptyString);
+    box_sizer_9->Add(m_banner, wxSizerFlags().Border(wxALL));
 
     page_3->SetSizerAndFit(box_sizer_4);
 

--- a/testing/ui/dlgmultitest_base.h
+++ b/testing/ui/dlgmultitest_base.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include <wx/bannerwindow.h>
 #include <wx/bitmap.h>
 #include <wx/button.h>
+#include <wx/colour.h>
 #include <wx/commandlinkbutton.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
@@ -15,6 +17,7 @@
 #include <wx/icon.h>
 #include <wx/image.h>
 #include <wx/notebook.h>
+#include <wx/settings.h>
 #include <wx/stattext.h>
 #include <wx/tglbtn.h>
 
@@ -37,6 +40,10 @@ protected:
 
     // Class member variables
 
+    wxBannerWindow* m_banner;
+    wxBannerWindow* m_banner_left;
+    wxBannerWindow* m_banner_right;
+    wxBannerWindow* m_banner_top;
     wxButton* m_btn;
     wxButton* m_btn_2;
     wxButton* m_btn_4;
@@ -44,7 +51,6 @@ protected:
     wxCommandLinkButton* m_btn_5;
     wxNotebook* m_notebook;
     wxStaticText* m_staticText;
-    wxStaticText* m_staticText_3;
     wxStaticText* m_staticText_4;
     wxStaticText* m_staticText_5;
     wxToggleButton* m_toggleBtn;

--- a/testing/ui/wxUiTesting.wxui
+++ b/testing/ui/wxUiTesting.wxui
@@ -1265,14 +1265,6 @@
                   tooltip="Bitmap should change when mouse is over button, or button is disabled."
                   column="2" />
                 <node
-                  class="wxCheckBox"
-                  class_access="none"
-                  label="Disable"
-                  var_name="disable_bitmaps"
-                  column="2"
-                  row="1"
-                  wxEVT_CHECKBOX="[this](wxCommandEvent&amp; event) { m_btn_bitmaps->Enable(!event.IsChecked()); }" />
-                <node
                   class="wxButton"
                   label="Right"
                   var_name="m_btn_4"
@@ -1286,6 +1278,14 @@
                   style="wxBU_EXACTFIT"
                   tooltip="Style set to exact fit, so it should be a bit smaller than usual."
                   column="4" />
+                <node
+                  class="wxCheckBox"
+                  class_access="none"
+                  label="Disable"
+                  var_name="disable_bitmaps"
+                  column="2"
+                  row="1"
+                  wxEVT_CHECKBOX="[this](wxCommandEvent&amp; event) { m_btn_bitmaps->Enable(!event.IsChecked()); }" />
               </node>
               <node
                 class="wxBoxSizer"
@@ -1303,18 +1303,46 @@
           </node>
           <node
             class="BookPage"
-            label="Tab 2"
+            bitmap="Header; ..\art\normal_png.h; ; [-1; -1]"
+            label="Banners"
             var_name="page_3"
             window_style="wxTAB_TRAVERSAL">
             <node
               class="wxBoxSizer"
               orientation="wxVERTICAL"
-              var_name="box_sizer_4">
+              var_name="box_sizer_4"
+              flags="wxEXPAND">
               <node
-                class="wxStaticText"
-                label="TODO: replace this control with something more useful..."
-                var_name="m_staticText_3"
-                wrap="200" />
+                class="wxBoxSizer"
+                var_name="box_sizer_8"
+                proportion="1">
+                <node
+                  class="wxBannerWindow"
+                  direction="wxLEFT"
+                  title="Left Banner"
+                  var_name="m_banner_left" />
+                <node
+                  class="wxBannerWindow"
+                  end_colour="wxSYS_COLOUR_HIGHLIGHT"
+                  message="This is the top banner message"
+                  start_colour="wxSYS_COLOUR_INACTIVECAPTION"
+                  title="Top Banner"
+                  var_name="m_banner_top" />
+                <node
+                  class="wxBannerWindow"
+                  direction="wxRIGHT"
+                  title="Right Banner"
+                  var_name="m_banner_right" />
+              </node>
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer_9">
+                <node
+                  class="wxBannerWindow"
+                  bitmap="Header; ..\art\wiztest_png.h; ; [-1; -1]"
+                  direction="wxLEFT"
+                  title="This is a long title" />
+              </node>
             </node>
           </node>
           <node


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This fixes the redraw problem when a wxBannerWindow `message` property changed. I also added several banners to the multi-test dialog to confirm color ranges, alignment, and background bitmap.

Issue #36 refers to the background being black with XPM files -- that doesn't really surprise me since XPM files don't have a transparent background, so I'm thinking that is by design.

Closes #36