### PR TITLE
Update Lambda formatting, regenerate files containing lambdas

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -549,16 +549,16 @@ void BaseCodeGenerator::GenSrcEventBinding(Node* node, const EventVector& events
                         {
                             m_source->Unindent();
                         }
-
-                        m_source->writeLine(code, indent::auto_keep_whitespace);
-
-                        if (code.contains("{"))
-                        {
-                            m_source->Indent();
-                        }
                         else if (!initial_bracket && code.contains("["))
                         {
                             initial_bracket = true;
+                            m_source->Indent();
+                        }
+
+                        m_source->writeLine(code, indent::auto_no_whitespace);
+
+                        if (code.contains("{"))
+                        {
                             m_source->Indent();
                         }
                     }

--- a/src/ui/eventhandlerdlg.cpp
+++ b/src/ui/eventhandlerdlg.cpp
@@ -190,13 +190,10 @@ void EventHandlerDlg::OnOK(wxCommandEvent& event)
         if (m_check_include_event->GetValue())
             handler << " event";
 
-        // REVIEW: [KeyWorks - 03-16-2021] Currently, our code generation assumes the entire lambda is a single line, so
-        // retaining any formatting is going to make the code generation look fairly terrible.
-
         ttlib::cstr body(m_stc->GetTextRaw().data());
 
         CompressLambda(body);
-        handler << ")@@{ " << body << "@@}";
+        handler << ")@@{" << body << "@@}";
         m_value = handler.wx_str();
     }
 

--- a/src/ui/insertwidget_base.cpp
+++ b/src/ui/insertwidget_base.cpp
@@ -42,8 +42,10 @@ bool InsertWidgetBase::Create(wxWindow *parent, wxWindowID id, const wxString &t
     Bind(wxEVT_INIT_DIALOG, &InsertWidgetBase::OnInit, this);
     m_text_name->Bind(wxEVT_TEXT, &InsertWidgetBase::OnNameText, this);
     m_listBox->Bind(wxEVT_LISTBOX,
-        [this](wxCommandEvent&) { m_stdBtn->GetAffirmativeButton()->Enable(); }
-        );
+        [this](wxCommandEvent&)
+        {
+            m_stdBtn->GetAffirmativeButton()->Enable();
+        } );
     m_listBox->Bind(wxEVT_LISTBOX_DCLICK, &InsertWidgetBase::OnListBoxDblClick, this);
     Bind(wxEVT_BUTTON, &InsertWidgetBase::OnOK, this, wxID_OK);
 

--- a/src/ui/mainframe_base.cpp
+++ b/src/ui/mainframe_base.cpp
@@ -376,15 +376,24 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     // Event handlers
     Bind(wxEVT_CLOSE_WINDOW, &MainFrameBase::OnClose, this);
     Bind(wxEVT_MENU,
-        [](wxCommandEvent&) { wxGetApp().NewProject(true); },
+        [](wxCommandEvent&)
+        {
+            wxGetApp().NewProject(true);
+        },
         id_NewProject);
     Bind(wxEVT_MENU, &MainFrameBase::OnOpenProject, this, id_OpenProject);
     Bind(wxEVT_MENU,
-        [](wxCommandEvent&) { wxGetApp().NewProject(false); },
+        [](wxCommandEvent&)
+        {
+            wxGetApp().NewProject(false);
+        },
         menu_import->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveProject, this, wxID_SAVE);
     Bind(wxEVT_UPDATE_UI,
-        [](wxUpdateUIEvent& event) { event.Enable(wxGetFrame().IsModified()); },
+        [](wxUpdateUIEvent& event)
+        {
+            event.Enable(wxGetFrame().IsModified());
+        },
         wxID_SAVE);
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveAsProject, this, id_SaveProjectAs);
     Bind(wxEVT_MENU, &MainFrameBase::OnImportWindowsResource, this, id_AppendWinRes);
