### PR TITLE
Add BETA_ERROR() and INTERNAL_ERROR() macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ endif()
 add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
 add_compile_definitions($<$<CONFIG:Debug>:WXUSINGDLL>)
 
+# Comment the following line out for a non-beta Release
+add_compile_definitions(BETA)
+
 # Setting CMAKE_MODULE_PATH causes ninja to fail rebuilding until CMake re-generates. Specifying the full path and extension
 # means ninja sees this as a normal dependency that didn't change any time one of the files it specifies changes.
 

--- a/src/bitmaps.cpp
+++ b/src/bitmaps.cpp
@@ -17,6 +17,8 @@
 
 #include "bitmaps.h"
 
+#include "uifuncs.h"  // Miscellaneous functions for displaying UI
+
 // [KeyWorks - 05-04-2021] Note that we don't display warnings or errors to the user since this will be called during project
 // loading, and there could be dozens of calls to the same problem file(s).
 
@@ -91,6 +93,7 @@ wxImage GetHeaderImage(ttlib::cview filename, size_t* p_original_size, ttString*
                 if (!*buf_ptr)
                 {
                     FAIL_MSG(ttlib::cstr() << filename << " doesn't contain a closing brace");
+                    appMsgBox(ttlib::cstr() << filename << " doesn't contain a closing brace");
                     return image;
                 }
             }
@@ -297,6 +300,7 @@ bool GetAnimationImage(wxAnimation& animation, ttlib::cview filename)
                 if (!*buf_ptr)
                 {
                     FAIL_MSG(ttlib::cstr() << filename << " doesn't contain a closing brace");
+                    appMsgBox(ttlib::cstr() << filename << " doesn't contain a closing brace");
                     return animation.IsOk();
                 }
             }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -531,13 +531,15 @@ void BaseCodeGenerator::GenSrcEventBinding(Node* node, const EventVector& events
     if (!propName)
     {
         FAIL_MSG(ttlib::cstr("Missing \"name\" property in ") << node->DeclName() << " class.");
+        BETA_ERROR(ttlib::cstr("\nMissing \"name\" property in ") << node->DeclName() << " class.")
         return;
     }
 
     auto& class_name = propName->as_string();
     if (class_name.empty())
     {
-        FAIL_MSG("Node name cannot be null");
+        FAIL_MSG("Property name cannot be null");
+        BETA_ERROR("Property name cannot be null")
         return;
     }
 
@@ -1030,7 +1032,8 @@ ttlib::cstr BaseCodeGenerator::GetDeclaration(Node* node)
         }
         else
         {
-            FAIL_MSG("Unrecognized class name so no idea how to declare it in the header file.");
+            FAIL_MSG("Unrecognized class name so no idea how to declare it in the header file.")
+            BETA_ERROR("Unrecognized class name so no idea how to declare it in the header file.")
         }
     }
     else if (class_name.is_sameas("CustomControl"))
@@ -1052,6 +1055,7 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     if (!form_node->HasValue(prop_class_name))
     {
         FAIL_MSG(ttlib::cstr("Missing \"name\" property in ") << form_node->DeclName());
+        BETA_ERROR(ttlib::cstr("\nMissing \"name\" property in ") << form_node->DeclName());
         return;
     }
 

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -114,6 +114,7 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
                 if (!subwindow)
                 {
                     FAIL_MSG("Child of splitter is not derived from wxWindow class.");
+                    BETA_ERROR("Child of splitter is not derived from wxWindow class.");
                     return;
                 }
 
@@ -129,6 +130,7 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
                 // splitter->PushEventHandler(new ContainerBarEvtHandler(splitter));
                 break;
             }
+
         case 2:
             {
                 auto subwindow0 = wxDynamicCast(GetMockup()->GetChild(wxobject, 0), wxWindow);
@@ -137,6 +139,7 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
                 if (!subwindow0 || !subwindow1)
                 {
                     FAIL_MSG("Child of splitter is not derived from wxWindow class.");
+                    BETA_ERROR("Child of splitter is not derived from wxWindow class.");
                     return;
                 }
 
@@ -169,6 +172,7 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
                 // splitter->PushEventHandler(new ContainerBarEvtHandler(splitter));
                 break;
             }
+
         default:
             return;
     }

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -358,7 +358,7 @@ void App::OnFatalException()
     #endif  // _DEBUG
 
     // Let the user know something terrible happened.
-    appMsgBox(_tt(strIdInternalError), txtVersion);
+    appMsgBox("An internal error has occurred!", txtVersion);
 }
 
 #endif
@@ -372,6 +372,7 @@ void App::ShowMsgWindow()
 
 void App::DbgCurrentTest(wxCommandEvent&)
 {
+    INTERNAL_ERROR(ttlib::cstr() << "\n\nInternal error test.")
     MSG_WARNING("Add code you want to test to (mainapp.cpp) App::DbgCurrentTest()");
 }
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -370,7 +370,8 @@ void MainFrame::OnInsertWidget(wxCommandEvent&)
         {
             return CreateToolNode(result->second);
         }
