### PR TITLE
wxUiTesing: switch to lambdas for events in Common Dialog

### DIFF
--- a/src/generate/listctrl_widgets.cpp
+++ b/src/generate/listctrl_widgets.cpp
@@ -154,5 +154,6 @@ std::optional<ttlib::cstr> EditListBoxGenerator::GenEvents(NodeEvent* event, con
 bool EditListBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/editlbox.h>", set_src, set_hdr);
+    InsertGeneratorInclude(node, "#include <wx/listbase.h>", set_src, set_hdr);
     return true;
 }

--- a/testing/src/ui/commonctrls.cpp
+++ b/testing/src/ui/commonctrls.cpp
@@ -18,51 +18,10 @@ CommonCtrls::CommonCtrls(wxWindow* parent) : CommonCtrlsBase(parent)
     m_bmpComboBox->Append("Home", wxArtProvider::GetBitmap(wxART_GO_HOME, wxART_MENU));
     m_bmpComboBox->Append("Print", wxArtProvider::GetBitmap(wxART_PRINT, wxART_MENU));
 }
+
 CommonCtrls::~CommonCtrls()
 {
     delete m_popup_win;
-}
-
-void CommonCtrls::OnProcessEnter(wxCommandEvent& WXUNUSED(event))
-{
-    m_infoBar->ShowMessage("wxEVT_TEXT_ENTER event");
-    Fit();
-}
-
-void CommonCtrls::OnCheckBox(wxCommandEvent& WXUNUSED(event))
-{
-    m_infoBar->ShowMessage("wxEVT_CHECKBOX event");
-    Fit();
-}
-
-void CommonCtrls::OnFirstBtn(wxCommandEvent& WXUNUSED(event))
-{
-    m_infoBar->ShowMessage("wxEVT_BUTTON event");
-    Fit();
-}
-
-void CommonCtrls::OnRadio(wxCommandEvent& WXUNUSED(event))
-{
-    m_infoBar->ShowMessage("wxEVT_RADIOBUTTON event");
-    Fit();
-}
-
-void CommonCtrls::OnChoice(wxCommandEvent& WXUNUSED(event))
-{
-    m_infoBar->ShowMessage("wxEVT_CHOICE event");
-    Fit();
-}
-
-void CommonCtrls::OnCombo(wxCommandEvent& WXUNUSED(event))
-{
-    m_infoBar->ShowMessage("wxEVT_COMBOBOX event");
-    Fit();
-}
-
-void CommonCtrls::OnComboClose(wxCommandEvent& WXUNUSED(event))
-{
-    m_infoBar->ShowMessage("wxEVT_COMBOBOX_CLOSEUP event");
-    Fit();
 }
 
 void CommonCtrls::OnListChecked(wxCommandEvent& WXUNUSED(event))
@@ -96,7 +55,7 @@ void CommonCtrls::OnPopupBtn(wxCommandEvent& event)
     m_popup_win = new PopupWin(this);
 
     auto btn = wxStaticCast(event.GetEventObject(), wxWindow);
-    auto pos = btn->ClientToScreen( wxPoint(0,0) );
+    auto pos = btn->ClientToScreen(wxPoint(0, 0));
     m_popup_win->Position(pos, btn->GetSize());
 
     m_popup_win->Popup();

--- a/testing/src/ui/commonctrls.h
+++ b/testing/src/ui/commonctrls.h
@@ -23,13 +23,6 @@ protected:
     void OnSlider(wxCommandEvent& event) override;
     void OnRadioBox(wxCommandEvent& event) override;
     void OnListChecked(wxCommandEvent& event) override;
-    void OnComboClose(wxCommandEvent& event) override;
-    void OnCombo(wxCommandEvent& event) override;
-    void OnChoice(wxCommandEvent& event) override;
-    void OnRadio(wxCommandEvent& event) override;
-    void OnFirstBtn(wxCommandEvent& event) override;
-    void OnCheckBox(wxCommandEvent& event) override;
-    void OnProcessEnter(wxCommandEvent& event) override;
 
 private:
     PopupWin* m_popup_win { nullptr };

