### PR TITLE
Enables WakaTime support in Release build

### DIFF
--- a/src/appoptions.cpp
+++ b/src/appoptions.cpp
@@ -18,11 +18,8 @@ void AppOptions::ReadConfig()
 
     m_sizers_all_borders = config->ReadBool("all_borders", true);
     m_sizers_always_expand = config->ReadBool("always_expand", true);
-    m_class_access = config->ReadBool("class_access", true);
+    m_enable_wakatime = config->ReadBool("enable_wakatime", true);
 
-    config->Read("src_extension", &m_src_extension, ".cpp");
-    config->Read("hdr_extension", &m_hdr_extension, ".h");
-    config->Read("member_prefix", &m_member_prefix, "m_");
     config->SetPath("/");
 }
 
@@ -33,10 +30,7 @@ void AppOptions::WriteConfig()
 
     config->Write("all_borders", m_sizers_all_borders);
     config->Write("always_expand", m_sizers_always_expand);
-    config->Write("class_access", m_class_access);
+    config->Write("enable_wakatime", m_enable_wakatime);
 
-    config->Write("src_extension", m_src_extension);
-    config->Write("hdr_extension", m_hdr_extension);
-    config->Write("member_prefix", m_member_prefix);
     config->SetPath("/");
 }

--- a/src/appoptions.h
+++ b/src/appoptions.h
@@ -15,21 +15,13 @@ public:
     void ReadConfig();
     void WriteConfig();
 
-    bool get_SizersAllBorders() { return m_sizers_all_borders; }
-    bool get_SizersExpand() { return m_sizers_always_expand; }
-    bool get_ClassAccess() { return m_class_access; }
+    bool get_SizersAllBorders() const { return m_sizers_all_borders; }
+    bool get_SizersExpand() const { return m_sizers_always_expand; }
+    bool get_isWakaTimeEnabled() const { return m_enable_wakatime; }
 
     void set_SizersAllBorders(bool setting) { m_sizers_all_borders = setting; }
     void set_SizersExpand(bool setting) { m_sizers_always_expand = setting; }
-    void set_ClassAccess(bool setting) { m_class_access = setting; }
-
-    wxString& get_SrcExtension() { return m_src_extension; }
-    wxString& get_HdrExtension() { return m_hdr_extension; }
-    wxString& get_MemberPrefix() { return m_member_prefix; }
-
-    void set_SrcExtension(const wxString& str) { m_src_extension = str; }
-    void set_HdrExtension(const wxString& str) { m_hdr_extension = str; }
-    void set_MemberPrefix(const wxString& str) { m_member_prefix = str; }
+    void set_isWakaTimeEnabled(bool setting) { m_enable_wakatime = setting; }
 
 #if defined(_DEBUG)
     bool get_FilterWarningMsgs() { return m_filter_warning_msgs; }
@@ -42,12 +34,7 @@ public:
 private:
     bool m_sizers_all_borders;
     bool m_sizers_always_expand;
-
-    bool m_class_access;  // controls default member access for new widgets
-
-    wxString m_src_extension;
-    wxString m_hdr_extension;
-    wxString m_member_prefix {};
+    bool m_enable_wakatime;
 
 #if defined(_DEBUG)
     bool m_filter_warning_msgs { false };  // controls display of warning messages in debug CMsgFrame window

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -26,6 +26,7 @@
 
 #include "mainframe.h"
 
+#include "appoptions.h"    // AppOptions -- Application-wide options
 #include "auto_freeze.h"   // AutoFreeze -- Automatically Freeze/Thaw a window
 #include "bitmaps.h"       // Map of bitmaps accessed by name
 #include "clipboard.h"     // wxUiEditorData -- Handles reading and writing OS clipboard data
@@ -1458,14 +1459,10 @@ Node* MainFrame::FindChildSizerItem(Node* node)
 
 void MainFrame::UpdateWakaTime(bool FileSavedEvent)
 {
-    // REVIEW: [KeyWorks - 10-14-2021] Before this can be added to release, we need an option that allows the user to disable
-    // it.
-#if defined(_DEBUG)
-    if (m_wakatime)
+    if (m_wakatime && GetAppOptions().get_isWakaTimeEnabled())
     {
         m_wakatime->SendHeartbeat(FileSavedEvent);
     }
-#endif  // _DEBUG
 }
 
 #if defined(_DEBUG)

