### PR TITLE
Add additional attempt to create a node that initially fails

### DIFF
--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -500,6 +500,19 @@ Node* Node::CreateChildNode(GenName name)
 
     auto new_node = g_NodeCreator.CreateNode(name, this);
 
+    Node* parent = this;
+
+    if (!new_node)
+    {
+        if ((IsForm() || IsContainer()) && GetChildCount() && GetChild(0)->isGen(gen_wxBoxSizer))
+        {
+            new_node = g_NodeCreator.CreateNode(name, GetChild(0));
+            if (!new_node)
+                return nullptr;
+            parent = GetChild(0);
+        }
+    }
+
     if (new_node)
     {
         if (isGen(gen_wxGridBagSizer))
@@ -534,7 +547,7 @@ Node* Node::CreateChildNode(GenName name)
 
         ttlib::cstr undo_str;
         undo_str << "insert " << map_GenNames[name];
-        frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), this, undo_str));
+        frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str));
     }
 
     // A "ribbonButton" component is used for both wxRibbonButtonBar and wxRibbonToolBar. If creating the node failed,
@@ -559,7 +572,7 @@ Node* Node::CreateChildNode(GenName name)
         // widget, and wants a new widget created right after the selected widget with both having the same parent
         // (typically a sizer).
 
-        auto parent = GetParent();
+        parent = GetParent();
 
         if (parent)
         {

--- a/src/winres/winres_ctrl.h
+++ b/src/winres/winres_ctrl.h
@@ -68,7 +68,11 @@ public:
     auto& GetOrginalLine() { return m_original_line; }
 #endif  // _DEBUG
 
-    NodeSharedPtr SetNodePtr(NodeSharedPtr node) { m_node = node; return m_node; }
+    NodeSharedPtr SetNodePtr(NodeSharedPtr node)
+    {
+        m_node = node;
+        return m_node;
+    }
 
 protected:
     // This will map window styles to wxWidgets styles and append them to prop_style

--- a/src/winres/winres_menu.cpp
+++ b/src/winres/winres_menu.cpp
@@ -183,7 +183,6 @@ void resForm::ParseMenuItem(Node* parent, ttlib::textfile& txtfile, size_t& curT
                         }
                     }
                 }
-
             }
         }
     }


### PR DESCRIPTION
This PR changes what happens if a node cannot be created. If the selected node is a form or container, and it contains a **wxBoxSizer** as it's first child, then an attempt will be made to create the node using that **wxBoxSizer** as the parent.

For the user, this means they can select either the form/container or it's main box sizer to create child widgets.

Closes #525

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
