### PR TITLE
Smart size

### DIFF
--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -51,7 +51,7 @@ CustomPointProperty::CustomPointProperty(const wxString& label, NodeProperty* pr
     if (type != CustomPointProperty::type_scale)
     {
         AddPrivateChild(new wxBoolProperty("using dialog units", wxPG_LABEL, m_dialog_units));
-        Item(2)->SetHelpString("When checked, values will be converted to dialog units before being used.");
+        Item(2)->SetHelpString("When checked, values will be converted to dialog units by calling ConvertPixelsToDialog().");
     }
 }
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -283,6 +283,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_show_effect, "show_effect" },
     { prop_show_hidden, "show_hidden" },
     { prop_size, "size" },
+    { prop_smart_size, "smart_size" },
     { prop_source_ext, "source_ext" },
     { prop_splitmode, "splitmode" },
     { prop_src_preamble, "src_preamble" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -283,6 +283,7 @@ namespace GenEnum
         prop_show_effect,
         prop_show_hidden,
         prop_size,
+        prop_smart_size,
         prop_source_ext,
         prop_splitmode,
         prop_src_preamble,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1594,7 +1594,7 @@ void BaseCodeGenerator::GenSettings(Node* node)
 
         GenerateWindowSettings(node, code);
         if (code.size())
-            m_source->writeLine(code);
+            m_source->writeLine(code, indent::auto_keep_whitespace);
     }
 }
 

--- a/src/generate/gen_inherit.cpp
+++ b/src/generate/gen_inherit.cpp
@@ -212,24 +212,38 @@ void GenerateWindowSettings(Node* node, ttlib::cstr& code)
     if (!is_smart_size && allow_minmax)
     {
         size = node->prop_as_wxSize(prop_minimum_size);
-        if (size.x != -1 || size.y != -1)
+        if (size != wxDefaultSize)
         {
             if (code.size())
                 code << "\n";
             code << node->get_node_name() << "->";
-            code << "SetMinSize(wxSize(" << size.x << ", " << size.y << "));";
+            code << "SetMinSize(";
+            if (node->prop_as_string(prop_minimum_size).contains("d", tt::CASE::either))
+                code << "ConvertPixelsToDialog(";
+
+            code << "wxSize(" << size.x << ", " << size.y;
+            if (node->prop_as_string(prop_minimum_size).contains("d", tt::CASE::either))
+                code << ')';  // close the ConvertPixelsToDialog function call
+            code << "));";
         }
     }
 
     size = node->prop_as_wxSize(prop_maximum_size);
