### PR TITLE
Add var_comment property

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -311,6 +311,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_validator_type, "validator_type" },
     { prop_validator_variable, "validator_variable" },
     { prop_value, "value" },
+    { prop_var_comment, "var_comment" },
     { prop_var_name, "var_name" },
     { prop_variant, "variant" },
     { prop_vgap, "vgap" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -311,6 +311,7 @@ namespace GenEnum
         prop_validator_type,
         prop_validator_variable,
         prop_value,
+        prop_var_comment,
         prop_var_name,
         prop_variant,
         prop_vgap,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -966,7 +966,6 @@ ttlib::cstr BaseCodeGenerator::GetDeclaration(Node* node)
             if (node->prop_as_string(prop_scale_mode) != "None")
                 code.Replace("wxStaticBitmap", "wxGenericStaticBitmap");
         }
-        return code;
     }
 
     else if (class_name == "StaticCheckboxBoxSizer")
@@ -1038,6 +1037,11 @@ ttlib::cstr BaseCodeGenerator::GetDeclaration(Node* node)
     else if (class_name.is_sameas("CustomControl"))
     {
         code << node->prop_as_string(prop_class_name) << "* " << node->get_node_name() << ';';
+    }
+
+    if (node->HasValue(prop_var_comment))
+    {
+        code << "  // " << node->prop_as_string(prop_var_comment);
     }
 
     return code;

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -614,11 +614,18 @@ void NodeCreator::ParseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
 
         elem_prop = elem_prop.next_sibling("property");
 
-        // Any time there is a var_name property, it needs to be followed by a class_access property. Rather than add this to
-        // all the XML generator specifications, we simply insert it here if it doesn't exist.
+        // Any time there is a var_name property, it needs to be followed by a var_comment and class_access property. Rather
+        // than add this to all the XML generator specifications, we simply insert it here if it doesn't exist.
 
         if (elem_prop && ttlib::is_sameas(name, map_PropNames[prop_var_name]))
         {
+            category.AddProperty(prop_var_comment);
+            prop_info = std::make_shared<PropDeclaration>(prop_var_comment, type_string_edit_single, tt_empty_cstr,
+                                                          "Comment to add to the variable name in the generated header file "
+                                                          "if the class access is set to protected of public",
+                                                          "");
+            obj_info->GetPropInfoMap()[map_PropNames[prop_var_comment]] = prop_info;
+
             category.AddProperty(prop_class_access);
             ttlib::cstr access("protected:");
 


### PR DESCRIPTION
Closes #516

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a var_name property which can be directly edited or via the single-line editor. If set, and the variable has class access, then when the variable is declared in the header file, it will be followed with "  // " followed by the comment.