### PR TITLE
Adds Embed image property type

### DIFF
--- a/src/customprops/img_props.h
+++ b/src/customprops/img_props.h
@@ -13,7 +13,8 @@
 
 class NodeProperty;
 
-inline constexpr std::array<const char*, 3> s_type_names = {
+inline constexpr std::array<const char*, 4> s_type_names = {
+    "Embed",
     "Header",
     "Art",
     "XPM",

--- a/src/customprops/img_string_prop.cpp
+++ b/src/customprops/img_string_prop.cpp
@@ -31,6 +31,27 @@ bool ImageDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGProperty* WX
         }
         return false;
     }
+    else if (m_img_props.type.contains("Embed"))
+    {
+        ttlib::cwd cwd(true);
+        if (wxGetApp().GetProject()->HasValue(prop_original_art))
+        {
+            ttlib::ChangeDir(wxGetApp().GetProjectPtr()->prop_as_string(prop_original_art));
+            cwd.assignCwd();
+        }
+
+        ttlib::cstr pattern = "All files|*.*|PNG|*.png|XPM|*.xpm|Tiff|*.tif;*.tiff|Bitmaps|*.bmp|Icon|*.ico||";
+        wxFileDialog dlg(propGrid->GetPanel(), _tt("Open Image"), cwd.wx_str(), wxEmptyString, pattern,
+                         wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+        if (dlg.ShowModal() == wxID_OK)
+        {
+            ttString path = dlg.GetPath();
+            path.make_relative(cwd);
+            SetValue(path);
+            return true;
+        }
+        return false;
+    }
     else if (m_img_props.type.contains("XPM") || m_img_props.type.contains("Header"))
     {
         ttlib::cwd cwd(true);
@@ -41,7 +62,7 @@ bool ImageDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGProperty* WX
         }
 
         ttlib::cstr pattern = m_img_props.type.contains("XPM") ? "XPM File (*.xpm)|*.xpm" : "Header|*.h_img";
-        wxFileDialog dlg(propGrid->GetPanel(), _tt("Open XPM file"), cwd.wx_str(), wxEmptyString, pattern,
+        wxFileDialog dlg(propGrid->GetPanel(), _tt("Open Image"), cwd.wx_str(), wxEmptyString, pattern,
                          wxFD_OPEN | wxFD_FILE_MUST_EXIST);
         if (dlg.ShowModal() == wxID_OK)
         {

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -46,6 +46,7 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
     types.Add(s_type_names[0]);
     types.Add(s_type_names[1]);
     types.Add(s_type_names[2]);
+    types.Add(s_type_names[3]);
 
     AddPrivateChild(new wxEnumProperty("type", wxPG_LABEL, types, 0));
     AddPrivateChild(new ImageStringProperty("image", m_img_props));

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1481,6 +1481,21 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
                         if (!embed)
                             continue;
                     }
+                    else
+                    {
+                        bool is_found = false;
+                        for (size_t idx = 0; idx < m_embedded_images.size(); ++idx)
+                        {
+                            if (m_embedded_images[idx] == embed)
+                            {
+                                is_found = true;
+                                break;
+                            }
+                        }
+                        if (is_found)
+                            continue;  // we already have this image
+                    }
+
 
                     m_embedded_images.emplace_back(embed);
                 }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -414,7 +414,7 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
                     is_namespace_written = true;
                 }
                 m_source->writeLine();
-                m_source->writeLine(ttlib::cstr("const unsigned char ")
+                m_source->writeLine(ttlib::cstr("inline const unsigned char ")
                                     << iter_array->array_name << '[' << iter_array->array_size << "] {");
 
                 size_t pos = 0;

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -402,11 +402,19 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
 
         if (m_embedded_images.size())
         {
-            m_source->writeLine();
-            m_source->writeLine("namespace wxue_img\n{");
-            m_source->Indent();
+            bool is_namespace_written = false;
             for (auto iter_array: m_embedded_images)
             {
+                if (iter_array->form != m_form_node)
+                    continue;
+
+                if (!is_namespace_written)
+                {
+                    m_source->writeLine();
+                    m_source->writeLine("namespace wxue_img\n{");
+                    m_source->Indent();
+                    is_namespace_written = true;
+                }
                 m_source->writeLine();
                 m_source->writeLine(ttlib::cstr("const unsigned char ")
                                     << iter_array->array_name << '[' << iter_array->array_size << "] {");
@@ -426,9 +434,12 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
                 }
                 m_source->writeLine("};");
             }
-            m_source->writeLine();
-            m_source->Unindent();
-            m_source->writeLine("}\n");
+            if (is_namespace_written)
+            {
+                m_source->writeLine();
+                m_source->Unindent();
+                m_source->writeLine("}\n");
+            }
         }
     }
 

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -34,9 +34,9 @@ using namespace GenEnum;
 
 // clang-format off
 
-inline constexpr const auto txt_GetImgFromHdrFunction = R"===(
+inline constexpr const auto txt_GetImageFromArrayFunction = R"===(
 // Convert a data header file into a wxImage
-static wxImage GetImgFromHdr(const unsigned char* data, size_t size_data)
+static wxImage GetImageFromArray(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
@@ -321,7 +321,7 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
         if (need_hdr_func)
         {
             ttlib::textfile function;
-            function.ReadString(txt_GetImgFromHdrFunction);
+            function.ReadString(txt_GetImageFromArrayFunction);
             for (auto& iter: function)
             {
                 m_source->writeLine(iter, indent::none);
@@ -1356,6 +1356,8 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
     }
 }
 
+// We're just trying to figure out if we need to generate code to include wx/mstream.h as well as generating the code to load
+// the image from memory.
 bool BaseCodeGenerator::FindImageHeader(Node* node)
 {
     for (size_t i = 0; i < node->GetChildCount(); i++)
@@ -1370,10 +1372,9 @@ bool BaseCodeGenerator::FindImageHeader(Node* node)
                 iter.BothTrim();
             }
 
-            if (parts[IndexType] == "Header" && parts[IndexImage].size())
+            if ((parts[IndexType] == "Embed" || parts[IndexType] == "Header") && parts[IndexImage].size())
             {
-                if (!parts[IndexImage].contains(".xpm", tt::CASE::either))
-                    return true;
+                return true;
             }
         }
         if (child->GetChildCount())

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -35,21 +35,19 @@ using namespace GenEnum;
 // clang-format off
 
 inline constexpr const auto txt_GetImageFromArrayFunction = R"===(
-// Convert a data header file into a wxImage
-static wxImage GetImageFromArray(const unsigned char* data, size_t size_data)
+// Convert a data array into a wxImage
+inline wxImage GetImageFromArray(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
-    if (!image.FindHandler(wxBITMAP_TYPE_PNG))
-        wxImage::AddHandler(new wxPNGHandler);
     image.LoadFile(strm);
     return image;
 };
 )===";
 
 inline constexpr const auto txt_GetAnimFromHdrFunction = R"===(
-// Convert a data header file into a wxAnimation
-static wxAnimation GetAnimFromHdr(const unsigned char* data, size_t size_data)
+// Convert a data array into a wxAnimation
+inline wxAnimation GetAnimFromHdr(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxAnimation animation;

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -93,7 +93,7 @@ BaseCodeGenerator::BaseCodeGenerator()
 
         g_map_handlers[wxBITMAP_TYPE_ICO] = "wxICOHandler";
         g_map_handlers[wxBITMAP_TYPE_CUR] = "wxCURHandler";
-        g_map_handlers[wxBITMAP_TYPE_XBM] = "wxXPMHandler";
+        g_map_handlers[wxBITMAP_TYPE_XPM] = "wxXPMHandler";
         g_map_handlers[wxBITMAP_TYPE_TIFF] = "wxTIFFHandler";
         g_map_handlers[wxBITMAP_TYPE_GIF] = "wxGIFHandler";
         g_map_handlers[wxBITMAP_TYPE_PNG] = "wxPNGHandler";

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -452,6 +452,33 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
         }
         m_header->writeLine();
     }
+
+    if (m_panel_type != CPP_PANEL && m_embedded_images.size())
+    {
+        bool is_namespace_written = false;
+        for (auto iter_array: m_embedded_images)
+        {
+            if (iter_array->form != m_form_node)
+                continue;
+
+            if (!is_namespace_written)
+            {
+                m_header->writeLine();
+                m_header->writeLine("namespace wxue_img\n{");
+                m_header->Indent();
+                m_header->writeLine("// Images declared in this class module:");
+                is_namespace_written = true;
+            }
+            m_header->writeLine();
+            m_header->writeLine(ttlib::cstr("extern const unsigned char ")
+                                << iter_array->array_name << '[' << iter_array->array_size << "];");
+        }
+        if (is_namespace_written)
+        {
+            m_header->Unindent();
+            m_header->writeLine("}\n");
+        }
+    }
 }
 
 void BaseCodeGenerator::GenSrcEventBinding(Node* node, const EventVector& events)
@@ -1429,10 +1456,6 @@ void BaseCodeGenerator::GenSettings(Node* node)
 
 void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& embedset)
 {
-    // Nothing we collect here is useful for the header file
-    if (m_panel_type == HDR_PANEL)
-        return;
-
     for (auto& iter: node->get_props_vector())
     {
         if (iter.type() == type_image || iter.type() == type_animation)

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -16,6 +16,8 @@ class NodeCreator;
 class WriteCode;
 class wxWindow;
 
+struct EmbededImage;
+
 using EventVector = std::vector<NodeEvent*>;
 
 namespace pugi
@@ -128,6 +130,11 @@ private:
 
     ttlib::cstr m_baseFullPath;
     EventVector m_CtxMenuEvents;
+
+    std::vector<const EmbededImage*> m_embedded_images;
+    std::set<wxBitmapType> m_type_generated;
+
+    Node* m_form_node;
 
     PANEL_TYPE m_panel_type { NOT_PANEL };
     bool m_artProvider;

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -567,7 +567,7 @@ ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description)
     }
 
     ttlib::cstr result;
