### PR TITLE
Add conditionalized inline versus static keyword to images

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -407,7 +407,10 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
                     is_namespace_written = true;
                 }
                 m_source->writeLine();
-                m_source->writeLine(ttlib::cstr("inline const unsigned char ")
+                m_source->writeLine("#if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))");
+                m_source->writeLine("\t\tinline", false);
+                m_source->writeLine("#endif");
+                m_source->writeLine(ttlib::cstr("const unsigned char ")
                                     << iter_array->array_name << '[' << iter_array->array_size << "] {");
 
                 size_t pos = 0;

--- a/src/ui/embedimg.cpp
+++ b/src/ui/embedimg.cpp
@@ -436,6 +436,17 @@ void EmbedImage::OnConvert(wxCommandEvent& WXUNUSED(event))
     SetOutputBitmap();
 }
 
+// clang-format off
+
+inline constexpr const auto txt_ImgPrefix =
+R"===(#if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
+    inline
+#else
+    static
+#endif)===";
+
+// clang-format on
+
 void EmbedImage::ImgageInHeaderOut()
 {
     ttString in_filename = m_fileOriginal->GetTextCtrlValue();
@@ -490,12 +501,10 @@ void EmbedImage::ImgageInHeaderOut()
     string_name.Replace(".", "_", true);
 
     ttlib::textfile file;
-    if (m_check_c17->GetValue())
-        file.addEmptyLine().Format("inline constexpr const unsigned char %s[%zu] = {", string_name.filename().c_str(),
-                                   read_stream->GetBufferSize());
-    else
-        file.addEmptyLine().Format("static const unsigned char %s[%zu] = {", string_name.filename().c_str(),
-                                   read_stream->GetBufferSize());
+    file.emplace_back(txt_ImgPrefix);
+
+    file.addEmptyLine().Format("const unsigned char %s[%zu] = {", string_name.filename().c_str(),
+                               read_stream->GetBufferSize());
 
     read_stream->Seek(0, wxFromStart);
 


### PR DESCRIPTION
Affects the Header file that Convert Image can create, as well as the Embedded array that we generate.

Note that only header files use `static` -- an embedded image is global unless a c++17 compiler is used.

Closes #423

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
