### PR TITLE
Insert class_access property instead of defining it in XML generator

### DIFF
--- a/src/xml/README.md
+++ b/src/xml/README.md
@@ -40,6 +40,7 @@ The files `gen_enums.h` and `gen_enums.cpp` _must_ be updated any time you add a
 - Add the generator class to one of the files in generate/ or create a new file
 - Add any required wxWidgets header file to gen_initialize.cpp
 - Add the generator class name to the InitGenerators() in gen_initialize.cpp
+- If the generator has a var_name property, and you want the default class access to be "none", then add the generator name to the lst_no_class_access list in node_init.cpp
 
 While testing, you can use any existing image, and insert the control using the Edit menu's `Insert Widget` command. Once ready for release, then take the following steps:
 

--- a/src/xml/aui_xml.xml
+++ b/src/xml/aui_xml.xml
@@ -6,12 +6,6 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_notebook</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="display_images" type="bool"
 			help="If true, will display an image on the tab in addition to any text.">0</property>
 		<property name="image_size" type="wxSize"
@@ -62,12 +56,6 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">m_auiToolBar</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="bitmapsize" type="wxSize"
 			help="Default size of each tool bitmap. The default bitmap size is 16 by 15 pixels." />
 		<property name="margins" type="wxSize"
@@ -107,12 +95,6 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="auitool" image="tool" type="aui_tool">
 		<property name="var_name" type="string">tool</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="label" type="string_escapes" />
 		<property name="bitmap" type="image"
 			help="The primary tool bitmap." />

--- a/src/xml/bars_xml.xml
+++ b/src/xml/bars_xml.xml
@@ -5,12 +5,6 @@ inline const char* bars_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">m_statusBar</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="fields" type="uint"
 			help="Number of fields in the statusbar.">1</property>
 		<property name="style" type="bitlist">

--- a/src/xml/books_xml.xml
+++ b/src/xml/books_xml.xml
@@ -6,12 +6,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_choicebook</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="persist_name" type="string"
 			help="If a name is specified, wxPersistenceManager will be used to save/restore the currently selected page." />
 		<property name="style" type="option">
@@ -38,12 +32,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_listbook</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="display_images" type="bool"
 			help="If true, will display an image on the tab in addition to any text.">0</property>
 		<property name="image_size" type="wxSize"
@@ -74,12 +62,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_notebook</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="display_images" type="bool"
 			help="If true, will display an image on the tab in addition to any text.">0</property>
 		<property name="image_size" type="wxSize"
@@ -118,12 +100,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_toolbook</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="image_size" type="wxSize"
 			help="All tool images will be scaled to this size.">16, 16</property>
 		<property name="style" type="bitlist">
@@ -141,12 +117,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_treebook</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="display_images" type="bool"
 			help="If true, will display an image on the tab in addition to any text.">0</property>
 		<property name="image_size" type="wxSize"
@@ -197,12 +167,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		</inherits>
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">page</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="label" type="string_escapes">page</property>
 		<property name="select" type="bool"
 			help="Select Page when Adding">0</property>

--- a/src/xml/containers_xml.xml
+++ b/src/xml/containers_xml.xml
@@ -8,12 +8,6 @@ inline const char* containers_xml = R"===(<?xml version="1.0"?>
 		</inherits>
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">panel</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 	</gen>
 
 	<gen class="wxSplitterWindow" image="wxSplitterWindow" type="splitter">
@@ -21,12 +15,6 @@ inline const char* containers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_splitter</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="splitmode" type="option">
 			<option name="wxSPLIT_VERTICAL"
 				help="Specifies a vertical split window." />
@@ -83,12 +71,6 @@ inline const char* containers_xml = R"===(<?xml version="1.0"?>
 		</inherits>
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_scroll_canvas</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="scroll_rate_x" type="uint"
 			help="Set the horizontal scrolling increment.">5</property>
 		<property name="scroll_rate_y" type="uint"
@@ -109,12 +91,6 @@ inline const char* containers_xml = R"===(<?xml version="1.0"?>
 		</inherits>
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_scroll_panel</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="scroll_rate_x" type="uint"
 			help="Set the horizontal scrolling increment.">5</property>
 		<property name="scroll_rate_y" type="uint"
