### PR TITLE
Update wxSplitterWIndow handling

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1204,6 +1204,12 @@ void MainFrame::PasteNode(Node* parent)
         parent = m_selected_node.get();
     }
 
+    if (parent->isGen(gen_wxSplitterWindow) && parent->GetChildCount() > 1)
+    {
+        wxMessageBox("A wxSplitterWindow can't have more than two windows.");
+        return;
+    }
+
     auto new_node = g_NodeCreator.MakeCopy(m_clipboard);
 
     if (!parent->IsChildAllowed(new_node))

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -197,6 +197,9 @@ bool Node::IsChildAllowed(Node* child)
     if (max_children == child_count::infinite)
         return true;
 
+    if (isGen(gen_wxSplitterWindow))
+        return (GetChildCount() < 2);
+
     // Because m_children contains shared_ptrs, we don't want to use an iteration loop which will get/release the shared
     // ptr. Using an index into the vector lets us access the raw pointer.
 

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -175,6 +175,12 @@ NodeSharedPtr NodeCreator::CreateNode(GenName name, Node* parent)
         {
             node = NewNode(node_decl);
         }
+        else if (parent->isGen(gen_wxSplitterWindow))
+        {
+            // for splitters, we only care if the type is allowed, and if the splitter only has one child so far.
+            if (parent->GetChildCount() < 2)
+                node = NewNode(node_decl);
+        }
         else
         {
             auto count = CountChildrenWithSameType(parent, node_decl->gen_type());

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -283,6 +283,18 @@ static const ParentChild lstParentChild[] = {
     // Misc
 
     { type_splitter, type_container, two },
+    { type_splitter, type_auinotebook, two },
+    { type_splitter, type_choicebook, two },
+    { type_splitter, type_listbook, two },
+    { type_splitter, type_notebook, two },
+    { type_splitter, type_simplebook, two },
+    { type_splitter, type_dataviewctrl, two },
+    { type_splitter, type_dataviewlistctrl, two },
+    { type_splitter, type_dataviewtreectrl, two },
+    { type_splitter, type_propgrid, two },
+    { type_splitter, type_propgridman, two },
+    { type_splitter, type_splitter, two },
+    { type_splitter, type_treelistctrl, two },
 
     { type_toolbar, type_tool, infinite },
     { type_toolbar, type_widget, infinite },

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -258,6 +258,12 @@ void NavigationPanel::OnEndDrag(wxTreeEvent& event)
         return;
     }
 
+    if (node_dst->isGen(gen_wxSplitterWindow) && node_dst->GetChildCount() > 1)
+    {
+        wxMessageBox("A wxSplitterWindow can't have more than two windows.");
+        return;
+    }
+
     auto dst_parent = node_dst;
     while (!dst_parent->IsChildAllowed(node_src))
     {

--- a/src/xml/containers_xml.xml
+++ b/src/xml/containers_xml.xml
@@ -27,9 +27,9 @@ inline const char* containers_xml = R"===(<?xml version="1.0"?>
 		<property name="sashsize" type="int"
 			help="Overrides platform metrics if greater than -1">-1</property>
 		<property name="sashgravity" type="float"
-			help="Sets the sash gravity. Gravity is real factor which controls position of sash while resizing wxSplitterWindow. Gravity tells wxSplitterWindow how much will left/top window grow while resizing.">0.0</property>
+			help="Gravity determines how much the left or top pane will grow while resizing.">0.0</property>
 		<property name="min_pane_size" type="uint"
-			help="Minimum size for the panes. A minimum less than 1 is not allowed in the designer, because the designer prevents un-splitting.">0</property>
+			help="Minimum size for the panes.">150</property>
 		<property name="persist_name" type="string"
 			help="If a name is specified, wxPersistenceManager will be used to save/restore the sash position." />
 		<property name="style" type="bitlist">
@@ -50,7 +50,7 @@ inline const char* containers_xml = R"===(<?xml version="1.0"?>
 			<option name="wxSP_NO_XP_THEME"
 				help="Under Windows XP, switches off the attempt to draw the splitter using Windows XP theming, so the borders and sash will take on the pre-XP look." />
 			<option name="wxSP_PERMIT_UNSPLIT"
-				help="Always allow to unsplit, even with the minimum pane size other than zero. Note: The designer prevents un-splitting." />
+				help="Always allow to unsplit, even with the minimum pane size other than zero." />
 			<option name="wxSP_LIVE_UPDATE"
 				help="Don't draw XOR line but resize the child windows immediately." />
 			wxSP_3D


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates the **wxSplitterWindow** class. It allows more sub-window types including books, property manager, data controls, etc. It also now prevents dragging or pasting into a splitter window that already has two children. It set the minimum pane size to 150 so that a dev can actually see the initial two windows, and it updates the help text to better explain what gravity does.

Closes #559