--- a/testing/src/ui/commonctrls_base.cpp
+++ b/testing/src/ui/commonctrls_base.cpp
@@ -55,7 +55,14 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
     box_sizer->Add(m_staticText, wxSizerFlags().Center().Border(wxLEFT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     m_textCtrl = new wxTextCtrl(this, wxID_ANY, "Text \"ctrl\"", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+    {
+        wxArrayString tmp_array;
+        tmp_array.push_back(wxString::FromUTF8("foo"));
+        tmp_array.push_back(wxString::FromUTF8("bar"));
+        m_textCtrl->AutoComplete(tmp_array);
+    }
     m_textCtrl->SetValidator(wxTextValidator(wxFILTER_NONE, &m_textCtrlValidate));
+    m_textCtrl->SetToolTip("Auto-complete contains \"foo\" and \"bar\"");
     box_sizer->Add(m_textCtrl, wxSizerFlags().Border(wxALL));
 
     m_staticText2 = new wxStaticText(this, wxID_ANY, "More text:");

--- a/testing/src/ui/commonctrls_base.cpp
+++ b/testing/src/ui/commonctrls_base.cpp
@@ -251,16 +251,64 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
 
     // Event handlers
     Bind(wxEVT_CONTEXT_MENU, &CommonCtrlsBase::OnContextMenu, this);
-    m_textCtrl->Bind(wxEVT_TEXT_ENTER, &CommonCtrlsBase::OnProcessEnter, this);
-    m_checkBox->Bind(wxEVT_CHECKBOX, &CommonCtrlsBase::OnCheckBox, this);
-    m_btn->Bind(wxEVT_BUTTON, &CommonCtrlsBase::OnFirstBtn, this);
+    m_textCtrl->Bind(wxEVT_TEXT_ENTER,
+        [this](wxCommandEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_TEXT_ENTER event");
+            Fit();
+
+        } );
+    m_checkBox->Bind(wxEVT_CHECKBOX,
+        [this](wxCommandEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_CHECKBOX event");
+            Fit();
+
+        } );
+    m_btn->Bind(wxEVT_BUTTON,
+        [this](wxCommandEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_BUTTON event");
+            Fit();
+
+        } );
     btn2->Bind(wxEVT_BUTTON, &CommonCtrlsBase::OnPopupBtn, this);
-    m_radioBtn->Bind(wxEVT_RADIOBUTTON, &CommonCtrlsBase::OnRadio, this);
+    m_radioBtn->Bind(wxEVT_RADIOBUTTON,
+        [this](wxCommandEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_RADIOBUTTON event");
+            Fit();
+
+        } );
     m_radioBtn2->Bind(wxEVT_RADIOBUTTON, &CommonCtrlsBase::OnRadio, this);
     m_checkBox2->Bind(wxEVT_CHECKBOX, &CommonCtrlsBase::OnCheckBox, this);
-    m_comboBox->Bind(wxEVT_COMBOBOX, &CommonCtrlsBase::OnCombo, this);
-    m_comboBox2->Bind(wxEVT_COMBOBOX_CLOSEUP, &CommonCtrlsBase::OnComboClose, this);
-    m_choice->Bind(wxEVT_CHOICE, &CommonCtrlsBase::OnChoice, this);
+    m_comboBox->Bind(wxEVT_COMBOBOX,
+        [this](wxCommandEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_COMBOBOX event");
+            Fit();
+
+        } );
+    m_comboBox2->Bind(wxEVT_COMBOBOX,
+        [this](wxCommandEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_COMBOBOX event");
+            Fit();
+        } );
+    m_comboBox2->Bind(wxEVT_COMBOBOX_CLOSEUP,
+        [this](wxCommandEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_COMBOBOX_CLOSEUP event");
+            Fit();
+
+        } );
+    m_choice->Bind(wxEVT_CHOICE,
+        [this](wxCommandEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_CHOICE event");
+            Fit();
+
+        } );
     m_choice2->Bind(wxEVT_CHOICE, &CommonCtrlsBase::OnChoice, this);
     m_listbox->Bind(wxEVT_LISTBOX, &CommonCtrlsBase::OnListBox, this);
     m_listBox2->Bind(wxEVT_LISTBOX, &CommonCtrlsBase::OnListBox, this);

--- a/testing/src/ui/commonctrls_base.cpp
+++ b/testing/src/ui/commonctrls_base.cpp
@@ -331,6 +331,12 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
             Fit();
 
         } );
+    m_edit_listbox->Bind(wxEVT_LIST_BEGIN_DRAG,
+        [this](wxListEvent&)
+        {
+            m_infoBar->ShowMessage("wxEVT_LIST_BEGIN_DRAG event");
+            Fit();
+        } );
     m_slider->Bind(wxEVT_SLIDER, &CommonCtrlsBase::OnSlider, this);
 
     return true;

--- a/testing/src/ui/commonctrls_base.cpp
+++ b/testing/src/ui/commonctrls_base.cpp
@@ -256,7 +256,6 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
         {
             m_infoBar->ShowMessage("wxEVT_TEXT_ENTER event");
             Fit();
-
         } );
     m_checkBox->Bind(wxEVT_CHECKBOX,
         [this](wxCommandEvent&)
@@ -270,7 +269,6 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
         {
             m_infoBar->ShowMessage("wxEVT_BUTTON event");
             Fit();
-
         } );
     btn2->Bind(wxEVT_BUTTON, &CommonCtrlsBase::OnPopupBtn, this);
     m_radioBtn->Bind(wxEVT_RADIOBUTTON,
@@ -278,7 +276,6 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
         {
             m_infoBar->ShowMessage("wxEVT_RADIOBUTTON event");
             Fit();
-
         } );
     m_radioBtn2->Bind(wxEVT_RADIOBUTTON, &CommonCtrlsBase::OnRadio, this);
     m_checkBox2->Bind(wxEVT_CHECKBOX, &CommonCtrlsBase::OnCheckBox, this);
