### PR TITLE
Remove convert_art, change original_art to art_directory

### DIFF
--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -36,9 +36,9 @@ ttlib::cstr ImageProperties::CombineValues()
 {
     if (type.size() && type != "Art")
     {
-        if (!image.file_exists() && wxGetApp().GetProject()->HasValue(prop_original_art))
+        if (!image.file_exists() && wxGetApp().GetProject()->HasValue(prop_art_directory))
         {
-            auto path = wxGetApp().GetProject()->prop_as_string(prop_original_art);
+            auto path = wxGetApp().GetProject()->prop_as_string(prop_art_directory);
             path.append_filename(image);
             path.make_relative(wxGetApp().getProjectPath());
             if (path.file_exists())

--- a/src/customprops/img_string_prop.cpp
+++ b/src/customprops/img_string_prop.cpp
@@ -30,9 +30,9 @@ bool ImageDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGProperty* WX
     else if (m_img_props.type.contains("Embed"))
     {
         ttSaveCwd cwd;
-        if (wxGetApp().GetProject()->HasValue(prop_original_art))
+        if (wxGetApp().GetProject()->HasValue(prop_art_directory))
         {
-            auto dir = wxGetApp().GetOriginalArtDir();
+            auto dir = wxGetApp().GetArtDirectory();
             if (dir.dir_exists())
             {
                 wxFileName::SetCwd(dir);
@@ -64,9 +64,9 @@ bool ImageDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGProperty* WX
     else if (m_img_props.type.contains("XPM") || m_img_props.type.contains("Header"))
     {
         ttSaveCwd cwd;
-        if (wxGetApp().GetProject()->HasValue(prop_original_art) && wxGetApp().GetOriginalArtDir().dir_exists())
+        if (wxGetApp().GetProject()->HasValue(prop_art_directory) && wxGetApp().GetArtDirectory().dir_exists())
         {
-            wxFileName::SetCwd(wxGetApp().GetOriginalArtDir());
+            wxFileName::SetCwd(wxGetApp().GetArtDirectory());
         }
 
         wxString pattern;

--- a/src/customprops/img_string_prop.cpp
+++ b/src/customprops/img_string_prop.cpp
@@ -64,11 +64,7 @@ bool ImageDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGProperty* WX
     else if (m_img_props.type.contains("XPM") || m_img_props.type.contains("Header"))
     {
         ttSaveCwd cwd;
-        if (wxGetApp().GetProject()->HasValue(prop_converted_art) && wxGetApp().GetOriginalArtDir().dir_exists())
-        {
-            wxFileName::SetCwd(wxGetApp().GetConvertedArtDir());
-        }
-        else if (wxGetApp().GetProject()->HasValue(prop_original_art) && wxGetApp().GetOriginalArtDir().dir_exists())
+        if (wxGetApp().GetProject()->HasValue(prop_original_art) && wxGetApp().GetOriginalArtDir().dir_exists())
         {
             wxFileName::SetCwd(wxGetApp().GetOriginalArtDir());
         }

--- a/src/customprops/pg_animation.cpp
+++ b/src/customprops/pg_animation.cpp
@@ -62,7 +62,7 @@ void PropertyGrid_Animation::RefreshChildren()
     if (m_old_type != m_img_props.type)
     {
         wxArrayString array_art_ids;
-        auto art_dir = wxGetApp().GetOriginalArtDir();
+        auto art_dir = wxGetApp().GetArtDirectory();
         if (art_dir.empty())
             art_dir = "./";
         wxDir dir;
@@ -116,7 +116,7 @@ wxVariant PropertyGrid_Animation::ChildChanged(wxVariant& thisValue, int childIn
                 ttString name(childValue.GetString());
                 if (!name.file_exists())
                 {
-                    name = wxGetApp().GetOriginalArtDir();
+                    name = wxGetApp().GetArtDirectory();
                     name.append_filename_wx(childValue.GetString());
                 }
                 name.make_relative_wx(wxGetApp().GetProjectPath());

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -222,21 +222,8 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
                     ttString name(childValue.GetString());
                     if (!name.file_exists())
                     {
-                        if (img_props.type == "Header" || img_props.type == "XPM")
-                        {
-                            name = wxGetApp().GetConvertedArtDir();
-                            name.append_filename_wx(childValue.GetString());
-                            if (!name.file_exists())
-                            {
-                                name = wxGetApp().GetOriginalArtDir();
-                                name.append_filename_wx(childValue.GetString());
-                            }
-                        }
-                        else
-                        {
-                            name = wxGetApp().GetOriginalArtDir();
-                            name.append_filename_wx(childValue.GetString());
-                        }
+                        name = wxGetApp().GetOriginalArtDir();
+                        name.append_filename_wx(childValue.GetString());
                     }
                     name.make_relative_wx(wxGetApp().GetProjectPath());
                     name.backslashestoforward();

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -156,7 +156,7 @@ void PropertyGrid_Image::SetAutoComplete()
     }
     else
     {
-        auto art_dir = wxGetApp().GetProject()->prop_as_string(prop_original_art);
+        auto art_dir = wxGetApp().GetProject()->prop_as_string(prop_art_directory);
         if (art_dir.empty())
             art_dir = "./";
         wxDir dir;
@@ -222,7 +222,7 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
                     ttString name(childValue.GetString());
                     if (!name.file_exists())
                     {
-                        name = wxGetApp().GetOriginalArtDir();
+                        name = wxGetApp().GetArtDirectory();
                         name.append_filename_wx(childValue.GetString());
                     }
                     name.make_relative_wx(wxGetApp().GetProjectPath());

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -233,7 +233,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_normal_color, "normal_color" },
     { prop_note, "note" },
     { prop_orientation, "orientation" },
-    { prop_original_art, "original_art" },
+    { prop_art_directory, "art_directory" },
     { prop_packing, "packing" },
     { prop_page_size, "page_size" },
     { prop_pagesize, "pagesize" },

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -116,7 +116,6 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_column_sizes, "column_sizes" },
     { prop_context_help, "context_help" },
     { prop_context_menu, "context_menu" },
-    { prop_converted_art, "converted_art" },
     { prop_current, "current" },
     { prop_default, "default" },
     { prop_default_button, "default_button" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -233,7 +233,7 @@ namespace GenEnum
         prop_normal_color,
         prop_note,
         prop_orientation,
-        prop_original_art,
+        prop_art_directory,
         prop_packing,
         prop_page_size,
         prop_pagesize,

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -116,7 +116,6 @@ namespace GenEnum
         prop_column_sizes,
         prop_context_help,
         prop_context_menu,
-        prop_converted_art,
         prop_current,
         prop_default,
         prop_default_button,

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -276,11 +276,6 @@ ttString App::GetOriginalArtDir()
     return m_project->prop_as_string(prop_original_art).wx_str();
 }
 
-ttString App::GetConvertedArtDir()
-{
-    return m_project->prop_as_string(prop_converted_art).wx_str();
-}
-
 #if defined(_DEBUG) && defined(wxUSE_ON_FATAL_EXCEPTION) && defined(wxUSE_STACKWALKER)
 
     #include <wx/stackwalk.h>

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -271,9 +271,9 @@ wxImage App::GetImage(const ttlib::cstr& description)
         return GetInternalImage("unknown");
 }
 
-ttString App::GetOriginalArtDir()
+ttString App::GetArtDirectory()
 {
-    return m_project->prop_as_string(prop_original_art).wx_str();
+    return m_project->prop_as_string(prop_art_directory).wx_str();
 }
 
 #if defined(_DEBUG) && defined(wxUSE_ON_FATAL_EXCEPTION) && defined(wxUSE_STACKWALKER)

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -50,7 +50,7 @@ public:
     const ttlib::cstr& getProjectPath();
     ttString GetProjectFileName();
     ttString GetProjectPath();
-    ttString GetOriginalArtDir();
+    ttString GetArtDirectory();
 
     wxImage GetImage(const ttlib::cstr& description);
 

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -51,7 +51,6 @@ public:
     ttString GetProjectFileName();
     ttString GetProjectPath();
     ttString GetOriginalArtDir();
-    ttString GetConvertedArtDir();
 
     wxImage GetImage(const ttlib::cstr& description);
 

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -84,12 +84,36 @@ MockupParent::MockupParent(wxWindow* parent, MainFrame* frame) : wxScrolled<wxPa
     Bind(EVT_NodeSelected, &MockupParent::OnNodeSelected, this);
     Bind(EVT_NodePropChange, &MockupParent::OnNodePropModified, this);
 
-    Bind(EVT_GridBagAction, [this](CustomEvent&) { CreateContent(); });
-    Bind(EVT_NodeCreated, [this](CustomEvent&) { CreateContent(); });
-    Bind(EVT_NodeDeleted, [this](CustomEvent&) { CreateContent(); });
-    Bind(EVT_ParentChanged, [this](CustomEvent&) { CreateContent(); });
-    Bind(EVT_PositionChanged, [this](CustomEvent&) { CreateContent(); });
-    Bind(EVT_ProjectUpdated, [this](CustomEvent&) { CreateContent(); });
+    Bind(EVT_GridBagAction,
+         [this](CustomEvent&)
+         {
+             CreateContent();
+         });
+    Bind(EVT_NodeCreated,
+         [this](CustomEvent&)
+         {
+             CreateContent();
+         });
+    Bind(EVT_NodeDeleted,
+         [this](CustomEvent&)
+         {
+             CreateContent();
+         });
+    Bind(EVT_ParentChanged,
+         [this](CustomEvent&)
+         {
+             CreateContent();
+         });
+    Bind(EVT_PositionChanged,
+         [this](CustomEvent&)
+         {
+             CreateContent();
+         });
+    Bind(EVT_ProjectUpdated,
+         [this](CustomEvent&)
+         {
+             CreateContent();
+         });
 
     frame->AddCustomEventHandler(GetEventHandler());
 }

--- a/src/nodes/node_constants.cpp
+++ b/src/nodes/node_constants.cpp
@@ -5,6 +5,12 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
+#ifdef _MSC_VER
+    #pragma warning(push)
+
+    #pragma warning(disable : 4267)  // conversion from 'size_t' to 'int', possible loss of data
+#endif
+
 #include <wx/animate.h>                // wxAnimation and wxAnimationCtrl
 #include <wx/anybutton.h>              // wxAnyButtonBase class
 #include <wx/aui/auibar.h>             // wxaui: wx advanced user interface - docking window manager
@@ -47,6 +53,10 @@
 #include <wx/treelist.h>               // wxTreeListCtrl class declaration.
 #include <wx/wizard.h>                 // wxWizard class: a GUI control presenting the user with a
 #include <wx/wrapsizer.h>              // provide wrapping sizer for layout (wxWrapSizer)
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
 
 #include "node_creator.h"
 

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -46,14 +46,46 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, bool GenerateDerivedCod
     Bind(wxEVT_FIND, &BasePanel::OnFind, this);
     Bind(wxEVT_FIND_NEXT, &BasePanel::OnFind, this);
 
-    Bind(EVT_EventHandlerChanged, [this](wxEvent&) { GenerateBaseClass(); });
-    Bind(EVT_GridBagAction, [this](wxEvent&) { GenerateBaseClass(); });
-    Bind(EVT_NodeCreated, [this](wxEvent&) { GenerateBaseClass(); });
-    Bind(EVT_NodeDeleted, [this](wxEvent&) { GenerateBaseClass(); });
-    Bind(EVT_NodePropChange, [this](wxEvent&) { GenerateBaseClass(); });
-    Bind(EVT_ParentChanged, [this](wxEvent&) { GenerateBaseClass(); });
-    Bind(EVT_PositionChanged, [this](wxEvent&) { GenerateBaseClass(); });
-    Bind(EVT_ProjectUpdated, [this](wxEvent&) { GenerateBaseClass(); });
+    Bind(EVT_EventHandlerChanged,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
+    Bind(EVT_GridBagAction,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
+    Bind(EVT_NodeCreated,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
+    Bind(EVT_NodeDeleted,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
+    Bind(EVT_NodePropChange,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
+    Bind(EVT_ParentChanged,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
+    Bind(EVT_PositionChanged,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
+    Bind(EVT_ProjectUpdated,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
 
     Bind(EVT_NodeSelected, &BasePanel::OnNodeSelected, this);
 

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -78,26 +78,54 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
     Bind(EVT_ParentChanged, &NavigationPanel::OnParentChange, this);
     Bind(EVT_PositionChanged, &NavigationPanel::OnPositionChange, this);
 
-    Bind(EVT_ProjectUpdated, [this](CustomEvent&) { OnProjectUpdated(); });
+    Bind(EVT_ProjectUpdated,
+         [this](CustomEvent&)
+         {
+             OnProjectUpdated();
+         });
 
     Bind(EVT_NodeCreated, &NavigationPanel::OnNodeCreated, this);
-    Bind(EVT_NodeDeleted, [this](CustomEvent& event) { DeleteNode(event.GetNode()); });
+    Bind(EVT_NodeDeleted,
+         [this](CustomEvent& event)
+         {
+             DeleteNode(event.GetNode());
+         });
 
     Bind(wxEVT_MENU, &NavigationPanel::OnExpand, this, NavToolbar::id_NavExpand);
     Bind(wxEVT_MENU, &NavigationPanel::OnCollapse, this, NavToolbar::id_NavCollapse);
     Bind(wxEVT_MENU, &NavigationPanel::OnCollExpand, this, NavToolbar::id_NavCollExpand);
 
     Bind(
-        wxEVT_MENU, [this](wxCommandEvent&) { m_pMainFrame->MoveNode(MoveDirection::Down); }, NavToolbar::id_NavMoveDown);
+        wxEVT_MENU,
+        [this](wxCommandEvent&)
+        {
+            m_pMainFrame->MoveNode(MoveDirection::Down);
+        },
+        NavToolbar::id_NavMoveDown);
 
     Bind(
-        wxEVT_MENU, [this](wxCommandEvent&) { m_pMainFrame->MoveNode(MoveDirection::Left); }, NavToolbar::id_NavMoveLeft);
+        wxEVT_MENU,
+        [this](wxCommandEvent&)
+        {
+            m_pMainFrame->MoveNode(MoveDirection::Left);
+        },
+        NavToolbar::id_NavMoveLeft);
 
     Bind(
-        wxEVT_MENU, [this](wxCommandEvent&) { m_pMainFrame->MoveNode(MoveDirection::Right); }, NavToolbar::id_NavMoveRight);
+        wxEVT_MENU,
+        [this](wxCommandEvent&)
+        {
+            m_pMainFrame->MoveNode(MoveDirection::Right);
+        },
+        NavToolbar::id_NavMoveRight);
 
     Bind(
-        wxEVT_MENU, [this](wxCommandEvent&) { m_pMainFrame->MoveNode(MoveDirection::Up); }, NavToolbar::id_NavMoveUp);
+        wxEVT_MENU,
+        [this](wxCommandEvent&)
+        {
+            m_pMainFrame->MoveNode(MoveDirection::Up);
+        },
+        NavToolbar::id_NavMoveUp);
 
     Bind(wxEVT_UPDATE_UI, &NavigationPanel::OnUpdateEvent, this);
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -87,8 +87,16 @@ PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(paren
 
     Bind(EVT_NodePropChange, &PropGridPanel::OnNodePropChange, this);
 
-    Bind(EVT_NodeSelected, [this](CustomEvent&) { Create(); });
-    Bind(EVT_ProjectUpdated, [this](CustomEvent&) { Create(); });
+    Bind(EVT_NodeSelected,
+         [this](CustomEvent&)
+         {
+             Create();
+         });
+    Bind(EVT_ProjectUpdated,
+         [this](CustomEvent&)
+         {
+             Create();
+         });
 
     frame->AddCustomEventHandler(GetEventHandler());
 }

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -147,7 +147,7 @@ wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool 
     {
         if (!path.file_exists())
         {
-            path = wxGetApp().GetProjectPtr()->prop_as_string(prop_converted_art);
+            path = wxGetApp().GetProjectPtr()->prop_as_string(prop_original_art);
             path.append_filename(parts[IndexImage]);
 
             if (result = m_images.find(path); result != m_images.end())

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -124,7 +124,7 @@ wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool 
     {
         if (!path.file_exists())
         {
-            path = wxGetApp().GetProjectPtr()->prop_as_string(prop_original_art);
+            path = wxGetApp().GetProjectPtr()->prop_as_string(prop_art_directory);
             path.append_filename(parts[IndexImage]);
         }
         auto embed = GetEmbeddedImage(path);
@@ -147,7 +147,7 @@ wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool 
     {
         if (!path.file_exists())
         {
-            path = wxGetApp().GetProjectPtr()->prop_as_string(prop_original_art);
+            path = wxGetApp().GetProjectPtr()->prop_as_string(prop_art_directory);
             path.append_filename(parts[IndexImage]);
 
             if (result = m_images.find(path); result != m_images.end())
@@ -229,7 +229,7 @@ wxAnimation ProjectSettings::GetPropertyAnimation(const ttlib::cstr& description
     ttlib::cstr path = parts[IndexImage];
     if (!path.file_exists())
     {
-        path = wxGetApp().GetProjectPtr()->prop_as_string(prop_original_art);
+        path = wxGetApp().GetProjectPtr()->prop_as_string(prop_art_directory);
         path.append_filename(parts[IndexImage]);
     }
 
@@ -273,9 +273,9 @@ bool ProjectSettings::AddEmbeddedImage(ttlib::cstr path, Node* form)
 
     if (!path.file_exists())
     {
-        if (wxGetApp().GetProject()->HasValue(prop_original_art))
+        if (wxGetApp().GetProject()->HasValue(prop_art_directory))
         {
-            ttlib::cstr art_path = wxGetApp().GetProject()->prop_as_string(prop_original_art);
+            ttlib::cstr art_path = wxGetApp().GetProject()->prop_as_string(prop_art_directory);
             art_path.append_filename(path);
             if (!art_path.file_exists())
                 return false;

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -285,7 +285,12 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
 
                     if (ttlib::is_sameas(iter.name(), "converted_art"))
                     {
-                        // If original_art supports multiple directories, then we can add this to that property
+                        // Just ignore it
+                        continue;
+                    }
+                    else if (ttlib::is_sameas(iter.name(), "original_art"))
+                    {
+                        new_node->prop_set_value(prop_art_directory, value);
                         continue;
                     }
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -279,6 +279,18 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
 
             if (auto value = iter.value(); *value)
             {
+                {
+                    // REVIEW: [KeyWorks - 11-30-2021] This code block deals with changes to the 1.2 project format prior to it being released
+                    // in beta. Once we make a full release, we should be able to safely remove all of this.
+
+                    if (ttlib::is_sameas(iter.name(), "converted_art"))
+                    {
+                        // If original_art supports multiple directories, then we can add this to that property
+                        continue;
+                    }
+
+                }
+
                 // We get here if a property is specified that we don't recognize. While we can continue to load
                 // just fine, if the user attempts to save the project than the property will be lost.
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -280,8 +280,9 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
             if (auto value = iter.value(); *value)
             {
                 {
-                    // REVIEW: [KeyWorks - 11-30-2021] This code block deals with changes to the 1.2 project format prior to it being released
-                    // in beta. Once we make a full release, we should be able to safely remove all of this.
+                    // REVIEW: [KeyWorks - 11-30-2021] This code block deals with changes to the 1.2 project format prior to
+                    // it being released in beta. Once we make a full release, we should be able to safely remove all of
+                    // this.
 
                     if (ttlib::is_sameas(iter.name(), "converted_art"))
                     {
@@ -293,7 +294,6 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
                         new_node->prop_set_value(prop_art_directory, value);
                         continue;
                     }
-
                 }
 
                 // We get here if a property is specified that we don't recognize. While we can continue to load

--- a/src/ui/embedimg.cpp
+++ b/src/ui/embedimg.cpp
@@ -74,6 +74,7 @@ EmbedImage::EmbedImage(wxWindow* parent) : EmbedImageBase(parent)
         dir = "./";
     dir.make_absolute();
     m_fileOriginal->SetInitialDirectory(dir);
+    m_fileOutput->SetInitialDirectory(dir);
 
 #if defined(_WIN32)
 
@@ -85,14 +86,6 @@ EmbedImage::EmbedImage(wxWindow* parent) : EmbedImageBase(parent)
     // By setting the path, the user can start typing and immediately get a drop-down list of matchning filenames.
     m_fileOriginal->SetPath(dir);
 #endif  // _WIN32
-
-    dir_property = wxGetApp().GetProject()->prop_as_string(prop_converted_art);
-    if (dir_property.size())
-        dir = dir_property;
-    else
-        dir = "./";
-    dir.make_absolute();
-    m_fileOutput->SetInitialDirectory(dir);
 
     m_btnClose->SetLabel("Close");
 
@@ -328,7 +321,7 @@ void EmbedImage::OnInputChange(wxFileDirPickerEvent& WXUNUSED(event))
 
         // Now that we have a loaded image, set the output file.
         ttString outFilename;
-        auto dir_property = wxGetApp().GetProject()->prop_as_string(prop_converted_art);
+        auto dir_property = wxGetApp().GetProject()->prop_as_string(prop_original_art);
         if (dir_property.size())
         {
             outFilename = dir_property;

--- a/src/ui/embedimg.cpp
+++ b/src/ui/embedimg.cpp
@@ -67,7 +67,7 @@ EmbedImage::EmbedImage(wxWindow* parent) : EmbedImageBase(parent)
     m_cwd.assignCwd();
 
     ttString dir;
-    auto dir_property = wxGetApp().GetProject()->prop_as_string(prop_original_art);
+    auto dir_property = wxGetApp().GetProject()->prop_as_string(prop_art_directory);
     if (dir_property.size())
         dir = dir_property;
     else
@@ -321,7 +321,7 @@ void EmbedImage::OnInputChange(wxFileDirPickerEvent& WXUNUSED(event))
 
         // Now that we have a loaded image, set the output file.
         ttString outFilename;
-        auto dir_property = wxGetApp().GetProject()->prop_as_string(prop_original_art);
+        auto dir_property = wxGetApp().GetProject()->prop_as_string(prop_art_directory);
         if (dir_property.size())
         {
             outFilename = dir_property;

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -3,8 +3,7 @@
   data_version="12">
   <node
     class="Project"
-    converted_art="../art_headers"
-    original_art="../art_src"
+    art_directory="../art_src"
     generate_cmake="true">
     <node
       class="Images"

--- a/src/winres/ctrl_utils.cpp
+++ b/src/winres/ctrl_utils.cpp
@@ -289,7 +289,7 @@ ttlib::cview resCtrl::StepOverComma(ttlib::cview line, ttlib::cstr& str)
     if (!ttlib::is_found(pos))
         return ttlib::emptystring;
 
-    if (pos +1 >= line.size())
+    if (pos + 1 >= line.size())
     {
         // This is an invalid control line
         line.remove_prefix(line.size());

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -20,8 +20,8 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 			help="The filename of a local precompiled header file. The file will be included in quotes." />
 		<property name="src_preamble" type="string_edit"
 			help="Code to generate at the top of the source file after the inclusion of any local precompiled header file. This can include er files, comments, macros, etc." />
-		<property name="original_art" type="path"
-			help="The directory containing your original artwork." />
+		<property name="art_directory" type="path"
+			help="The directory containing your images (png, ico, xpm, etc.)." />
 		<property name="internationalize" type="bool"
 			help="Wrap strings in a _() macro which expands into a call to wxGetTranslation().">0</property>
 		<property name="help_provider" type="option"

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -22,8 +22,6 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 			help="Code to generate at the top of the source file after the inclusion of any local precompiled header file. This can include er files, comments, macros, etc." />
 		<property name="original_art" type="path"
 			help="The directory containing your original artwork." />
-		<property name="converted_art" type="path"
-			help="The directory containing XPM and PNG header files." />
 		<property name="internationalize" type="bool"
 			help="Wrap strings in a _() macro which expands into a call to wxGetTranslation().">0</property>
 		<property name="help_provider" type="option"

--- a/testing/src/ui/wxUiTesting.wxui
+++ b/testing/src/ui/wxUiTesting.wxui
@@ -3,9 +3,8 @@
   data_version="12">
   <node
     class="Project"
-    converted_art="../art"
+    art_directory="../art"
     local_pch_file="pch.h"
-    original_art="../art"
     generate_cmake="true">
     <node
       class="wxFrame"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes the `converted_art` property and changes the `original_art` property name to `art_directory`.
