### PR TITLE
Refactor to use new and update ttLib classes

### DIFF
--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -16,11 +16,7 @@
 
 void ImageProperties::InitValues(const char* value)
 {
-    ttlib::multistr mstr(value, ';');
-    for (auto& iter: mstr)
-    {
-        iter.BothTrim();
-    }
+    ttlib::multiview mstr(value, ';', tt::TRIM::both);
 
     if (mstr.size() > IndexType)
         type = mstr[IndexType];
@@ -30,30 +26,7 @@ void ImageProperties::InitValues(const char* value)
 
     if (mstr.size() > IndexImage + 1)
     {
-        if (mstr[IndexScale][0] == '[')
-        {
-            m_size.x = atoi(mstr[IndexScale].c_str() + 1);
-            if (auto pos_comma = mstr[IndexScale].find(','); ttlib::is_found(pos_comma))
-            {
-                m_size.y = atoi(mstr[IndexScale].c_str() + pos_comma + 1);
-            }
-            else
-            {
-                m_size.y = atoi(mstr[IndexScale + 1]);
-            }
-        }
-        else
-        {
-            ttlib::multiview scale;
-            if (mstr[IndexScale].contains(";"))
-                scale.SetString(value, ';');
-            else
-                scale.SetString(value, ',');
-
-            m_size.x = scale[0].atoi();
-            if (scale.size() > 1)
-                m_size.y = scale[1].atoi();
-        }
+        GetScaleInfo(m_size, mstr[IndexScale]);
     }
 }
 

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -312,6 +312,9 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
     ttlib::multistr names;
     if (namespace_prop.size())
     {
+        // BUGBUG: [KeyWorks - 09-01-2021] ttlib::multistr works fine with a string as the separator. So does
+        // ttlib::multiview which is what we should be using here.
+
         // ttlib::multistr works with a single char, not a string.
         namespace_prop.Replace("::", ":");
         // we also accept using semi-colons to separate the namespaces
@@ -1460,11 +1463,7 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
 
             if (value.is_sameprefix("Embed"))
             {
-                ttlib::multistr parts(value, BMP_PROP_SEPARATOR);
-                for (auto& iter_parts: parts)
-                {
-                    iter_parts.BothTrim();
-                }
+                ttlib::multiview parts(value, BMP_PROP_SEPARATOR, tt::TRIM::both);
 
                 if (parts[IndexImage].size())
                 {
@@ -1532,11 +1531,9 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
         {
             if ((iter.type() == type_image || iter.type() == type_animation) && iter.HasValue())
             {
-                ttlib::multistr parts(iter.as_string(), BMP_PROP_SEPARATOR);
+                ttlib::multiview parts(iter.as_string(), BMP_PROP_SEPARATOR, tt::TRIM::both);
                 if (parts.size() < IndexImage + 1)
                     continue;
-                parts[IndexType].BothTrim();
-                parts[IndexImage].BothTrim();
 
                 if ((parts[IndexType] == "Embed" || parts[IndexType] == "Header"))
                 {

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -438,6 +438,7 @@ int GetStyleInt(Node* node)
     GenStyle(node, styles);
 
     int result = 0;
+    // GetConstantAsInt() searches an unordered_map, so we need a std::string to pass to it
     ttlib::multistr mstr(styles, '|');
     for (auto& iter: mstr)
     {
@@ -539,11 +540,7 @@ ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description)
         return code;
     }
 
-    ttlib::multistr parts(description, BMP_PROP_SEPARATOR);
-    for (auto& iter: parts)
-    {
-        iter.BothTrim();
-    }
+    ttlib::multiview parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
 
     if (parts[IndexImage].empty())
     {
@@ -556,18 +553,7 @@ ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description)
     // If a dimension was specified, then it will have been split out, so we need to combine them
     if (parts.size() > IndexScale)
     {
-        ttlib::multiview scale;
-        if (parts[IndexScale].contains(";"))
-            scale.SetString(parts[IndexScale], ';');
-        else
-            scale.SetString(parts[IndexScale], ',');
-
-        if (scale[0].front() == '[')
-            scale[0].remove_prefix(1);
-
-        scale_size.x = scale[0].atoi();
-        if (scale.size() > 1)
-            scale_size.y = scale[1].atoi();
+        GetScaleInfo(scale_size, parts[IndexScale]);
     }
 
     if (parts[IndexType].contains("Art"))

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -102,6 +102,9 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_TYP
     // Make a copy of the string so that we can tweak it
     if (auto namespace_prop = project->prop_as_string(prop_name_space); namespace_prop.size())
     {
+        // BUGBUG: [KeyWorks - 01-25-2021] Need to look for base_class_name property of all children, and add each name
+        // as a forwarded class.
+
         // ttlib::multistr works with a single char, not a string.
         namespace_prop.Replace("::", ":");
         // we also accept using semi-colons to separate the namespaces
@@ -152,7 +155,8 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_TYP
         m_header->writeLine("public:");
         m_header->Indent();
 
-        m_header->writeLine(ttlib::cstr() << derived_name << "();  // If you use this constructor, you must call Create(parent)");
+        m_header->writeLine(ttlib::cstr() << derived_name
+                                          << "();  // If you use this constructor, you must call Create(parent)");
         m_header->writeLine(ttlib::cstr() << derived_name << "(wxWindow* parent);");
 
         m_header->Unindent();

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -89,7 +89,7 @@ std::optional<ttlib::cstr> AnimationGenerator::GenConstruction(Node* node)
 
     if (node->HasValue(prop_animation))
     {
-        ttlib::multistr parts(node->prop_as_string(prop_animation), ';');
+        ttlib::multiview parts(node->prop_as_string(prop_animation), ';');
         ttlib::cstr name(parts[IndexImage].filename());
         name.remove_extension();
         name.LeftTrim();

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -549,7 +549,7 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
 
     if (auto& growable = node->prop_as_string(prop_growablecols); growable.size())
     {
-        ttlib::multistr values(growable, ',');
+        ttlib::multiview values(growable, ',');
         for (auto& iter: values)
         {
             if (!isExpanded)
@@ -561,7 +561,7 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
             int proportion = 0;
             if (auto pos = iter.find(':'); ttlib::is_found(pos))
             {
-                proportion = ttlib::atoi(ttlib::find_nonspace(iter.c_str() + pos + 1));
+                proportion = ttlib::atoi(ttlib::find_nonspace(iter.data() + pos + 1));
             }
             code << "\n\t    " << node->get_node_name() << "->AddGrowableCol(" << val;
             if (proportion > 0)
@@ -572,7 +572,7 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
 
     if (auto& growable = node->prop_as_string(prop_growablerows); growable.size())
     {
-        ttlib::multistr values(growable, ',');
+        ttlib::multiview values(growable, ',');
         for (auto& iter: values)
         {
             if (!isExpanded)
@@ -584,7 +584,7 @@ std::optional<ttlib::cstr> FlexGridSizerGenerator::GenConstruction(Node* node)
             int proportion = 0;
             if (auto pos = iter.find(':'); ttlib::is_found(pos))
             {
-                proportion = ttlib::atoi(ttlib::find_nonspace(iter.c_str() + pos + 1));
+                proportion = ttlib::atoi(ttlib::find_nonspace(iter.data() + pos + 1));
             }
             code << "\n\t    " << node->get_node_name() << "->AddGrowableRow(" << val;
             if (proportion > 0)
@@ -768,7 +768,7 @@ std::optional<ttlib::cstr> GridBagSizerGenerator::GenConstruction(Node* node)
 
     if (auto& growable = node->prop_as_string(prop_growablerows); growable.size())
     {
-        ttlib::multistr values(growable, ',');
+        ttlib::multiview values(growable, ',');
         for (auto& iter: values)
         {
             if (!isExpanded)
@@ -780,7 +780,7 @@ std::optional<ttlib::cstr> GridBagSizerGenerator::GenConstruction(Node* node)
             int proportion = 0;
             if (auto pos = iter.find(':'); ttlib::is_found(pos))
             {
-                proportion = ttlib::atoi(ttlib::find_nonspace(iter.c_str() + pos + 1));
+                proportion = ttlib::atoi(ttlib::find_nonspace(iter.data() + pos + 1));
             }
             code << "\n\t    " << node->get_node_name() << "->AddGrowableRow(" << val;
             if (proportion > 0)

--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -18,7 +18,7 @@
 
 #include "node_creator.h"  // NodeCreator class
 
-void WriteCode::WriteCodeLine(ttlib::cview code, size_t indentation)
+void WriteCode::WriteCodeLine(ttlib::sview code, size_t indentation)
 {
     if (indentation == indent::auto_no_whitespace)
     {
@@ -80,7 +80,7 @@ void WriteCode::writeLine(std::string& code, size_t indentation)
     }
     if (ttlib::is_found(code.find('\n')))
     {
-        ttlib::multistr lines(code, '\n');
+        ttlib::multiview lines(code, '\n');
         for (auto& iter: lines)
         {
             WriteCodeLine(iter, indentation);
@@ -88,14 +88,11 @@ void WriteCode::writeLine(std::string& code, size_t indentation)
     }
     else
     {
-        code.erase(std::find_if(code.rbegin(), code.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(),
-                   code.end());
-
         WriteCodeLine(code, indentation);
     }
 }
 
-void WriteCode::writeLine(ttlib::cview code, bool auto_indent)
+void WriteCode::writeLine(ttlib::sview code, bool auto_indent)
 {
     if (code.empty())
     {
@@ -104,7 +101,7 @@ void WriteCode::writeLine(ttlib::cview code, bool auto_indent)
     }
     if (ttlib::is_found(code.find('\n')))
     {
-        ttlib::multistr lines(code, '\n');
+        ttlib::multiview lines(code, '\n');
         for (auto& iter: lines)
         {
             WriteCodeLine(iter, auto_indent);
@@ -125,7 +122,7 @@ void WriteCode::writeLine()
     m_IsLastLineBlank = true;
 }
 
-void WriteCode::write(ttlib::cview code, bool auto_indent)
+void WriteCode::write(ttlib::sview code, bool auto_indent)
 {
     // Early abort to not produce lines with trailing whitespace
     if (code.empty())
@@ -184,9 +181,9 @@ void PanelCodeWriter::Clear()
     m_Scintilla->ClearAll();
 }
 
-void PanelCodeWriter::doWrite(ttlib::cview code)
+void PanelCodeWriter::doWrite(ttlib::sview code)
 {
-    m_Scintilla->AddTextRaw(code);
+    m_Scintilla->AddTextRaw(code.data(), static_cast<int>(code.length()));
 }
 
 //////////////////////////////////////////// FileCodeWriter class /////////////////////////////////////////////

--- a/src/generate/write_code.h
+++ b/src/generate/write_code.h
@@ -35,13 +35,13 @@ public:
     void writeLine(std::string& lines, size_t indentation = indent::auto_no_whitespace);
 
     // This will NOT right trim a single line
-    void writeLine(ttlib::cview, bool auto_indent = true);
+    void writeLine(ttlib::sview, bool auto_indent = true);
 
     // Write an empty line (unless the previous line was also empty)
     void writeLine();
 
     // Write the code without adding a trailing \n.
-    void write(ttlib::cview code, bool auto_indent = true);
+    void write(ttlib::sview code, bool auto_indent = true);
 
     // Call this to prevent any further blank lines from being written until the next non-blank line is
     // written
@@ -51,9 +51,9 @@ public:
 
 protected:
     // Derived class provides this to write text to whatever output device is being used
-    virtual void doWrite(ttlib::cview code) = 0;
+    virtual void doWrite(ttlib::sview code) = 0;
 
-    void WriteCodeLine(ttlib::cview code, size_t indentation);
+    void WriteCodeLine(ttlib::sview code, size_t indentation);
 
 private:
     int m_indent { 0 };
@@ -71,7 +71,7 @@ public:
     void Clear() override;
 
 protected:
-    void doWrite(ttlib::cview code) override;
+    void doWrite(ttlib::sview code) override;
 
 private:
     wxStyledTextCtrl* m_Scintilla;
@@ -89,7 +89,7 @@ public:
     int WriteFile(bool test_only = false);
 
 protected:
-    void doWrite(ttlib::cview code) override { m_buffer << code; };
+    void doWrite(ttlib::sview code) override { m_buffer << code; };
 
     ttlib::cstr m_buffer;
 

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -711,7 +711,7 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
     else if (prop_name.is_sameas("style") && class_name.is_sameas("wxCheckBox"))
     {
         // wxCHK_2STATE and wxCHK_3STATE are part of the type property instead of style
-        ttlib::multistr styles(xml_prop.text().as_string());
+        ttlib::multiview styles(xml_prop.text().as_string());
         ttlib::cstr new_style;
         for (auto& iter: styles)
         {
@@ -755,8 +755,7 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
     }
     else if (prop_name.is_sameas("subclass"))
     {
-        ttlib::multistr parts(xml_prop.text().as_string());
-        parts[0].BothTrim();
+        ttlib::multistr parts(xml_prop.text().as_string(), ';', tt::TRIM::both);
         if (parts[0].empty())
             return;
         if (auto prop = newobject->get_prop_ptr(prop_derived_class); prop)
@@ -764,7 +763,6 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
             prop->set_value(parts[0]);
             if (parts.size() > 0 && !parts[1].contains("forward_declare"))
             {
-                parts[1].BothTrim();
                 prop = newobject->get_prop_ptr(prop_derived_header);
                 if (prop)
                 {

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -108,7 +108,7 @@ wxColour NodeProperty::as_color() const
     }
     else
     {
-        ttlib::multistr mstr(m_value, ',');
+        ttlib::multiview mstr(m_value, ',');
         unsigned long rgb = 0;
         if (mstr.size() > 2)
         {

--- a/src/pch.h
+++ b/src/pch.h
@@ -85,6 +85,7 @@
 #include "ttcstr.h"   // ttlib::cstr -- std::string with additional functions
 #include "ttcview.h"  // ttlib::cview -- string_view functionality on a zero-terminated char string.
 #include "ttstr.h"    // ttString -- wxString with ttlib::cstr equivalent functions
+#include "ttsview.h"  // sview -- std::string_view with additional methods
 
 #if !defined(int_t)
 

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -50,7 +50,7 @@ public:
     wxAnimation GetPropertyAnimation(const ttlib::cstr& description);
 
     bool AddEmbeddedImage(ttlib::cstr path, Node* form);
-    const EmbededImage* GetEmbeddedImage(ttlib::cstr path);
+    const EmbededImage* GetEmbeddedImage(ttlib::sview path);
 
     // This will launch a thread to start collecting all the embedded images in the project
     void ParseEmbeddedImages();
@@ -70,7 +70,7 @@ private:
 
     std::thread* m_collect_thread { nullptr };
 
-    std::map<std::string, std::unique_ptr<EmbededImage>> m_map_embedded;
+    std::map<std::string, std::unique_ptr<EmbededImage>, std::less<>> m_map_embedded;
 
     bool m_is_terminating { false };
 };

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -227,11 +227,7 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
                     {
                         // Old style conversion -- remove once we're certain all projects have been updated
 
-                        ttlib::multistr parts(iter.value(), BMP_PROP_SEPARATOR);
-                        for (auto& iter_parts: parts)
-                        {
-                            iter_parts.BothTrim();
-                        }
+                        ttlib::multiview parts(iter.value(), BMP_PROP_SEPARATOR, tt::TRIM::both);
 
                         ttlib::cstr bitmap(parts[IndexType]);
                         bitmap << "; " << parts[IndexImage];

--- a/src/utils/font_prop.cpp
+++ b/src/utils/font_prop.cpp
@@ -38,11 +38,11 @@ FontProperty::FontProperty(ttlib::cview font)
 void FontProperty::Convert(ttlib::cview font)
 {
     // face name, style, weight, point size, family, underlined, aliased, encoding
-    ttlib::multistr mstr(font, ',');
+    ttlib::multiview mstr(font, ',');
 
     if (mstr.size() > 0)
     {
-        m_face = mstr[0];
+        m_face = mstr[0].wx_str();
     }
 
     if (mstr.size() > 1)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -40,7 +40,7 @@ ttlib::cstr ClearPropFlag(ttlib::cview flag, ttlib::cview currentValue)
         return result;
     }
 
-    ttlib::multistr mstr(currentValue, '|');
+    ttlib::multiview mstr(currentValue, '|');
     for (auto& iter: mstr)
     {
         if (iter != flag)
@@ -95,10 +95,10 @@ ttlib::cstr SetPropFlag(ttlib::cview flag, ttlib::cview currentValue)
         return result;
     }
 
-    ttlib::multistr mstr(currentValue, '|');
+    ttlib::multiview mstr(currentValue, '|');
     for (auto& iter: mstr)
     {
-        if (iter == flag)
+        if (iter.is_sameas(flag))
         {
             return result;  // flag has already been added
         }
@@ -256,7 +256,7 @@ wxColour ConvertToColour(ttlib::cview value)
     }
     else
     {
-        ttlib::multistr mstr(value, ',');
+        ttlib::multiview mstr(value, ',');
         unsigned long rgb = 0;
         if (mstr.size() > 2)
         {
@@ -455,4 +455,18 @@ wxSize DlgSize(wxObject* parent, Node* node, GenEnum::PropName prop)
     {
         return node->prop_as_wxSize(prop);
     }
+}
+
+void GetScaleInfo(wxSize& size, ttlib::sview description)
+{
+    ttlib::multiview scale;
+    if (description.contains(";"))
+        scale.SetString(description, ';', tt::TRIM::left);
+    else
+        scale.SetString(description, ',');
+
+    size_t start = scale[0].front() == '[' ? 1 : 0;
+    size.x = scale[0].atoi(start);
+    if (scale.size() > 1)
+        size.y = scale[1].atoi();
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -9,7 +9,8 @@
 
 #include <wx/settings.h>
 
-#include "ttcstr.h"  // ttlib::cstr -- std::string with additional methods
+#include "ttcstr.h"   // ttlib::cstr -- std::string with additional methods
+#include "ttsview.h"  // sview -- std::string_view with additional methods
 
 #include "gen_enums.h"  // Enumerations for generators
 
@@ -73,3 +74,6 @@ wxPoint DlgPoint(wxObject* parent, Node* node, GenEnum::PropName prop);
 
 // If the property specifies dialog units, then parent will be used to do the conversion
 wxSize DlgSize(wxObject* parent, Node* node, GenEnum::PropName prop);
+
+// Convert the parts[IndexScale] or equivalent string into wxSize dimensions
+void GetScaleInfo(wxSize& size, ttlib::sview description);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
**ttLib** added a `ttllib::sview` class (`std::string_view` with additional methods) and updated the `ttlib::multiview` class to use the new `sview` class. Between the two, it makes it possible to split apart strings in place with no memory allocation/copying overhead, and still have almost all of the methods that ttlib::cstr/ttlib::cview provide. As a way to improve performance, this PR refactors code that was using `ttlib::multistr` so that most of it now uses `ttlib::multiview`.