@@ -394,46 +403,82 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendXRC, this, id_AppendXRC);
     Bind(wxEVT_MENU, &MainFrameBase::OnOptionsDlg, this, id_OptionsDlg);
     Bind(wxEVT_MENU,
-        [](wxCommandEvent&) { wxGetFrame().Undo(); },
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().Undo();
+        },
         wxID_UNDO);
     Bind(wxEVT_UPDATE_UI,
-        [](wxUpdateUIEvent& event) { event.Enable(wxGetFrame().CanUndo()); },
+        [](wxUpdateUIEvent& event)
+        {
+            event.Enable(wxGetFrame().CanUndo());
+        },
         wxID_UNDO);
     Bind(wxEVT_MENU,
-        [](wxCommandEvent&) { wxGetFrame().Redo(); },
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().Redo();
+        },
         wxID_REDO);
     Bind(wxEVT_UPDATE_UI,
-        [](wxUpdateUIEvent& event) { event.Enable(wxGetFrame().CanRedo()); },
+        [](wxUpdateUIEvent& event)
+        {
+            event.Enable(wxGetFrame().CanRedo());
+        },
         wxID_REDO);
     Bind(wxEVT_MENU, &MainFrameBase::OnCut, this, wxID_CUT);
     Bind(wxEVT_UPDATE_UI,
-        [](wxUpdateUIEvent& event) { event.Enable(wxGetFrame().CanCopyNode()); },
+        [](wxUpdateUIEvent& event)
+        {
+            event.Enable(wxGetFrame().CanCopyNode());
+        },
         wxID_CUT);
     Bind(wxEVT_MENU, &MainFrameBase::OnCopy, this, wxID_COPY);
     Bind(wxEVT_UPDATE_UI,
-        [](wxUpdateUIEvent& event) { event.Enable(wxGetFrame().CanCopyNode()); },
+        [](wxUpdateUIEvent& event)
+        {
+            event.Enable(wxGetFrame().CanCopyNode());
+        },
         wxID_COPY);
     Bind(wxEVT_MENU, &MainFrameBase::OnPaste, this, wxID_PASTE);
     Bind(wxEVT_UPDATE_UI,
-        [](wxUpdateUIEvent& event) { event.Enable(wxGetFrame().CanPasteNode()); },
+        [](wxUpdateUIEvent& event)
+        {
+            event.Enable(wxGetFrame().CanPasteNode());
+        },
         wxID_PASTE);
     Bind(wxEVT_MENU, &MainFrameBase::OnDelete, this, wxID_DELETE);
     Bind(wxEVT_UPDATE_UI,
-        [](wxUpdateUIEvent& event) { event.Enable(wxGetFrame().CanCopyNode()); },
+        [](wxUpdateUIEvent& event)
+        {
+            event.Enable(wxGetFrame().CanCopyNode());
+        },
         wxID_DELETE);
     Bind(wxEVT_MENU, &MainFrameBase::OnFindDialog, this, wxID_FIND);
     Bind(wxEVT_MENU, &MainFrameBase::OnInsertWidget, this, id_insert_widget);
     Bind(wxEVT_MENU,
-        [](wxCommandEvent&) { wxGetFrame().MoveNode(MoveDirection::Up); },
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().MoveNode(MoveDirection::Up);
+        },
         id_MoveUp);
     Bind(wxEVT_MENU,
-        [](wxCommandEvent&) { wxGetFrame().MoveNode(MoveDirection::Down); },
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().MoveNode(MoveDirection::Down);
+        },
         id_MoveDown);
     Bind(wxEVT_MENU,
-        [](wxCommandEvent&) { wxGetFrame().MoveNode(MoveDirection::Left); },
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().MoveNode(MoveDirection::Left);
+        },
         id_MoveLeft);
     Bind(wxEVT_MENU,
-        [](wxCommandEvent&) { wxGetFrame().MoveNode(MoveDirection::Right); },
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().MoveNode(MoveDirection::Right);
+        },
         id_MoveRight);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignLeft);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignCenterHorizontal);

