### PR TITLE
Improve .cmake generation

### DIFF
--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -47,9 +47,21 @@ int WriteCMakeFile(bool test_only)
     out.emplace_back();
     out.at(out.size() - 1) << "set (" << project->prop_as_string(prop_cmake_varname) << '\n';
 
+    std::set<ttlib::cstr> base_files;
+
     for (auto& iter: project->GetChildNodePtrs())
     {
         ttlib::cstr base_file = iter->prop_as_string(prop_base_file);
+        // "filename_base" is the default filename given to all form files. Unless it's changed, no code will be
+        // generated.
+        if (base_file == "filename_base")
+            continue;
+
+        base_files.emplace(base_file);
+    }
+
+    for (auto base_file: base_files)
+    {
         base_file.make_relative(wxGetApp().getProjectPath());
         base_file.backslashestoforward();
         base_file.remove_extension();

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -48,6 +48,9 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
 
     if (WriteCMakeFile(NeedsGenerateCheck) != result::exists)
     {
+        if (NeedsGenerateCheck && !pClassList)
+            return true;
+
         ++currentFiles;
         results.emplace_back() << project->prop_as_string(prop_cmake_file) << " saved" << '\n';
     }

--- a/testing/src/ui/wxui_code.cmake
+++ b/testing/src/ui/wxui_code.cmake
@@ -4,17 +4,17 @@
 
 set (wxue_generated_code
 
-    ${CMAKE_CURRENT_LIST_DIR}/mainframe_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/commonctrls_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/ribbondlg_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/wizard_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/choicebook_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/notebook_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/listbook_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/treebook_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/toolbook_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/popupwin_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/other_ctrls_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/commonctrls_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dlgmultitest_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/listbook_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mainframe_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/notebook_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/other_ctrls_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/popupwin_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ribbondlg_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/toolbook_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/treebook_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wizard_base.cpp
 
 )


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes some minor changes to how the .cmake file is generated:

- No longer adds source file if it is the default filename_base
- Properly indicates that code needs to be generated if .cmake would change
- Sorts the filenames in the .cmake list

Closes #462