@@ -287,7 +284,6 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
         {
             m_infoBar->ShowMessage("wxEVT_COMBOBOX event");
             Fit();
-
         } );
     m_comboBox2->Bind(wxEVT_COMBOBOX,
         [this](wxCommandEvent&)
@@ -300,14 +296,12 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
         {
             m_infoBar->ShowMessage("wxEVT_COMBOBOX_CLOSEUP event");
             Fit();
-
         } );
     m_choice->Bind(wxEVT_CHOICE,
         [this](wxCommandEvent&)
         {
             m_infoBar->ShowMessage("wxEVT_CHOICE event");
             Fit();
-
         } );
     m_choice2->Bind(wxEVT_CHOICE, &CommonCtrlsBase::OnChoice, this);
     m_listbox->Bind(wxEVT_LISTBOX, &CommonCtrlsBase::OnListBox, this);
@@ -325,6 +319,10 @@ bool CommonCtrlsBase::Create(wxWindow *parent, wxWindowID id, const wxString &ti
             {  
                 m_animation_ctrl->Stop();
             }
+
+            m_infoBar->ShowMessage("wxEVT_TOGGLEBUTTON event");
+            Fit();
+
         } );
     m_slider->Bind(wxEVT_SLIDER, &CommonCtrlsBase::OnSlider, this);
 

