### PR TITLE
Replace '\n' with blank line when creating .cmake file

### DIFF
--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -45,7 +45,8 @@ int WriteCMakeFile(bool test_only)
     out.emplace_back();
 
     out.emplace_back();
-    out.at(out.size() - 1) << "set (" << project->prop_as_string(prop_cmake_varname) << '\n';
+    out.at(out.size() - 1) << "set (" << project->prop_as_string(prop_cmake_varname);
+    out.emplace_back();
 
     std::set<ttlib::cstr> base_files;
 


### PR DESCRIPTION
In order to compare with what's on disk, you can't use '\n' to get a blank line since it means the number of lines won't match until after the file is written.

Closes #481

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
