### PR TITLE
Add UpdateEmbedNodes() function to ProjectSettings

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -120,6 +120,12 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
     std::thread thrd_get_events(&BaseCodeGenerator::CollectEventHandlers, this, form_node, std::ref(events));
     std::thread thrd_need_img_func(&BaseCodeGenerator::ParseImageProperties, this, form_node);
 
+    // If the code files are being written to disk, then UpdateEmbedNodes() has already been called.
+    if (panel_type != NOT_PANEL)
+    {
+        wxGetApp().GetProjectSettings()->UpdateEmbedNodes();
+    }
+
     m_panel_type = panel_type;
 
     m_header->Clear();
@@ -1498,7 +1504,6 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
                     m_embedded_images.emplace_back(embed);
                 }
             }
-            // else if (iter.type() == type_image)
             else if (value.is_sameprefix("Header") || value.is_sameprefix("XPM"))
             {
                 ttlib::multiview parts(value);

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -405,6 +405,7 @@ void MainFrame::OnImportProject(wxCommandEvent&)
 
 void MainFrame::OnGenerateCode(wxCommandEvent&)
 {
+    wxGetApp().GetProjectSettings()->UpdateEmbedNodes();
     GenerateCodeFiles(this);
     m_isProject_generated = true;
 

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -30,6 +30,12 @@ public:
     ProjectSettings();
     ~ProjectSettings();
 
+    // This will parse the entire project, and ensure that each embedded image is associated
+    // with the form node of the form it first appears in.
+    //
+    // Returns true if an associated node changed
+    bool UpdateEmbedNodes();
+
     ttlib::cstr& getProjectFile() { return m_projectFile; }
     ttString GetProjectFile() { return ttString() << m_projectFile.wx_str(); }
 
@@ -50,12 +56,13 @@ public:
     wxAnimation GetPropertyAnimation(const ttlib::cstr& description);
 
     bool AddEmbeddedImage(ttlib::cstr path, Node* form);
-    const EmbededImage* GetEmbeddedImage(ttlib::sview path);
+    EmbededImage* GetEmbeddedImage(ttlib::sview path);
 
     // This will launch a thread to start collecting all the embedded images in the project
     void ParseEmbeddedImages();
 
 protected:
+    bool CheckNode(Node* node);
     void CollectEmbeddedImages();
     void CollectNodeImages(Node* node, Node* form);
 


### PR DESCRIPTION
This PR adds a method to the `ProjectSettings` class which can be called to ensure that all embedded images have the correct form node for where they first appeared. The method is called before displaying source or header code in the **Generated** panel, and before code gets written to disk. 

Closes #406

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