--- a/testing/src/ui/commonctrls_base.h
+++ b/testing/src/ui/commonctrls_base.h
@@ -95,13 +95,9 @@ protected:
 
     virtual void OnCheckBox(wxCommandEvent& event) { event.Skip(); }
     virtual void OnChoice(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnCombo(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnComboClose(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnFirstBtn(wxCommandEvent& event) { event.Skip(); }
     virtual void OnListBox(wxCommandEvent& event) { event.Skip(); }
     virtual void OnListChecked(wxCommandEvent& event) { event.Skip(); }
     virtual void OnPopupBtn(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnProcessEnter(wxCommandEvent& event) { event.Skip(); }
     virtual void OnRadio(wxCommandEvent& event) { event.Skip(); }
     virtual void OnRadioBox(wxCommandEvent& event) { event.Skip(); }
     virtual void OnSlider(wxCommandEvent& event) { event.Skip(); }

--- a/testing/src/ui/commonctrls_base.h
+++ b/testing/src/ui/commonctrls_base.h
@@ -22,6 +22,7 @@
 #include <wx/icon.h>
 #include <wx/image.h>
 #include <wx/infobar.h>
+#include <wx/listbase.h>
 #include <wx/listbox.h>
 #include <wx/radiobox.h>
 #include <wx/radiobut.h>

--- a/testing/src/ui/mainframe_base.cpp
+++ b/testing/src/ui/mainframe_base.cpp
@@ -22,13 +22,15 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menuDialogs = new wxMenu();
 
-    auto menuItem = new wxMenuItem(menuDialogs, wxID_ANY, "DlgMulitTest...",
-        "Launch DlgMultiTest Dialog", wxITEM_NORMAL);
-    menuDialogs->Append(menuItem);
-
     auto menuItem_2 = new wxMenuItem(menuDialogs, wxID_ANY, "Common Controls...",
         "Common controls", wxITEM_NORMAL);
+    menuItem_2->SetBitmap(wxArtProvider::GetBitmap(wxART_LIST_VIEW, wxART_MENU));
     menuDialogs->Append(menuItem_2);
+
+    auto menuItem = new wxMenuItem(menuDialogs, wxID_ANY, "DlgMulitTest...",
+        "Launch DlgMultiTest Dialog", wxITEM_NORMAL);
+    menuItem->SetBitmap(wxArtProvider::GetBitmap(wxART_REPORT_VIEW, wxART_MENU));
+    menuDialogs->Append(menuItem);
 
     auto menuItem1 = new wxMenuItem(menuDialogs, wxID_ANY, "Other Controls Dialog...");
     menuDialogs->Append(menuItem1);
@@ -66,7 +68,9 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     SetMenuBar(menubar);
 
     m_toolBar = CreateToolBar();
-    auto tool = m_toolBar->AddTool(wxID_ANY, "DlgMulitTest...", wxArtProvider::GetBitmap(wxART_REPORT_VIEW, wxART_OTHER), wxNullBitmap, wxITEM_NORMAL, 
+    auto tool_2 = m_toolBar->AddTool(wxID_ANY, "Common Controls...", wxArtProvider::GetBitmap(wxART_LIST_VIEW, wxART_TOOLBAR));
+
+    auto tool = m_toolBar->AddTool(wxID_ANY, "DlgMulitTest...", wxArtProvider::GetBitmap(wxART_REPORT_VIEW, wxART_TOOLBAR), wxNullBitmap, wxITEM_NORMAL, 
             "Launch DlgMultiTest Dialog", "Launch DlgMultiTest Dialog");
 
     m_toolBar->Realize();
@@ -76,8 +80,8 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     Centre(wxBOTH);
 
     // Event handlers
-    Bind(wxEVT_MENU, &MainFrameBase::OnMultiTestDialog, this, menuItem->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnCommonDialog, this, menuItem_2->GetId());
+    Bind(wxEVT_MENU, &MainFrameBase::OnMultiTestDialog, this, menuItem->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnOtherCtrls, this, menuItem1->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnRibbonDialog, this, menuItem2->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnWizard, this, menuItem3->GetId());
@@ -87,5 +91,6 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     Bind(wxEVT_MENU, &MainFrameBase::OnToolbook, this, menu_toolbook->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnTreebook, this, menu_treebook->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnQuit, this, wxID_EXIT);
+    Bind(wxEVT_TOOL, &MainFrameBase::OnCommonDialog, this, tool_2->GetId());
     Bind(wxEVT_TOOL, &MainFrameBase::OnMultiTestDialog, this, tool->GetId());
 }

--- a/testing/src/ui/wxUiTesting.wxui
+++ b/testing/src/ui/wxUiTesting.wxui
@@ -144,9 +144,11 @@
             borders="wxLEFT|wxTOP|wxBOTTOM" />
           <node
             class="wxTextCtrl"
+            auto_complete="&quot;foo&quot; &quot;bar&quot;"
             style="wxTE_PROCESS_ENTER"
             value="Text &quot;ctrl&quot;"
             validator_variable="m_textCtrlValidate"
+            tooltip="Auto-complete contains &quot;foo&quot; and &quot;bar&quot;"
             wxEVT_TEXT_ENTER="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_TEXT_ENTER event&quot;);@@Fit();@@}" />
           <node
             class="wxStaticText"

--- a/testing/src/ui/wxUiTesting.wxui
+++ b/testing/src/ui/wxUiTesting.wxui
@@ -147,7 +147,7 @@
             style="wxTE_PROCESS_ENTER"
             value="Text &quot;ctrl&quot;"
             validator_variable="m_textCtrlValidate"
-            wxEVT_TEXT_ENTER="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_TEXT_ENTER event&quot;);@@    Fit();@@@@}" />
+            wxEVT_TEXT_ENTER="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_TEXT_ENTER event&quot;);@@Fit();@@}" />
           <node
             class="wxStaticText"
             label="More text:"
@@ -171,7 +171,7 @@
           <node
             class="wxButton"
             label="First btn"
-            wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_BUTTON event&quot;);@@    Fit();@@@@}" />
+            wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_BUTTON event&quot;);@@Fit();@@}" />
           <node
             class="wxButton"
             class_access="none"