-    if (parts[IndexType].is_sameas("XPM") || parts[IndexImage].filename().has_extension(".xpm"))
+    if (parts[IndexType].is_sameas("XPM"))
     {
         code << "wxImage(";
 

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -616,7 +616,7 @@ ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description)
     }
     else
     {
-        code << "GetImgFromHdr(";
+        code << "GetImageFromArray(";
 
         ttlib::cstr name(parts[1].filename());
         name.remove_extension();

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -13,9 +13,10 @@
 
 #include "gen_common.h"
 
-#include "mainapp.h"  // App -- App class
-#include "node.h"     // Node class
-#include "utils.h"    // Utility functions that work with properties
+#include "mainapp.h"      // App -- App class
+#include "node.h"         // Node class
+#include "pjtsettings.h"  // ProjectSettings -- Hold data for currently loaded project
+#include "utils.h"        // Utility functions that work with properties
 
 ttlib::cstr GenerateSizerFlags(Node* node)
 {
@@ -621,6 +622,16 @@ ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description)
         ttlib::cstr name(parts[1].filename());
         name.remove_extension();
         name.Replace(".", "_", true);  // wxFormBuilder writes files with the extra dots that have to be converted to '_'
+
+        if (parts[0].is_sameprefix("Embed"))
+        {
+            auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(parts[1]);
+            if (embed)
+            {
+                name = "wxue_img::" + embed->array_name;
+            }
+        }
+
         code << name << ", sizeof(" << name << "))";
 
         if (parts[IndexType].is_sameas("Header"))

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -65,7 +65,7 @@ void GenerateWindowSettings(Node* node, ttlib::cstr& code);
 
 // Converts bitmap property into code. Code is set to wxNullBitmap if no bitmap. Art will
 // return either a bitmap or an image if scaling is requested. XPM returns wxImage and HDR
-// returns GetImgFromHdr() (which is a wxImage).
+// returns GetImageFromArray() (which is a wxImage).
 ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description);
 
 // Converts color text into code.

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -813,42 +813,13 @@ void FormBuilder::BitmapProperty(pugi::xml_node& xml_prop, NodeProperty* prop)
         }
         else
         {
-            {
-                ttSaveCwd saveCwd;
-                ttString newDir(m_importProjectFile);
-                newDir.remove_filename();
-                newDir.ChangeDir();
-
-                if (!filename.file_exists())
-                {
-                    ttlib::cstr tmp_filename = filename;
-                    tmp_filename.make_absolute();
-                    if (tmp_filename.file_exists())
-                    {
-                        filename = tmp_filename;
-                    }
-                    else
-                    {
-                        if (m_eventGeneration.size())
-                        {
-                            tmp_filename = m_eventGeneration;
-                            tmp_filename.append_filename(filename);
-                            if (tmp_filename.file_exists())
-                            {
-                                filename = tmp_filename;
-                            }
-                        }
-                    }
-                }
-
-                // It needs to be absolute to the current directory since we're about to switch back to the previous
-                // directory
-                filename.make_absolute();
-            }
-
-            ttlib::cstr value("XPM; ; ");
-            value << filename << "; [-1; -1]";
-            prop->set_value(value);
+            ttlib::cstr bitmap("Embed; ");
+            ttString relative(filename.wx_str());
+            relative.make_relative_wx(wxGetCwd());
+            relative.backslashestoforward();
+            bitmap << relative.wx_str();
+            bitmap << "; ; [-1; -1]";
+            prop->set_value(bitmap);
         }
     }
     else if (org_value.contains("Load From Art"))

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -11,12 +11,13 @@
 
 #include "import_xml.h"
 
-#include "gen_enums.h"  // Enumerations for generators
-#include "mainapp.h"    // App -- Main application class
-#include "mainframe.h"  // Main window frame
-#include "node.h"       // Node class
-#include "uifuncs.h"    // Miscellaneous functions for displaying UI
-#include "utils.h"      // Utility functions that work with properties
+#include "gen_enums.h"    // Enumerations for generators
+#include "mainapp.h"      // App -- Main application class
+#include "mainframe.h"    // Main window frame
+#include "node.h"         // Node class
+#include "pjtsettings.h"  // ProjectSettings -- Hold data for currently loaded project
+#include "uifuncs.h"      // Miscellaneous functions for displaying UI
+#include "utils.h"        // Utility functions that work with properties
 
 using namespace GenEnum;
 
@@ -614,6 +615,27 @@ void ImportXML::ProcessBitmap(const pugi::xml_node& xml_obj, Node* node)
         {
             ttlib::cstr bitmap("XPM; ");
             bitmap << file;
+            bitmap << "; ; [-1; -1]";
+
+            if (auto prop = node->get_prop_ptr(prop_bitmap); prop)
+            {
+                prop->set_value(bitmap);
+                if (node->isGen(gen_wxButton))
+                    node->prop_set_value(prop_markup, true);
+            }
+        }
+        else
+        {
+            ttlib::cstr bitmap("Embed; ");
+
+            // wxGlade doubles the backslash after the drive letter on Windows, and that causes the conversion to a relative
+            // path to be incorrect
+            file.Replace(":\\\\", ":\\");
+
+            ttString relative(file.wx_str());
+            relative.make_relative_wx(wxGetCwd());
+            relative.backslashestoforward();
+            bitmap << relative.wx_str();
             bitmap << "; ; [-1; -1]";
 
             if (auto prop = node->get_prop_ptr(prop_bitmap); prop)

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -237,8 +237,7 @@ int App::OnExit()
 
 #endif  // defined(_WIN32) && defined(_DEBUG) && defined(USE_CRT_MEMORY_DUMP)
 
-    // Probably not necessary to delete this -- presumably any wxBitmaps that it stores will get freed without calling
-    // the dtor, but this ensures we don't leave any operating system resource handles lying around.
+    // This must get deleted in order to stop any thread it started to process embedded images
     delete m_pjtSettings;
 
     return wxApp::OnExit();

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -246,8 +246,11 @@ int App::OnExit()
 
 wxImage App::GetImage(const ttlib::cstr& description)
 {
-    if (description.is_sameprefix("XPM;") || description.is_sameprefix("Header;") || description.is_sameprefix("Art;"))
+    if (description.is_sameprefix("Embed;") || description.is_sameprefix("XPM;") || description.is_sameprefix("Header;") ||
+        description.is_sameprefix("Art;"))
+    {
         return m_pjtSettings->GetPropertyBitmap(description);
+    }
     else
         return GetInternalImage("unknown");
 }

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -163,7 +163,7 @@ wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool 
     }
 
     // cache it so that we don't need to read it from disk again
-    if (result == m_images.end())
+    if (!parts[IndexType].contains("Embed") && result == m_images.end())
         m_images[path] = image;
 
     // Scale if needed

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -222,33 +222,28 @@ bool ProjectSettings::AddEmbeddedImage(ttlib::cstr path, Node* form)
                 m_map_embedded[path.filename().c_str()] = m_embedded_images.size() - 1;
 
                 // At this point, other threads can lookup and add an embedded image, they just can't access the data of this
-                // image until we're done.
+                // image until we're done. I.e., GetEmbeddedImage() won't return until retrieve_lock is released.
 
                 std::unique_lock<std::mutex> retrieve_lock(m_mutex_embed_retrieve);
                 add_lock.unlock();
 
-                wxMemoryOutputStream save_stream;
-                auto mime_type = handler->GetMimeType();
-                auto type = handler->GetType();
-
                 // If possible, convert the file to a PNG -- even if the original file is a PNG, since we might end up with
                 // better compression.
 
-                if (isConvertibleMime(mime_type))
+                if (isConvertibleMime(handler->GetMimeType()))
                 {
                     // Maximize compression
                     image.SetOption(wxIMAGE_OPTION_PNG_COMPRESSION_LEVEL, 9);
                     image.SetOption(wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL, 9);
-                    image.SaveFile(save_stream, wxBITMAP_TYPE_PNG);
-                }
-                else
-                {
-                    image.SaveFile(save_stream, type);
+                    embed.type = wxBITMAP_TYPE_PNG;
                 }
 
+                wxMemoryOutputStream save_stream;
+                image.SaveFile(save_stream, embed.type);
                 auto read_stream = save_stream.GetOutputStreamBuffer();
 
                 embed.form = form;
+                embed.type = handler->GetType();
                 embed.array_size = read_stream->GetBufferSize();
                 embed.array_data = std::make_unique<unsigned char[]>(embed.array_size);
                 memcpy(embed.array_data.get(), read_stream->GetBufferStart(), embed.array_size);

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -55,6 +55,5 @@ private:
 
     std::map<std::string, wxImage> m_images;
 
-    std::vector<EmbededImage> m_embedded_images;
-    std::map<std::string, size_t> m_map_embedded;
+    std::map<std::string, std::unique_ptr<EmbededImage>> m_map_embedded;
 };

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -1,17 +1,26 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Hold data for currently loaded project
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
 #include <map>
+#include <mutex>
 
 #include <wx/bitmap.h>
 
 class Node;
+
+struct EmbededImage
+{
+    Node* form;  // the form node the image is declared in
+    ttlib::cstr array_name;
+    size_t array_size;
+    std::unique_ptr<unsigned char[]> array_data;
+};
 
 class ProjectSettings
 {
@@ -33,9 +42,18 @@ public:
     // to load. The image is cached for as long as the project is open.
     wxImage GetPropertyBitmap(const ttlib::cstr& description, bool want_scaled = true);
 
+    bool AddEmbeddedImage(ttlib::cstr path, Node* form);
+    const EmbededImage* GetEmbeddedImage(ttlib::cstr path);
+
 private:
     ttlib::cstr m_projectFile;
     ttlib::cstr m_projectPath;
 
+    std::mutex m_mutex_embed_add;
+    std::mutex m_mutex_embed_retrieve;
+
     std::map<std::string, wxImage> m_images;
+
+    std::vector<EmbededImage> m_embedded_images;
+    std::map<std::string, size_t> m_map_embedded;
 };

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -13,7 +13,6 @@
 #include <wx/bitmap.h>
 
 class Node;
-class std::thread;
 
 struct EmbededImage
 {

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -13,6 +13,7 @@
 #include <wx/bitmap.h>
 
 class Node;
+class std::thread;
 
 struct EmbededImage
 {
@@ -27,6 +28,7 @@ class ProjectSettings
 {
 public:
     ProjectSettings();
+    ~ProjectSettings();
 
     ttlib::cstr& getProjectFile() { return m_projectFile; }
     ttString GetProjectFile() { return ttString() << m_projectFile.wx_str(); }
@@ -46,6 +48,13 @@ public:
     bool AddEmbeddedImage(ttlib::cstr path, Node* form);
     const EmbededImage* GetEmbeddedImage(ttlib::cstr path);
 
+    // This will launch a thread to start collecting all the embedded images in the project
+    void ParseEmbeddedImages();
+
+protected:
+    void CollectEmbeddedImages();
+    void CollectNodeImages(Node* node, Node* form);
+
 private:
     ttlib::cstr m_projectFile;
     ttlib::cstr m_projectPath;
@@ -55,5 +64,9 @@ private:
 
     std::map<std::string, wxImage> m_images;
 
+    std::thread* m_collect_thread { nullptr };
+
     std::map<std::string, std::unique_ptr<EmbededImage>> m_map_embedded;
+
+    bool m_is_terminating { false };
 };

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -20,6 +20,7 @@ struct EmbededImage
     ttlib::cstr array_name;
     size_t array_size;
     std::unique_ptr<unsigned char[]> array_data;
+    wxBitmapType type;
 };
 
 class ProjectSettings

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -340,11 +340,12 @@ bool App::Import(ImportXML& import, ttString& file, bool append)
         m_pjtSettings->SetProjectFile(file);
         m_pjtSettings->SetProjectPath(file);
 
+        // Start a thread to collect all of the embedded images
+        m_pjtSettings->ParseEmbeddedImages();
+
         wxGetFrame().SetImportedFlag(true);
         wxGetFrame().FireProjectLoadedEvent();
         wxGetFrame().SetModified();
-
-        // An imported project will have already processed all embedded images, so there is no need to call ParseEmbeddedImages()
 
         return true;
     }