--- a/src/ui/optionsdlg.cpp
+++ b/src/ui/optionsdlg.cpp
@@ -21,13 +21,9 @@ void MainFrame::OnOptionsDlg(wxCommandEvent& WXUNUSED(event))
 void OptionsDlg::OnInit(wxInitDialogEvent& event)
 {
     auto& options = GetAppOptions();
-    m_class_access = options.get_ClassAccess();
     m_sizers_all_borders = options.get_SizersAllBorders();
     m_sizers_always_expand = options.get_SizersExpand();
-
-    m_hdr_extension = options.get_HdrExtension();
-    m_member_prefix = options.get_MemberPrefix();
-    m_src_extension = options.get_SrcExtension();
+    m_isWakaTimeEnabled = options.get_isWakaTimeEnabled();
 
     event.Skip();  // transfer all validator data to their windows and update UI
 }
@@ -38,12 +34,6 @@ void OptionsDlg::OnAffirmative(wxCommandEvent& WXUNUSED(event))
 
     auto& options = GetAppOptions();
     bool option_changed = false;
-
-    if (m_class_access != options.get_ClassAccess())
-    {
-        options.set_ClassAccess(m_class_access);
-        option_changed = true;
-    }
 
     if (m_sizers_all_borders != options.get_SizersAllBorders())
     {
@@ -57,32 +47,16 @@ void OptionsDlg::OnAffirmative(wxCommandEvent& WXUNUSED(event))
         option_changed = true;
     }
 
-    if (m_hdr_extension != options.get_HdrExtension())
+    if (m_isWakaTimeEnabled != options.get_isWakaTimeEnabled())
     {
-        options.set_HdrExtension(m_hdr_extension);
-        option_changed = true;
-    }
-
-    if (m_hdr_extension != options.get_HdrExtension())
-    {
-        options.set_HdrExtension(m_hdr_extension);
-        option_changed = true;
-    }
-
-    if (m_src_extension != options.get_SrcExtension())
-    {
-        options.set_SrcExtension(m_src_extension);
-        option_changed = true;
-    }
-
-    if (m_member_prefix != options.get_MemberPrefix())
-    {
-        options.set_MemberPrefix(m_member_prefix);
+        options.set_isWakaTimeEnabled(m_isWakaTimeEnabled);
         option_changed = true;
     }
 
     if (option_changed)
+    {
         options.WriteConfig();
+    }
 
     EndModal(wxID_OK);
 }

--- a/src/ui/optionsdlg_base.cpp
+++ b/src/ui/optionsdlg_base.cpp
@@ -6,10 +6,7 @@
 
 #include <wx/button.h>
 #include <wx/checkbox.h>
-#include <wx/choice.h>
 #include <wx/sizer.h>
-#include <wx/stattext.h>
-#include <wx/textctrl.h>
 #include <wx/valgen.h>
 
 #include "optionsdlg_base.h"