-        FAIL_MSG(ttlib::cstr() << "No property enum type exists for dlg.GetWidget()! This should be impossible...");
+        FAIL_MSG(ttlib::cstr() << "No property enum type exists for dlg.GetWidget()! This should be impossible...")
+        BETA_ERROR("\nNo property enum type exists for dlg.GetWidget().")
     }
 }
 

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -180,6 +180,7 @@ NodeSharedPtr NodeCreator::CreateNode(ttlib::cview name, Node* parent)
     if (result == rmap_GenNames.end())
     {
         FAIL_MSG(ttlib::cstr() << "No component definition for " << name);
+        BETA_ERROR(ttlib::cstr() << "\nNo component definition for " << name);
         return {};
     }
 

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -470,6 +470,8 @@ void NavigationPanel::OnNodeSelected(CustomEvent& event)
     {
         FAIL_MSG(ttlib::cstr("There is no tree item associated with this object.\n\tClass: ")
                  << node->DeclName() << "\n\tName: " << node->prop_as_string(prop_var_name).wx_str());
+        BETA_ERROR(ttlib::cstr("\nThere is no tree item associated with this object.\n\tClass: ")
+                   << node->DeclName() << "\n\tName: " << node->prop_as_string(prop_var_name).wx_str());
     }
 }
 

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -318,9 +318,7 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
         // If this actually happens, then we silently do nothing leaving the user no idea of why it didn't work
         FAIL_MSG("If this occurs, we need to figure out why and then add a message to let the user know why.")
 #if !defined(_DEBUG)
-        appMsgBox(ttlib::cstr("An internal error occurred. The following node is missing a parent: ")
-                      << node->get_node_name(),
-                  "CreateSizerParent()");
+        INTERNAL_ERROR(ttlib::cstr() << "\nThe following node is missing a parent: " << node->get_node_name())
         throw;
 #else
         return;
@@ -339,8 +337,7 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
         // If this actually happens, then we silently do nothing leaving the user no idea of why it didn't work
         FAIL_MSG("If this occurs, we need to figure out why and then add a message to let the user know why.")
 #if !defined(_DEBUG)
-        appMsgBox(ttlib::cstr("An internal error occurred creating a sizer parent for ") << node->get_node_name(),
-                  "CreateSizerParent()");
+        INTERNAL_ERROR(ttlib::cstr() << "\nThe following node is missing a sizer parent: " << node->get_node_name())
         throw;
 #else
         return;

--- a/src/pch.h
+++ b/src/pch.h
@@ -58,8 +58,9 @@
 
 #endif
 
-// This is included because mainframe.h needs it, and changing mainframe.h results in 37 files needing to read this.
-#include <wx/gdicmn.h>
+#include <wx/gdicmn.h>  // Common GDI classes, types and declarations
+#include <wx/msgdlg.h>  // common header and base class for wxMessageDialog
+#include <wx/string.h>  // wxString class
 
 #ifdef _MSC_VER
     #pragma warning(pop)
@@ -114,6 +115,28 @@ extern ttlib::cstr tt_empty_cstr;
 constexpr const char BMP_PROP_SEPARATOR = ';';
 
 //////////////////////////////////////// macros ////////////////////////////////////////
+
+// Use INTERNAL_ERROR(msg) if you always want to report a problem in any Debug or Release build. Use BETA_ERROR(msg) if this
+// is just something you want reported on during a Debug or Release beta build (which presumably will be fixed and not occur
+// before a non-beta Release). You do not need to call these if you are instead calling throw std::...()
+
+#if defined(BETA)
+    #define BETA_ERROR(msg)                                                                                              \
+        {                                                                                                                \
+            wxMessageBox(wxString("An internal error occured in ") << __func__ << " at line " << __LINE__ << '.' << msg, \
+                         txtVersion);                                                                                    \
+        }
+#else
+    #define BETA_ERROR(msg) \
+        {                   \
+        }
+#endif
+
+#define INTERNAL_ERROR(msg)                                                                                          \
+    {                                                                                                                \
+        wxMessageBox(wxString("An internal error occured in ") << __func__ << " at line " << __LINE__ << '.' << msg, \
+                     txtVersion);                                                                                    \
+    }
 
 #if defined(NDEBUG)
 

--- a/src/uifuncs.h
+++ b/src/uifuncs.h
@@ -7,9 +7,6 @@
 
 #pragma once
 
-#include <wx/msgdlg.h>
-#include <wx/string.h>
-
 #include "ttstrings.h"  // Functions accessing translatable strings
 
 #include "strings.h"  // Localized strings


### PR DESCRIPTION
These are used to report problems in Release builds.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds BETA_ERROR() and INTERNAL_ERROR() macros for displaying a message to the user indicating that an internal error occurred.

There are several places where we have FAIL_MSG() macros which is extremely helpful if running under a debugger. However, if this isn't followed with a throw, then we never let the user know that something bad happened in any type of Release build.

The BETA_ERROR() only gets compiled if BETA is defined. That means it can be used where an error is extremely unlikely, and/or we are certain it will be found and fixed before the final Release, or we just simply want some additional reporting while in Beta.

Note that neither BETA_ERROR() or INTERNAL_ERROR() do anything besides display a message to the user. It's still up to the caller as to how to continue after the message is displayed.