### PR TITLE
Prevent most invalid alignment/expand property changes

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -102,7 +102,8 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
                     alignment.contains("wxALIGN_CENTER_HORIZONTAL") || alignment.contains("wxALIGN_TOP") ||
                     alignment.contains("wxALIGN_BOTTOM") || alignment.contains("wxALIGN_CENTER_VERTICAL"))
                 {
-                    wxMessageBox("You can't set the wxEXPAND flag if you have either horizontal or vertical alignment set.", "Invalid alignment");
+                    wxMessageBox("You can't set the wxEXPAND flag if you have either horizontal or vertical alignment set.",
+                                 "Invalid alignment");
                     event->Veto();
                     return false;
                 }

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -5,7 +5,10 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include <wx/event.h>  // Event classes
+#include "node.h"                  // Node class
+#include "node_prop.h"             // NodeProperty -- NodeProperty class
+#include <wx/event.h>              // Event classes
+#include <wx/propgrid/propgrid.h>  // wxPropertyGrid
 
 #include "base_generator.h"
 
@@ -27,4 +30,85 @@ void BaseGenerator::OnLeftClick(wxMouseEvent& event)
         wxGetFrame().GetMockup()->SelectNode(wxobject);
     }
     event.Skip();
+}
+
+bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty* prop, Node* node)
+{
+    if (prop->isProp(prop_alignment))
+    {
+        auto property = wxStaticCast(event->GetProperty(), wxFlagsProperty);
+        auto variant = event->GetPropertyValue();
+        ttString newValue = property->ValueToString(variant);
+        if (newValue.IsEmpty())
+            return true;
+
+        auto parent = node->GetParent();
+        if (newValue == "wxALIGN_TOP" || newValue == "wxALIGN_BOTTOM" || newValue == "wxALIGN_CENTER_VERTICAL")
+        {
+            if (parent && parent->IsSizer() && parent->prop_as_string(prop_orientation).contains("wxVERTICAL"))
+            {
+                wxMessageBox("You can't set vertical alignment when the parent sizer is oriented vertically.",
+                             "Invalid alignment");
+                event->Veto();
+                return false;
+            }
+            else if (node->prop_as_string(prop_flags).contains("wxEXPAND"))
+            {
+                wxMessageBox("You can't set vertical alignment if the wxEXPAND flag is set.", "Invalid alignment");
+                event->Veto();
+                return false;
+            }
+        }
+        else if (newValue == "wxALIGN_LEFT" || newValue == "wxALIGN_RIGHT" || newValue == "wxALIGN_CENTER_HORIZONTAL")
+        {
+            if (parent && parent->IsSizer() && parent->prop_as_string(prop_orientation).contains("wxHORIZONTAL"))
+            {
+                wxMessageBox("You can't set horizontal alignment when the parent sizer is oriented horizontally.",
+                             "Invalid alignment");
+                event->Veto();
+                return false;
+            }
+            else if (node->prop_as_string(prop_flags).contains("wxEXPAND"))
+            {
+                wxMessageBox("You can't set horizontal alignment if the wxEXPAND flag is set.", "Invalid alignment");
+                event->Veto();
+                return false;
+            }
+        }
+    }
+    else if (prop->isProp(prop_flags))
+    {
+        auto property = wxStaticCast(event->GetProperty(), wxFlagsProperty);
+        auto variant = event->GetPropertyValue();
+        ttString newValue = property->ValueToString(variant);
+        if (newValue.IsEmpty())
+            return true;
+
+        // Remove the original flags so that all we are checking is the changed flag.
+        if (node->HasValue(prop_flags))
+        {
+            auto original = node->prop_as_wxString(prop_flags);
+            original.Replace("|", ", ");
+            newValue.Replace(original, "");
+        }
+
+        // The newValue may have a flag removed, so this might not be the flag that got unchecked.
+        if (newValue.contains("wxEXPAND"))
+        {
+            if (node->HasValue(prop_alignment))
+            {
+                auto& alignment = node->prop_as_string(prop_alignment);
+                if (alignment.contains("wxALIGN_LEFT") || alignment.contains("wxALIGN_RIGHT") ||
+                    alignment.contains("wxALIGN_CENTER_HORIZONTAL") || alignment.contains("wxALIGN_TOP") ||
+                    alignment.contains("wxALIGN_BOTTOM") || alignment.contains("wxALIGN_CENTER_VERTICAL"))
+                {
+                    wxMessageBox("You can't set the wxEXPAND flag if you have either horizontal or vertical alignment set.", "Invalid alignment");
+                    event->Veto();
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
 }

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -13,12 +13,13 @@
 
 #include "node_classes.h"  // Forward defintions of Node classes
 
-class wxObject;
-class MockupParent;
-class wxWindow;
-class wxMouseEvent;
-class WriteCode;
 class BaseCodeGenerator;
+class MockupParent;
+class WriteCode;
+class wxMouseEvent;
+class wxObject;
+class wxPropertyGridEvent;
+class wxWindow;
 
 namespace pugi
 {
@@ -76,6 +77,9 @@ public:
 
     // Return true if the widget was changed which will resize and repaint the Mockup window
     virtual bool OnPropertyChange(wxObject*, Node*, NodeProperty*) { return false; }
+
+    // Called while processing an wxEVT_PG_CHANGING event.
+    virtual bool AllowPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*);
 
     // Bind wxEVT_LEFT_DOWN to this so that clicking on the widget will select it in the navigation panel
     void OnLeftClick(wxMouseEvent& event);

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -17,6 +17,8 @@
 
 #include "node_classes.h"  // Forward defintions of Node classes
 
+class wxPropertyGridEvent;
+
 // Common component functions
 
 // Flags are added with no space around '|' character.

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1253,10 +1253,10 @@ void MainFrame::OnToggleExpandLayout(wxCommandEvent&)
     if (!wasExpanded)
     {
         auto alignment = m_selected_node->get_prop_ptr(prop_alignment);
-        if (alignment && isPropFlagSet("wxALIGN_RIGHT", alignment->as_cview()))
+        if (alignment && alignment->as_cview().size())
         {
-            auto new_value = ClearPropFlag("wxALIGN_RIGHT", alignment->as_cview());
-            ModifyProperty(alignment, new_value);
+            // All alignment flags are invalid if wxEXPAND is set
+            ModifyProperty(alignment, "");
         }
     }
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -20,18 +20,19 @@
 
 #include "propgrid_panel.h"
 
-#include "appoptions.h"   // AppOptions -- Application-wide options
-#include "auto_freeze.h"  // AutoFreeze -- Automatically Freeze/Thaw a window
-#include "bitmaps.h"      // Map of bitmaps accessed by name
-#include "category.h"     // NodeCategory class
-#include "cstm_event.h"   // CustomEvent -- Custom Event class
-#include "font_prop.h"    // FontProperty -- FontProperty class
-#include "mainframe.h"    // MainFrame -- Main window frame
-#include "node.h"         // Node class
-#include "node_decl.h"    // NodeDeclaration class
-#include "node_prop.h"    // NodeProperty -- NodeProperty class
-#include "prop_decl.h"    // PropChildDeclaration and PropDeclaration classes
-#include "utils.h"        // Utility functions that work with properties
+#include "appoptions.h"      // AppOptions -- Application-wide options
+#include "auto_freeze.h"     // AutoFreeze -- Automatically Freeze/Thaw a window
+#include "base_generator.h"  // BaseGenerator -- Base widget generator class
+#include "bitmaps.h"         // Map of bitmaps accessed by name
+#include "category.h"        // NodeCategory class
+#include "cstm_event.h"      // CustomEvent -- Custom Event class
+#include "font_prop.h"       // FontProperty -- FontProperty class
+#include "mainframe.h"       // MainFrame -- Main window frame
+#include "node.h"            // Node class
+#include "node_decl.h"       // NodeDeclaration class
+#include "node_prop.h"       // NodeProperty -- NodeProperty class
+#include "prop_decl.h"       // PropChildDeclaration and PropDeclaration classes
+#include "utils.h"           // Utility functions that work with properties
 
 // Various customized wxPGProperty classes
 
@@ -716,6 +717,15 @@ void PropGridPanel::OnPropertyGridChanging(wxPropertyGridEvent& event)
 
     auto prop = it->second;
     auto node = prop->GetNode();
+    auto generator = node->GetGenerator();
+    if (generator)
+    {
+        if (!generator->AllowPropertyChange(&event, prop, node))
+        {
+            m_failure_handled = true;
+            return;
+        }
+    }
 
     switch (prop->type())
     {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a virtual `AllowPropertyChange()` method to the `BaseGenerator` class. This is called in response to a `wxEVT_PG_CHANGING` event, allowing any generator to look at the property being changed and optionally display an error message and veto the change.

The `BaseGenerator` version of this method will check alignment flags. It prevents adding vertical alignment if the parent sizer is oriented vertically. It prevents horizontal alignment if the parent sizer is oriented horizontally. It also checks the wxEXPAND flag preventing turning on alignment if the flag is checked, or turning on wxEXPAND if any alignment has been set.

Note that it is still possible for the flags to end up invalid -- changing the orientation of a sizer won't affect the children's flags. Importing from a different project like wxFormBuilder may contain invalid flag combinations.

Closes #73