### PR TITLE
Refactor Navigation Panel treectrl handling

### DIFF
--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -36,11 +36,10 @@ public:
     // This will expand the specified node and collapse all other siblings
     void ExpandCollapse(Node* node);
 
-protected:
     void InsertNode(Node* node);
     void DeleteNode(Node* item);
-    void RecreateChildren(Node* node);
 
+protected:
     Node* GetNode(wxTreeItemId item);
 
     int GetImageIndex(Node* node);

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -317,7 +317,13 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
     {
         // If this actually happens, then we silently do nothing leaving the user no idea of why it didn't work
         FAIL_MSG("If this occurs, we need to figure out why and then add a message to let the user know why.")
+#if !defined(_DEBUG)
+        appMsgBox(ttlib::cstr("An internal error occurred. The following node is missing a parent: ") << node->get_node_name(),
+                  "CreateSizerParent()");
+        throw;
+#else
         return;
+#endif  // _DEBUG
     }
 
     auto childPos = parent->GetChildPosition(node);
@@ -331,7 +337,13 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
     {
         // If this actually happens, then we silently do nothing leaving the user no idea of why it didn't work
         FAIL_MSG("If this occurs, we need to figure out why and then add a message to let the user know why.")
+#if !defined(_DEBUG)
+        appMsgBox(ttlib::cstr("An internal error occurred creating a sizer parent for ") << node->get_node_name(),
+                  "CreateSizerParent()");
+        throw;
+#else
         return;
+#endif  // _DEBUG
     }
 
     // Avoid the temptation to set new_sizer to the raw pointer so that .get() doesn't have to be called below. Doing so will
@@ -343,6 +355,13 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
         wxGetFrame().Freeze();
         wxGetFrame().PushUndoAction(
             std::make_shared<InsertNodeAction>(new_sizer.get(), parent, "Insert new sizer", childPos));
+
+        // InsertNodeAction does not fire the creation event since that's usually handled by the caller as needed. We don't
+        // want to fire an event because we don't want the Mockup or Code panels to update until we have changed the parent.
+        // However we *do* need to let the navigation panel know that a new node has been added.
+
+        wxGetFrame().GetNavigationPanel()->InsertNode(new_sizer.get());
+
         wxGetFrame().PushUndoAction(std::make_shared<ChangeParentAction>(node, new_sizer.get()));
         wxGetFrame().SelectNode(node, true, true);
         wxGetFrame().Thaw();

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -318,7 +318,8 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
         // If this actually happens, then we silently do nothing leaving the user no idea of why it didn't work
         FAIL_MSG("If this occurs, we need to figure out why and then add a message to let the user know why.")
 #if !defined(_DEBUG)
-        appMsgBox(ttlib::cstr("An internal error occurred. The following node is missing a parent: ") << node->get_node_name(),
+        appMsgBox(ttlib::cstr("An internal error occurred. The following node is missing a parent: ")
+                      << node->get_node_name(),
                   "CreateSizerParent()");
         throw;
 #else

--- a/src/ui/gridbag_item.cpp
+++ b/src/ui/gridbag_item.cpp
@@ -17,7 +17,7 @@ GridBagItem::GridBagItem(wxWindow* parent) : GridBagItemBase(parent) {}
 
 void GridBagItem::OnInit(wxInitDialogEvent& WXUNUSED(event))
 {
-    if (auto cur_node = wxGetFrame().GetSelectedNode(); cur_node)
+    if (auto cur_node = wxGetFrame().GetSelectedNode(); cur_node && !cur_node->isGen(gen_Project))
     {
         if (cur_node->isGen(gen_wxGridBagSizer))
         {

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -274,6 +274,7 @@ ChangeParentAction::ChangeParentAction(Node* node, Node* parent)
 void ChangeParentAction::Change()
 {
     m_revert_parent->RemoveChild(m_node);
+    wxGetFrame().GetNavigationPanel()->DeleteNode(m_node.get());
     if (m_change_parent->isGen(gen_wxGridBagSizer))
     {
         GridBag grid_bag(m_change_parent.get());
@@ -282,6 +283,8 @@ void ChangeParentAction::Change()
             m_node->SetParent(m_revert_parent);
             m_revert_parent->AddChild(m_node);
             m_revert_parent->ChangeChildPosition(m_node, m_revert_position);
+            // Since we deleted it from Navigation Panel, need to add it back
+            wxGetFrame().FireParentChangedEvent(this);
             wxGetFrame().SelectNode(m_node);
         }
     }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes several changes to the way the treectrl is updated in the Navigation panel. As such, it is a potentially risky change that may introduce some new bugs while fixing old bugs and reducing the amount of redraw and recreation of tree items.

### EraseAllMaps()

This was erasing the node first, then all of it's children. However, if you delete a treectrl item it will automatically delete all children, which meant when we deleted the children we got warnings because they were already deleted. Now we recursively step in each child looking for children so that childless children are always deleted first before the parent is deleted.

Closes #506

### RecreateChildren()

This function would delete all children and then recreate them followed by expanding all child nodes. The following two functions called this, which causing problems. Now that those two functions have been refactored so that they no longer call this function, we can remove

### OnParentChange()

This was completely deleting and recreating both the old parent and the new parent. The updated code simply deletes the old node and inserts the new node.

Closes #94

### OnPositionChange()

Previously, this deleted and recreated the parent. Now it simply deletes the treeitem and all it's children and then inserts it into the new position. By not recreating all the children, this means you can move items up and down without changing the expansion state of any of the parent's children.
