### PR TITLE
Initialize all buttons if wxStdDialogButtonSizer access is not none

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -875,6 +875,8 @@ ttlib::cstr BaseCodeGenerator::GetDeclaration(Node* node)
                 code << "\n\twxButton* " << node->get_node_name() << "No;";
             if (node->prop_as_bool(prop_Cancel))
                 code << "\n\twxButton* " << node->get_node_name() << "Cancel;";
+            if (node->prop_as_bool(prop_Close))
+                code << "\n\twxButton* " << node->get_node_name() << "Close;";
             if (node->prop_as_bool(prop_Help))
                 code << "\n\twxButton* " << node->get_node_name() << "Help;";
             if (node->prop_as_bool(prop_ContextHelp))

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -1058,6 +1058,29 @@ std::optional<ttlib::cstr> StdDialogButtonSizerGenerator::GenConstruction(Node* 
 
     code << "\n\t" << node->get_node_name() << "->Realize();\n";
 
+    if (!node->IsLocal())
+    {
+        if (node->prop_as_bool(prop_OK))
+            code << node->get_node_name() << "OK = wxStaticCast(FindWindowById(wxID_OK), wxButton);\n";
+        if (node->prop_as_bool(prop_Yes))
+            code << node->get_node_name() << "Yes = wxStaticCast(FindWindowById(wxID_YES), wxButton);\n";
+        if (node->prop_as_bool(prop_Save))
+            code << node->get_node_name() << "Save = wxStaticCast(FindWindowById(wxID_SAVE), wxButton);\n";
+        if (node->prop_as_bool(prop_Apply))
+            code << node->get_node_name() << "Apply = wxStaticCast(FindWindowById(wxID_APPLY), wxButton);\n";
+
+        if (node->prop_as_bool(prop_No))
+            code << node->get_node_name() << "No = wxStaticCast(FindWindowById(wxID_NO), wxButton);\n";
+        if (node->prop_as_bool(prop_Cancel))
+            code << node->get_node_name() << "Cancel = wxStaticCast(FindWindowById(wxID_CANCEL), wxButton);\n";
+        if (node->prop_as_bool(prop_Close))
+            code << node->get_node_name() << "Close = wxStaticCast(FindWindowById(wxID_CLOSE), wxButton);\n";
+        if (node->prop_as_bool(prop_Help))
+            code << node->get_node_name() << "Help = wxStaticCast(FindWindowById(wxID_HELP), wxButton);\n";
+        if (node->prop_as_bool(prop_ContextHelp))
+            code << node->get_node_name() << "ContextHelp = wxStaticCast(FindWindowById(wxID_CONTEXT_HELP), wxButton);\n";
+    }
+
     return code;
 }
 


### PR DESCRIPTION
This initializes the same button variables that wxFormBuilder uses, as well as initializing the same variables that we were still creating.

Closes #26

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
