### PR TITLE
Reduce bitmap property from 4 parameters to 3.

### DIFF
--- a/src/customprops/art_prop_dlg.cpp
+++ b/src/customprops/art_prop_dlg.cpp
@@ -29,10 +29,17 @@ ArtBrowserDialog::ArtBrowserDialog(wxWindow* parent, const ImageProperties& img_
     m_choice_client->Append("wxART_MESSAGE_BOX");
     m_choice_client->Append("wxART_OTHER");
 
-    if (img_props.convert.size())
-        m_client = img_props.convert;
+    if (auto pos = img_props.image.find('|'); ttlib::is_found(pos))
+    {
+        m_client = img_props.image.subview(pos + 1);
+    }
     else
-        m_client = "wxART_OTHER";
+    {
+        if (img_props.convert.size())
+            m_client = img_props.convert;
+        else
+            m_client = "wxART_OTHER";
+    }
 
     m_choice_client->SetStringSelection(m_client);
     ChangeClient();

--- a/src/customprops/art_prop_dlg.cpp
+++ b/src/customprops/art_prop_dlg.cpp
@@ -35,10 +35,7 @@ ArtBrowserDialog::ArtBrowserDialog(wxWindow* parent, const ImageProperties& img_
     }
     else
     {
-        if (img_props.convert.size())
-            m_client = img_props.convert;
-        else
-            m_client = "wxART_OTHER";
+        m_client = "wxART_OTHER";
     }
 
     m_choice_client->SetStringSelection(m_client);

--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -28,12 +28,9 @@ void ImageProperties::InitValues(const char* value)
     if (mstr.size() > IndexImage)
         image = mstr[IndexImage];
 
-    if (mstr.size() > IndexConvert)
-        convert = mstr[IndexConvert];
-
-    if (mstr.size() > IndexSize)
+    if (mstr.size() > IndexImage)
     {
-        ttlib::multistr dimensions(mstr[IndexSize], ',');
+        ttlib::multistr dimensions(mstr[IndexScale], ',');
         for (auto& iter: dimensions)
         {
             iter.BothTrim();
@@ -48,15 +45,11 @@ void ImageProperties::InitValues(const char* value)
 
 ttlib::cstr ImageProperties::CombineValues()
 {
-    // The user may have picked the filename from the autocomplete, in which case it's in the converted_art directory.
-    // Or they may have chosen it from the File Open dialog which uses the converted_art as the default directory. In
-    // either case, we need to change the path to the file's actual location.
-
     if (type.size() && type != "Art")
     {
-        if (!image.file_exists() && wxGetApp().GetProject()->HasValue(prop_converted_art))
+        if (!image.file_exists() && wxGetApp().GetProject()->HasValue(prop_original_art))
         {
-            auto path = wxGetApp().GetProject()->prop_as_string(prop_converted_art);
+            auto path = wxGetApp().GetProject()->prop_as_string(prop_original_art);
             path.append_filename(image);
             path.make_relative(wxGetApp().getProjectPath());
             if (path.file_exists())
@@ -67,6 +60,6 @@ ttlib::cstr ImageProperties::CombineValues()
     }
 
     ttlib::cstr value;
-    value << type << ';' << image << ';' << convert << ";[" << size.x << ',' << size.y << "]";
+    value << type << ';' << image << ";[" << size.x << ',' << size.y << "]";
     return value;
 }

--- a/src/customprops/img_props.h
+++ b/src/customprops/img_props.h
@@ -14,18 +14,17 @@
 class NodeProperty;
 
 inline constexpr std::array<const char*, 4> s_type_names = {
-    "Embed",
-    "Header",
     "Art",
+    "Embed",
     "XPM",
+    "Header",
 };
 
 struct ImageProperties
 {
 public:
-    ttlib::cstr type { s_type_names[0] };
+    ttlib::cstr type { s_type_names[1] };
     ttlib::cstr image;
-    ttlib::cstr convert;
     wxSize size { wxDefaultSize };
 
     NodeProperty* node_property;

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -43,14 +43,13 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
 
     wxPGChoices types;
 
-    types.Add(s_type_names[0]);
-    types.Add(s_type_names[1]);
-    types.Add(s_type_names[2]);
-    types.Add(s_type_names[3]);
+    types.Add(s_type_names[0]);  // Art
+    types.Add(s_type_names[1]);  // Embed
+    types.Add(s_type_names[2]);  // XPM
+    types.Add(s_type_names[3]);  // Header
 
     AddPrivateChild(new wxEnumProperty("type", wxPG_LABEL, types, 0));
     AddPrivateChild(new ImageStringProperty("image", m_img_props));
-    AddPrivateChild(new wxStringProperty("convert_from", wxPG_LABEL, m_img_props.convert.wx_str()));
     AddPrivateChild(new CustomSizeProperty("size", m_img_props.size));
 }
 
@@ -64,15 +63,24 @@ void PropertyGrid_Image::RefreshChildren()
         if (m_img_props.type == "Art")
         {
             Item(IndexImage)->SetLabel("id");
-            Item(IndexConvert)->SetLabel("client");
-            Item(IndexConvert)
-                ->SetHelpString("Serves as a hint to wxArtProvider that helps it to choose the best looking image.");
+            Item(IndexImage)->SetHelpString("Specifies the art ID and optional Client (separated by a | character).");
         }
         else
         {
             Item(IndexImage)->SetLabel("image");
-            Item(IndexConvert)->SetLabel("convert_from");
-            Item(IndexConvert)->SetHelpString("Specifies the original art file that should be converted to the image file.");
+        }
+
+        if (m_img_props.type == "Embed")
+        {
+            Item(IndexImage)->SetHelpString("Specifies the original image which will be embedded into a generated class source file as an unsigned char array.");
+        }
+        else if (m_img_props.type == "XPM")
+        {
+            Item(IndexImage)->SetHelpString("Specifies the XPM file to include.");
+        }
+        else if (m_img_props.type == "Header")
+        {
+            Item(IndexImage)->SetHelpString("Specifies an external file containing the image as an unsigned char array.");
         }
 
         if (m_old_image != m_img_props.image || m_old_type != m_img_props.type)
@@ -114,12 +122,12 @@ void PropertyGrid_Image::RefreshChildren()
             }
             else
             {
-                auto art_dir = wxGetApp().GetProject()->prop_as_string(prop_converted_art);
+                auto art_dir = wxGetApp().GetProject()->prop_as_string(prop_original_art);
                 if (art_dir.empty())
                     art_dir = "./";
                 wxDir dir;
                 wxArrayString array_files;
-                dir.GetAllFiles(art_dir, &array_files, m_img_props.type == "XPM" ? "*.xpm" : "*.h_img");
+                dir.GetAllFiles(art_dir, &array_files, m_img_props.type == "XPM" ? "*.xpm" : "*.png");
                 for (size_t pos = 0; pos < array_files.size(); ++pos)
                 {
                     ttString* ptr = static_cast<ttString*>(&array_files[pos]);
@@ -134,8 +142,7 @@ void PropertyGrid_Image::RefreshChildren()
 
     Item(IndexType)->SetValue(m_img_props.type.wx_str());
     Item(IndexImage)->SetValue(m_img_props.image.wx_str());
-    Item(IndexConvert)->SetValue(m_img_props.convert.wx_str());
-    Item(IndexSize)->SetValue((wxVariant(m_img_props.size)));
+    Item(IndexScale)->SetValue((wxVariant(m_img_props.size)));
 }
 
 wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex, wxVariant& childValue) const
@@ -157,9 +164,8 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
                 {
                     img_props.type = s_type_names[index];
 
-                    // If the type has changed, then the image and convert properties are no longer valid, so we clear them
+                    // If the type has changed, then the image property is no longer valid
                     img_props.image.clear();
-                    img_props.convert.clear();
                 }
                 break;
             }
@@ -170,11 +176,7 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
             }
             break;
 
-        case IndexConvert:
-            img_props.convert = childValue.GetString().utf8_str().data();
-            break;
-
-        case IndexSize:
+        case IndexScale:
             img_props.size = wxSizeRefFromVariant(childValue);
             break;
     }

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -166,15 +166,7 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
 
         case IndexImage:
             {
-                ttlib::cstr results;
-                results << childValue.GetString().wx_str();
-                auto pos = results.find_first_of('|');
-                if (ttlib::is_found(pos))
-                {
-                    img_props.convert = results.subview(pos + 1);
-                    results.erase(pos);
-                }
-                img_props.image = results;
+                img_props.image.assign_wx(childValue.GetString());
             }
             break;
 

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -538,14 +538,18 @@ ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description)
 
     if (parts[IndexType].contains("Art"))
     {
-        code << "wxArtProvider::GetBitmap(" << parts[IndexArtID];
-        if (parts[IndexArtClient].size())
-            code << ", " << parts[IndexArtClient];
-        code << ')';
+        ttlib::cstr art_id(parts[IndexArtID]);
+        ttlib::cstr art_client(parts[IndexArtClient]);
+        if (auto pos = art_id.find('|'); ttlib::is_found(pos))
+        {
+            art_client = art_id.subview(pos + 1);
+            art_id.erase(pos);
+        }
 
-        // This code is obsolete!
-        if (!parts[IndexType].is_sameas("Art"))
-            return code;
+        code << "wxArtProvider::GetBitmap(" << art_id;
+        if (art_client.size())
+            code << ", " << art_client;
+        code << ')';
 
         // Scale if needed
         if (parts.size() > IndexConvert && parts[IndexSize].size())

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -22,7 +22,7 @@ class ImportXML;
 
 // Current version of wxUiEditor project files
 constexpr const auto curWxuiMajorVer = 1;
-constexpr const auto curWxuiMinorVer = 1;
+constexpr const auto curWxuiMinorVer = 2;
 
 class App : public wxApp
 {
@@ -104,6 +104,8 @@ public:
 
     void ShowPreferences(wxWindow* parent);
 
+    auto GetProjectVersion() { return m_ProjectVersion; }
+
 protected:
     bool OnInit() override;
     bool Import(ImportXML& import, ttString& file, bool append = false);
@@ -117,6 +119,7 @@ protected:
 
     auto LoadProject(pugi::xml_document& doc) -> std::shared_ptr<Node>;
 
+
 private:
     std::shared_ptr<Node> m_project;
 
@@ -129,6 +132,7 @@ private:
     wxLanguage m_lang;  // language specified by user
     wxLocale m_locale;  // locale we'll be using
 
+    int m_ProjectVersion;
     bool m_isMainFrameClosing { false };
     bool m_isProject_updated { false };
 };

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -124,10 +124,8 @@ wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool 
         }
         else
         {
-            if (parts[IndexArtClient].empty())
-                parts[IndexArtClient] = "wxART_OTHER";
-            image = wxArtProvider::GetBitmap(parts[IndexArtID], wxART_MAKE_CLIENT_ID_FROM_STR(parts[IndexArtClient]))
-                        .ConvertToImage();
+            image =
+                wxArtProvider::GetBitmap(parts[IndexArtID], wxART_MAKE_CLIENT_ID_FROM_STR("wxART_OTHER")).ConvertToImage();
         }
     }
     else if (parts[IndexType].contains("Embed"))