@@ -145,11 +121,5 @@ inline const char* containers_xml = R"===(<?xml version="1.0"?>
 		</property>
 		<event name="wxEVT_COLLAPSIBLEPANE_CHANGED" class="wxCollapsiblePaneEvent"
 			help="The user expanded or collapsed the collapsible pane." />
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 	</gen>
 </GeneratorDefinitions>)===";

--- a/src/xml/dataview_xml.xml
+++ b/src/xml/dataview_xml.xml
@@ -6,12 +6,6 @@ inline const char* dataview_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_dataViewCtrl</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="style" type="bitlist">
 			<option name="wxDV_SINGLE"
 				help="Single selection mode. This is the default." />
@@ -71,12 +65,6 @@ inline const char* dataview_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_dataViewTreeCtrl</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="style" type="bitlist">
 			<option name="wxDV_SINGLE"
 				help="Single selection mode. This is the default." />
@@ -136,12 +124,6 @@ inline const char* dataview_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_dataViewListCtrl</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="style" type="bitlist">
 			<option name="wxDV_SINGLE"
 				help="Single selection mode. This is the default." />
@@ -199,12 +181,6 @@ inline const char* dataview_xml = R"===(<?xml version="1.0"?>
 R"===(
 	<gen class="dataViewColumn" image="dataviewlist_column" type="dataviewcolumn">
 		<property name="var_name" type="string">m_dataViewColumn</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="label" type="string_escapes">Name</property>
 		<property name="model_column" type="uint">0</property>
 		<property name="type" type="option">
@@ -275,12 +251,6 @@ R"===(
 
 	<gen class="dataViewListColumn" image="dataviewlist_column" type="dataviewlistcolumn">
 		<property name="var_name" type="string">m_dataViewListColumn</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="label" type="string_escapes">Name</property>
 		<property name="type" type="option">
 			<option name="Text"

--- a/src/xml/grid_xml.xml
+++ b/src/xml/grid_xml.xml
@@ -6,12 +6,6 @@ inline const char* grid_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_grid</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="rows" type="uint"
 			help="Number of Rows.">5</property>
 		<property name="cols" type="uint"

--- a/src/xml/menus_xml.xml
+++ b/src/xml/menus_xml.xml
@@ -30,12 +30,6 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">m_menubar</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="style" type="bitlist">
 			<option name="wxMB_DOCKABLE"
 				help="Allows the menu bar to be detached (wxGTK only)." />
@@ -44,23 +38,11 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="wxMenu" image="menu" type="menu">
 		<property name="var_name" type="string">m_menu</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="label" type="string_escapes">MyMenu</property>
 	</gen>
 
 	<gen class="submenu" image="submenu" type="submenu">
 		<property name="var_name" type="string">submenu</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="label" type="string_escapes">MySubMenu</property>
 		<property name="bitmap" type="image"
 			help="Bitmap for the submenu item." />
@@ -68,12 +50,6 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="wxMenuItem" image="menuitem" type="menuitem">
 		<property name="var_name" type="string">menu_item</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="label" type="string_escapes"
 			help="Text for the menu item, as shown on the menu. An accelerator key can be specified using the ampersand &quot;&amp;&quot; character.">MyMenuItem</property>
 		<property name="shortcut" type="string_escapes"

--- a/src/xml/propgrid_xml.xml
+++ b/src/xml/propgrid_xml.xml
@@ -6,12 +6,6 @@ inline const char* propgrid_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_propertyGrid</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="include_advanced" type="bool"
 			help="Include Advanced Properties">1</property>
 		<property name="bitmap" type="image"
@@ -70,12 +64,6 @@ inline const char* propgrid_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_propertyGridManager</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="include_advanced" type="bool"
 			help="Include Advanced Properties">1</property>
 		<property name="style" type="bitlist">
@@ -149,12 +137,6 @@ inline const char* propgrid_xml = R"===(<?xml version="1.0"?>
 	<gen class="propGridPage" image="propgridpage" type="propgridpage">
 		<property name="var_name" type="string"
 			help="Instance name.">m_propertyGridPage</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="label" type="string_escapes"
 			help="Label shown as a tooltip of the manager's tool button.">Page</property>
 		<property name="bitmap" type="image"
