### PR TITLE
Fix various selection problems

### DIFF
--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -75,7 +75,7 @@ public:
     };
     virtual OptionalIncludes GetEventIncludes(Node*) { return {}; }
 
-    // Return true if the widget was changed which will resize and repaint the Mockup window
+    // Return false if the entire Mockup contents should be recreated due to the property change
     virtual bool OnPropertyChange(wxObject*, Node*, NodeProperty*) { return false; }
 
     // Called while processing an wxEVT_PG_CHANGING event.

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -225,6 +225,9 @@ void MockupParent::CreateContent()
 
 void MockupParent::OnNodeSelected(CustomEvent& event)
 {
+    if (wxGetFrame().GetSelectedForm() != m_form)
+        m_isIgnoreSelection = false;
+
     if (m_isIgnoreSelection)
     {
         m_isIgnoreSelection = false;

--- a/src/mockup/mockup_parent.h
+++ b/src/mockup/mockup_parent.h
@@ -62,4 +62,5 @@ private:
     bool m_IsMagnifyWindow { false };
     bool m_ShowHiddenControls { false };
     bool m_isIgnoreSelection { false };
+    bool m_isPropertyChanging { false };
 };

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -593,7 +593,7 @@ void NodeCreator::ParseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
         GenEnum::PropType property_type { type_unknown };
         for (auto& iter: map_PropTypes)
         {
-            if (prop_type.is_sameprefix(iter.second))
+            if (prop_type.is_sameas(iter.second))
             {
                 property_type = iter.first;
                 break;

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -126,8 +126,10 @@ void PropGridPanel::SaveDescBoxHeight()
 
 void PropGridPanel::Create()
 {
-    auto node = wxGetFrame().GetSelectedNode();
-    if (node)
+    if (m_locked)
+        return;
+
+    if (auto node = wxGetFrame().GetSelectedNode(); node)
     {
         AutoFreeze freeze(this);
 
@@ -154,8 +156,7 @@ void PropGridPanel::Create()
         m_property_map.clear();
         m_event_map.clear();
 
-        auto declaration = node->GetNodeDeclaration();
-        if (declaration)
+        if (auto declaration = node->GetNodeDeclaration(); declaration)
         {
             // These sets are used to prevent trying to add a duplicate property or event to the property grid. In Debug
             // builds, attempting to do so will generate an assert message telling you the name of the duplicate and the node

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -36,6 +36,15 @@ public:
     // Returns true if a validation failure message has already been displayed to the user
     bool WasFailureHandled() { return m_failure_handled; }
 
+    // Prevents creation of node's properties until UnLock() is called.
+    void Lock() { m_locked = true; }
+
+    // Allows creation of node properties
+    void UnLock() { m_locked = false; }
+
+    // Creates properties for currently selected node.
+    void Create();
+
 protected:
     wxString GetCategoryDisplayName(const wxString& original);
 
@@ -56,7 +65,6 @@ protected:
 
     wxPGProperty* GetProperty(NodeProperty* prop);
 
-    void Create();
 
     void ReselectItem();
 
@@ -106,4 +114,6 @@ private:
 
     // Set to true if a VerifyChangeFile() function already disaplayed a message to the user.
     bool m_failure_handled { false };
+
+    bool m_locked { false };
 };

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -65,7 +65,6 @@ protected:
 
     wxPGProperty* GetProperty(NodeProperty* prop);
 
-
     void ReselectItem();
 
     void ModifyProperty(NodeProperty* prop, const wxString& str);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a number of problems with correct display in Mockup and Property panels. 

Things get complicated when an item within a book page is selected. After creating the book, Mockup needs to select the correct page -- which then fires off an event so that the page gets selected in the Navigation panel. Processing that event is required so that the user can select a page directly in the Mockup panel and have it selected in the Navigation Panel and the properties displayed in the Property panel.

The navigation panel can now lock the Property Panel until all events from Mockup get fired, and only then call the Property Panel to recreate it's properties.