### PR TITLE
Remove C++17 checkbox from Convert Image dialog

### DIFF
--- a/src/ui/embedimg.cpp
+++ b/src/ui/embedimg.cpp
@@ -162,7 +162,7 @@ void EmbedImage::OnInputChange(wxFileDirPickerEvent& WXUNUSED(event))
     m_orginal_size = 0;
 
     bool isImageLoaded { false };
-    if (file.has_extension(".h_img"))
+    if (file.has_extension(".h_img") || file.has_extension(".h"))
     {
         {
             wxBusyCursor wait;
@@ -173,8 +173,8 @@ void EmbedImage::OnInputChange(wxFileDirPickerEvent& WXUNUSED(event))
         {
             isImageLoaded = true;
 
-            // Note that we allow header to header conversion. That makes converting wxFormBuilder headers, and the options
-            // png conversion and c++17.
+            // Note that we allow header to header conversion. That makes converting wxFormBuilder headers, and changing
+            // conversion options.
         }
         else
         {
@@ -976,14 +976,6 @@ void EmbedImage::OnCheckPngConversion(wxCommandEvent& WXUNUSED(event))
     {
         EnableConvertButton();
         AdjustOutputFilename();
-    }
-}
-
-void EmbedImage::OnC17Encoding(wxCommandEvent& WXUNUSED(event))
-{
-    if (IsHeaderPage())
-    {
-        EnableConvertButton();
     }
 }
 

--- a/src/ui/embedimg.h
+++ b/src/ui/embedimg.h
@@ -27,7 +27,6 @@ protected:
 
     // Handlers for EmbedImageBase events.
 
-    void OnC17Encoding(wxCommandEvent& event) override;
     void OnCheckPngConversion(wxCommandEvent& event) override;
     void OnConvert(wxCommandEvent& event) override;
     void OnConvertAlpha(wxCommandEvent& event) override;

--- a/src/ui/embedimg_base.cpp
+++ b/src/ui/embedimg_base.cpp
@@ -84,10 +84,6 @@ bool EmbedImageBase::Create(wxWindow *parent, wxWindowID id, const wxString &tit
     m_check_make_png->SetToolTip(wxString::FromUTF8("If checked, image will be converted to PNG before being saved."));
     box_sizer_2->Add(m_check_make_png, wxSizerFlags().Border(wxALL));
 
-    m_check_c17 = new wxCheckBox(hdr_static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("C++1&7 &encoding"));
-    m_check_c17->SetToolTip(wxString::FromUTF8("If checked, this will prefix the array with \"inline constexpr\" instead of \"static\"."));
-    box_sizer_2->Add(m_check_c17, wxSizerFlags().Border(wxALL));
-
     m_ForceHdrMask = new wxCheckBox(hdr_static_box->GetStaticBox(), wxID_ANY, wxString::FromUTF8("&Force Mask"));
     m_ForceHdrMask->SetToolTip(wxString::FromUTF8("Check this to override any mask specified in the original image file."));
     box_sizer_2->Add(m_ForceHdrMask, wxSizerFlags().Border(wxALL));
@@ -203,7 +199,6 @@ bool EmbedImageBase::Create(wxWindow *parent, wxWindowID id, const wxString &tit
     m_fileOutput->Bind(wxEVT_FILEPICKER_CHANGED, &EmbedImageBase::OnOutputChange, this);
     m_choicebook->Bind(wxEVT_CHOICEBOOK_PAGE_CHANGED, &EmbedImageBase::OnPageChanged, this);
     m_check_make_png->Bind(wxEVT_CHECKBOX, &EmbedImageBase::OnCheckPngConversion, this);
-    m_check_c17->Bind(wxEVT_CHECKBOX, &EmbedImageBase::OnC17Encoding, this);
     m_ForceHdrMask->Bind(wxEVT_CHECKBOX, &EmbedImageBase::OnForceHdrMask, this);
     m_comboHdrMask->Bind(wxEVT_COMBOBOX, &EmbedImageBase::OnComboHdrMask, this);
     m_ConvertAlphaChannel->Bind(wxEVT_CHECKBOX, &EmbedImageBase::OnConvertAlpha, this);

--- a/src/ui/embedimg_base.h
+++ b/src/ui/embedimg_base.h
@@ -41,7 +41,6 @@ protected:
     wxCheckBox* m_ConvertAlphaChannel;
     wxCheckBox* m_ForceHdrMask;
     wxCheckBox* m_ForceXpmMask;
-    wxCheckBox* m_check_c17;
     wxCheckBox* m_check_make_png;
     wxChoicebook* m_choicebook;
     wxComboBox* m_comboHdrMask;
@@ -62,7 +61,6 @@ protected:
 
     // Virtual event handlers -- override them in your derived class
 
-    virtual void OnC17Encoding(wxCommandEvent& event) { event.Skip(); }
     virtual void OnCheckPngConversion(wxCommandEvent& event) { event.Skip(); }
     virtual void OnComboHdrMask(wxCommandEvent& event) { event.Skip(); }
     virtual void OnComboXpmMask(wxCommandEvent& event) { event.Skip(); }

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -326,12 +326,6 @@
                       wxEVT_CHECKBOX="OnCheckPngConversion" />
                     <node
                       class="wxCheckBox"
-                      label="C++1&amp;7 &amp;encoding"
-                      var_name="m_check_c17"
-                      tooltip="If checked, this will prefix the array with &quot;inline constexpr&quot; instead of &quot;static&quot;."
-                      wxEVT_CHECKBOX="OnC17Encoding" />
-                    <node
-                      class="wxCheckBox"
                       label="&amp;Force Mask"
                       var_name="m_ForceHdrMask"
                       tooltip="Check this to override any mask specified in the original image file."


### PR DESCRIPTION
Closes #428

This also re-enables converting a .h file in order to convert wxFormBuilder header files.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