@@ -23,50 +20,27 @@ bool OptionsDlgBase::Create(wxWindow *parent, wxWindowID id, const wxString &tit
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
     auto box_sizer = new wxBoxSizer(wxVERTICAL);
-    parent_sizer->Add(box_sizer, wxSizerFlags().Border(wxALL));
+    parent_sizer->Add(box_sizer, wxSizerFlags().Expand().Border(wxALL));
 
-    auto checkBox = new wxCheckBox(this, wxID_ANY, "New sizers have &borders on all sides");
-    checkBox->SetValidator(wxGenericValidator(&m_sizers_all_borders));
-    box_sizer->Add(checkBox, wxSizerFlags().Border(wxALL));
+    auto checkBox_borders = new wxCheckBox(this, wxID_ANY, "New sizers have &borders on all sides");
+    checkBox_borders->SetValue(true);
+    checkBox_borders->SetValidator(wxGenericValidator(&m_sizers_all_borders));
+    checkBox_borders->SetToolTip("If checked, all new sizers will be created with wxALL for the border.");
+    box_sizer->Add(checkBox_borders, wxSizerFlags().Border(wxALL));
 
-    auto checkBox2 = new wxCheckBox(this, wxID_ANY, "New sizers have wx&EXPAND set");
-    checkBox2->SetValidator(wxGenericValidator(&m_sizers_always_expand));
-    box_sizer->Add(checkBox2, wxSizerFlags().Border(wxALL));
+    auto checkBox_expand = new wxCheckBox(this, wxID_ANY, "New sizers have wx&EXPAND set");
+    checkBox_expand->SetValue(true);
+    checkBox_expand->SetValidator(wxGenericValidator(&m_sizers_always_expand));
+    checkBox_expand->SetToolTip("If checked, new sizers will be created with the wxEXPAND flag.");
+    box_sizer->Add(checkBox_expand, wxSizerFlags().Border(wxALL));
 
-    auto checkBox3 = new wxCheckBox(this, wxID_ANY, "New widgets always have a class &member");
-    checkBox3->SetValidator(wxGenericValidator(&m_class_access));
-    box_sizer->Add(checkBox3, wxSizerFlags().Border(wxALL));
+    box_sizer->AddSpacer(16);
 
-    auto flex_grid_sizer = new wxFlexGridSizer(2, 0, 0);
-    box_sizer->Add(flex_grid_sizer, wxSizerFlags().Expand().Border(wxALL));
-
-    auto staticTextSrcExt = new wxStaticText(this, wxID_ANY, "&Source code extension:");
-    flex_grid_sizer->Add(staticTextSrcExt, wxSizerFlags().Left().Border(wxALL));
-
-    auto choiceSrc = new wxChoice(this, wxID_ANY);
-    choiceSrc->Append(".cpp");
-    choiceSrc->Append(".cxx");
-    choiceSrc->Append(".cc");
-    choiceSrc->SetValidator(wxGenericValidator(&m_src_extension));
-    flex_grid_sizer->Add(choiceSrc, wxSizerFlags().Border(wxALL));
-
-    auto staticTextHrdExt = new wxStaticText(this, wxID_ANY, "&Header file extension:");
-    flex_grid_sizer->Add(staticTextHrdExt, wxSizerFlags().Left().Border(wxALL));
-
-    auto choiceHdr = new wxChoice(this, wxID_ANY);
-    choiceHdr->Append(".h");
-    choiceHdr->Append(".hpp");
-    choiceHdr->Append(".hxx");
-    choiceHdr->Append(".hh");
-    choiceHdr->SetValidator(wxGenericValidator(&m_hdr_extension));
-    flex_grid_sizer->Add(choiceHdr, wxSizerFlags().Border(wxALL));
-
-    auto staticText = new wxStaticText(this, wxID_ANY, "&Class member prefix");
-    flex_grid_sizer->Add(staticText, wxSizerFlags().Border(wxALL));
-
-    auto textCtrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
-    textCtrl->SetValidator(wxGenericValidator(&m_member_prefix));
-    flex_grid_sizer->Add(textCtrl, wxSizerFlags().Border(wxALL));
+    auto checkBox_wakatime = new wxCheckBox(this, wxID_ANY, "Enable WakaTime");
+    checkBox_wakatime->SetValue(true);
+    checkBox_wakatime->SetValidator(wxGenericValidator(&m_isWakaTimeEnabled));
+    checkBox_wakatime->SetToolTip("If you have WakaTime installed, checking this will record time spent in the editor as \"designing\". (See https://wakatime.com/about)");
+    box_sizer->Add(checkBox_wakatime, wxSizerFlags().Border(wxALL));
 
     auto stdBtn = CreateStdDialogButtonSizer(wxOK|wxCANCEL);
     parent_sizer->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));

--- a/src/ui/optionsdlg_base.h
+++ b/src/ui/optionsdlg_base.h
@@ -29,12 +29,9 @@ protected:
 
     // Validator variables
 
-    bool m_class_access { false };
-    bool m_sizers_all_borders { false };
-    bool m_sizers_always_expand { false };
-    wxString m_hdr_extension;
-    wxString m_member_prefix;
-    wxString m_src_extension;
+    bool m_isWakaTimeEnabled { true };
+    bool m_sizers_all_borders { true };
+    bool m_sizers_always_expand { true };
 
     // Virtual event handlers -- override them in your derived class
 

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -1825,64 +1825,35 @@
         var_name="parent_sizer">
         <node
           class="wxBoxSizer"