@@ -422,6 +423,9 @@ bool App::NewProject(bool create_empty)
         }
         m_frame->SetImportedFlag();
     }
+
+    // Start a thread to collect all of the embedded images
+    m_pjtSettings->ParseEmbeddedImages();
 
     wxGetFrame().FireProjectLoadedEvent();
     if (m_project->GetChildCount())

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -110,6 +110,9 @@ bool App::LoadProject(const ttString& file)
     m_pjtSettings->SetProjectFile(file);
     m_pjtSettings->SetProjectPath(file);
 
+    // Start a thread to collect all of the embedded images
+    m_pjtSettings->ParseEmbeddedImages();
+
     wxGetFrame().SetImportedFlag(false);
     wxGetFrame().FireProjectLoadedEvent();
 
@@ -340,6 +343,8 @@ bool App::Import(ImportXML& import, ttString& file, bool append)
         wxGetFrame().SetImportedFlag(true);
         wxGetFrame().FireProjectLoadedEvent();
         wxGetFrame().SetModified();
+
+        // An imported project will have already processed all embedded images, so there is no need to call ParseEmbeddedImages()
 
         return true;
     }

--- a/src/ui/embedimg.cpp
+++ b/src/ui/embedimg.cpp
@@ -36,7 +36,7 @@
 // Any mime type in the following list with NOT be converted to PNG even if m_check_make_png is set to true
 
 // clang-format off
