### PR TITLE
Fix importing of invalid wxGridSizer settings

### DIFF
--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -470,6 +470,12 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
         }
     }
 
+    if (newobject->isGen(gen_wxGridSizer))
+    {
+        if (newobject->prop_as_int(prop_rows) > 0 && newobject->prop_as_int(prop_cols) > 0)
+            newobject->prop_set_value(prop_rows, 0);
+    }
+
     auto xml_event = xml_obj.child("event");
     while (xml_event)
     {

--- a/src/import/import_wxsmith.cpp
+++ b/src/import/import_wxsmith.cpp
@@ -214,6 +214,12 @@ NodeSharedPtr WxSmith::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, Node
         ProcessProperties(xml_obj, new_node.get());
     }
 
+    if (new_node->isGen(gen_wxGridSizer))
+    {
+        if (new_node->prop_as_int(prop_rows) > 0 && new_node->prop_as_int(prop_cols) > 0)
+            new_node->prop_set_value(prop_rows, 0);
+    }
+
     while (child)
     {
         CreateXrcNode(child, new_node.get());


### PR DESCRIPTION
Don't allow both rows and columns to be specified on import.

Closes #14

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
