### PR TITLE
Only list usable Windows Resource files

### DIFF
--- a/src/ui/import_base.cpp
+++ b/src/ui/import_base.cpp
@@ -39,9 +39,6 @@ bool ImportBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
     auto box_sizer6 = new wxBoxSizer(wxHORIZONTAL);
     m_import_staticbox->Add(box_sizer6, wxSizerFlags().Expand().Border(wxALL));
 
-    m_staticFiles = new wxStaticText(m_import_staticbox->GetStaticBox(), wxID_ANY, "&Files:");
-    box_sizer6->Add(m_staticFiles, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
-
     m_btnAddFile = new wxButton(m_import_staticbox->GetStaticBox(), wxID_ANY, "&Directory...");
     m_btnAddFile->SetToolTip("You can add multiple formbuilder projects to a single wxUiEdtior project.");
     box_sizer6->Add(m_btnAddFile, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
@@ -52,6 +49,9 @@ bool ImportBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
 
     auto box_sizer7 = new wxBoxSizer(wxVERTICAL);
     m_import_staticbox->Add(box_sizer7, wxSizerFlags(1).Expand().Border(wxALL));
+
+    m_staticImportList = new wxStaticText(m_import_staticbox->GetStaticBox(), wxID_ANY, "&Files:");
+    box_sizer7->Add(m_staticImportList, wxSizerFlags().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
 
     m_checkListProjects = new wxCheckListBox(m_import_staticbox->GetStaticBox(), wxID_ANY);
     m_checkListProjects->SetMinSize(wxSize(-1, 240));

--- a/src/ui/import_base.h
+++ b/src/ui/import_base.h
@@ -43,7 +43,7 @@ protected:
     wxRadioButton* m_radio_wxGlade;
     wxRadioButton* m_radio_wxSmith;
     wxStaticBoxSizer* m_import_staticbox;
-    wxStaticText* m_staticFiles;
+    wxStaticText* m_staticImportList;
     wxStaticText* m_static_cwd;
     wxStdDialogButtonSizer* m_stdBtn;
     wxButton* m_stdBtnOK;

--- a/src/ui/import_dlg.h
+++ b/src/ui/import_dlg.h
@@ -26,6 +26,7 @@ public:
     std::vector<ttString>& GetFileList() { return m_lstProjects; };
 
 protected:
+    void CheckResourceFiles(wxArrayString& files);
     void OnWxGlade(wxCommandEvent& event) override;
     void OnCheckFiles(wxCommandEvent& event) override;
     void OnDirectory(wxCommandEvent& event) override;

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -732,12 +732,6 @@
             var_name="box_sizer6"
             flags="wxEXPAND">
             <node
-              class="wxStaticText"
-              label="&amp;Files:"
-              var_name="m_staticFiles"
-              alignment="wxALIGN_CENTER"
-              borders="wxLEFT|wxRIGHT|wxTOP" />
-            <node
               class="wxButton"
               label="&amp;Directory..."
               var_name="m_btnAddFile"
@@ -759,6 +753,11 @@
             var_name="box_sizer7"
             flags="wxEXPAND"
             proportion="1">
+            <node
+              class="wxStaticText"
+              label="&amp;Files:"
+              var_name="m_staticImportList"
+              borders="wxLEFT|wxRIGHT|wxTOP" />
             <node
               class="wxCheckListBox"
               var_name="m_checkListProjects"


### PR DESCRIPTION
If the resource file doesn't contain a DIALOG or MENU statement, then there's nothing in it that we can convert, so don't list it in the Import dialog list.

Closes #520

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
