### PR TITLE
Use activation even to track idle time for wakatime reporting

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -485,6 +485,17 @@ void MainFrame::ProjectLoaded()
 
     m_selected_node = wxGetApp().GetProjectPtr();
 
+    if (!m_iswakatime_bound)
+    {
+        m_iswakatime_bound = true;
+        Bind(wxEVT_ACTIVATE,
+             [this](wxActivateEvent&)
+             {
+                 if (m_wakatime && wxTheApp->IsActive())
+                     m_wakatime->ResetHeartbeat();
+             });
+    }
+
     UpdateFrame();
 }
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -296,6 +296,8 @@ private:
     bool m_isProject_generated { false };
     bool m_isProject_modified { false };
 
+    bool m_iswakatime_bound { false };
+
     // If true, the entire project was imported, and a Save As must be done before a Save is
     // allowed.
     bool m_isImported { false };

--- a/src/wakatime.cpp
+++ b/src/wakatime.cpp
@@ -154,3 +154,17 @@ void WakaTime::SendHeartbeat(bool FileSavedEvent)
         }
     }
 }
+
+void WakaTime::ResetHeartbeat()
+{
+    auto result = time(nullptr);
+
+    if (result > m_last_heartbeat && (result - m_last_heartbeat >= waka_interval))
+    {
+        // If the user just switched away for a short period of time, we'll continue sending the heartbeats normally.
+        // However, if too much time has passed, then reset the heartbeat timer so that the user doesn't get credited for
+        // time spent with another app activated.
+
+        m_last_heartbeat = static_cast<intmax_t>(result);
+    }
+}

--- a/src/wakatime.h
+++ b/src/wakatime.h
@@ -12,6 +12,11 @@ class WakaTime
 public:
     WakaTime();
 
+    // Call this to reset the heartbeat timer so that the next heartbeat won't get sent for
+    // two minutes. This is used to prevent app switching from generating heartbeats even
+    // though wxUiEditor wasn't being used.
+    void ResetHeartbeat();
+
     void SendHeartbeat(bool FileSavedEvent = false);
 
     static bool IsWakaTimeAvailable();


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR handles a wxEVT_ACTIVATE event, and if the app is active, it calls into the wakatime handler to possibly reset the heartbeat counter. The wakatime handler looks to see how long it's been since the last heartbeat, and if it was too long it resets the counter -- which means no more heartbeat sent until the next interval.

This is _not_ a perfect solution. This might delay the heartbeat to the point that when the next legitimate heartbeat is sent to wakatime, then the idle time interval will be too great, and wakatime will discard it. However, the worst case in this scenario is the user isn't credited for two minutes of time.

Closes #474