@@ -183,7 +183,7 @@
             label="First radio"
             style="wxRB_GROUP"
             alignment="wxALIGN_CENTER"
-            wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_RADIOBUTTON event&quot;);@@    Fit();@@@@}" />
+            wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_RADIOBUTTON event&quot;);@@Fit();@@}" />
           <node
             class="wxRadioButton"
             label="Second radio"
@@ -221,7 +221,7 @@
                 selection_string="item #2"
                 tooltip="Item #0 should be selected by default"
                 flags="wxEXPAND"
-                wxEVT_COMBOBOX="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX event&quot;);@@    Fit();@@@@}" />
+                wxEVT_COMBOBOX="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX event&quot;);@@Fit();@@}" />
               <node
                 class="wxStaticText"
                 label="Sorted"
@@ -234,8 +234,8 @@
                 style="wxCB_SORT"
                 var_name="m_comboBox2"
                 tooltip="Item #2 should be selected by default"
-                wxEVT_COMBOBOX="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX event&quot;);@@    Fit();@@}"
-                wxEVT_COMBOBOX_CLOSEUP="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX_CLOSEUP event&quot;);@@    Fit();@@@@}" />
+                wxEVT_COMBOBOX="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX event&quot;);@@Fit();@@}"
+                wxEVT_COMBOBOX_CLOSEUP="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX_CLOSEUP event&quot;);@@Fit();@@}" />
             </node>
             <node
               class="wxStaticBoxSizer"
@@ -251,7 +251,7 @@
                 choices="&quot;item #1&quot; &quot;item #2&quot; &quot;item #0&quot;"
                 selection_int="2"
                 tooltip="Item #0 should be selected by default"
-                wxEVT_CHOICE="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_CHOICE event&quot;);@@    Fit();@@@@}" />
+                wxEVT_CHOICE="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_CHOICE event&quot;);@@Fit();@@}" />
               <node
                 class="wxStaticText"
                 label="Sorted"
@@ -341,7 +341,7 @@
             class="wxToggleButton"
             label="Play Animation"
             style="wxBU_EXACTFIT"
-            wxEVT_TOGGLEBUTTON="[this](wxCommandEvent&amp;)@@{@@if (m_toggleBtn->GetValue()) @@{@@    m_animation_ctrl->Play();@@}@@else @@{  @@    m_animation_ctrl->Stop();@@}@@}" />
+            wxEVT_TOGGLEBUTTON="[this](wxCommandEvent&amp;)@@{@@if (m_toggleBtn->GetValue()) @@{@@    m_animation_ctrl->Play();@@}@@else @@{  @@    m_animation_ctrl->Stop();@@}@@@@m_infoBar->ShowMessage(&quot;wxEVT_TOGGLEBUTTON event&quot;);@@Fit();@@@@}" />
           <node
             class="wxAnimationCtrl"
             animation="Header; ..\art\clr_hourglass_gif.hxx"

--- a/testing/src/ui/wxUiTesting.wxui
+++ b/testing/src/ui/wxUiTesting.wxui
@@ -26,16 +26,18 @@
           var_name="menuDialogs">
           <node
             class="wxMenuItem"
-            help="Launch DlgMultiTest Dialog"
-            label="DlgMulitTest..."
-            var_name="menuItem"
-            wxEVT_MENU="OnMultiTestDialog" />
-          <node
-            class="wxMenuItem"
+            bitmap="Art;wxART_LIST_VIEW|wxART_MENU;[-1,-1]"
             help="Common controls"
             label="Common Controls..."
             var_name="menuItem_2"
             wxEVT_MENU="OnCommonDialog" />
+          <node
+            class="wxMenuItem"
+            bitmap="Art;wxART_REPORT_VIEW|wxART_MENU;[-1,-1]"
+            help="Launch DlgMultiTest Dialog"
+            label="DlgMulitTest..."
+            var_name="menuItem"
+            wxEVT_MENU="OnMultiTestDialog" />
           <node
             class="wxMenuItem"
             label="Other Controls Dialog..."
@@ -94,7 +96,13 @@
         class="wxToolBar">
         <node
           class="tool"
