### PR TITLE
Add wxSnapshot so that wxWidgets libraries can be built directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,10 @@ if (NOT isMultiConfig)
     endif()
 endif()
 
+# This will build wxCLib.lib and wxWidgets.lib
+add_subdirectory(wxSnapshot)
+
 add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
-add_compile_definitions($<$<CONFIG:Debug>:WXUSINGDLL>)
 
 # Comment the following line out for a non-beta Release
 add_compile_definitions(BETA)
@@ -205,6 +207,8 @@ add_executable(wxUiEditor WIN32
     $<$<CONFIG:Debug>:ttLib/src/winsrc/ttdebug_min.cpp>  # ttAssertionMsg
 )
 
+target_link_libraries(wxUiEditor PRIVATE wxCLib wxWidgets)
+
 if (MSVC)
     # /GL -- combined with the Linker flag /LTCG to perform whole program optimization in Release build
     # /FC -- Full path to source code file in diagnostics
@@ -220,6 +224,7 @@ endif()
 target_precompile_headers(wxUiEditor PRIVATE "src/pch.h")
 
 target_include_directories(wxUiEditor PRIVATE
+    wxSnapshot/include
     src/
     src/nodes
     src/generate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![logo](src/art_src/logo64.png) wxUiEditor
 
-This Windows GUI tool is used to create and maintain [wxWidgets](https://docs.wxwidgets.org/trunk/index.html) UI elements (dialogs, menus, etc.), generating C++ output code. Minimal requirement for compiling output files is a c++11 compliant compiler and **wxWidgets** 3.0 (version 3.1 needed for full functionality).
+This Windows GUI tool is used to create and maintain [wxWidgets](https://docs.wxwidgets.org/trunk/index.html) UI elements (dialogs, menus, etc.), generating C++ output code. Minimal requirement for compiling output files is a C++11 compliant compiler and **wxWidgets** 3.0 (version 3.1 needed for full functionality).
 
 In addition to creating new projects, the following project types can be imported:
 
@@ -12,14 +12,14 @@ In addition to creating new projects, the following project types can be importe
 
 ## Building
 
-Currently, you will need wxWidgets 3.15 installed somewhere with the `wx/` directory in your $INCLUDE environment variable, and a path to the wxWidgets libraries in your $LIB environment variable. Note that the Debug build uses the wxWidgets dlls, but the Release build expects static libraries. Currently, it's not possible to use vcpkg for the Release build because it also requires static versions of the CRT.
-
-The easiest way to build the libraries is to run the following commands:
+To build the Windows version of **wxUiEditor**, run the following two commands from the root of the repository:
 
 ```
     cmake -G "Ninja Multi-Config" . -B build
     cmake.exe --build build --config Release
 ```
+
+Note that the linking stage of the Release build will take quite a bit of time.
 
 See [Developer notes](docs/DEV_NOTES.md) for more information about the code.
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -25,9 +25,6 @@
 #include "pugixml.hpp"
 
 #ifdef _MSC_VER
-    #define wxMSVC_VERSION_ABI_COMPAT
-    #include <msvc/wx/setup.h>  // This will add #pragmas for the wxWidgets libraries
-
     #if defined(_WIN32)
 
         #pragma comment(lib, "kernel32.lib")


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the sub-module **wxSnapshot** as a sub-module. This allows us to build the **wxWidget** sources into two static libraries: **wxCLib** and **wxWidgets**. Building the library ourselves has certain advantages, particularly for MSVC builds:

- Ensures that everyone is building using the same version of wxWidgets (including github actions)
- Static release build can use dll versions of C runtime (not possible with vcpkg) (MSVC)
- Optimizes for space, saving 1M+ in executable size (MSVC)
- Allows for whole-program optimization including the wxWidgets libaries (MSVC)