@@ -164,12 +146,6 @@ inline const char* propgrid_xml = R"===(<?xml version="1.0"?>
 	<gen class="propGridItem" image="propgriditem" type="propgriditem">
 		<property name="var_name" type="string"
 			help="Instance name and an internal name of the property item.">m_propertyGridItem</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="label" type="string_escapes"
 			help="Label shown in parent property grid/page.">Name</property>
 		<property name="type" type="option"

--- a/src/xml/ribbon_xml.xml
+++ b/src/xml/ribbon_xml.xml
@@ -6,12 +6,6 @@ inline const char* ribbon_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_rbnBar</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="theme" type="option"
 			help="Select the RibbonBar theme.">
 			<option name="Default"
@@ -69,12 +63,6 @@ inline const char* ribbon_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">rbnPage</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="label" type="string_escapes">MyRibbonPage</property>
 		<property name="bitmap" type="image"
 			help="wxRibbonPage bitmap." />
@@ -86,12 +74,6 @@ inline const char* ribbon_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">rbnPanel</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="label" type="string_escapes">MyRibbonPanel</property>
 		<property name="bitmap" type="image"
 			help="wxRibbonPanel bitmap." />
@@ -118,12 +100,6 @@ inline const char* ribbon_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">rbnBtnBar</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<event name="EVT_RIBBONBUTTONBAR_CLICKED" class="wxRibbonToolBarEvent"
 			help="Triggered when the normal (non-dropdown) region of a button on the button bar is clicked." />
 		<event name="EVT_RIBBONBUTTONBAR_DROPDOWN_CLICKED" class="wxRibbonToolBarEvent"
@@ -159,12 +135,6 @@ inline const char* ribbon_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">rbnToolBar</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="min_rows" type="int"
 			help="Minimum number of rows.">1</property>
 		<property name="max_rows" type="int"
@@ -203,12 +173,6 @@ inline const char* ribbon_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">rbnGallery</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<event name="wxEVT_RIBBONGALLERY_SELECTED" class="wxRibbonGalleryEvent"
 			help="Triggered when the user selects an item from the gallery." />
 		<event name="wxEVT_RIBBONGALLERY_CLICKED" class="wxRibbonGalleryEvent"

--- a/src/xml/sizers_xml.xml
+++ b/src/xml/sizers_xml.xml
@@ -16,16 +16,11 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 	</gen>
 
 	<gen class="splitteritem" type="splitteritem" />
+
 	<gen class="wxBoxSizer" image="sizer_horizontal" type="sizer">
 		<inherits class="sizer_dimension" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">box_sizer</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="orientation" type="option">
 			<option name="wxVERTICAL"
 				help="Align items vertically" />
@@ -39,12 +34,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="sizer_dimension" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">box_sizer</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="orientation" type="option">
 			<option name="wxVERTICAL"
 				help="Align items vertically" />
@@ -58,12 +47,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="sizer_dimension" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">static_box</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="label" type="string_escapes">label</property>
 		<property name="orientation" type="option">
 			<option name="wxVERTICAL"
@@ -86,12 +69,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="sizer_child" />
 		<inherits class="Boolean Validator" />
 		<property name="var_name" type="string">static_box</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="checkbox_var_name" type="string">m_checkBox</property>
 		<property name="label" type="string_escapes">label</property>
 		<property name="checked" type="bool">1</property>
@@ -124,12 +101,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="sizer_child" />
 		<inherits class="Boolean Validator" />
 		<property name="var_name" type="string">static_box</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="radiobtn_var_name" type="string">m_radioBtn</property>
 		<property name="label" type="string_escapes">label</property>
 		<property name="checked" type="bool">1</property>
@@ -157,12 +128,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="sizer_dimension" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">wrap_sizer</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="orientation" type="option">
 			<option name="wxVERTICAL"
 				help="Align items vertically" />
@@ -183,12 +148,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="sizer_dimension" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">grid_sizer</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="rows" type="uint"
 			help="Number of Rows. If '0', wxWidgets will automatically calculate the number of rows required to hold the supplied items.">0</property>
 		<property name="cols" type="uint"
@@ -204,12 +163,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="flexgridsizerbase" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">flex_grid_sizer</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="rows" type="uint"
 			help="Number of Rows. '0' tells wxWidgets to calculate the number of rows required to hold the supplied items. If you choose to fix the row number, set the 'cols' figure to zero instead.">0</property>
 		<property name="cols" type="uint"