-          orientation="wxVERTICAL">
+          orientation="wxVERTICAL"
+          flags="wxEXPAND">
           <node
             class="wxCheckBox"
+            checked="true"
             class_access="none"
             label="New sizers have &amp;borders on all sides"
-            var_name="checkBox"
-            validator_variable="m_sizers_all_borders" />
+            var_name="checkBox_borders"
+            validator_variable="m_sizers_all_borders"
+            tooltip="If checked, all new sizers will be created with wxALL for the border." />
           <node
             class="wxCheckBox"
+            checked="true"
             class_access="none"
             label="New sizers have wx&amp;EXPAND set"
-            var_name="checkBox2"
-            validator_variable="m_sizers_always_expand" />
+            var_name="checkBox_expand"
+            validator_variable="m_sizers_always_expand"
+            tooltip="If checked, new sizers will be created with the wxEXPAND flag." />
+          <node
+            class="spacer"
+            height="16" />
           <node
             class="wxCheckBox"
+            checked="true"
             class_access="none"
-            label="New widgets always have a class &amp;member"
-            var_name="checkBox3"
-            validator_variable="m_class_access" />
-          <node
-            class="wxFlexGridSizer"
-            flags="wxEXPAND">
-            <node
-              class="wxStaticText"
-              class_access="none"
-              label="&amp;Source code extension:"
-              var_name="staticTextSrcExt"
-              alignment="wxALIGN_LEFT" />
-            <node
-              class="wxChoice"
-              choices="&quot;.cpp&quot; &quot;.cxx&quot; &quot;.cc&quot;"
-              class_access="none"
-              var_name="choiceSrc"
-              validator_variable="m_src_extension" />
-            <node
-              class="wxStaticText"
-              class_access="none"
-              label="&amp;Header file extension:"
-              var_name="staticTextHrdExt"
-              alignment="wxALIGN_LEFT" />
-            <node
-              class="wxChoice"
-              choices="&quot;.h&quot; &quot;.hpp&quot; &quot;.hxx&quot; &quot;.hh&quot;"
-              class_access="none"
-              var_name="choiceHdr"
-              validator_variable="m_hdr_extension" />
-            <node
-              class="wxStaticText"
-              class_access="none"
-              label="&amp;Class member prefix"
-              var_name="staticText" />
-            <node
-              class="wxTextCtrl"
-              class_access="none"
-              var_name="textCtrl"
-              validator_type="wxGenericValidator"
-              validator_variable="m_member_prefix" />
-          </node>
+            label="Enable WakaTime"
+            var_name="checkBox_wakatime"
+            validator_variable="m_isWakaTimeEnabled"
+            tooltip="If you have WakaTime installed, checking this will record time spent in the editor as &quot;designing&quot;. (See https://wakatime.com/about)" />
         </node>
         <node
           class="wxStdDialogButtonSizer"

--- a/src/wakatime.cpp
+++ b/src/wakatime.cpp
@@ -11,7 +11,8 @@
 
 #include "wakatime.h"  // WakaTime
 
-#include "mainapp.h"  // App -- Main application class
+#include "appoptions.h"  // AppOptions -- Application-wide options
+#include "mainapp.h"     // App -- Main application class
 
 WakaTime::WakaTime()
 {
@@ -123,6 +124,11 @@ constexpr const intmax_t waka_interval = 120;
 
 void WakaTime::SendHeartbeat(bool FileSavedEvent)
 {
+    if (!GetAppOptions().get_isWakaTimeEnabled())
+    {
+        return;
+    }
+
     if (m_waka_cli.empty())
     {
         return;
@@ -157,6 +163,11 @@ void WakaTime::SendHeartbeat(bool FileSavedEvent)
 
 void WakaTime::ResetHeartbeat()
 {
+    if (!GetAppOptions().get_isWakaTimeEnabled())
+    {
+        return;
+    }
+
     auto result = time(nullptr);
 
     if (result > m_last_heartbeat && (result - m_last_heartbeat >= waka_interval))


### PR DESCRIPTION
Closes #470

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes unsupported options from the Options Dialog, and adds support for WakaTime.

Note that the prefix setting was removed -- the reason is that if this is changed in an existing project, it can break code generation for any of the old style prefixes. By "break" I mean that the code generation may not compile due to conflicts with derived code.
