### PR TITLE
Add option to create missing directory when generating files

### DIFF
--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -54,6 +54,7 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
         results.emplace_back() << project->prop_as_string(prop_cmake_file) << " saved" << '\n';
     }
 
+    bool generate_result = true;
     for (size_t pos = 0; pos < project->GetChildCount(); ++pos)
     {
         auto form = project->GetChild(pos);
@@ -111,6 +112,7 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
             else if (retval < 0)
             {
                 results.emplace_back() << "Cannot create or write to the file " << path << '\n';
+                generate_result = false;
             }
             else  // retval == result::exists)
             {
@@ -135,7 +137,7 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
                     }
                     else
                     {
-                        return true;
+                        return generate_result;
                     }
                 }
             }
@@ -162,7 +164,7 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
     if (NeedsGenerateCheck)
     {
         if (pClassList && pClassList->size())
-            return true;
+            return generate_result;
         else
             return false;
     }
@@ -188,7 +190,7 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
         msg << '\n' << "All " << currentFiles << " generated files are current";
         wxMessageBox(msg, "Code Generation", wxOK, parent);
     }
-    return true;
+    return generate_result;
 }
 
 void MainFrame::OnGenInhertedClass(wxCommandEvent& WXUNUSED(e))

--- a/src/generate/write_code.h
+++ b/src/generate/write_code.h
@@ -94,7 +94,7 @@ protected:
     ttlib::cstr m_buffer;
 
 private:
-    wxString m_filename;
+    ttString m_filename;
 
 #if defined(_DEBUG)
     bool hasWriteFileBeenCalled { false };

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -109,6 +109,9 @@ public:
 
     auto GetProjectVersion() { return m_ProjectVersion; }
 
+    bool AskedAboutMissingDir(const wxString path) { return (m_missing_dirs.find(path) != m_missing_dirs.end()); }
+    void AddMissingDir(const wxString path) { m_missing_dirs.insert(path); }
+
 protected:
     bool OnInit() override;
     bool Import(ImportXML& import, ttString& file, bool append = false);
@@ -124,6 +127,11 @@ protected:
 
 private:
     std::shared_ptr<Node> m_project;
+
+    // Every time we try to write to a directory that doesn't exist, we ask the user if they
+    // want to create it. If they choose No then we store the path here and never ask again
+    // for the current session.
+    std::set<wxString> m_missing_dirs;
 
     ProjectSettings* m_pjtSettings { nullptr };
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -494,10 +494,11 @@ void MainFrame::OnImportProject(wxCommandEvent&)
 void MainFrame::OnGenerateCode(wxCommandEvent&)
 {
     wxGetApp().GetProjectSettings()->UpdateEmbedNodes();
-    GenerateCodeFiles(this);
+    m_isProject_generated = GenerateCodeFiles(this);
     UpdateWakaTime();
 
-    m_isProject_generated = true;
+    // m_isProject_generated = true;
+    // m_isProject_generated = true;
 
     m_menuTools->Enable(id_GenerateCode, !m_isProject_generated);
     m_toolbar->EnableTool(id_GenerateCode, !m_isProject_generated);
@@ -574,7 +575,7 @@ void MainFrame::ProjectLoaded()
         Bind(wxEVT_ACTIVATE,
              [this](wxActivateEvent&)
              {
-                 if (m_wakatime && wxTheApp->IsActive())
+                 if (m_wakatime)
                      m_wakatime->ResetHeartbeat();
              });
     }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a check to code generation so that if the user has specified creating the files in a directory that doesn't exist, we first ask the user for permission to create the folder. If the user says no, then we don't ask again about that folder for the rest of the session.

This also changes the method used to determine if the original file is identical to what would be generated. The update version can handle UTF8 paths on Windows.