### PR TITLE
Don't use original ID when converting Windows resource dialogs

### DIFF
--- a/src/winres/ctrl_utils.cpp
+++ b/src/winres/ctrl_utils.cpp
@@ -150,10 +150,13 @@ ttlib::cview resCtrl::GetID(ttlib::cview line)
         m_node->prop_set_value(prop_id, "wxID_HELP");
     else if (id == "IDC_APPLY")
         m_node->prop_set_value(prop_id, "wxID_APPLY");
-    else if (id == "IDC_STATIC")
-        m_node->prop_set_value(prop_id, "wxID_ANY");
     else
-        m_node->prop_set_value(prop_id, id);
+        m_node->prop_set_value(prop_id, "wxID_ANY");
+
+    if (m_node->prop_as_string(prop_id) != "wxID_ANY" || !id.is_sameprefix("IDC_STATIC"))
+    {
+        m_node->prop_set_value(prop_var_comment, id);
+    }
 
     line.moveto_nonspace();
     return line;

--- a/src/winres/winres_form.cpp
+++ b/src/winres/winres_form.cpp
@@ -52,19 +52,6 @@ void resForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, s
 
     ParseDimensions(line, m_du_rect, m_pixel_rect);
 
-    auto lst_includes = pWinResource->GetIncludeLines();
-    if (lst_includes.size())
-    {
-        value.clear();
-        for (auto& iter: lst_includes)
-        {
-            if (value.size())
-                value << '\n';
-            value << iter;
-        }
-        m_form_node->prop_set_value(prop_base_src_includes, value);
-    }
-
     for (++curTxtLine; curTxtLine < txtfile.size(); ++curTxtLine)
     {
         line = txtfile[curTxtLine].subview(txtfile[curTxtLine].find_nonspace());


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Add the id as a comment, if appropriate, and use wxID_ANY as the default id.

Closes #517