### PR TITLE
Update Form, Project, and Bar menus

### DIFF
--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -399,6 +399,7 @@ ttlib::cstr NavigationPanel::GetDisplayName(Node* node) const
 
 void NavigationPanel::ExpandAllNodes(Node* node)
 {
+    AutoFreeze freeze(this);
     if (auto item_it = m_node_tree_map.find(node); item_it != m_node_tree_map.end())
     {
         if (m_tree_ctrl->ItemHasChildren(item_it->second))
@@ -670,6 +671,11 @@ void NavigationPanel::OnCollExpand(wxCommandEvent&)
     if (!node)
         return;  // This is theoretically impossible
 
+    ExpandCollapse(node);
+}
+
+void NavigationPanel::ExpandCollapse(Node* node)
+{
     AutoFreeze freeze(this);
 
     auto parent = node->GetParent();

--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -33,6 +33,9 @@ public:
     void AddAllChildren(Node* node_parent);
     void ExpandAllNodes(Node* node);
 
+    // This will expand the specified node and collapse all other siblings
+    void ExpandCollapse(Node* node);
+
 protected:
 
     void InsertNode(Node* node);

--- a/src/panels/navpopupmenu.h
+++ b/src/panels/navpopupmenu.h
@@ -28,11 +28,12 @@ protected:
     void OnSortForms(wxCommandEvent& WXUNUSED(event));
     void OnUpdateEvent(wxUpdateUIEvent& event);
 
-    void CreateNormalMenu(Node* node);
     void CreateBarMenu(Node* node);
     void CreateBookMenu(Node* node);
     void CreateContainerMenu(Node* node);
+    void CreateFormMenu(Node* node);
     void CreateMenuMenu(Node* node);
+    void CreateNormalMenu(Node* node);
     void CreateProjectMenu(Node* node);
     void CreateTopSizerMenu(Node* node);
     void CreateWizardMenu(Node* node);
@@ -104,12 +105,14 @@ protected:
         MenuPROJECT_ADD_WIZARD,
         MenuPROJECT_SORT_FORMS,
 
+        MenuEXPAND_ALL,
+
         MenuTESTING_INFO,
         MenuDEBUG_KEYHH,
     };
 
 private:
-    Node* m_node;
+    Node* m_node { nullptr };
     Node* m_child { nullptr };
     GenEnum::GenName m_tool_name { GenEnum::GenName::gen_name_array_size };  // used by MenuNEW_ITEM -> wxGetApp().CreateToolNode(m_tool_name)
 };


### PR DESCRIPTION
Form menu shortened to cut/copy/expand. Project menu has Paste if available. Bar menus have cut/copy.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Cose #74