--- a/src/ui/newdialog_base.cpp
+++ b/src/ui/newdialog_base.cpp
@@ -79,8 +79,10 @@ bool NewDialogBase::Create(wxWindow *parent, wxWindowID id, const wxString &titl
     // Event handlers
     Bind(wxEVT_INIT_DIALOG, &NewDialogBase::OnInit, this);
     m_check_tabs->Bind(wxEVT_CHECKBOX,
-        [this](wxCommandEvent&) { m_spinCtrlTabs->Enable(m_check_tabs->GetValue()); }
-        );
+        [this](wxCommandEvent&)
+        {
+            m_spinCtrlTabs->Enable(m_check_tabs->GetValue());
+        } );
 
     return true;
 }

--- a/src/ui/newframe_base.cpp
+++ b/src/ui/newframe_base.cpp
@@ -69,8 +69,11 @@ bool NewFrameBase::Create(wxWindow *parent, wxWindowID id, const wxString &title
 
     // Event handlers
     Bind(wxEVT_INIT_DIALOG,
-        [this](wxInitDialogEvent& event) { m_classname->SetFocus();  event.Skip(); }
-        );
+        [this](wxInitDialogEvent& event)
+        {
+            m_classname->SetFocus();
+            event.Skip();
+        } );
     m_checkBox_mainframe->Bind(wxEVT_CHECKBOX, &NewFrameBase::OnCheckMainFrame, this);
 
     return true;

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -899,7 +899,7 @@
             size="-1,300"
             flags="wxEXPAND"
             proportion="1"
-            wxEVT_LISTBOX="[this](wxCommandEvent&amp;) { m_stdBtn->GetAffirmativeButton()->Enable(); }"
+            wxEVT_LISTBOX="[this](wxCommandEvent&amp;)@@{@@m_stdBtn->GetAffirmativeButton()->Enable();@@}"
             wxEVT_LISTBOX_DCLICK="OnListBoxDblClick" />
         </node>
         <node
@@ -933,7 +933,7 @@
             id="id_NewProject"
             label="&amp;New Project...&#09;Ctrl+N"
             var_name="menuItem"
-            wxEVT_MENU="[](wxCommandEvent&amp;) { wxGetApp().NewProject(true); }" />
+            wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@wxGetApp().NewProject(true);@@}" />
           <node
             class="wxMenuItem"
             bitmap="Art; wxART_FILE_OPEN|wxART_MENU; [-1,-1]"
@@ -951,7 +951,7 @@
             class="wxMenuItem"
             label="&amp;Import..."
             var_name="menu_import"
-            wxEVT_MENU="[](wxCommandEvent&amp;) { wxGetApp().NewProject(false); }" />
+            wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@wxGetApp().NewProject(false);@@}" />
           <node
             class="separator" />
           <node
@@ -961,7 +961,7 @@
             id="wxID_SAVE"
             label="&amp;Save&#09;Ctrl+S"
             wxEVT_MENU="OnSaveProject"
-            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event) { event.Enable(wxGetFrame().IsModified()); }" />
+            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event)@@{@@event.Enable(wxGetFrame().IsModified());@@}" />
           <node
             class="wxMenuItem"
             bitmap="Art; wxART_FILE_SAVE_AS|wxART_MENU; [-1,-1]"
@@ -1042,16 +1042,16 @@
             id="wxID_UNDO"
             label=""
             var_name="menu_undo"
-            wxEVT_MENU="[](wxCommandEvent&amp;) { wxGetFrame().Undo(); }"
-            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event) { event.Enable(wxGetFrame().CanUndo()); }" />
+            wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@wxGetFrame().Undo();@@}"
+            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event)@@{@@event.Enable(wxGetFrame().CanUndo());@@}" />
           <node
             class="wxMenuItem"
             bitmap="Art; wxART_REDO|wxART_MENU; [-1,-1]"
             id="wxID_REDO"
             label=""
             var_name="menu_redo"