-          bitmap="Art;wxART_REPORT_VIEW|wxART_OTHER;[-1,-1]"
+          bitmap="Art;wxART_LIST_VIEW|wxART_TOOLBAR;[-1,-1]"
+          label="Common Controls..."
+          var_name="tool_2"
+          wxEVT_TOOL="OnCommonDialog" />
+        <node
+          class="tool"
+          bitmap="Art;wxART_REPORT_VIEW|wxART_TOOLBAR;[-1,-1]"
           label="DlgMulitTest..."
           statusbar="Launch DlgMultiTest Dialog"
           tooltip="Launch DlgMultiTest Dialog"

--- a/testing/src/ui/wxUiTesting.wxui
+++ b/testing/src/ui/wxUiTesting.wxui
@@ -352,7 +352,8 @@
             class="spacer" />
           <node
             class="wxEditableListBox"
-            strings="&quot;item #1&quot; &quot;item #2&quot; &quot;item #3&quot;" />
+            strings="&quot;item #1&quot; &quot;item #2&quot; &quot;item #3&quot;"
+            wxEVT_LIST_BEGIN_DRAG="[this](wxListEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_LIST_BEGIN_DRAG event&quot;);@@Fit();@@}" />
         </node>
         <node
           class="wxBoxSizer"

--- a/testing/src/ui/wxUiTesting.wxui
+++ b/testing/src/ui/wxUiTesting.wxui
@@ -139,7 +139,7 @@
             style="wxTE_PROCESS_ENTER"
             value="Text &quot;ctrl&quot;"
             validator_variable="m_textCtrlValidate"
-            wxEVT_TEXT_ENTER="OnProcessEnter" />
+            wxEVT_TEXT_ENTER="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_TEXT_ENTER event&quot;);@@    Fit();@@@@}" />
           <node
             class="wxStaticText"
             label="More text:"
@@ -154,7 +154,7 @@
             class="wxCheckBox"
             label="2-state Checkbox"
             alignment="wxALIGN_CENTER"
-            wxEVT_CHECKBOX="OnCheckBox" />
+            wxEVT_CHECKBOX="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_CHECKBOX event&quot;);@@    Fit();@@@@}" />
         </node>
         <node
           class="wxBoxSizer"
@@ -163,7 +163,7 @@
           <node
             class="wxButton"
             label="First btn"
-            wxEVT_BUTTON="OnFirstBtn" />
+            wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_BUTTON event&quot;);@@    Fit();@@@@}" />
           <node
             class="wxButton"
             class_access="none"
@@ -175,7 +175,7 @@
             label="First radio"
             style="wxRB_GROUP"
             alignment="wxALIGN_CENTER"
-            wxEVT_RADIOBUTTON="OnRadio" />
+            wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_RADIOBUTTON event&quot;);@@    Fit();@@@@}" />
           <node
             class="wxRadioButton"
             label="Second radio"
@@ -213,7 +213,7 @@
                 selection_string="item #2"
                 tooltip="Item #0 should be selected by default"
                 flags="wxEXPAND"
-                wxEVT_COMBOBOX="OnCombo" />
+                wxEVT_COMBOBOX="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX event&quot;);@@    Fit();@@@@}" />
               <node
                 class="wxStaticText"
                 label="Sorted"
@@ -226,7 +226,8 @@
                 style="wxCB_SORT"
                 var_name="m_comboBox2"
                 tooltip="Item #2 should be selected by default"
-                wxEVT_COMBOBOX_CLOSEUP="OnComboClose" />
+                wxEVT_COMBOBOX="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX event&quot;);@@    Fit();@@}"
+                wxEVT_COMBOBOX_CLOSEUP="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_COMBOBOX_CLOSEUP event&quot;);@@    Fit();@@@@}" />
             </node>
             <node
               class="wxStaticBoxSizer"
@@ -242,7 +243,7 @@
                 choices="&quot;item #1&quot; &quot;item #2&quot; &quot;item #0&quot;"
                 selection_int="2"
                 tooltip="Item #0 should be selected by default"
-                wxEVT_CHOICE="OnChoice" />
+                wxEVT_CHOICE="[this](wxCommandEvent&amp;)@@{@@    m_infoBar->ShowMessage(&quot;wxEVT_CHOICE event&quot;);@@    Fit();@@@@}" />
               <node
                 class="wxStaticText"
                 label="Sorted"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR switches to using lambdas for most of the events in the Common Dialogs portion of the wxUiTesting app. It also fixes an issue with a missing header required for wxEditableListBox events.