@@ -221,12 +174,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<inherits class="flexgridsizerbase" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">grid_bag_sizer</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="empty_cell_size" type="wxSize"
 			help="The size used for cells in the grid with no item." />
 	</gen>
@@ -234,12 +181,6 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 	<gen class="TextSizer" image="text_sizer" type="widget">
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">sizer_text</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="text" type="string_edit_escapes"
 			help="Splits text up at newlines and places the lines into wxStaticText objects with the specified maximum width in a vertical wxBoxSizer.">MyText</property>
 		<property name="width" type="int"

--- a/src/xml/std_dlg_btns_xml.xml
+++ b/src/xml/std_dlg_btns_xml.xml
@@ -5,12 +5,6 @@ inline const char* std_dlg_btns_xml = R"===(<?xml version="1.0"?>
 		<inherits class="sizer_dimension" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">stdBtn</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="OK" type="bool"
 			help="Create a 'OK' button. Cannot be combined with Yes or Save buttons.">1</property>
 		<property name="Yes" type="bool"

--- a/src/xml/toolbars_xml.xml
+++ b/src/xml/toolbars_xml.xml
@@ -45,12 +45,6 @@ inline const char* toolbars_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_toolBar</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="bitmapsize" type="wxSize"
 			help="Default size of each tool bitmap. The default bitmap size is 16 by 15 pixels." />
 		<property name="margins" type="wxSize"
@@ -92,12 +86,6 @@ inline const char* toolbars_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="tool" image="tool" type="tool">
 		<property name="var_name" type="string">tool</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="label" type="string_escapes" />
 		<property name="bitmap" type="image"
 			help="The primary tool bitmap." />

--- a/src/xml/trees_xml.xml
+++ b/src/xml/trees_xml.xml
@@ -7,12 +7,6 @@ inline const char* trees_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_treeCtrl</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="style" type="bitlist">
 			<option name="wxTR_EDIT_LABELS"
 				help="Use this style if you wish the user to be able to edit labels in the tree control." />
@@ -91,12 +85,6 @@ inline const char* trees_xml = R"===(<?xml version="1.0"?>
 	<gen class="TreeListCtrlColumn" image="treelistctrlcolumn" type="treelistctrlcolumn">
 		<property name="var_name" type="string_escapes"
 			help="The column label.">Column</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="width" type="editoption"
 			help="The width of the column in pixels or the special wxCOL_WIDTH_AUTOSIZE value indicating that the column should adjust to its contents. Notice that the first column is special and will be always resized to fill all the space not taken by the other columns, i.e. the width specified here is ignored for it.">
 			<option name="wxCOL_WIDTH_DEFAULT"

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -6,12 +6,6 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_indicator</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 	</gen>
 
 	<gen class="wxAnimationCtrl" image="wxAnimation" type="widget">
@@ -19,12 +13,6 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_animation_ctrl</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			protected:
-		</property>
 		<property name="style" type="bitlist">
 			<option name="wxAC_DEFAULT_STYLE"
 				help="The default style: wxBORDER_NONE." />
@@ -122,12 +110,6 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">bmp</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="scale_mode" type="option">
 			<option name="None"
 				help="Do not scale the image." />
@@ -148,12 +130,6 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">static_line</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="style" type="option">
 			<option name="wxLI_HORIZONTAL"
 				help="Creates a horizontal line." />

--- a/src/xml/wizard_xml.xml
+++ b/src/xml/wizard_xml.xml
@@ -89,12 +89,6 @@ inline const char* wizard_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<property name="var_name" type="string">wizPage</property>
-		<property name="class_access" type="option">
-			<option name="none" />
-			<option name="protected:" />
-			<option name="public:" />
-			none
-		</property>
 		<property name="bitmap" type="image"
 			help="Page-specific bitmap (default: none)." />
 	</gen>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR overhauls how the `class_access` property gets added. Instead of having it appear in some of the XML generator declaration, the code was changed so that any time a
`var_name` property appears, a class access property will be inserted after it. A `lst_no_class_access` determines whether the default class access should be set to "none" instead of "protected:".