-            wxEVT_MENU="[](wxCommandEvent&amp;) { wxGetFrame().Redo(); }"
-            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event) { event.Enable(wxGetFrame().CanRedo()); }" />
+            wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@wxGetFrame().Redo();@@}"
+            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event)@@{@@event.Enable(wxGetFrame().CanRedo());@@}" />
           <node
             class="separator"
             var_name="separator5" />
@@ -1062,7 +1062,7 @@
             label=""
             var_name="menu_cut"
             wxEVT_MENU="OnCut"
-            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event) { event.Enable(wxGetFrame().CanCopyNode()); }" />
+            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event)@@{@@event.Enable(wxGetFrame().CanCopyNode());@@}" />
           <node
             class="wxMenuItem"
             bitmap="Art; wxART_COPY|wxART_MENU; [-1,-1]"
@@ -1070,7 +1070,7 @@
             label=""
             var_name="menu_copy"
             wxEVT_MENU="OnCopy"
-            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event) { event.Enable(wxGetFrame().CanCopyNode()); }" />
+            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event)@@{@@event.Enable(wxGetFrame().CanCopyNode());@@}" />
           <node
             class="wxMenuItem"
             bitmap="Art; wxART_PASTE|wxART_MENU; [-1,-1]"
@@ -1078,7 +1078,7 @@
             label=""
             var_name="menu_paste"
             wxEVT_MENU="OnPaste"
-            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event) { event.Enable(wxGetFrame().CanPasteNode()); }" />
+            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event)@@{@@event.Enable(wxGetFrame().CanPasteNode());@@}" />
           <node
             class="wxMenuItem"
             bitmap="Art; wxART_DELETE|wxART_MENU; [-1,-1]"
@@ -1087,7 +1087,7 @@
             label=""
             var_name="menu_delete"
             wxEVT_MENU="OnDelete"
-            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event) { event.Enable(wxGetFrame().CanCopyNode()); }" />
+            wxEVT_UPDATE_UI="[](wxUpdateUIEvent&amp; event)@@{@@event.Enable(wxGetFrame().CanCopyNode());@@}" />
           <node
             class="separator"
             var_name="separator6" />
@@ -1122,7 +1122,7 @@
               label="Up"
               shortcut="Alt+Up"
               var_name="menu_item4"
-              wxEVT_MENU="[](wxCommandEvent&amp;) { wxGetFrame().MoveNode(MoveDirection::Up); }" />
+              wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@wxGetFrame().MoveNode(MoveDirection::Up);@@}" />
             <node
               class="wxMenuItem"
               bitmap="Embed;../art_src/nav_movedown.png;[-1,-1]"
@@ -1131,7 +1131,7 @@
               label="Down"
               shortcut="Alt+Down"
               var_name="menu_item5"
-              wxEVT_MENU="[](wxCommandEvent&amp;) { wxGetFrame().MoveNode(MoveDirection::Down); }" />
+              wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@wxGetFrame().MoveNode(MoveDirection::Down);@@}" />
             <node
               class="wxMenuItem"
               bitmap="Embed;../art_src/nav_moveleft.png;[-1,-1]"
@@ -1140,7 +1140,7 @@
               label="Left"
               shortcut="Alt+Left"
               var_name="menu_item6"
-              wxEVT_MENU="[](wxCommandEvent&amp;) { wxGetFrame().MoveNode(MoveDirection::Left); }" />
+              wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@wxGetFrame().MoveNode(MoveDirection::Left);@@}" />
             <node
               class="wxMenuItem"
               bitmap="Embed;../art_src/nav_moveright.png;[-1,-1]"
@@ -1149,7 +1149,7 @@
               label="Right"
               shortcut="Alt+Right"
               var_name="menu_item7"
-              wxEVT_MENU="[](wxCommandEvent&amp;) { wxGetFrame().MoveNode(MoveDirection::Right); }" />
+              wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@wxGetFrame().MoveNode(MoveDirection::Right);@@}" />
           </node>
           <node
             class="submenu"
@@ -1642,7 +1642,7 @@
               label="Tabbed &amp;Dialog"
               var_name="m_check_tabs"
               validator_variable="m_has_tabs"