@@ -189,9 +187,9 @@ wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool 
         m_images[path] = image;
 
     // Scale if needed
-    if (want_scaled && parts.size() > IndexConvert && parts[IndexSize].size() && parts[IndexSize] != "-1, -1")
+    if (want_scaled && parts.size() > IndexScale && parts[IndexScale].size() && parts[IndexScale] != "[-1,-1]")
     {
-        auto scale_size = ConvertToSize(parts[IndexSize]);
+        auto scale_size = ConvertToSize(parts[IndexScale]);
         if (scale_size.x != -1 || scale_size.y != -1)
         {
             auto original_size = image.GetSize();

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -221,7 +221,9 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
                 {
                     prop->set_value(iter.as_bool());
                 }
-                else if (prop->isProp(prop_bitmap) && wxGetApp().GetProjectVersion() == 11)
+                else if (wxGetApp().GetProjectVersion() == 11 && prop->type() == type_image &&
+                         (prop->isProp(prop_bitmap) || prop->isProp(prop_disabled_bmp) || prop->isProp(prop_icon) ||
+                          prop->isProp(prop_focus) || prop->isProp(prop_current) || prop->isProp(prop_inactive_bitmap)))
                 {
                     // Old style conversion -- remove once we're certain all projects have been updated
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -21,11 +21,9 @@ class Node;
 enum PropIndex
 {
     IndexType = 0,
-    IndexImage = 1,
-    IndexArtID = 1,
-    IndexConvert = 2,
-    IndexArtClient = 2,
-    IndexSize
+    IndexImage,
+    IndexArtID = IndexImage,
+    IndexScale
 };
 
 ttlib::cstr ClearPropFlag(ttlib::cview flag, ttlib::cview currentValue);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR combines client and id for the image field of an Art Provider. That made it possible to completely remove the third field that was used for `convert_from` and `client`.

The change required a project version change since we went from 4 bitmap parameters to 3. Code has been added temporarily to `LoadProject()` to automatically do the conversion.