-    if (size.x != -1 || size.y != -1)
+    if (size != wxDefaultSize)
     {
         if (allow_minmax)
         {
             if (code.size())
                 code << "\n";
             code << node->get_node_name() << "->";
-            code << "SetMaxSize(wxSize(" << size.x << ", " << size.y << "));";
+            code << "SetMaxSize(";
+            if (node->prop_as_string(prop_minimum_size).contains("d", tt::CASE::either))
+                code << "ConvertPixelsToDialog(";
+
+            code << "wxSize(" << size.x << ", " << size.y;
+            if (node->prop_as_string(prop_minimum_size).contains("d", tt::CASE::either))
+                code << ')';  // close the ConvertPixelsToDialog function call
+            code << "));";
         }
     }
 

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -335,14 +335,28 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
 
 void MockupContent::SetWindowProperties(Node* node, wxWindow* window)
 {
-    if (auto size = node->prop_as_wxSize(prop_size); size != wxDefaultSize)
+    bool is_smart_size { false };  // true means prop_size and prop_minimum_size will be ignored
+
+    if (auto size = node->prop_as_wxSize(prop_smart_size); size != wxDefaultSize)
     {
-        window->SetSize(size);
+        is_smart_size = true;
+        if (size.x > 0)
+            size.x = (size.x > window->GetBestSize().x ? size.x : -1);
+        if (size.y > 0)
+            size.y = (size.y > window->GetBestSize().y ? size.y : -1);
+
+        if (node->prop_as_string(prop_smart_size).contains("d", tt::CASE::either))
+            window->SetInitialSize(m_mockupParent->ConvertPixelsToDialog(size));
+        else
+            window->SetInitialSize(size);
     }
 
-    if (auto minsize = node->prop_as_wxSize(prop_minimum_size); minsize != wxDefaultSize)
+    if (!is_smart_size)
     {
-        window->SetMinSize(minsize);
+        if (auto minsize = node->prop_as_wxSize(prop_minimum_size); minsize != wxDefaultSize)
+        {
+            window->SetMinSize(minsize);
+        }
     }
 
     if (auto maxsize = node->prop_as_wxSize(prop_maximum_size); maxsize != wxDefaultSize)

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -355,13 +355,19 @@ void MockupContent::SetWindowProperties(Node* node, wxWindow* window)
     {
         if (auto minsize = node->prop_as_wxSize(prop_minimum_size); minsize != wxDefaultSize)
         {
-            window->SetMinSize(minsize);
+            if (node->prop_as_string(prop_minimum_size).contains("d", tt::CASE::either))
+                window->SetMinSize(m_mockupParent->ConvertPixelsToDialog(minsize));
+            else
+                window->SetMinSize(minsize);
         }
     }
 
     if (auto maxsize = node->prop_as_wxSize(prop_maximum_size); maxsize != wxDefaultSize)
     {
-        window->SetMaxSize(maxsize);
+        if (node->prop_as_string(prop_maximum_size).contains("d", tt::CASE::either))
+            window->SetMaxSize(m_mockupParent->ConvertPixelsToDialog(maxsize));
+        else
+            window->SetMaxSize(maxsize);
     }
 
     if (!node->isPropValue(prop_variant, "normal"))

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <wx/image.h>  // wxImage class
+
 #include <map>
 #include <optional>
 #include <set>

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <wx/bitmap.h>  // wxBitmap class interface
+
 #include "font_prop.h"     // FontProperty class
 #include "node_classes.h"  // Forward defintions of Node classes
 #include "prop_decl.h"     // PropDeclaration -- PropChildDeclaration and PropDeclaration classes

--- a/src/pch.h
+++ b/src/pch.h
@@ -9,16 +9,15 @@
 
 #pragma once
 
-#define wxUSE_UNICODE     1
 #define wxUSE_GUI         1
-#define wxUSE_NO_MANIFEST 1  // This is required for compiling using CLANG 9 and earlier
-
-// This *IS* a legitimate warning, however while wxWidgets 3.1.15 has made some progress, there are still header files that
-// do this, and of course we can't assume the user is compiling with a version of wxWidgets where it has been fixed.
+#define wxUSE_NO_MANIFEST 1
+#define wxUSE_UNICODE     1
 
 #if (wxMAJOR_VERSION < 4) && (wxMINOR_VERSION < 2) && (wxRELEASE_NUMBER < 6)
     #if (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
         #ifdef _MSC_VER
+            // This *IS* a legitimate warning, however while wxWidgets 3.1.15 has made some progress, there are still header
+            // files that do this.
             #pragma warning(disable : 5054)  // operator '|': deprecated between enumerations of different types
         #endif
     #endif
@@ -51,10 +50,20 @@
 
 #if (wxMAJOR_VERSION < 4) && (wxMINOR_VERSION < 2) && (wxRELEASE_NUMBER < 16)
 
+    #ifdef _MSC_VER
+        #pragma warning(disable : 4267)  // conversion from 'size_t' to 'int', possible loss of data
+        #pragma warning(disable : 4244)  // conversion from 'size_t' to 'int', possible loss of data
+    #endif
+
+    #if !defined(_WIN32) || defined(__clang__)
+        // warning: unused typedef 'complete' in scopedptr.h
+        #pragma clang diagnostic ignored "-Wunused-local-typedef"
+    #endif
+
     // We include these here so that C4244 and C4267 get disabled
-    #include <wx/choicebk.h>                 // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
-    #include <wx/htmllbox.h>                 // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
-    #include <wx/richtext/richtextbuffer.h>  // conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data
+    #include <wx/choicebk.h>
+    #include <wx/htmllbox.h>
+    #include <wx/richtext/richtextbuffer.h>
 
 #endif
 

--- a/src/ui/import_dlg.cpp
+++ b/src/ui/import_dlg.cpp
@@ -10,6 +10,10 @@
 #include <wx/dirdlg.h>   // wxDirDialog base class
 #include <wx/filedlg.h>  // wxFileDialog base header
 
+#if defined(_DEBUG)
+    #include <wx/filename.h>
+#endif
+
 #include "pugixml.hpp"   // xml processing
 #include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
 

--- a/src/xml/window_interfaces_xml.xml
+++ b/src/xml/window_interfaces_xml.xml
@@ -107,7 +107,7 @@ inline const char* window_interfaces_xml = R"===(<?xml version="1.0"?>
 		<property name="pos" type="wxPoint"
 			help="Specifies the position to pass to the constructor for the window. A -1 indicates that the value should be calculated automatically." />
 		<property name="size" type="wxSize"
-			help="Specifies the size to pass to the constructor for the window. A -1 indicates that the value should be calculated automatically. Automatic layout (such as calling SetSizerAndFit) may override these values. This property is ignored if the smart_size property is used." />
+			help="Specifies the size to pass to the constructor for the window. A -1 indicates that the value should be calculated automatically. Automatic layout (such as calling SetSizerAndFit) may override these values." />
 		<property name="minimum_size" type="wxSize"
 			help="Sets the minimum size of the window. Any positive value will override the automatic size calculation that would normally be done. This property is ignored if the smart_size property is used." />
 		<property name="derived_class" type="string"

--- a/src/xml/window_interfaces_xml.xml
+++ b/src/xml/window_interfaces_xml.xml
@@ -30,15 +30,10 @@ inline const char* window_interfaces_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="wxWindow" type="interface">
 		<property name="id" type="id">wxID_ANY</property>
-		<property name="pos" type="wxPoint"
-			help="Window position. The default is (-1, -1) which indicates that wxWidgets should generate a default position for the window." />
-		<property name="size" type="wxSize"
-			help="Window size. The default is (-1, -1) which indicates that wxWidgets should generate a default size for the window." />
-		<property name="minimum_size" type="wxSize"
-			help="Sets the minimum size of the window, to indicate to the sizer layout mechanism that this is the minimum required size." />
-		<property name="maximum_size" type="wxSize"
-			help="Sets the maximum size of the window, to indicate to the sizer layout mechanism that this is the maximum allowable size." />
-		<property name="variant" type="option">
+		<property name="smart_size" type="wxSize"
+			help="If a positive value is used, the minimum size of the window will be set to that if it is larger then what automatic layout would have calculated. A -1 indicates that the value should always be calculated automatically." />
+		<property name="variant" type="option"
+			help="Chooses a different variant of the window display to use (calls SetWindowVariant).">
 			<option name="normal"
 				help="Normal size" />
 			<option name="small"
@@ -49,6 +44,8 @@ inline const char* window_interfaces_xml = R"===(<?xml version="1.0"?>
 				help="About 35% larger than normal." />
 			normal
 		</property>
+		<property name="maximum_size" type="wxSize"
+			help="Sets the maximum allowable size of the window." />
 		<property name="window_style" type="bitlist">
 			<option name="wxBORDER_DEFAULT"
 				help="The window class will decide the kind of border to show, if any." />
@@ -99,19 +96,25 @@ inline const char* window_interfaces_xml = R"===(<?xml version="1.0"?>
 			help="Disable the window for user input. Note that when a parent window is disabled, all of its children are disabled as well and they are reenabled again when the parent is.">0</property>
 		<property name="hidden" type="bool"
 			help="Shows or hides the window.">0</property>
-		<property name="font" type="wxFont"
-			help="Sets the font for this window. This should not be use for a parent window if you don't want its font to be inherited by its children" />
 		<property name="foreground_colour" type="wxColour"
 			help="Sets the foreground colour of the window. Use &quot;Window&quot; to let wxWidgets choose the color, otherwise specify one of the system colors in the list." />
 		<property name="background_colour" type="wxColour"
 			help="Sets the background colour of the window. Use &quot;Window&quot; to let wxWidgets choose the color, otherwise specify one of the system colors in the list." />
 		<property name="context_help" type="string_escapes"
 			help="Sets the help text to be used as context-sensitive help for this window." />
-		<property name="window_name" type="string_escapes"
-			help="The name of the window. This parameter is used to associate a name with the item, allowing the application user to set Motif resource values for individual windows." />
+		<property name="font" type="wxFont"
+			help="Sets the font for this window. This should not be use for a parent window if you don't want its font to be inherited by its children" />
+		<property name="pos" type="wxPoint"
+			help="Specifies the position to pass to the constructor for the window. A -1 indicates that the value should be calculated automatically." />
+		<property name="size" type="wxSize"
+			help="Specifies the size to pass to the constructor for the window. A -1 indicates that the value should be calculated automatically. Automatic layout (such as calling SetSizerAndFit) may override these values. This property is ignored if the smart_size property is used." />
+		<property name="minimum_size" type="wxSize"
+			help="Sets the minimum size of the window. Any positive value will override the automatic size calculation that would normally be done. This property is ignored if the smart_size property is used." />
 		<property name="derived_class" type="string"
 			help="If you have derived a class from a wxWidget class and you want this component to use your derived class, then specify that class name here. You will need to add the header file for your class to the derived_header property." />
 		<property name="derived_header" type="file"
 			help="Specify the name of the header file that declares your derived class." />
+		<property name="window_name" type="string_escapes"
+			help="The name of the window. This parameter is used to associate a name with the item, allowing the application user to set Motif resource values for individual windows." />
 	</gen>
 </GeneratorDefinitions>)===";


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `smart_size` property. If either value is positive, then it will be compared with the same dimension in `GetBestSize()` and use whichever value is larger. Setting either value to a positive number will result in the minimum_size property being ignored.

This also fixes minimum_size and maximum_size so that they properly handle their dimensions if the user requested dialog units.

The order of the wxWindow settings has been changed. `pos`, `size`, and `minimum_size` are near the bottom since they _should_ be rarely used. The `variant` property has been moved up under the new `smart_size` since they both affect size, and it is now followed by `maximum_size`. That puts all the most useful size settings grouped together near the top.

Closes #546