-              wxEVT_CHECKBOX="[this](wxCommandEvent&amp;) { m_spinCtrlTabs->Enable(m_check_tabs->GetValue()); }" />
+              wxEVT_CHECKBOX="[this](wxCommandEvent&amp;)@@{@@m_spinCtrlTabs->Enable(m_check_tabs->GetValue());@@}" />
             <node
               class="wxStaticText"
               class_access="none"
@@ -1679,7 +1679,7 @@
       derived_class_name="NewFrame"
       derived_file="newframe"
       title="New wxFrame window"
-      wxEVT_INIT_DIALOG="[this](wxInitDialogEvent&amp; event) { m_classname->SetFocus();  event.Skip(); }">
+      wxEVT_INIT_DIALOG="[this](wxInitDialogEvent&amp; event)@@{@@m_classname->SetFocus();@@event.Skip();@@}">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"

--- a/testing/src/ui/choicebook_base.cpp
+++ b/testing/src/ui/choicebook_base.cpp
@@ -102,11 +102,15 @@ bool ChoiceBookBase::Create(wxWindow *parent, wxWindowID id, const wxString &tit
 
     // Event handlers
     btn->Bind(wxEVT_BUTTON,
-        [this](wxCommandEvent&) { m_choicebook->SetSelection(0); }
-        );
+        [this](wxCommandEvent&)
+        {
+            m_choicebook->SetSelection(0);
+        } );
     btn_2->Bind(wxEVT_BUTTON,
-        [this](wxCommandEvent&) { m_choicebook->SetSelection(2); }
-        );
+        [this](wxCommandEvent&)
+        {
+            m_choicebook->SetSelection(2);
+        } );
 
     return true;
 }

--- a/testing/src/ui/commonctrls_base.cpp
+++ b/testing/src/ui/commonctrls_base.cpp
@@ -253,8 +253,17 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
     m_checkList->Bind(wxEVT_CHECKLISTBOX, &CommonCtrlsBase::OnListChecked, this);
     m_radioBox->Bind(wxEVT_RADIOBOX, &CommonCtrlsBase::OnRadioBox, this);
     m_toggleBtn->Bind(wxEVT_TOGGLEBUTTON,
-        [this](wxCommandEvent&) { if (m_toggleBtn->GetValue())  m_animation_ctrl->Play();  else  m_animation_ctrl->Stop(); }
-        );
+        [this](wxCommandEvent&)
+        {
+            if (m_toggleBtn->GetValue()) 
+            {
+                m_animation_ctrl->Play();
+            }
+            else 
+            {  
+                m_animation_ctrl->Stop();
+            }
+        } );
     m_slider->Bind(wxEVT_SLIDER, &CommonCtrlsBase::OnSlider, this);
 
     return true;

--- a/testing/src/ui/dlgmultitest_base.cpp
+++ b/testing/src/ui/dlgmultitest_base.cpp
@@ -172,8 +172,10 @@ bool DlgMultiTestBase::Create(wxWindow *parent, wxWindowID id, const wxString &t
 
     // Event handlers
     disable_bitmaps->Bind(wxEVT_CHECKBOX,
-        [this](wxCommandEvent& event) { m_btn_bitmaps->Enable(!event.IsChecked()); }
-        );
+        [this](wxCommandEvent& event)
+        {
+            m_btn_bitmaps->Enable(!event.IsChecked());
+        } );
 
     return true;
 }

--- a/testing/src/ui/ribbondlg_base.cpp
+++ b/testing/src/ui/ribbondlg_base.cpp
@@ -118,11 +118,15 @@ bool RibbonDlgBase::Create(wxWindow *parent, wxWindowID id, const wxString &titl
 
     // Event handlers
     m_btn->Bind(wxEVT_BUTTON,
-        [this](wxCommandEvent&) { m_scintilla->ClearAll();  m_scintilla->AddTextRaw("This is a sentence in English."); }
-        );
+        [this](wxCommandEvent&)
+        {
+            m_scintilla->ClearAll();  m_scintilla->AddTextRaw("This is a sentence in English.");
+        } );
     m_btn_2->Bind(wxEVT_BUTTON,
-        [this](wxCommandEvent&) { m_scintilla->ClearAll();  m_scintilla->AddTextRaw("Ceci est une phrase en français."); }
-        );
+        [this](wxCommandEvent&)
+        {
+            m_scintilla->ClearAll();  m_scintilla->AddTextRaw("Ceci est une phrase en français.");
+        } );
 
     return true;
 }