-static constexpr const char* lst_no_png_conversion[] = {
+inline constexpr const char* lst_no_png_conversion[] = {
 
     "image/x-ani",
     "image/x-cur",

--- a/src/ui/mainframe_base.cpp
+++ b/src/ui/mainframe_base.cpp
@@ -39,7 +39,7 @@
 #include <wx/mstream.h>  // Memory stream classes
 
 // Convert a data header file into a wxImage
-static wxImage GetImgFromHdr(const unsigned char* data, size_t size_data)
+static wxImage GetImageFromArray(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
@@ -61,7 +61,7 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menuItem = new wxMenuItem(m_menuFile, id_NewProject, wxString::FromUTF8("&New Project...\tCtrl+N"),
     wxString::FromUTF8("Create an empty project"), wxITEM_NORMAL);
-    menuItem->SetBitmap(GetImgFromHdr(new_png, sizeof(new_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
+    menuItem->SetBitmap(GetImageFromArray(new_png, sizeof(new_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
     m_menuFile->Append(menuItem);
 
     auto menuItem2 = new wxMenuItem(m_menuFile, id_OpenProject, wxString::FromUTF8("&Open Project...\tCtrl+O"),
@@ -79,7 +79,7 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_item = new wxMenuItem(m_menuFile, wxID_SAVE, wxString::FromUTF8("&Save\tCtrl+S"),
     wxString::FromUTF8("Save current project"), wxITEM_NORMAL);
-    menu_item->SetBitmap(GetImgFromHdr(save_png, sizeof(save_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
+    menu_item->SetBitmap(GetImageFromArray(save_png, sizeof(save_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
     m_menuFile->Append(menu_item);
 
     auto menu_item2 = new wxMenuItem(m_menuFile, id_SaveProjectAs, wxString::FromUTF8("Save &As...\tCtrl-Shift+S"),
@@ -172,22 +172,22 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_item4 = new wxMenuItem(submenu3, id_MoveUp, wxString::FromUTF8("Up") + '\t' + "Alt+Up",
     wxString::FromUTF8("Moves selected item up"), wxITEM_NORMAL);
-    menu_item4->SetBitmap(GetImgFromHdr(nav_moveup_png, sizeof(nav_moveup_png)));
+    menu_item4->SetBitmap(GetImageFromArray(nav_moveup_png, sizeof(nav_moveup_png)));
     submenu3->Append(menu_item4);
 
     auto menu_item5 = new wxMenuItem(submenu3, id_MoveDown, wxString::FromUTF8("Down") + '\t' + "Alt+Down",
     wxString::FromUTF8("Moves selected item down"), wxITEM_NORMAL);
-    menu_item5->SetBitmap(GetImgFromHdr(nav_movedown_png, sizeof(nav_movedown_png)));
+    menu_item5->SetBitmap(GetImageFromArray(nav_movedown_png, sizeof(nav_movedown_png)));
     submenu3->Append(menu_item5);
 
     auto menu_item6 = new wxMenuItem(submenu3, id_MoveLeft, wxString::FromUTF8("Left") + '\t' + "Alt+Left",
     wxString::FromUTF8("Moves selected item left"), wxITEM_NORMAL);
-    menu_item6->SetBitmap(GetImgFromHdr(nav_moveleft_png, sizeof(nav_moveleft_png)));
+    menu_item6->SetBitmap(GetImageFromArray(nav_moveleft_png, sizeof(nav_moveleft_png)));
     submenu3->Append(menu_item6);
 
     auto menu_item7 = new wxMenuItem(submenu3, id_MoveRight, wxString::FromUTF8("Right") + '\t' + "Alt+Right",
     wxString::FromUTF8("Moves selected item right"), wxITEM_NORMAL);
-    menu_item7->SetBitmap(GetImgFromHdr(nav_moveright_png, sizeof(nav_moveright_png)));
+    menu_item7->SetBitmap(GetImageFromArray(nav_moveright_png, sizeof(nav_moveright_png)));
     submenu3->Append(menu_item7);
     m_menuEdit->AppendSubMenu(submenu3, wxString::FromUTF8("Move"));
 
@@ -195,35 +195,35 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_item8 = new wxMenuItem(submenu2, id_AlignLeft, wxString::FromUTF8("&Left") + '\t' + "Alt+Shift+Left",
     wxString::FromUTF8("Align selected item to the left"), wxITEM_CHECK);
-    menu_item8->SetBitmap(GetImgFromHdr(alignleft_png, sizeof(alignleft_png)));
+    menu_item8->SetBitmap(GetImageFromArray(alignleft_png, sizeof(alignleft_png)));
     submenu2->Append(menu_item8);
 
     auto menu_item10 = new wxMenuItem(submenu2, id_AlignCenterHorizontal, wxString::FromUTF8("Center &Horizontal") + '\t' + "Alt+Shift+H",
     wxString::FromUTF8("Align selected item to the center horizontally"), wxITEM_CHECK);
-    menu_item10->SetBitmap(GetImgFromHdr(aligncenter_png, sizeof(aligncenter_png)));
+    menu_item10->SetBitmap(GetImageFromArray(aligncenter_png, sizeof(aligncenter_png)));
     submenu2->Append(menu_item10);
     menu_item10->Check();
 
     auto menu_item9 = new wxMenuItem(submenu2, id_AlignRight, wxString::FromUTF8("&Right") + '\t' + "Alt+Shift+Right",
     wxString::FromUTF8("Align selected item to the right"), wxITEM_CHECK);
-    menu_item9->SetBitmap(GetImgFromHdr(alignright_png, sizeof(alignright_png)));
+    menu_item9->SetBitmap(GetImageFromArray(alignright_png, sizeof(alignright_png)));
     submenu2->Append(menu_item9);
 
     submenu2->AppendSeparator();
 
     auto menu_item11 = new wxMenuItem(submenu2, id_AlignTop, wxString::FromUTF8("&Top") + '\t' + "Alt+Shift+Up",
     wxString::FromUTF8("Align selected item to the top"), wxITEM_CHECK);
-    menu_item11->SetBitmap(GetImgFromHdr(aligntop_png, sizeof(aligntop_png)));
+    menu_item11->SetBitmap(GetImageFromArray(aligntop_png, sizeof(aligntop_png)));
     submenu2->Append(menu_item11);
 
     auto menu_item12 = new wxMenuItem(submenu2, id_AlignCenterVertical, wxString::FromUTF8("Center &Vertical") + '\t' + "Alt+Shift+V",
     wxString::FromUTF8("Align selected item to the center vertically"), wxITEM_CHECK);
-    menu_item12->SetBitmap(GetImgFromHdr(alignvertcenter_png, sizeof(alignvertcenter_png)));
+    menu_item12->SetBitmap(GetImageFromArray(alignvertcenter_png, sizeof(alignvertcenter_png)));
     submenu2->Append(menu_item12);
 
     auto menu_item13 = new wxMenuItem(submenu2, id_AlignBottom, wxString::FromUTF8("&Bottom") + '\t' + "Alt+Shift+Down",
     wxString::FromUTF8("Align selected item to the bottom"), wxITEM_CHECK);
-    menu_item13->SetBitmap(GetImgFromHdr(alignbottom_png, sizeof(alignbottom_png)));
+    menu_item13->SetBitmap(GetImageFromArray(alignbottom_png, sizeof(alignbottom_png)));
     submenu2->Append(menu_item13);
     m_menuEdit->AppendSubMenu(submenu2, wxString::FromUTF8("Align"));
 
@@ -231,28 +231,28 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_item14 = new wxMenuItem(submenu4, id_BorderLeft, wxString::FromUTF8("&Left"),
     wxString::FromUTF8("Toggle border on the left side of the item"), wxITEM_CHECK);
-    menu_item14->SetBitmap(GetImgFromHdr(left_png, sizeof(left_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
+    menu_item14->SetBitmap(GetImageFromArray(left_png, sizeof(left_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
     submenu4->Append(menu_item14);
 
     auto menu_item15 = new wxMenuItem(submenu4, id_BorderRight, wxString::FromUTF8("&Right"),
     wxString::FromUTF8("Toggle border on the right side of the item"), wxITEM_CHECK);
-    menu_item15->SetBitmap(GetImgFromHdr(top_png, sizeof(top_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
+    menu_item15->SetBitmap(GetImageFromArray(top_png, sizeof(top_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
     submenu4->Append(menu_item15);
 
     auto menu_item16 = new wxMenuItem(submenu4, id_BorderTop, wxString::FromUTF8("&Top"),
     wxString::FromUTF8("Toggle border on the top side of the item"), wxITEM_CHECK);
-    menu_item16->SetBitmap(GetImgFromHdr(top_png, sizeof(top_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
+    menu_item16->SetBitmap(GetImageFromArray(top_png, sizeof(top_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
     submenu4->Append(menu_item16);
 
     auto menu_item17 = new wxMenuItem(submenu4, id_BorderBottom, wxString::FromUTF8("&Bottom"),
     wxString::FromUTF8("Toggle border on the bottom side of the item"), wxITEM_CHECK);
-    menu_item17->SetBitmap(GetImgFromHdr(bottom_png, sizeof(bottom_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
+    menu_item17->SetBitmap(GetImageFromArray(bottom_png, sizeof(bottom_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
     submenu4->Append(menu_item17);
     m_menuEdit->AppendSubMenu(submenu4, wxString::FromUTF8("Borders"));
 
     auto menu_item18 = new wxMenuItem(m_menuEdit, id_Expand, wxString::FromUTF8("&Expand") + '\t' + "Alt+E",
     wxString::FromUTF8("Toggle the wxEXPAND flag"), wxITEM_CHECK);
-    menu_item18->SetBitmap(GetImgFromHdr(expand_png, sizeof(expand_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
+    menu_item18->SetBitmap(GetImageFromArray(expand_png, sizeof(expand_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
     m_menuEdit->Append(menu_item18);
     m_menubar->Append(m_menuEdit, wxString::FromUTF8("&Edit"));
 
@@ -260,7 +260,7 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_item19 = new wxMenuItem(m_menuTools, id_GenerateCode, wxString::FromUTF8("&Generate Base Code"),
     wxString::FromUTF8("Generates C++ Code for each top level form"), wxITEM_NORMAL);
-    menu_item19->SetBitmap(GetImgFromHdr(generate_png, sizeof(generate_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
+    menu_item19->SetBitmap(GetImageFromArray(generate_png, sizeof(generate_png)).Scale(16, 16, wxIMAGE_QUALITY_HIGH));
     m_menuTools->Append(menu_item19);
 
     auto menu_item20 = new wxMenuItem(m_menuTools, id_GenerateDerived, wxString::FromUTF8("Create &Derived Code"),
@@ -285,16 +285,16 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     m_toolbar = CreateToolBar(wxTB_FLAT|wxTB_HORIZONTAL);
 
-    m_toolbar->AddTool(id_NewProject, wxString::FromUTF8("New"), GetImgFromHdr(new_png, sizeof(new_png)),
+    m_toolbar->AddTool(id_NewProject, wxString::FromUTF8("New"), GetImageFromArray(new_png, sizeof(new_png)),
     wxString::FromUTF8("New Project (Ctrl+N)"));
 
     m_toolbar->AddTool(id_OpenProject, wxString::FromUTF8("Open"), wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_TOOLBAR),
     wxString::FromUTF8("Open Project (Ctrl+O)"));
 
-    m_toolbar->AddTool(wxID_SAVE, wxString::FromUTF8("Save"), GetImgFromHdr(save_png, sizeof(save_png)),
+    m_toolbar->AddTool(wxID_SAVE, wxString::FromUTF8("Save"), GetImageFromArray(save_png, sizeof(save_png)),
     wxString::FromUTF8("Save current project"));
 
-    m_toolbar->AddTool(id_GenerateCode, wxEmptyString, GetImgFromHdr(generate_png, sizeof(generate_png)),
+    m_toolbar->AddTool(id_GenerateCode, wxEmptyString, GetImageFromArray(generate_png, sizeof(generate_png)),
     wxString::FromUTF8("Generate base class code"));
 
     m_toolbar->AddSeparator();
@@ -321,51 +321,51 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     m_toolbar->AddSeparator();
 
-    m_toolbar->AddTool(id_AlignLeft, wxEmptyString, GetImgFromHdr(alignleft_png, sizeof(alignleft_png)),
+    m_toolbar->AddTool(id_AlignLeft, wxEmptyString, GetImageFromArray(alignleft_png, sizeof(alignleft_png)),
     wxString::FromUTF8("Align left"), wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_AlignCenterHorizontal, wxEmptyString, GetImgFromHdr(aligncenter_png, sizeof(aligncenter_png)),
+    m_toolbar->AddTool(id_AlignCenterHorizontal, wxEmptyString, GetImageFromArray(aligncenter_png, sizeof(aligncenter_png)),
     wxString::FromUTF8("Center horizontally"), wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_AlignRight, wxEmptyString, GetImgFromHdr(alignright_png, sizeof(alignright_png)),
+    m_toolbar->AddTool(id_AlignRight, wxEmptyString, GetImageFromArray(alignright_png, sizeof(alignright_png)),
     wxString::FromUTF8("Align right"), wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
 
-    m_toolbar->AddTool(id_AlignTop, wxEmptyString, GetImgFromHdr(aligntop_png, sizeof(aligntop_png)),
+    m_toolbar->AddTool(id_AlignTop, wxEmptyString, GetImageFromArray(aligntop_png, sizeof(aligntop_png)),
     wxString::FromUTF8("Align top"), wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_AlignCenterVertical, wxEmptyString, GetImgFromHdr(alignvertcenter_png, sizeof(alignvertcenter_png)),
+    m_toolbar->AddTool(id_AlignCenterVertical, wxEmptyString, GetImageFromArray(alignvertcenter_png, sizeof(alignvertcenter_png)),
     wxString::FromUTF8("Center vertically"), wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_AlignBottom, wxEmptyString, GetImgFromHdr(alignbottom_png, sizeof(alignbottom_png)),
+    m_toolbar->AddTool(id_AlignBottom, wxEmptyString, GetImageFromArray(alignbottom_png, sizeof(alignbottom_png)),
     wxString::FromUTF8("Align bottom"), wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
 
-    m_toolbar->AddTool(id_BorderLeft, wxEmptyString, GetImgFromHdr(left_png, sizeof(left_png)),
+    m_toolbar->AddTool(id_BorderLeft, wxEmptyString, GetImageFromArray(left_png, sizeof(left_png)),
     wxString::FromUTF8("Left border"), wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_BorderRight, wxEmptyString, GetImgFromHdr(right_png, sizeof(right_png)),
+    m_toolbar->AddTool(id_BorderRight, wxEmptyString, GetImageFromArray(right_png, sizeof(right_png)),
     wxString::FromUTF8("Right border"), wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_BorderTop, wxEmptyString, GetImgFromHdr(top_png, sizeof(top_png)),
+    m_toolbar->AddTool(id_BorderTop, wxEmptyString, GetImageFromArray(top_png, sizeof(top_png)),
     wxString::FromUTF8("Top border"), wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_BorderBottom, wxEmptyString, GetImgFromHdr(bottom_png, sizeof(bottom_png)),
+    m_toolbar->AddTool(id_BorderBottom, wxEmptyString, GetImageFromArray(bottom_png, sizeof(bottom_png)),
     wxString::FromUTF8("Bottom border"), wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
 
-    m_toolbar->AddTool(id_Expand, wxEmptyString, GetImgFromHdr(expand_png, sizeof(expand_png)),
+    m_toolbar->AddTool(id_Expand, wxEmptyString, GetImageFromArray(expand_png, sizeof(expand_png)),
     wxString::FromUTF8("Expand to fill the space"), wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
 
-    m_toolbar->AddTool(id_ShowHidden, wxEmptyString, GetImgFromHdr(hidden_png, sizeof(hidden_png)),
+    m_toolbar->AddTool(id_ShowHidden, wxEmptyString, GetImageFromArray(hidden_png, sizeof(hidden_png)),
     wxString::FromUTF8("Show hidden controls in Mockup panel"), wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_Magnify, wxEmptyString, GetImgFromHdr(magnify_png, sizeof(magnify_png)),
+    m_toolbar->AddTool(id_Magnify, wxEmptyString, GetImageFromArray(magnify_png, sizeof(magnify_png)),
     wxString::FromUTF8("Magnify the size of the Mockup window"), wxITEM_CHECK);
 
     m_toolbar->Realize();

--- a/src/ui/msgframe_base.cpp
+++ b/src/ui/msgframe_base.cpp
@@ -16,7 +16,7 @@
 #include <wx/mstream.h>  // Memory stream classes
 
 // Convert a data header file into a wxImage
-static wxImage GetImgFromHdr(const unsigned char* data, size_t size_data)
+static wxImage GetImageFromArray(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
@@ -45,7 +45,7 @@ MsgFrameBase::MsgFrameBase(wxWindow* parent, wxWindowID id, const wxString& titl
     menu_file->Append(menu_item_clear);
 
     auto menu_item_hide = new wxMenuItem(menu_file, id_hide, wxString::FromUTF8("&Hide"));
-    menu_item_hide->SetBitmap(GetImgFromHdr(hidden_png, sizeof(hidden_png)));
+    menu_item_hide->SetBitmap(GetImageFromArray(hidden_png, sizeof(hidden_png)));
     menu_file->Append(menu_item_hide);
     menubar->Append(menu_file, wxString::FromUTF8("&File"));
 

--- a/src/ui/ribbonpanel_base.cpp
+++ b/src/ui/ribbonpanel_base.cpp
@@ -105,7 +105,7 @@ using namespace GenEnum;
 #include <wx/mstream.h>  // Memory stream classes
 
 // Convert a data header file into a wxImage
-static wxImage GetImgFromHdr(const unsigned char* data, size_t size_data)
+static wxImage GetImageFromArray(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
@@ -131,21 +131,21 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto forms_bar_windows = new wxRibbonToolBar(panel_form_windows, wxID_ANY);
     {
-        forms_bar_windows->AddTool(CreateNewDialog, GetImgFromHdr(wxDialog_png, sizeof(wxDialog_png)), wxString::FromUTF8("wxDialog"), wxRIBBON_BUTTON_NORMAL);
-        forms_bar_windows->AddTool(gen_PanelForm, GetImgFromHdr(wxPanel_png, sizeof(wxPanel_png)), wxString::FromUTF8("wxPanel"), wxRIBBON_BUTTON_NORMAL);
-        forms_bar_windows->AddTool(CreateNewFrame, GetImgFromHdr(wxFrame_png, sizeof(wxFrame_png)), wxString::FromUTF8("wxFrame"), wxRIBBON_BUTTON_NORMAL);
-        forms_bar_windows->AddTool(gen_wxPopupTransientWindow, GetImgFromHdr(wxPopupTransientWindow_png, sizeof(wxPopupTransientWindow_png)), wxString::FromUTF8("wxPopupTransientWindow"), wxRIBBON_BUTTON_NORMAL);
-        forms_bar_windows->AddTool(gen_wxContextMenuEvent, GetImgFromHdr(menuitem_png, sizeof(menuitem_png)), wxString::FromUTF8("wxContextMenuEvent"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_windows->AddTool(CreateNewDialog, GetImageFromArray(wxDialog_png, sizeof(wxDialog_png)), wxString::FromUTF8("wxDialog"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_windows->AddTool(gen_PanelForm, GetImageFromArray(wxPanel_png, sizeof(wxPanel_png)), wxString::FromUTF8("wxPanel"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_windows->AddTool(CreateNewFrame, GetImageFromArray(wxFrame_png, sizeof(wxFrame_png)), wxString::FromUTF8("wxFrame"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_windows->AddTool(gen_wxPopupTransientWindow, GetImageFromArray(wxPopupTransientWindow_png, sizeof(wxPopupTransientWindow_png)), wxString::FromUTF8("wxPopupTransientWindow"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_windows->AddTool(gen_wxContextMenuEvent, GetImageFromArray(menuitem_png, sizeof(menuitem_png)), wxString::FromUTF8("wxContextMenuEvent"), wxRIBBON_BUTTON_NORMAL);
     }
     forms_bar_windows->Realize();
 
     auto panel_wizard = new wxRibbonPanel(page_forms, wxID_ANY, wxString::FromUTF8("Wizard"),
-    GetImgFromHdr(wxWizard_png, sizeof(wxWizard_png)));
+    GetImageFromArray(wxWizard_png, sizeof(wxWizard_png)));
 
     auto forms_bar_wizard = new wxRibbonToolBar(panel_wizard, wxID_ANY);
     {
-        forms_bar_wizard->AddTool(gen_wxWizard, GetImgFromHdr(wxWizard_png, sizeof(wxWizard_png)), wxString::FromUTF8("wxWizard"), wxRIBBON_BUTTON_NORMAL);
-        forms_bar_wizard->AddTool(gen_wxWizardPageSimple, GetImgFromHdr(wxWizardPageSimple_png, sizeof(wxWizardPageSimple_png)), wxString::FromUTF8("wxWizardPageSimple"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_wizard->AddTool(gen_wxWizard, GetImageFromArray(wxWizard_png, sizeof(wxWizard_png)), wxString::FromUTF8("wxWizard"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_wizard->AddTool(gen_wxWizardPageSimple, GetImageFromArray(wxWizardPageSimple_png, sizeof(wxWizardPageSimple_png)), wxString::FromUTF8("wxWizardPageSimple"), wxRIBBON_BUTTON_NORMAL);
     }
     forms_bar_wizard->Realize();
 
@@ -153,9 +153,9 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto forms_bar_bars = new wxRibbonToolBar(panel_bars, wxID_ANY);
     {
-        forms_bar_bars->AddTool(gen_MenuBar, GetImgFromHdr(wxMenuBar_png, sizeof(wxMenuBar_png)), wxString::FromUTF8("wxMenuBar"), wxRIBBON_BUTTON_NORMAL);
-        forms_bar_bars->AddTool(gen_ToolBar, GetImgFromHdr(wxToolBar_png, sizeof(wxToolBar_png)), wxString::FromUTF8("wxToolBar"), wxRIBBON_BUTTON_NORMAL);
-        forms_bar_bars->AddTool(CreateNewFormRibbon, GetImgFromHdr(ribbon_bar_png, sizeof(ribbon_bar_png)), wxString::FromUTF8("wxRibbonBar"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_bars->AddTool(gen_MenuBar, GetImageFromArray(wxMenuBar_png, sizeof(wxMenuBar_png)), wxString::FromUTF8("wxMenuBar"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_bars->AddTool(gen_ToolBar, GetImageFromArray(wxToolBar_png, sizeof(wxToolBar_png)), wxString::FromUTF8("wxToolBar"), wxRIBBON_BUTTON_NORMAL);
+        forms_bar_bars->AddTool(CreateNewFormRibbon, GetImageFromArray(ribbon_bar_png, sizeof(ribbon_bar_png)), wxString::FromUTF8("wxRibbonBar"), wxRIBBON_BUTTON_NORMAL);
     }
     forms_bar_bars->Realize();
 
@@ -165,10 +165,10 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto sizer_bar_basic = new wxRibbonToolBar(panel_basic, wxID_ANY);
     {
-        sizer_bar_basic->AddTool(gen_wxBoxSizer, GetImgFromHdr(sizer_horizontal_png, sizeof(sizer_horizontal_png)), wxString::FromUTF8("Horizontal wxBoxSizer"), wxRIBBON_BUTTON_NORMAL);
-        sizer_bar_basic->AddTool(gen_VerticalBoxSizer, GetImgFromHdr(sizer_png, sizeof(sizer_png)), wxString::FromUTF8("Vertical wxBoxSizer"), wxRIBBON_BUTTON_NORMAL);
-        sizer_bar_basic->AddTool(NewStaticSizer, GetImgFromHdr(wxStaticBoxSizer_png, sizeof(wxStaticBoxSizer_png)), wxString::FromUTF8("wxStaticBoxSizer"), wxRIBBON_BUTTON_DROPDOWN);
-        sizer_bar_basic->AddTool(gen_wxWrapSizer, GetImgFromHdr(wrap_sizer_png, sizeof(wrap_sizer_png)), wxString::FromUTF8("wxWrapSizer"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_basic->AddTool(gen_wxBoxSizer, GetImageFromArray(sizer_horizontal_png, sizeof(sizer_horizontal_png)), wxString::FromUTF8("Horizontal wxBoxSizer"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_basic->AddTool(gen_VerticalBoxSizer, GetImageFromArray(sizer_png, sizeof(sizer_png)), wxString::FromUTF8("Vertical wxBoxSizer"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_basic->AddTool(NewStaticSizer, GetImageFromArray(wxStaticBoxSizer_png, sizeof(wxStaticBoxSizer_png)), wxString::FromUTF8("wxStaticBoxSizer"), wxRIBBON_BUTTON_DROPDOWN);
+        sizer_bar_basic->AddTool(gen_wxWrapSizer, GetImageFromArray(wrap_sizer_png, sizeof(wrap_sizer_png)), wxString::FromUTF8("wxWrapSizer"), wxRIBBON_BUTTON_NORMAL);
     }
     sizer_bar_basic->Realize();
 
@@ -176,9 +176,9 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto sizer_bar_grids = new wxRibbonToolBar(sizer_panel_grids, wxID_ANY);
     {
-        sizer_bar_grids->AddTool(gen_wxGridSizer, GetImgFromHdr(grid_sizer_png, sizeof(grid_sizer_png)), wxString::FromUTF8("wxGridSizer"), wxRIBBON_BUTTON_NORMAL);
-        sizer_bar_grids->AddTool(gen_wxFlexGridSizer, GetImgFromHdr(flex_grid_sizer_png, sizeof(flex_grid_sizer_png)), wxString::FromUTF8("wxFlexGridSizer"), wxRIBBON_BUTTON_NORMAL);
-        sizer_bar_grids->AddTool(gen_wxGridBagSizer, GetImgFromHdr(grid_bag_sizer_png, sizeof(grid_bag_sizer_png)), wxString::FromUTF8("wxGridBagSizer"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_grids->AddTool(gen_wxGridSizer, GetImageFromArray(grid_sizer_png, sizeof(grid_sizer_png)), wxString::FromUTF8("wxGridSizer"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_grids->AddTool(gen_wxFlexGridSizer, GetImageFromArray(flex_grid_sizer_png, sizeof(flex_grid_sizer_png)), wxString::FromUTF8("wxFlexGridSizer"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_grids->AddTool(gen_wxGridBagSizer, GetImageFromArray(grid_bag_sizer_png, sizeof(grid_bag_sizer_png)), wxString::FromUTF8("wxGridBagSizer"), wxRIBBON_BUTTON_NORMAL);
     }
     sizer_bar_grids->Realize();
 
@@ -186,9 +186,9 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto sizer_bar_other = new wxRibbonToolBar(sizer_panel_other, wxID_ANY);
     {
-        sizer_bar_other->AddTool(gen_wxStdDialogButtonSizer, GetImgFromHdr(stddialogbuttonsizer_png, sizeof(stddialogbuttonsizer_png)), wxString::FromUTF8("wxStdDialogButtonSizer"), wxRIBBON_BUTTON_NORMAL);
-        sizer_bar_other->AddTool(gen_TextSizer, GetImgFromHdr(text_sizer_png, sizeof(text_sizer_png)), wxString::FromUTF8("wxTextSizerWrapper"), wxRIBBON_BUTTON_NORMAL);
-        sizer_bar_other->AddTool(gen_spacer, GetImgFromHdr(spacer_png, sizeof(spacer_png)), wxString::FromUTF8("spacer"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_other->AddTool(gen_wxStdDialogButtonSizer, GetImageFromArray(stddialogbuttonsizer_png, sizeof(stddialogbuttonsizer_png)), wxString::FromUTF8("wxStdDialogButtonSizer"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_other->AddTool(gen_TextSizer, GetImageFromArray(text_sizer_png, sizeof(text_sizer_png)), wxString::FromUTF8("wxTextSizerWrapper"), wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_other->AddTool(gen_spacer, GetImageFromArray(spacer_png, sizeof(spacer_png)), wxString::FromUTF8("spacer"), wxRIBBON_BUTTON_NORMAL);
     }
     sizer_bar_other->Realize();
 
@@ -200,12 +200,12 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto common_bar_controls = new wxRibbonToolBar(panel_common_controls, wxID_ANY);
     {
-        common_bar_controls->AddTool(gen_wxStaticText, GetImgFromHdr(wxStaticText_png, sizeof(wxStaticText_png)), wxString::FromUTF8("wxStaticText"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_controls->AddTool(gen_wxTextCtrl, GetImgFromHdr(wxTextCtrl_png, sizeof(wxTextCtrl_png)), wxString::FromUTF8("wxTextCtrl"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_controls->AddTool(NewCheckbox, GetImgFromHdr(wxCheckBox_png, sizeof(wxCheckBox_png)), wxString::FromUTF8("Check Boxes"), wxRIBBON_BUTTON_DROPDOWN);
-        common_bar_controls->AddTool(gen_wxRadioButton, GetImgFromHdr(wxRadioButton_png, sizeof(wxRadioButton_png)), wxString::FromUTF8("wxRadioButton"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_controls->AddTool(NewButton, GetImgFromHdr(wxButton_png, sizeof(wxButton_png)), wxString::FromUTF8("Buttons"), wxRIBBON_BUTTON_DROPDOWN);
-        common_bar_controls->AddTool(NewSpin, GetImgFromHdr(spin_ctrl_png, sizeof(spin_ctrl_png)), wxString::FromUTF8("Spin controls"), wxRIBBON_BUTTON_DROPDOWN);
+        common_bar_controls->AddTool(gen_wxStaticText, GetImageFromArray(wxStaticText_png, sizeof(wxStaticText_png)), wxString::FromUTF8("wxStaticText"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_controls->AddTool(gen_wxTextCtrl, GetImageFromArray(wxTextCtrl_png, sizeof(wxTextCtrl_png)), wxString::FromUTF8("wxTextCtrl"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_controls->AddTool(NewCheckbox, GetImageFromArray(wxCheckBox_png, sizeof(wxCheckBox_png)), wxString::FromUTF8("Check Boxes"), wxRIBBON_BUTTON_DROPDOWN);
+        common_bar_controls->AddTool(gen_wxRadioButton, GetImageFromArray(wxRadioButton_png, sizeof(wxRadioButton_png)), wxString::FromUTF8("wxRadioButton"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_controls->AddTool(NewButton, GetImageFromArray(wxButton_png, sizeof(wxButton_png)), wxString::FromUTF8("Buttons"), wxRIBBON_BUTTON_DROPDOWN);
+        common_bar_controls->AddTool(NewSpin, GetImageFromArray(spin_ctrl_png, sizeof(spin_ctrl_png)), wxString::FromUTF8("Spin controls"), wxRIBBON_BUTTON_DROPDOWN);
     }
     common_bar_controls->Realize();
 
@@ -215,9 +215,9 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto common_bar_choices = new wxRibbonToolBar(panel_choices, wxID_ANY);
     {
-        common_bar_choices->AddTool(NewCombobox, GetImgFromHdr(wxComboBox_png, sizeof(wxComboBox_png)), wxString::FromUTF8("Combos & Choice"), wxRIBBON_BUTTON_DROPDOWN);
-        common_bar_choices->AddTool(NewListbox, GetImgFromHdr(wxListBox_png, sizeof(wxListBox_png)), wxString::FromUTF8("Lists"), wxRIBBON_BUTTON_DROPDOWN);
-        common_bar_choices->AddTool(gen_wxRadioBox, GetImgFromHdr(radio_box_png, sizeof(radio_box_png)), wxString::FromUTF8("wxRadioBox"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_choices->AddTool(NewCombobox, GetImageFromArray(wxComboBox_png, sizeof(wxComboBox_png)), wxString::FromUTF8("Combos & Choice"), wxRIBBON_BUTTON_DROPDOWN);
+        common_bar_choices->AddTool(NewListbox, GetImageFromArray(wxListBox_png, sizeof(wxListBox_png)), wxString::FromUTF8("Lists"), wxRIBBON_BUTTON_DROPDOWN);
+        common_bar_choices->AddTool(gen_wxRadioBox, GetImageFromArray(radio_box_png, sizeof(radio_box_png)), wxString::FromUTF8("wxRadioBox"), wxRIBBON_BUTTON_NORMAL);
     }
     common_bar_choices->Realize();
 
@@ -227,12 +227,12 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto common_bar_pickers = new wxRibbonToolBar(panel_pickkers, wxID_ANY);
     {
-        common_bar_pickers->AddTool(gen_wxFilePickerCtrl, GetImgFromHdr(filePicker_png, sizeof(filePicker_png)), wxString::FromUTF8("wxFilePickerCtrl"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_pickers->AddTool(gen_wxDirPickerCtrl, GetImgFromHdr(dirPicker_png, sizeof(dirPicker_png)), wxString::FromUTF8("wxDirPickerCtrl"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_pickers->AddTool(gen_wxFontPickerCtrl, GetImgFromHdr(fontPicker_png, sizeof(fontPicker_png)), wxString::FromUTF8("wxFontPickerCtrl"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_pickers->AddTool(gen_wxColourPickerCtrl, GetImgFromHdr(colourPickerIcon_png, sizeof(colourPickerIcon_png)), wxString::FromUTF8("wxColourPickerCtrl"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_pickers->AddTool(gen_wxDatePickerCtrl, GetImgFromHdr(datepicker_png, sizeof(datepicker_png)), wxString::FromUTF8("wxDatePickerCtrl"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_pickers->AddTool(gen_wxTimePickerCtrl, GetImgFromHdr(timepicker_png, sizeof(timepicker_png)), wxString::FromUTF8("wxTimePickerCtrl"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_pickers->AddTool(gen_wxFilePickerCtrl, GetImageFromArray(filePicker_png, sizeof(filePicker_png)), wxString::FromUTF8("wxFilePickerCtrl"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_pickers->AddTool(gen_wxDirPickerCtrl, GetImageFromArray(dirPicker_png, sizeof(dirPicker_png)), wxString::FromUTF8("wxDirPickerCtrl"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_pickers->AddTool(gen_wxFontPickerCtrl, GetImageFromArray(fontPicker_png, sizeof(fontPicker_png)), wxString::FromUTF8("wxFontPickerCtrl"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_pickers->AddTool(gen_wxColourPickerCtrl, GetImageFromArray(colourPickerIcon_png, sizeof(colourPickerIcon_png)), wxString::FromUTF8("wxColourPickerCtrl"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_pickers->AddTool(gen_wxDatePickerCtrl, GetImageFromArray(datepicker_png, sizeof(datepicker_png)), wxString::FromUTF8("wxDatePickerCtrl"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_pickers->AddTool(gen_wxTimePickerCtrl, GetImageFromArray(timepicker_png, sizeof(timepicker_png)), wxString::FromUTF8("wxTimePickerCtrl"), wxRIBBON_BUTTON_NORMAL);
     }
     common_bar_pickers->Realize();
 
@@ -242,10 +242,10 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto common_bar_other = new wxRibbonToolBar(panel_other, wxID_ANY);
     {
-        common_bar_other->AddTool(gen_wxStaticBitmap, GetImgFromHdr(static_bitmap_png, sizeof(static_bitmap_png)), wxString::FromUTF8("wxStaticBitmap"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_other->AddTool(gen_wxStaticLine, GetImgFromHdr(static_line_png, sizeof(static_line_png)), wxString::FromUTF8("wxStaticLine"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_other->AddTool(gen_wxSlider, GetImgFromHdr(slider_png, sizeof(slider_png)), wxString::FromUTF8("wxSlider"), wxRIBBON_BUTTON_NORMAL);
-        common_bar_other->AddTool(gen_wxGauge, GetImgFromHdr(gauge_png, sizeof(gauge_png)), wxString::FromUTF8("wxGauge"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_other->AddTool(gen_wxStaticBitmap, GetImageFromArray(static_bitmap_png, sizeof(static_bitmap_png)), wxString::FromUTF8("wxStaticBitmap"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_other->AddTool(gen_wxStaticLine, GetImageFromArray(static_line_png, sizeof(static_line_png)), wxString::FromUTF8("wxStaticLine"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_other->AddTool(gen_wxSlider, GetImageFromArray(slider_png, sizeof(slider_png)), wxString::FromUTF8("wxSlider"), wxRIBBON_BUTTON_NORMAL);
+        common_bar_other->AddTool(gen_wxGauge, GetImageFromArray(gauge_png, sizeof(gauge_png)), wxString::FromUTF8("wxGauge"), wxRIBBON_BUTTON_NORMAL);
     }
     common_bar_other->Realize();
 
@@ -255,10 +255,10 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto container_bar_windows = new wxRibbonToolBar(panel_windows, wxID_ANY);
     {
-        container_bar_windows->AddTool(gen_wxPanel, GetImgFromHdr(wxPanel_png, sizeof(wxPanel_png)), wxString::FromUTF8("wxPanel"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_windows->AddTool(gen_wxSplitterWindow, GetImgFromHdr(wxSplitterWindow_png, sizeof(wxSplitterWindow_png)), wxString::FromUTF8("wxSplitterWindow"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_windows->AddTool(gen_wxScrolledWindow, GetImgFromHdr(wxScrolledWindow_png, sizeof(wxScrolledWindow_png)), wxString::FromUTF8("wxScrolledWindow"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_windows->AddTool(gen_wxCollapsiblePane, GetImgFromHdr(wxCollapsiblePane_png, sizeof(wxCollapsiblePane_png)), wxString::FromUTF8("wxCollapsiblePane"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_windows->AddTool(gen_wxPanel, GetImageFromArray(wxPanel_png, sizeof(wxPanel_png)), wxString::FromUTF8("wxPanel"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_windows->AddTool(gen_wxSplitterWindow, GetImageFromArray(wxSplitterWindow_png, sizeof(wxSplitterWindow_png)), wxString::FromUTF8("wxSplitterWindow"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_windows->AddTool(gen_wxScrolledWindow, GetImageFromArray(wxScrolledWindow_png, sizeof(wxScrolledWindow_png)), wxString::FromUTF8("wxScrolledWindow"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_windows->AddTool(gen_wxCollapsiblePane, GetImageFromArray(wxCollapsiblePane_png, sizeof(wxCollapsiblePane_png)), wxString::FromUTF8("wxCollapsiblePane"), wxRIBBON_BUTTON_NORMAL);
     }
     container_bar_windows->Realize();
 
@@ -266,13 +266,13 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto container_bar_books = new wxRibbonToolBar(panel_books, wxID_ANY);
     {
-        container_bar_books->AddTool(gen_wxAuiNotebook, GetImgFromHdr(auinotebook_png, sizeof(auinotebook_png)), wxString::FromUTF8("wxAuiNotebook"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_books->AddTool(gen_wxChoicebook, GetImgFromHdr(wxChoicebook_png, sizeof(wxChoicebook_png)), wxString::FromUTF8("wxChoicebook"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_books->AddTool(gen_wxListbook, GetImgFromHdr(wxListbook_png, sizeof(wxListbook_png)), wxString::FromUTF8("wxListbook"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_books->AddTool(gen_wxNotebook, GetImgFromHdr(wxNotebook_png, sizeof(wxNotebook_png)), wxString::FromUTF8("wxNotebook"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_books->AddTool(gen_wxSimplebook, GetImgFromHdr(wxSimplebook_png, sizeof(wxSimplebook_png)), wxString::FromUTF8("wxSimplebook"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_books->AddTool(gen_wxToolbook, GetImgFromHdr(wxToolbook_png, sizeof(wxToolbook_png)), wxString::FromUTF8("wxToolbook"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_books->AddTool(gen_wxTreebook, GetImgFromHdr(wxTreebook_png, sizeof(wxTreebook_png)), wxString::FromUTF8("wxTreebook"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_books->AddTool(gen_wxAuiNotebook, GetImageFromArray(auinotebook_png, sizeof(auinotebook_png)), wxString::FromUTF8("wxAuiNotebook"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_books->AddTool(gen_wxChoicebook, GetImageFromArray(wxChoicebook_png, sizeof(wxChoicebook_png)), wxString::FromUTF8("wxChoicebook"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_books->AddTool(gen_wxListbook, GetImageFromArray(wxListbook_png, sizeof(wxListbook_png)), wxString::FromUTF8("wxListbook"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_books->AddTool(gen_wxNotebook, GetImageFromArray(wxNotebook_png, sizeof(wxNotebook_png)), wxString::FromUTF8("wxNotebook"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_books->AddTool(gen_wxSimplebook, GetImageFromArray(wxSimplebook_png, sizeof(wxSimplebook_png)), wxString::FromUTF8("wxSimplebook"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_books->AddTool(gen_wxToolbook, GetImageFromArray(wxToolbook_png, sizeof(wxToolbook_png)), wxString::FromUTF8("wxToolbook"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_books->AddTool(gen_wxTreebook, GetImageFromArray(wxTreebook_png, sizeof(wxTreebook_png)), wxString::FromUTF8("wxTreebook"), wxRIBBON_BUTTON_NORMAL);
     }
     container_bar_books->Realize();
 
@@ -280,8 +280,8 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto container_bar_page = new wxRibbonToolBar(panel_page, wxID_ANY);
     {
-        container_bar_page->AddTool(gen_BookPage, GetImgFromHdr(book_page_png, sizeof(book_page_png)), wxString::FromUTF8("Adds a wxPanel, allowing for multiple controls"), wxRIBBON_BUTTON_NORMAL);
-        container_bar_page->AddTool(gen_PageCtrl, GetImgFromHdr(pagectrl_png, sizeof(pagectrl_png)), wxString::FromUTF8("Adds a single control as the page"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_page->AddTool(gen_BookPage, GetImageFromArray(book_page_png, sizeof(book_page_png)), wxString::FromUTF8("Adds a wxPanel, allowing for multiple controls"), wxRIBBON_BUTTON_NORMAL);
+        container_bar_page->AddTool(gen_PageCtrl, GetImageFromArray(pagectrl_png, sizeof(pagectrl_png)), wxString::FromUTF8("Adds a single control as the page"), wxRIBBON_BUTTON_NORMAL);
     }
     container_bar_page->Realize();
 
@@ -291,7 +291,7 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto data_bar_grid = new wxRibbonToolBar(panel_misc, wxID_ANY);
     {
-        data_bar_grid->AddTool(gen_wxGrid, GetImgFromHdr(grid_png, sizeof(grid_png)), wxString::FromUTF8("wxGrid"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_grid->AddTool(gen_wxGrid, GetImageFromArray(grid_png, sizeof(grid_png)), wxString::FromUTF8("wxGrid"), wxRIBBON_BUTTON_NORMAL);
     }
     data_bar_grid->Realize();
 
@@ -299,10 +299,10 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto data_bar_properties = new wxRibbonToolBar(panel_properties, wxID_ANY);
     {
-        data_bar_properties->AddTool(gen_wxPropertyGrid, GetImgFromHdr(wxPropertyGrid_png, sizeof(wxPropertyGrid_png)), wxString::FromUTF8("wxPropertyGrid"), wxRIBBON_BUTTON_NORMAL);
-        data_bar_properties->AddTool(gen_wxPropertyGridManager, GetImgFromHdr(wxPropertyGridManager_png, sizeof(wxPropertyGridManager_png)), wxString::FromUTF8("wxPropertyGridManager"), wxRIBBON_BUTTON_NORMAL);
-        data_bar_properties->AddTool(gen_propGridPage, GetImgFromHdr(propgridpage_png, sizeof(propgridpage_png)), wxString::FromUTF8("wxPropertyGrid Page"), wxRIBBON_BUTTON_NORMAL);
-        data_bar_properties->AddTool(gen_propGridItem, GetImgFromHdr(propgriditem_png, sizeof(propgriditem_png)), wxString::FromUTF8("wxPropertyGrid Item"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_properties->AddTool(gen_wxPropertyGrid, GetImageFromArray(wxPropertyGrid_png, sizeof(wxPropertyGrid_png)), wxString::FromUTF8("wxPropertyGrid"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_properties->AddTool(gen_wxPropertyGridManager, GetImageFromArray(wxPropertyGridManager_png, sizeof(wxPropertyGridManager_png)), wxString::FromUTF8("wxPropertyGridManager"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_properties->AddTool(gen_propGridPage, GetImageFromArray(propgridpage_png, sizeof(propgridpage_png)), wxString::FromUTF8("wxPropertyGrid Page"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_properties->AddTool(gen_propGridItem, GetImageFromArray(propgriditem_png, sizeof(propgriditem_png)), wxString::FromUTF8("wxPropertyGrid Item"), wxRIBBON_BUTTON_NORMAL);
     }
     data_bar_properties->Realize();
 
@@ -310,9 +310,9 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto data_bar_trees = new wxRibbonToolBar(panel_data_trees, wxID_ANY);
     {
-        data_bar_trees->AddTool(gen_wxTreeCtrl, GetImgFromHdr(tree_ctrl_png, sizeof(tree_ctrl_png)), wxString::FromUTF8("wxTreeCtrl"), wxRIBBON_BUTTON_NORMAL);
-        data_bar_trees->AddTool(gen_wxTreeListCtrl, GetImgFromHdr(treelistctrl_png, sizeof(treelistctrl_png)), wxString::FromUTF8("wxTreeListCtrl"), wxRIBBON_BUTTON_NORMAL);
-        data_bar_trees->AddTool(gen_TreeListCtrlColumn, GetImgFromHdr(treelistctrlcolumn_png, sizeof(treelistctrlcolumn_png)), wxString::FromUTF8("wxTreeListCtrl Column"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_trees->AddTool(gen_wxTreeCtrl, GetImageFromArray(tree_ctrl_png, sizeof(tree_ctrl_png)), wxString::FromUTF8("wxTreeCtrl"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_trees->AddTool(gen_wxTreeListCtrl, GetImageFromArray(treelistctrl_png, sizeof(treelistctrl_png)), wxString::FromUTF8("wxTreeListCtrl"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_trees->AddTool(gen_TreeListCtrlColumn, GetImageFromArray(treelistctrlcolumn_png, sizeof(treelistctrlcolumn_png)), wxString::FromUTF8("wxTreeListCtrl Column"), wxRIBBON_BUTTON_NORMAL);
     }
     data_bar_trees->Realize();
 
@@ -320,9 +320,9 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto data_bar_dataview = new wxRibbonToolBar(panel_trees, wxID_ANY);
     {
-        data_bar_dataview->AddTool(NewDataCtrl, GetImgFromHdr(dataview_ctrl_png, sizeof(dataview_ctrl_png)), wxString::FromUTF8("Data Control"), wxRIBBON_BUTTON_DROPDOWN);
-        data_bar_dataview->AddTool(gen_dataViewColumn, GetImgFromHdr(dataviewlist_column_png, sizeof(dataviewlist_column_png)), wxString::FromUTF8("DataView Column"), wxRIBBON_BUTTON_NORMAL);
-        data_bar_dataview->AddTool(gen_dataViewListColumn, GetImgFromHdr(doc_mdi_parent_frame_png, sizeof(doc_mdi_parent_frame_png)), wxString::FromUTF8("DataViewList Column"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_dataview->AddTool(NewDataCtrl, GetImageFromArray(dataview_ctrl_png, sizeof(dataview_ctrl_png)), wxString::FromUTF8("Data Control"), wxRIBBON_BUTTON_DROPDOWN);
+        data_bar_dataview->AddTool(gen_dataViewColumn, GetImageFromArray(dataviewlist_column_png, sizeof(dataviewlist_column_png)), wxString::FromUTF8("DataView Column"), wxRIBBON_BUTTON_NORMAL);
+        data_bar_dataview->AddTool(gen_dataViewListColumn, GetImageFromArray(doc_mdi_parent_frame_png, sizeof(doc_mdi_parent_frame_png)), wxString::FromUTF8("DataViewList Column"), wxRIBBON_BUTTON_NORMAL);
     }
     data_bar_dataview->Realize();
 
@@ -332,11 +332,11 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto bars_bar_menu = new wxRibbonToolBar(panel_bars_menu, wxID_ANY);
     {
-        bars_bar_menu->AddTool(gen_wxMenuBar, GetImgFromHdr(wxMenuBar_png, sizeof(wxMenuBar_png)), wxString::FromUTF8("wxMenuBar"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_menu->AddTool(gen_wxMenu, GetImgFromHdr(menu_png, sizeof(menu_png)), wxString::FromUTF8("wxMenu"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_menu->AddTool(gen_wxMenuItem, GetImgFromHdr(menuitem_png, sizeof(menuitem_png)), wxString::FromUTF8("wxMenuItem"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_menu->AddTool(gen_submenu, GetImgFromHdr(submenu_png, sizeof(submenu_png)), wxString::FromUTF8("submenu"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_menu->AddTool(gen_separator, GetImgFromHdr(separator_png, sizeof(separator_png)), wxString::FromUTF8("separator"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_menu->AddTool(gen_wxMenuBar, GetImageFromArray(wxMenuBar_png, sizeof(wxMenuBar_png)), wxString::FromUTF8("wxMenuBar"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_menu->AddTool(gen_wxMenu, GetImageFromArray(menu_png, sizeof(menu_png)), wxString::FromUTF8("wxMenu"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_menu->AddTool(gen_wxMenuItem, GetImageFromArray(menuitem_png, sizeof(menuitem_png)), wxString::FromUTF8("wxMenuItem"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_menu->AddTool(gen_submenu, GetImageFromArray(submenu_png, sizeof(submenu_png)), wxString::FromUTF8("submenu"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_menu->AddTool(gen_separator, GetImageFromArray(separator_png, sizeof(separator_png)), wxString::FromUTF8("separator"), wxRIBBON_BUTTON_NORMAL);
     }
     bars_bar_menu->Realize();
 
@@ -344,9 +344,9 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto bars_bar_tool = new wxRibbonToolBar(panel_bars_tool, wxID_ANY);
     {
-        bars_bar_tool->AddTool(gen_wxToolBar, GetImgFromHdr(wxToolBar_png, sizeof(wxToolBar_png)), wxString::FromUTF8("wxToolBar"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_tool->AddTool(gen_tool, GetImgFromHdr(tool_png, sizeof(tool_png)), wxString::FromUTF8("Tool"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_tool->AddTool(gen_toolSeparator, GetImgFromHdr(toolseparator_png, sizeof(toolseparator_png)), wxString::FromUTF8("Tool Separator"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_tool->AddTool(gen_wxToolBar, GetImageFromArray(wxToolBar_png, sizeof(wxToolBar_png)), wxString::FromUTF8("wxToolBar"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_tool->AddTool(gen_tool, GetImageFromArray(tool_png, sizeof(tool_png)), wxString::FromUTF8("Tool"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_tool->AddTool(gen_toolSeparator, GetImageFromArray(toolseparator_png, sizeof(toolseparator_png)), wxString::FromUTF8("Tool Separator"), wxRIBBON_BUTTON_NORMAL);
     }
     bars_bar_tool->Realize();
 
@@ -354,13 +354,13 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto bars_bar_ribbon = new wxRibbonToolBar(panel_bars_ribbon, wxID_ANY);
     {
-        bars_bar_ribbon->AddTool(CreateNewRibbon, GetImgFromHdr(ribbon_bar_png, sizeof(ribbon_bar_png)), wxString::FromUTF8("wxRibbonBar"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_ribbon->AddTool(gen_wxRibbonPage, GetImgFromHdr(ribbon_page_png, sizeof(ribbon_page_png)), wxString::FromUTF8("wxRibbonPage"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_ribbon->AddTool(gen_wxRibbonPanel, GetImgFromHdr(ribbon_panel_png, sizeof(ribbon_panel_png)), wxString::FromUTF8("wxRibbonPanel"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_ribbon->AddTool(NewRibbonType, GetImgFromHdr(ribbon_buttonbar_png, sizeof(ribbon_buttonbar_png)), wxString::FromUTF8("Ribbon Bar Type"), wxRIBBON_BUTTON_DROPDOWN);
-        bars_bar_ribbon->AddTool(gen_ribbonButton, GetImgFromHdr(ribbon_button_png, sizeof(ribbon_button_png)), wxString::FromUTF8("Ribbon Button"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_ribbon->AddTool(gen_ribbonSeparator, GetImgFromHdr(toolseparator_png, sizeof(toolseparator_png)), wxString::FromUTF8("Tool Separator"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_ribbon->AddTool(gen_ribbonGalleryItem, GetImgFromHdr(ribbon_gallery_item_png, sizeof(ribbon_gallery_item_png)), wxString::FromUTF8("Ribbon Gallery Item"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_ribbon->AddTool(CreateNewRibbon, GetImageFromArray(ribbon_bar_png, sizeof(ribbon_bar_png)), wxString::FromUTF8("wxRibbonBar"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_ribbon->AddTool(gen_wxRibbonPage, GetImageFromArray(ribbon_page_png, sizeof(ribbon_page_png)), wxString::FromUTF8("wxRibbonPage"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_ribbon->AddTool(gen_wxRibbonPanel, GetImageFromArray(ribbon_panel_png, sizeof(ribbon_panel_png)), wxString::FromUTF8("wxRibbonPanel"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_ribbon->AddTool(NewRibbonType, GetImageFromArray(ribbon_buttonbar_png, sizeof(ribbon_buttonbar_png)), wxString::FromUTF8("Ribbon Bar Type"), wxRIBBON_BUTTON_DROPDOWN);
+        bars_bar_ribbon->AddTool(gen_ribbonButton, GetImageFromArray(ribbon_button_png, sizeof(ribbon_button_png)), wxString::FromUTF8("Ribbon Button"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_ribbon->AddTool(gen_ribbonSeparator, GetImageFromArray(toolseparator_png, sizeof(toolseparator_png)), wxString::FromUTF8("Tool Separator"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_ribbon->AddTool(gen_ribbonGalleryItem, GetImageFromArray(ribbon_gallery_item_png, sizeof(ribbon_gallery_item_png)), wxString::FromUTF8("Ribbon Gallery Item"), wxRIBBON_BUTTON_NORMAL);
     }
     bars_bar_ribbon->Realize();
 
@@ -368,8 +368,8 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto bars_bar_other = new wxRibbonToolBar(panel_bars_rother, wxID_ANY);
     {
-        bars_bar_other->AddTool(gen_wxStatusBar, GetImgFromHdr(statusbar_png, sizeof(statusbar_png)), wxString::FromUTF8("wxStatusBar"), wxRIBBON_BUTTON_NORMAL);
-        bars_bar_other->AddTool(gen_wxInfoBar, GetImgFromHdr(infobar_png, sizeof(infobar_png)), wxString::FromUTF8("wxInfoBar"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_other->AddTool(gen_wxStatusBar, GetImageFromArray(statusbar_png, sizeof(statusbar_png)), wxString::FromUTF8("wxStatusBar"), wxRIBBON_BUTTON_NORMAL);
+        bars_bar_other->AddTool(gen_wxInfoBar, GetImageFromArray(infobar_png, sizeof(infobar_png)), wxString::FromUTF8("wxInfoBar"), wxRIBBON_BUTTON_NORMAL);
     }
     bars_bar_other->Realize();
 
@@ -379,8 +379,8 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto other_bar_editors = new wxRibbonToolBar(panel_editors, wxID_ANY);
     {
-        other_bar_editors->AddTool(gen_wxRichTextCtrl, GetImgFromHdr(richtextctrl_png, sizeof(richtextctrl_png)), wxString::FromUTF8("wxRichTextCtrl"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_editors->AddTool(gen_wxStyledTextCtrl, GetImgFromHdr(scintilla_png, sizeof(scintilla_png)), wxString::FromUTF8("wxStyledTextCtrl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_editors->AddTool(gen_wxRichTextCtrl, GetImageFromArray(richtextctrl_png, sizeof(richtextctrl_png)), wxString::FromUTF8("wxRichTextCtrl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_editors->AddTool(gen_wxStyledTextCtrl, GetImageFromArray(scintilla_png, sizeof(scintilla_png)), wxString::FromUTF8("wxStyledTextCtrl"), wxRIBBON_BUTTON_NORMAL);
     }
     other_bar_editors->Realize();
 
@@ -388,15 +388,15 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto other_bar_ctrls = new wxRibbonToolBar(panel_controls, wxID_ANY);
     {
-        other_bar_ctrls->AddTool(gen_wxHyperlinkCtrl, GetImgFromHdr(hyperlink_ctrl_png, sizeof(hyperlink_ctrl_png)), wxString::FromUTF8("wxHyperlinkCtrl"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_wxSearchCtrl, GetImgFromHdr(search_png, sizeof(search_png)), wxString::FromUTF8("wxSearchCtrl"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_wxCalendarCtrl, GetImgFromHdr(calendar_png, sizeof(calendar_png)), wxString::FromUTF8("wxCalendarCtrl"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_wxFileCtrl, GetImgFromHdr(wxFileCtrl_png, sizeof(wxFileCtrl_png)), wxString::FromUTF8("wxFileCtrl"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_wxGenericDirCtrl, GetImgFromHdr(genericdir_ctrl_png, sizeof(genericdir_ctrl_png)), wxString::FromUTF8("wxGenericDirCtrl"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_wxActivityIndicator, GetImgFromHdr(wxActivityIndicator_png, sizeof(wxActivityIndicator_png)), wxString::FromUTF8("wxActivityIndicator"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_wxAnimationCtrl, GetImgFromHdr(wxAnimation_png, sizeof(wxAnimation_png)), wxString::FromUTF8("wxAnimationCtrl"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_wxBannerWindow, GetImgFromHdr(wxBannerWindow_png, sizeof(wxBannerWindow_png)), wxString::FromUTF8("wxBannerWindow"), wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_CustomControl, GetImgFromHdr(CustomControl_png, sizeof(CustomControl_png)), wxString::FromUTF8("CustomControl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxHyperlinkCtrl, GetImageFromArray(hyperlink_ctrl_png, sizeof(hyperlink_ctrl_png)), wxString::FromUTF8("wxHyperlinkCtrl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxSearchCtrl, GetImageFromArray(search_png, sizeof(search_png)), wxString::FromUTF8("wxSearchCtrl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxCalendarCtrl, GetImageFromArray(calendar_png, sizeof(calendar_png)), wxString::FromUTF8("wxCalendarCtrl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxFileCtrl, GetImageFromArray(wxFileCtrl_png, sizeof(wxFileCtrl_png)), wxString::FromUTF8("wxFileCtrl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxGenericDirCtrl, GetImageFromArray(genericdir_ctrl_png, sizeof(genericdir_ctrl_png)), wxString::FromUTF8("wxGenericDirCtrl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxActivityIndicator, GetImageFromArray(wxActivityIndicator_png, sizeof(wxActivityIndicator_png)), wxString::FromUTF8("wxActivityIndicator"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxAnimationCtrl, GetImageFromArray(wxAnimation_png, sizeof(wxAnimation_png)), wxString::FromUTF8("wxAnimationCtrl"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxBannerWindow, GetImageFromArray(wxBannerWindow_png, sizeof(wxBannerWindow_png)), wxString::FromUTF8("wxBannerWindow"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_CustomControl, GetImageFromArray(CustomControl_png, sizeof(CustomControl_png)), wxString::FromUTF8("CustomControl"), wxRIBBON_BUTTON_NORMAL);
     }
     other_bar_ctrls->Realize();
 
@@ -404,7 +404,7 @@ RibbonPanelBase::RibbonPanelBase(wxWindow* parent, wxWindowID id) : wxPanel()
 
     auto other_bar_html = new wxRibbonToolBar(panel_html, wxID_ANY);
     {
-        other_bar_html->AddTool(gen_wxHtmlWindow, GetImgFromHdr(htmlwin_png, sizeof(htmlwin_png)), wxString::FromUTF8("wxHtmlWindow"), wxRIBBON_BUTTON_NORMAL);
+        other_bar_html->AddTool(gen_wxHtmlWindow, GetImageFromArray(htmlwin_png, sizeof(htmlwin_png)), wxString::FromUTF8("wxHtmlWindow"), wxRIBBON_BUTTON_NORMAL);
     }
     other_bar_html->Realize();
     m_rbnBar->Realize();


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds an `Embed` image property type. When specified, the image data will be generated after all the class construction code. Compared to the `Header` type we were defaulting to, this method has the advantage of automatically picking up any changes to the original art and it does not need to create any external files.

Imported images now default to being converted to `Embed` unless they point to an XPM file.

Closes #402