### PR TITLE
Change GenConstruction() virtual method

### DIFF
--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -18,6 +18,7 @@ class MockupParent;
 class wxWindow;
 class wxMouseEvent;
 class WriteCode;
+class BaseCodeGenerator;
 
 namespace pugi
 {
@@ -58,7 +59,7 @@ public:
     virtual std::optional<ttlib::cstr> GenConstruction(Node*) { return {}; }
 
     // Return true if all construction and settings code was written to src_code
-    virtual bool GenConstruction(Node*, WriteCode* /* src_code */) { return false; }
+    virtual bool GenConstruction(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
 
     // Generate specific additional code
     virtual std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType /* command */, Node* /* node */) { return {}; }

--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -7,6 +7,7 @@
 
 #include "pch.h"
 
+#include "gen_base.h"    // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "gen_common.h"  // GeneratorLibrary -- Generator classes
 #include "node.h"        // Node class
 #include "utils.h"       // Utility functions that work with properties
@@ -16,15 +17,18 @@
 
 //////////////////////////////////////////  DialogFormGenerator  //////////////////////////////////////////
 
-bool DialogFormGenerator::GenConstruction(Node* node, WriteCode* src_code)
+bool DialogFormGenerator::GenConstruction(Node* node, BaseCodeGenerator* code_gen)
 {
+    auto src_code = code_gen->GetSrcWriter();
+
     ttlib::cstr code;
 
-    code
-        << "bool " << node->prop_as_string(prop_class_name)
-        << "::Create(wxWindow *parent, wxWindowID id, const wxString &title,\n\t\tconst wxPoint&pos, const wxSize& size, long "
-           "style, const wxString &name)\n{\n\tif (!wxDialog::Create(parent, id, title, pos, size, style, name))\n\t\treturn "
-           "false;\n\n";
+    code << "bool " << node->prop_as_string(prop_class_name)
+         << "::Create(wxWindow *parent, wxWindowID id, const wxString &title,\n\t\tconst wxPoint&pos, const wxSize& size, "
+            "long "
+            "style, const wxString &name)\n{\n\tif (!wxDialog::Create(parent, id, title, pos, size, style, "
+            "name))\n\t\treturn "
+            "false;\n\n";
 
     src_code->writeLine(code, indent::none);
     src_code->Indent();
@@ -39,6 +43,8 @@ bool DialogFormGenerator::GenConstruction(Node* node, WriteCode* src_code)
 
     if (node->HasValue(prop_icon))
     {
+        code_gen->GenerateHandlers();
+
         auto image_code = GenerateBitmapCode(node->prop_as_string(prop_icon));
         if (!image_code.contains(".Scale") && image_code.is_sameprefix("wxImage("))
         {
@@ -367,8 +373,10 @@ bool PopupWinGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 
 //////////////////////////////////////////  PanelFormGenerator  //////////////////////////////////////////
 
-bool PanelFormGenerator::GenConstruction(Node* node, WriteCode* src_code)
+bool PanelFormGenerator::GenConstruction(Node* node, BaseCodeGenerator* code_gen)
 {
+    auto src_code = code_gen->GetSrcWriter();
+
     ttlib::cstr code;
     code << node->prop_as_string(prop_class_name) << "::" << node->prop_as_string(prop_class_name);
 

--- a/src/generate/form_widgets.h
+++ b/src/generate/form_widgets.h
@@ -37,7 +37,7 @@ class PanelFormGenerator : public BaseGenerator
 {
 public:
     // Return true if all construction and settings code was written to src_code
-    bool GenConstruction(Node*, WriteCode* src_code) override;
+    bool GenConstruction(Node*, BaseCodeGenerator* code_gen) override;
 
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
@@ -49,7 +49,7 @@ class DialogFormGenerator : public BaseGenerator
 {
 public:
     // Return true if all construction and settings code was written to src_code
-    bool GenConstruction(Node*, WriteCode* src_code) override;
+    bool GenConstruction(Node*, BaseCodeGenerator* code_gen) override;
 
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1113,22 +1113,9 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
                     m_source->writeLine(iter_line, indent::none);
                     if (iter_line.front() == '{')
                     {
-                        for (auto& iter_img: m_embedded_images)
-                        {
-                            m_source->Indent();
-                            if (iter_img->type != wxBITMAP_TYPE_BMP &&
-                                m_type_generated.find(iter_img->type) == m_type_generated.end())
-                            {
-                                m_source->writeLine(ttlib::cstr("if (!wxImage::FindHandler(")
-                                                    << g_map_types[iter_img->type] << "))");
-                                m_source->Indent();
-                                m_source->writeLine(ttlib::cstr("\twxImage::AddHandler(new ")
-                                                    << g_map_handlers[iter_img->type] << ");");
-                                m_source->Unindent();
-                                m_type_generated.insert(iter_img->type);
-                            }
-                            m_source->Unindent();
-                        }
+                        m_source->Indent();
+                        GenerateHandlers();
+                        m_source->Unindent();
                     }
                 }
             }
@@ -1150,21 +1137,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
         m_source->Indent();
     }
 
-    if (m_embedded_images.size())
-    {
-        for (auto& iter_img: m_embedded_images)
-        {
-            if (iter_img->type != wxBITMAP_TYPE_BMP && m_type_generated.find(iter_img->type) == m_type_generated.end())
-            {
-                m_source->writeLine(ttlib::cstr("if (!wxImage::FindHandler(") << g_map_types[iter_img->type] << "))");
-                m_source->Indent();
-                m_source->writeLine(ttlib::cstr("\twxImage::AddHandler(new ") << g_map_handlers[iter_img->type] << ");");
-                m_source->Unindent();
-                m_type_generated.insert(iter_img->type);
-            }
-        }
-        m_source->writeLine();
-    }
+    GenerateHandlers();
 
     if (form_node->get_prop_ptr(prop_window_extra_style))
     {
@@ -1696,5 +1669,24 @@ void BaseCodeGenerator::GenCtxConstruction(Node* node)
             }
             m_source->writeLine();
         }
+    }
+}
+
+void BaseCodeGenerator::GenerateHandlers()
+{
+    if (m_embedded_images.size())
+    {
+        for (auto& iter_img: m_embedded_images)
+        {
+            if (iter_img->type != wxBITMAP_TYPE_BMP && m_type_generated.find(iter_img->type) == m_type_generated.end())
+            {
+                m_source->writeLine(ttlib::cstr("if (!wxImage::FindHandler(") << g_map_types[iter_img->type] << "))");
+                m_source->Indent();
+                m_source->writeLine(ttlib::cstr("\twxImage::AddHandler(new ") << g_map_handlers[iter_img->type] << ");");
+                m_source->Unindent();
+                m_type_generated.insert(iter_img->type);
+            }
+        }
+        m_source->writeLine();
     }
 }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1096,7 +1096,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
 
     auto generator = form_node->GetNodeDeclaration()->GetGenerator();
 
-    if (!generator->GenConstruction(form_node, m_source))
+    if (!generator->GenConstruction(form_node, this))
     {
         if (auto result = generator->GenConstruction(form_node); result)
         {

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -58,6 +58,7 @@ class BaseCodeGenerator
 public:
     BaseCodeGenerator();
 
+
     void SetHdrWriteCode(WriteCode* cw) { m_header = cw; }
     void SetSrcWriteCode(WriteCode* cw) { m_source = cw; }
 
@@ -67,6 +68,9 @@ public:
 
     // Returns result::fail, result::exists, result::created, or result::ignored
     int GenerateDerivedClass(Node* project, Node* form_node, PANEL_TYPE panel_type = NOT_PANEL);
+
+    // Write code to m_source that will load any handlers needed by the form's class
+    void GenerateHandlers();
 
 protected:
     void GenCtxConstruction(Node* node);

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -69,6 +69,9 @@ public:
     // Returns result::fail, result::exists, result::created, or result::ignored
     int GenerateDerivedClass(Node* project, Node* form_node, PANEL_TYPE panel_type = NOT_PANEL);
 
+    auto GetHeaderWriter() { return m_header; }
+    auto GetSrcWriter() { return m_source; }
+
     // Write code to m_source that will load any handlers needed by the form's class
     void GenerateHandlers();
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the virtual `GenConstruction()` method to take a `BaseCodeGenerator*` parameter instead of a `WriteCode*` parameter. This gives access to the `GenerateHandlers()` function which will generate the code in the source file that loads any image handlers needed by the generated class.

Currently, this only gets used by the wxDialog generator, allowing it to generate any handlers needed to load an image to use as the dialog's icon.