--- a/testing/src/ui/wxUiTesting.wxui
+++ b/testing/src/ui/wxUiTesting.wxui
@@ -323,7 +323,7 @@
             class="wxToggleButton"
             label="Play Animation"
             style="wxBU_EXACTFIT"
-            wxEVT_TOGGLEBUTTON="[this](wxCommandEvent&amp;) { if (m_toggleBtn->GetValue())  m_animation_ctrl->Play();  else  m_animation_ctrl->Stop(); }" />
+            wxEVT_TOGGLEBUTTON="[this](wxCommandEvent&amp;)@@{@@if (m_toggleBtn->GetValue()) @@{@@    m_animation_ctrl->Play();@@}@@else @@{  @@    m_animation_ctrl->Stop();@@}@@}" />
           <node
             class="wxAnimationCtrl"
             animation="Header; ..\art\clr_hourglass_gif.hxx"
@@ -437,7 +437,7 @@
                     class="wxButton"
                     label="Switch"
                     alignment="wxALIGN_CENTER_HORIZONTAL"
-                    wxEVT_BUTTON="[this](wxCommandEvent&amp;) { m_scintilla->ClearAll();  m_scintilla->AddTextRaw(&quot;This is a sentence in English.&quot;); }" />
+                    wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@m_scintilla->ClearAll();  m_scintilla->AddTextRaw(&quot;This is a sentence in English.&quot;);@@}" />
                 </node>
               </node>
             </node>
@@ -468,7 +468,7 @@
                     label="Switch"
                     var_name="m_btn_2"
                     alignment="wxALIGN_CENTER_HORIZONTAL"
-                    wxEVT_BUTTON="[this](wxCommandEvent&amp;) { m_scintilla->ClearAll();  m_scintilla->AddTextRaw(&quot;Ceci est une phrase en français.&quot;); }" />
+                    wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@m_scintilla->ClearAll();  m_scintilla->AddTextRaw(&quot;Ceci est une phrase en français.&quot;);@@}" />
                 </node>
               </node>
             </node>
@@ -648,13 +648,13 @@
             class_access="none"
             label="First"
             var_name="btn"
-            wxEVT_BUTTON="[this](wxCommandEvent&amp;) { m_choicebook->SetSelection(0); }" />
+            wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@m_choicebook->SetSelection(0);@@}" />
           <node
             class="wxButton"
             class_access="none"
             label="Last"
             var_name="btn_2"
-            wxEVT_BUTTON="[this](wxCommandEvent&amp;) { m_choicebook->SetSelection(2); }" />
+            wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@m_choicebook->SetSelection(2);@@}" />
           <node
             class="BookPage"
             bitmap="XPM; ..\art\english.xpm; [-1,-1]"
@@ -1286,7 +1286,7 @@
                   var_name="disable_bitmaps"
                   column="2"
                   row="1"
-                  wxEVT_CHECKBOX="[this](wxCommandEvent&amp; event) { m_btn_bitmaps->Enable(!event.IsChecked()); }" />
+                  wxEVT_CHECKBOX="[this](wxCommandEvent&amp; event)@@{@@m_btn_bitmaps->Enable(!event.IsChecked());@@}" />
               </node>
               <node
                 class="wxBoxSizer"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR improves the formatting of lambdas, in particular when an id is specified as a Bind parameter after the lambda. It also updates all the lambdas in wxUiEditor and wxUiTesting to use the new method of storing lambda information, and then regenerates all the files that use lambdas.