### PR TITLE
Enhance CustomControl support

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -229,6 +229,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_model_column, "model_column" },
     { prop_moveable, "moveable" },
     { prop_name_space, "name_space" },
+    { prop_namespace, "namespace" },
     { prop_native_col_header, "native_col_header" },
     { prop_native_col_labels, "native_col_labels" },
     { prop_non_flexible_grow_mode, "non_flexible_grow_mode" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -231,6 +231,7 @@ namespace GenEnum
         prop_model_column,
         prop_moveable,
         prop_name_space,
+        prop_namespace,
         prop_native_col_header,
         prop_native_col_labels,
         prop_non_flexible_grow_mode,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1053,6 +1053,8 @@ ttlib::cstr BaseCodeGenerator::GetDeclaration(Node* node)
     }
     else if (class_name.is_sameas("CustomControl"))
     {
+        if (node->HasValue(prop_namespace))
+            code << node->prop_as_string(prop_namespace) << "::";
         code << node->prop_as_string(prop_class_name) << "* " << node->get_node_name() << ';';
     }
 

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -844,3 +844,8 @@ bool CustomControl::GetIncludes(Node* node, std::set<std::string>& set_src, std:
     }
     return true;
 }
+
+std::optional<ttlib::cstr> CustomControl::GenEvents(NodeEvent* event, const std::string& class_name)
+{
+    return GenEventCode(event, class_name);
+}

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -803,8 +803,10 @@ std::optional<ttlib::cstr> CustomControl::GenConstruction(Node* node)
     ttlib::cstr code;
     if (node->IsLocal())
         code << "auto ";
-    code << node->get_node_name() << " = new " << node->prop_as_string(prop_class_name)
-         << node->prop_as_string(prop_parameters) << ';';
+    code << node->get_node_name() << " = new ";
+    if (node->HasValue(prop_namespace))
+        code << node->prop_as_string(prop_namespace) << "::";
+    code << node->prop_as_string(prop_class_name) << node->prop_as_string(prop_parameters) << ';';
 
     return code;
 }
@@ -832,7 +834,13 @@ bool CustomControl::GetIncludes(Node* node, std::set<std::string>& set_src, std:
 
     if (node->prop_as_string(prop_class_access) != "none" && node->HasValue(prop_class_name))
     {
-        set_hdr.insert(ttlib::cstr() << "class " << node->prop_as_string(prop_class_name) << ';');
+        if (node->HasValue(prop_namespace))
+        {
+            set_hdr.insert(ttlib::cstr("namespace ") << node->prop_as_string(prop_namespace) << "\n{\n\t"
+                                                     << "class " << node->prop_as_string(prop_class_name) << ";\n}");
+        }
+        else
+            set_hdr.insert(ttlib::cstr() << "class " << node->prop_as_string(prop_class_name) << ';');
     }
     return true;
 }

--- a/src/generate/misc_widgets.h
+++ b/src/generate/misc_widgets.h
@@ -43,6 +43,7 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
+    std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };
 

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -50,18 +50,23 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 	</gen>
 
 	<gen class="CustomControl" image="CustomControl" type="widget">
-		<inherits class="wxWindow" />
+		<inherits class="wxWindow">
+			<hide name="derived_class" />
+			<hide name="derived_header" />
+		</inherits>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_custom</property>
 		<property name="class_name" type="string"
 			help="The name of the custom class.">CustomClass</property>
+		<property name="header" type="file"
+			help="The header file that declares the class." />
+		<property name="namespace" type="string"
+			help="The namespace the class is declared in." />
 		<property name="parameters" type="string"
 			help="The parameters to use when the class is constructed.">(this)</property>
-		<property name="header" type="file"
-			help="The header file that declares the class."></property>
 		<property name="settings_code" type="string_edit_escapes"
-			help="Additional code to include after the class is constructed."></property>
+			help="Additional code to include after the class is constructed." />
 	</gen>
 
 	<gen class="wxRearrangeCtrl" image="wxRearrangeCtrl" type="widget">
@@ -238,8 +243,7 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 				help="Display the value of the gauge in the application taskbar button under Windows 7 and later and the dock icon under OS X. Ignored under the other platforms. Requires wxWidgets 3.1 or higher." />
 		</property>
 	</gen>
-)==="
-R"===(
+	)===" R"===(
 	<gen class="wxScrollBar" image="scrollbar" type="widget">
 		<inherits class="Integer Validator" />
 		<inherits class="wxWindow" />
@@ -371,8 +375,7 @@ R"===(
 		<event name="wxEVT_HTML_LINK_CLICKED" class="wxHtmlLinkEvent"
 			help="" />
 	</gen>
-)==="
-R"===(
+	)===" R"===(
 	<gen class="wxWebView" image="webview" type="widget">
 		<inherits class="wxWindow">
 			<property name="proportion" type="uint">1</property>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates Custom Controls. It removes the `derived_class` and `derived_header` properties, adds a `namespace` property, and generates code for **wxWindow** events.