### PR TITLE
Increase support for friendly names instead of wxWidgets constatns

### DIFF
--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -84,11 +84,15 @@ void GenPos(Node* node, ttlib::cstr& code);
 void GenSize(Node* node, ttlib::cstr& code);
 
 // This will output "0" if there are no styles (style, window_style, tab_position etc.)
-void GenStyle(Node* node, ttlib::cstr& code);
+//
+// If style is a friendly name, add the prefix parameter to prefix lookups.
+void GenStyle(Node* node, ttlib::cstr& code, const char* prefix = nullptr);
 
 // Returns the integer value of all style properties for the node. Includes style,
 // window_style, tab_position etc.
-int GetStyleInt(Node* node);
+//
+// If style is a friendly name, add the prefix parameter to prefix lookups.
+int GetStyleInt(Node* node, const char* prefix = nullptr);
 
 // Version of GenAdditionalCode() specifically for forms
 ttlib::cstr GenFormCode(GenEnum::GenCodeType command, Node* node);

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -732,8 +732,8 @@ wxObject* InfoBarGenerator::CreateMockup(Node* node, wxObject* parent)
 
     m_infobar->ShowMessage("Message ...", wxICON_INFORMATION);
 
-    m_infobar->SetShowHideEffects((wxShowEffect) node->prop_as_int(prop_show_effect),
-                                  (wxShowEffect) node->prop_as_int(prop_hide_effect));
+    m_infobar->SetShowHideEffects((wxShowEffect) node->prop_as_mockup(prop_show_effect, "info_"),
+                                  (wxShowEffect) node->prop_as_mockup(prop_hide_effect, "info_"));
     m_infobar->SetEffectDuration(node->prop_as_int(prop_duration));
 
     m_infobar->Bind(wxEVT_BUTTON, &InfoBarGenerator::OnButton, this);
@@ -757,8 +757,8 @@ std::optional<ttlib::cstr> InfoBarGenerator::GenSettings(Node* node, size_t& /* 
 {
     ttlib::cstr code;
 
-    code << '\t' << node->get_node_name() << "->SetShowHideEffects(" << node->prop_as_string(prop_show_effect) << ", "
-         << node->prop_as_string(prop_hide_effect) << ");";
+    code << '\t' << node->get_node_name() << "->SetShowHideEffects(" << node->prop_as_constant(prop_show_effect, "info_")
+         << ", " << node->prop_as_constant(prop_hide_effect, "info_") << ");";
 
     if (node->prop_as_int(prop_duration) != 500)
     {

--- a/src/generate/radio_widgets.cpp
+++ b/src/generate/radio_widgets.cpp
@@ -120,7 +120,7 @@ wxObject* RadioBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
     auto widget = new wxRadioBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
                                  DlgPoint(parent, node, prop_pos), DlgSize(parent, node, prop_size), choices,
-                                 node->prop_as_int(prop_majorDimension), GetStyleInt(node));
+                                 node->prop_as_int(prop_majorDimension), GetStyleInt(node, "rb_"));
 
     if (int selection = node->prop_as_int(prop_selection); static_cast<size_t>(selection) < choices.Count())
     {
@@ -205,17 +205,17 @@ std::optional<ttlib::cstr> RadioBoxGenerator::GenConstruction(Node* node)
         code << ", ";
         if (!isDimSet)
             code << "0, ";
-        GenStyle(node, code);
+        GenStyle(node, code, "rb_");
         code << ", wxDefaultValidator, " << node->prop_as_string(prop_window_name) << ");";
     }
     else
     {
-        if (node->prop_as_string(prop_window_style).size() || node->prop_as_string(prop_style) != "wxRA_SPECIFY_COLS")
+        if (node->prop_as_string(prop_window_style).size() || node->prop_as_string(prop_style) != "columns")
         {
             code << ", ";
             if (!isDimSet)
                 code << "0, ";
-            GenStyle(node, code);
+            GenStyle(node, code, "rb_");
         }
         code << ");";
     }

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -327,11 +327,11 @@ wxObject* StyledTextGenerator::CreateMockup(Node* node, wxObject* parent)
         scintilla->SetMarginSensitive(margin, true);
         if (node->HasValue(prop_automatic_folding))
         {
-            scintilla->SetAutomaticFold(node->prop_as_int(prop_automatic_folding));
+            scintilla->SetAutomaticFold(node->prop_as_mockup(prop_automatic_folding, "stc_"));
         }
         if (node->HasValue(prop_fold_flags))
         {
-            scintilla->SetFoldFlags(node->prop_as_int(prop_fold_flags));
+            scintilla->SetFoldFlags(node->prop_as_mockup(prop_fold_flags, "stc_"));
         }
     }
 
@@ -407,11 +407,14 @@ wxObject* StyledTextGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_eol_mode))
     {
-        scintilla->SetEOLMode(node->prop_as_int(prop_eol_mode));
+        scintilla->SetEOLMode(node->prop_as_mockup(prop_eol_mode, "stc_"));
     }
 
-    scintilla->SetViewEOL((node->prop_as_int(prop_view_eol)));
-    scintilla->SetViewWhiteSpace(g_NodeCreator.GetConstantAsInt(node->prop_as_string(prop_view_whitespace)));
+    scintilla->SetViewEOL(node->prop_as_bool(prop_view_eol));
+    if (node->isPropValue(prop_view_whitespace, "invisible"))
+    {
+        scintilla->SetViewWhiteSpace(node->prop_as_mockup(prop_view_whitespace, "stc_"));
+    }
     if (node->prop_as_bool(prop_view_tab_strikeout))
     {
         scintilla->SetTabDrawMode(wxSTC_TD_STRIKEOUT);
@@ -510,7 +513,8 @@ std::optional<ttlib::cstr> StyledTextGenerator::GenSettings(Node* node, size_t& 
 
     if (node->HasValue(prop_eol_mode))
     {
-        code << "\n\t\t" << node->get_node_name() << "->SetEOLMode(" << node->prop_as_string(prop_eol_mode) << ");";
+        code << "\n\t\t" << node->get_node_name() << "->SetEOLMode(" << node->prop_as_constant(prop_eol_mode, "stc_")
+             << ");";
     }
 
     // Default is false, so only set if true
@@ -520,10 +524,10 @@ std::optional<ttlib::cstr> StyledTextGenerator::GenSettings(Node* node, size_t& 
     }
 
     // Default is false, so only set if true
-    if (node->HasValue(prop_view_whitespace))
+    if (!node->isPropValue(prop_view_whitespace, "invisible"))
     {
-        code << "\n\t\t" << node->get_node_name() << "->SetViewWhiteSpace(" << node->prop_as_string(prop_view_whitespace)
-             << ");";
+        code << "\n\t\t" << node->get_node_name() << "->SetViewWhiteSpace("
+             << node->prop_as_constant(prop_view_whitespace, "stc_") << ");";
         if (node->prop_as_bool(prop_view_tab_strikeout))
         {
             code << "\n\t\t" << node->get_node_name() << "->SetTabDrawMode(wxSTC_TD_STRIKEOUT);";
@@ -670,11 +674,12 @@ std::optional<ttlib::cstr> StyledTextGenerator::GenSettings(Node* node, size_t& 
         if (node->HasValue(prop_automatic_folding))
         {
             code << "\n\t\t" << node->get_node_name() << "->SetAutomaticFold("
-                 << node->prop_as_string(prop_automatic_folding) << ");";
+                 << node->prop_as_constant(prop_automatic_folding, "stc_") << ");";
         }
         if (node->HasValue(prop_fold_flags))
         {
-            code << "\n\t\t" << node->get_node_name() << "->SetFoldFlags(" << node->prop_as_string(prop_fold_flags) << ");";
+            code << "\n\t\t" << node->get_node_name() << "->SetFoldFlags(" << node->prop_as_constant(prop_fold_flags, "stc_")
+                 << ");";
         }
 
         if (node->prop_as_string(prop_fold_marker_style) == "arrow" ||

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -21,41 +21,6 @@
 
 // Call g_NodeCreator->GetConstantAsInt("wx_define") to get the #defined integer value -- see node_creator.h
 
-std::map<std::string, const char*> g_stc_flags = {
-
-    { "no wrapping", "wxSTC_WRAP_NONE" },
-    { "word", "wxSTC_WRAP_WORD" },
-    { "character", "wxSTC_WRAP_CHAR" },
-    { "whitespace", "wxSTC_WRAP_WHITESPACE" },
-
-    // Visual flags
-    { "end", "wxSTC_WRAPVISUALFLAG_END" },
-    { "start", "wxSTC_WRAPVISUALFLAG_START" },
-    { "margin", "wxSTC_WRAPVISUALFLAG_MARGIN" },
-
-    { "end_text", "wxSTC_WRAPVISUALFLAGLOC_END_BY_TEXT" },
-    { "start_text", "wxSTC_WRAPVISUALFLAGLOC_START_BY_TEXT" },
-
-    { "fixed", "wxSTC_WRAPINDENT_FIXED" },
-    { "same", "wxSTC_WRAPINDENT_SAME" },
-    { "indent", "wxSTC_WRAPINDENT_INDENT" },
-
-    { "symbol", "wxSTC_MARGIN_SYMBOL" },
-    { "number", "wxSTC_MARGIN_NUMBER" },
-    { "background", "wxSTC_MARGIN_BACK" },
-    { "foreground", "wxSTC_MARGIN_FORE" },
-    { "text", "wxSTC_MARGIN_TEXT" },
-    { "right-aligned text", "wxSTC_MARGIN_RTEXT" },
-    { "colour", "wxSTC_MARGIN_COLOUR" },
-
-    { "no guides", "wxSTC_IV_NONE" },
-    { "real", "wxSTC_IV_REAL" },
-    { "forward", "wxSTC_IV_LOOKFORWARD" },
-    { "both", "wxSTC_IV_LOOKBOTH" },
-
-    // { "deep_indent", "SC_WRAPINDENT_DEEPINDENT" }, // not supported in 3.1.15
-};
-
 // To get the constant, prefix the name with "wxSTC_LEX_"
 std::map<std::string, int> g_stc_lexers = {
 
@@ -223,37 +188,20 @@ wxObject* StyledTextGenerator::CreateMockup(Node* node, wxObject* parent)
     //////////// Wrap category settings ////////////
 
     if (!node->prop_as_string(prop_stc_wrap_mode).is_sameas("no wrapping"))
-        scintilla->SetWrapMode(g_NodeCreator.GetConstantAsInt(g_stc_flags.at(node->prop_as_string(prop_stc_wrap_mode))));
+    {
+        scintilla->SetWrapMode(node->prop_as_mockup(prop_stc_wrap_mode, "stc_"));
+    }
     if (node->HasValue(prop_stc_wrap_visual_flag))
     {
-        ttlib::multistr flags(node->prop_as_string(prop_stc_wrap_visual_flag), '|');
-        int value = 0;
-        for (auto& iter: flags)
-        {
-            value |= g_NodeCreator.GetConstantAsInt(g_stc_flags.at(iter));
-        }
-        if (value)
-        {
-            scintilla->SetWrapVisualFlags(value);
-        }
+        scintilla->SetWrapVisualFlags(node->prop_as_mockup(prop_stc_wrap_visual_flag, "stc_"));
     }
     if (node->HasValue(prop_stc_wrap_visual_location))
     {
-        ttlib::multistr flags(node->prop_as_string(prop_stc_wrap_visual_location), '|');
-        int value = 0;
-        for (auto& iter: flags)
-        {
-            value |= g_NodeCreator.GetConstantAsInt(g_stc_flags.at(iter));
-        }
-        if (value)
-        {
-            scintilla->SetWrapVisualFlagsLocation(value);
-        }
+        scintilla->SetWrapVisualFlagsLocation(node->prop_as_mockup(prop_stc_wrap_visual_location, "stc_"));
     }
     if (!node->prop_as_string(prop_stc_wrap_indent_mode).is_sameas("fixed"))
     {
-        scintilla->SetWrapIndentMode(
-            g_NodeCreator.GetConstantAsInt(g_stc_flags.at(node->prop_as_string(prop_stc_wrap_indent_mode))));
+        scintilla->SetWrapIndentMode(node->prop_as_mockup(prop_stc_wrap_indent_mode, "stc_"));
     }
     if (node->HasValue(prop_stc_wrap_start_indent))
     {
@@ -409,8 +357,7 @@ wxObject* StyledTextGenerator::CreateMockup(Node* node, wxObject* parent)
         auto margin = node->prop_as_string(prop_custom_margin).atoi();
         scintilla->SetMarginWidth(margin, node->prop_as_int(prop_custom_width));
 
-        if (auto result = g_stc_flags.find(node->prop_as_string(prop_custom_type)); result != g_stc_flags.end())
-            scintilla->SetMarginType(margin, g_NodeCreator.GetConstantAsInt(result->second));
+        scintilla->SetMarginType(margin, node->prop_as_mockup(prop_custom_type, "stc_"));
 
         if (node->prop_as_string(prop_custom_type) == "colour" && node->HasValue(prop_custom_colour))
         {
@@ -438,8 +385,7 @@ wxObject* StyledTextGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_indentation_guides))
     {
-        scintilla->SetIndentationGuides(
-            g_NodeCreator.GetConstantAsInt(g_stc_flags.at(node->prop_as_string(prop_indentation_guides))));
+        scintilla->SetIndentationGuides(node->prop_as_mockup(prop_indentation_guides, "stc_"));
     }
     scintilla->SetIndent(node->prop_as_int(prop_stc_indentation_size));
     scintilla->SetUseTabs((node->prop_as_int(prop_use_tabs)));
@@ -588,39 +534,27 @@ std::optional<ttlib::cstr> StyledTextGenerator::GenSettings(Node* node, size_t& 
 
     if (!node->prop_as_string(prop_stc_wrap_mode).is_sameas("no wrapping"))
     {
-        code << "\n\t\t" << node->get_node_name() << "->SetWrapMode("
-             << g_stc_flags.at(node->prop_as_string(prop_stc_wrap_mode)) << ");";
+        code << "\n\t\t" << node->get_node_name() << "->SetWrapMode(" << node->prop_as_constant(prop_stc_wrap_mode, "stc_")
+             << ");";
     }
     if (node->HasValue(prop_stc_wrap_visual_flag))
     {
-        ttlib::multistr flags(node->prop_as_string(prop_stc_wrap_visual_flag), '|');
-        ttlib::cstr value;
-        for (auto& iter: flags)
+        if (auto result = node->prop_as_constant(prop_stc_wrap_visual_flag, "stc_"); result.size())
         {
-            if (value.size())
-                value << '|';
-            value << g_stc_flags.at(iter);
+            code << "\n\t\t" << node->get_node_name() << "->SetWrapVisualFlags(" << result << ");";
         }
-        if (value.size())
-            code << "\n\t\t" << node->get_node_name() << "->SetWrapVisualFlags(" << value << ");";
     }
     if (node->HasValue(prop_stc_wrap_visual_location))
     {
-        ttlib::multistr flags(node->prop_as_string(prop_stc_wrap_visual_location), '|');
-        ttlib::cstr value;
-        for (auto& iter: flags)
+        if (auto result = node->prop_as_constant(prop_stc_wrap_visual_location, "stc_"); result.size())
         {
-            if (value.size())
-                value << '|';
-            value << g_stc_flags.at(iter);
+            code << "\n\t\t" << node->get_node_name() << "->SetWrapVisualFlagsLocation(" << result << ");";
         }
-        if (value.size())
-            code << "\n\t\t" << node->get_node_name() << "->SetWrapVisualFlagsLocation(" << value << ");";
     }
     if (!node->prop_as_string(prop_stc_wrap_indent_mode).is_sameas("fixed"))
     {
         code << "\n\t\t" << node->get_node_name() << "->SetWrapIndentMode("
-             << g_stc_flags.at(node->prop_as_string(prop_stc_wrap_indent_mode)) << ");";
+             << node->prop_as_constant(prop_stc_wrap_indent_mode, "stc_") << ");";
     }
     if (node->HasValue(prop_stc_wrap_start_indent))
     {
@@ -876,10 +810,8 @@ std::optional<ttlib::cstr> StyledTextGenerator::GenSettings(Node* node, size_t& 
         code << "\n\t\t" << node->get_node_name() << "->SetMarginWidth(" << margin << ", "
              << node->prop_as_int(prop_custom_width) << ");";
 
-        if (auto result = g_stc_flags.find(node->prop_as_string(prop_custom_type)); result != g_stc_flags.end())
-        {
-            code << "\n\t\t" << node->get_node_name() << "->SetMarginType(" << margin << ", " << result->second << ");";
-        }
+        code << "\n\t\t" << node->get_node_name() << "->SetMarginType(" << margin << ", "
+             << node->prop_as_constant(prop_custom_type, "stc_") << ");";
 
         if (node->prop_as_string(prop_custom_type) == "colour" && node->HasValue(prop_custom_colour))
         {
@@ -902,7 +834,7 @@ std::optional<ttlib::cstr> StyledTextGenerator::GenSettings(Node* node, size_t& 
     if (node->HasValue(prop_indentation_guides))
     {
         code << "\n\t\t" << node->get_node_name() << "->SetIndentationGuides("
-             << g_stc_flags.at(node->prop_as_string(prop_indentation_guides)) << ");";
+             << node->prop_as_constant(prop_indentation_guides, "stc_") << ");";
     }
     if (node->prop_as_int(prop_stc_indentation_size) != 0)
     {

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -23,6 +23,7 @@ class ImportXML;
 // Current version of wxUiEditor project files
 constexpr const auto curWxuiMajorVer = 1;
 constexpr const auto curWxuiMinorVer = 3;
+constexpr const auto curCombinedVer = 13;
 
 class App : public wxApp
 {

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -317,6 +317,14 @@ int Node::prop_as_int(PropName name) const
         return 0;
 }
 
+int Node::prop_as_mockup(PropName name, std::string_view prefix) const
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_mockup(prefix);
+    else
+        return 0;
+}
+
 wxColour Node::prop_as_wxColour(PropName name) const
 {
     if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
@@ -401,6 +409,14 @@ const ttlib::cstr& Node::prop_as_string(PropName name) const
 {
     if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
         return m_properties[result->second].as_string();
+    else
+        return tt_empty_cstr;
+}
+
+const ttlib::cstr& Node::prop_as_constant(PropName name, std::string_view prefix)
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_constant(prefix);
     else
         return tt_empty_cstr;
 }

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -170,6 +170,7 @@ public:
     // If type is option, id, or bitlist, this will convert that constant name to it's value
     // (see g_NodeCreator.GetConstantAsInt()). Otherwise, it calls atoi().
     int prop_as_int(PropName name) const;
+    int prop_as_mockup(PropName name, std::string_view prefix) const;
 
     wxColour prop_as_wxColour(PropName name) const;
     wxFont prop_as_font(PropName name) const;
@@ -183,6 +184,7 @@ public:
     double prop_as_double(PropName name) const;
 
     const ttlib::cstr& prop_as_string(PropName name) const;
+    const ttlib::cstr& prop_as_constant(PropName name, std::string_view prefix);
 
     // Use with caution! This allows you to modify the property string directly.
     //

--- a/src/nodes/node_constants.cpp
+++ b/src/nodes/node_constants.cpp
@@ -759,3 +759,36 @@ void NodeCreator::AddAllConstants()
     m_map_constants["Tab_Wrap"] = wxGrid::Tab_Wrap;
     m_map_constants["Tab_Leave"] = wxGrid::Tab_Leave;
 }
+
+std::unordered_map<std::string, const char*> g_friend_constant = {
+
+    { "stc_end_text", "wxSTC_WRAPVISUALFLAGLOC_END_BY_TEXT" },
+    { "stc_start_text", "wxSTC_WRAPVISUALFLAGLOC_START_BY_TEXT" },
+
+    { "stc_end", "wxSTC_WRAPVISUALFLAG_END" },
+    { "stc_start", "wxSTC_WRAPVISUALFLAG_START" },
+    { "stc_margin", "wxSTC_WRAPVISUALFLAG_MARGIN" },
+
+    { "stc_no wrapping", "wxSTC_WRAP_NONE" },
+    { "stc_word", "wxSTC_WRAP_WORD" },
+    { "stc_character", "wxSTC_WRAP_CHAR" },
+    { "stc_whitespace", "wxSTC_WRAP_WHITESPACE" },
+
+    { "stc_fixed", "wxSTC_WRAPINDENT_FIXED" },
+    { "stc_same", "wxSTC_WRAPINDENT_SAME" },
+    { "stc_indent", "wxSTC_WRAPINDENT_INDENT" },
+
+    { "stc_symbol", "wxSTC_MARGIN_SYMBOL" },
+    { "stc_number", "wxSTC_MARGIN_NUMBER" },
+    { "stc_background", "wxSTC_MARGIN_BACK" },
+    { "stc_foreground", "wxSTC_MARGIN_FORE" },
+    { "stc_text", "wxSTC_MARGIN_TEXT" },
+    { "stc_right-aligned text", "wxSTC_MARGIN_RTEXT" },
+    { "stc_colour", "wxSTC_MARGIN_COLOUR" },
+
+    { "stc_no guides", "wxSTC_IV_NONE" },
+    { "stc_real", "wxSTC_IV_REAL" },
+    { "stc_forward", "wxSTC_IV_LOOKFORWARD" },
+    { "stc_both", "wxSTC_IV_LOOKBOTH" },
+
+};

--- a/src/nodes/node_constants.cpp
+++ b/src/nodes/node_constants.cpp
@@ -822,7 +822,10 @@ std::unordered_map<std::string, const char*> g_friend_constant = {
     { "info_slide to right", "wxSHOW_EFFECT_SLIDE_TO_RIGHT" },
     { "info_slide to top", "wxSHOW_EFFECT_SLIDE_TO_TOP" },
     { "info_slide to bottom", "wxSHOW_EFFECT_SLIDE_TO_BOTTOM" },
-    { "info_", "blend" },
-    { "info_", "expand" },
+    { "info_blend", "wxSHOW_EFFECT_BLEND" },
+    { "info_expand", "wxSHOW_EFFECT_EXPAND" },
+
+    { "rb_rows", "wxRA_SPECIFY_ROWS" },
+    { "rb_columns", "wxRA_SPECIFY_COLS" },
 
 };

--- a/src/nodes/node_constants.cpp
+++ b/src/nodes/node_constants.cpp
@@ -762,6 +762,8 @@ void NodeCreator::AddAllConstants()
 
 std::unordered_map<std::string, const char*> g_friend_constant = {
 
+    // CAUTION! All entries *must* have a prefix!
+
     { "stc_end_text", "wxSTC_WRAPVISUALFLAGLOC_END_BY_TEXT" },
     { "stc_start_text", "wxSTC_WRAPVISUALFLAGLOC_START_BY_TEXT" },
 
@@ -810,5 +812,17 @@ std::unordered_map<std::string, const char*> g_friend_constant = {
     { "stc_always visible", "wxSTC_WS_VISIBLEALWAYS" },
     { "stc_visible after indent", "wxSTC_WS_VISIBLEAFTERINDENT" },
     { "stc_only indent visible", "wxSTC_WS_VISIBLEONLYININDENT" },
+
+    { "info_no effects", "wxSHOW_EFFECT_NONE" },
+    { "info_roll to left", "wxSHOW_EFFECT_ROLL_TO_LEFT" },
+    { "info_roll to right", "wxSHOW_EFFECT_ROLL_TO_RIGHT" },
+    { "info_roll to top", "wxSHOW_EFFECT_ROLL_TO_TOP" },
+    { "info_roll to bottom", "wxSHOW_EFFECT_ROLL_TO_BOTTOM" },
+    { "info_slide to left", "wxSHOW_EFFECT_SLIDE_TO_LEFT" },
+    { "info_slide to right", "wxSHOW_EFFECT_SLIDE_TO_RIGHT" },
+    { "info_slide to top", "wxSHOW_EFFECT_SLIDE_TO_TOP" },
+    { "info_slide to bottom", "wxSHOW_EFFECT_SLIDE_TO_BOTTOM" },
+    { "info_", "blend" },
+    { "info_", "expand" },
 
 };

--- a/src/nodes/node_constants.cpp
+++ b/src/nodes/node_constants.cpp
@@ -791,4 +791,24 @@ std::unordered_map<std::string, const char*> g_friend_constant = {
     { "stc_forward", "wxSTC_IV_LOOKFORWARD" },
     { "stc_both", "wxSTC_IV_LOOKBOTH" },
 
+    { "stc_show lines as needed", "wxSTC_AUTOMATICFOLD_SHOW" },
+    { "stc_handle margin clicks", "wxSTC_AUTOMATICFOLD_CLICK" },
+    { "stc_show changes", "wxSTC_AUTOMATICFOLD_CHANGE" },
+
+    { "stc_before if expanded changes", "wxSTC_FOLDFLAG_LINEBEFORE_EXPANDED" },
+    { "stc_before if contracted", "wxSTC_FOLDFLAG_LINEBEFORE_CONTRACTED" },
+    { "stc_after if expanded", "wxSTC_FOLDFLAG_LINEAFTER_EXPANDED" },
+    { "stc_after if contracted", "wxSTC_FOLDFLAG_LINEAFTER_CONTRACTED" },
+    { "stc_debug hex levels", "wxSTC_FOLDFLAG_LEVELNUMBERS" },
+    { "stc_debug line state", "wxSTC_FOLDFLAG_LINESTATE" },
+
+    { "stc_\\r\\n (CR/LF)", "wxSTC_EOL_CRLF" },
+    { "stc_\\r (CR)", "wxSTC_EOL_CR" },
+    { "stc_\\n (LF)", "wxSTC_EOL_LF" },
+
+    { "stc_invisible", "wxSTC_WS_INVISIBLE" },
+    { "stc_always visible", "wxSTC_WS_VISIBLEALWAYS" },
+    { "stc_visible after indent", "wxSTC_WS_VISIBLEAFTERINDENT" },
+    { "stc_only indent visible", "wxSTC_WS_VISIBLEONLYININDENT" },
+
 };

--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -99,3 +99,6 @@ private:
 };
 
 extern NodeCreator g_NodeCreator;
+
+// Map of friendly name to wxWidgets constant string
+extern std::unordered_map<std::string, const char*> g_friend_constant;

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -61,6 +61,146 @@ int NodeProperty::as_int() const
     }
 }
 
+int NodeProperty::as_mockup(std::string_view prefix) const
+{
+    switch (type())
+    {
+        case type_editoption:
+        case type_option:
+        case type_id:
+            if (m_value.is_sameprefix("wx"))
+            {
+                return g_NodeCreator.GetConstantAsInt(m_value, 0);
+            }
+            else
+            {
+                if (prefix.size())
+                {
+                    ttlib::cstr name;
+                    name << prefix << m_value;
+                    if (auto result = g_friend_constant.find(name); result != g_friend_constant.end())
+                    {
+                        return g_NodeCreator.GetConstantAsInt(result->second, 0);
+                    }
+                }
+                else
+                {
+                    if (auto result = g_friend_constant.find(m_value); result != g_friend_constant.end())
+                    {
+                        return g_NodeCreator.GetConstantAsInt(result->second, 0);
+                    }
+                }
+            }
+            return 0;
+
+        case type_bitlist:
+            {
+                ttlib::multistr mstr(m_value, '|');
+                int value = 0;
+                for (auto& iter: mstr)
+                {
+                    if (iter.is_sameprefix("wx"))
+                    {
+                        value |= g_NodeCreator.GetConstantAsInt(iter);
+                    }
+                    else
+                    {
+                        if (prefix.size())
+                        {
+                            iter.insert(0, prefix);
+                        }
+                        if (auto result = g_friend_constant.find(iter); result != g_friend_constant.end())
+                        {
+                            value |= g_NodeCreator.GetConstantAsInt(result->second);
+                        }
+                    }
+                }
+                return value;
+            }
+
+        default:
+            return m_value.atoi();  // this will return 0 if the m_value is an empty string
+    }
+}
+
+const ttlib::cstr& NodeProperty::as_constant(std::string_view prefix)
+{
+    switch (type())
+    {
+        case type_editoption:
+        case type_option:
+        case type_id:
+            if (m_value.is_sameprefix("wx"))
+            {
+                return m_value;
+            }
+            else
+            {
+                if (prefix.size())
+                {
+                    m_constant.clear();
+                    m_constant << prefix << m_value;
+                    if (auto result = g_friend_constant.find(m_constant); result != g_friend_constant.end())
+                    {
+                        m_constant = result->second;
+                    }
+                    else
+                    {
+                        m_constant.clear();
+                    }
+                }
+                else
+                {
+                    if (auto result = g_friend_constant.find(m_value); result != g_friend_constant.end())
+                    {
+                        m_constant = result->second;
+                    }
+                    else
+                    {
+                        m_constant.clear();
+                    }
+                }
+                return m_constant;
+            }
+
+        case type_bitlist:
+            {
+                ttlib::multistr mstr(m_value, '|');
+                m_constant.clear();
+                for (auto& iter: mstr)
+                {
+                    if (iter.is_sameprefix("wx"))
+                    {
+                        if (m_constant.size())
+                        {
+                            m_constant << '|';
+                        }
+                        m_constant << iter;
+                    }
+                    else
+                    {
+                        if (prefix.size())
+                        {
+                            iter.insert(0, prefix);
+                        }
+                        if (auto result = g_friend_constant.find(iter); result != g_friend_constant.end())
+                        {
+                            if (m_constant.size())
+                            {
+                                m_constant << " | ";
+                            }
+                            m_constant << result->second;
+                        }
+                    }
+                }
+                return m_constant;
+            }
+
+        default:
+            return m_value;  // this will return 0 if the m_value is an empty string
+    }
+}
+
 wxPoint NodeProperty::as_point() const
 {
     wxPoint result { -1, -1 };

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -95,7 +95,7 @@ int NodeProperty::as_mockup(std::string_view prefix) const
 
         case type_bitlist:
             {
-                ttlib::multistr mstr(m_value, '|');
+                ttlib::multistr mstr(m_value, '|', tt::TRIM::both);
                 int value = 0;
                 for (auto& iter: mstr)
                 {
@@ -165,7 +165,7 @@ const ttlib::cstr& NodeProperty::as_constant(std::string_view prefix)
 
         case type_bitlist:
             {
-                ttlib::multistr mstr(m_value, '|');
+                ttlib::multistr mstr(m_value, '|', tt::TRIM::both);
                 m_constant.clear();
                 for (auto& iter: mstr)
                 {

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -38,7 +38,7 @@ public:
     bool as_bool() const { return (as_int() != 0); };
     double as_float() const;
 
-    const auto& as_string() const { return m_value; }
+    // REVIEW: [KeyWorks - 12-30-2021] Why do we need this? This just adds ctor/dtor code.
     auto as_cview() const { return ttlib::cview(m_value.c_str(), m_value.length()); }
 
     // Use with caution! This allows you to modify the property string directly.
@@ -53,6 +53,15 @@ public:
     wxSize as_size() const;
     auto as_wxString() const { return m_value.wx_str(); }
     wxArrayString as_wxArrayString() const;
+
+    const ttlib::cstr& as_string() const { return m_value; }
+
+    // Converts friendly name to wxWidgets constant
+    const ttlib::cstr& as_constant(std::string_view prefix);
+
+    // Converts friendly name to wxWidgets constant, and then returns the integer value of
+    // that constant.
+    int as_mockup(std::string_view prefix) const;
 
     auto as_vector() const -> std::vector<ttlib::cstr>;
 
@@ -98,4 +107,5 @@ private:
     PropDeclaration* m_declaration;
     Node* m_node;  // node this property is a child of
     ttlib::cstr m_value;
+    ttlib::cstr m_constant;  // filled in by as_constant() if m_value is a friendly name
 };

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -54,7 +54,7 @@ bool App::LoadProject(const ttString& file)
 
     m_ProjectVersion = root.attribute("data_version").as_int((curWxuiMajorVer * 10) + curWxuiMinorVer);
 
-    if (m_ProjectVersion > (curWxuiMajorVer * 10) + curWxuiMinorVer)
+    if (m_ProjectVersion > curCombinedVer)
     {
         if (wxMessageBox("wxUiEditor does not recognize this version of the data file.\n"
                          "You may be able to load the file, but if you then save it you could lose data.\n\n"
@@ -63,7 +63,7 @@ bool App::LoadProject(const ttString& file)
             return false;
     }
 
-    else if (m_ProjectVersion < (curWxuiMajorVer * 10) + curWxuiMinorVer)
+    else if (m_ProjectVersion < curCombinedVer)
     {
         if (!root.child("object") && !root.child("node"))
         {
@@ -112,7 +112,7 @@ bool App::LoadProject(const ttString& file)
     wxGetFrame().SetImportedFlag(false);
     wxGetFrame().FireProjectLoadedEvent();
 
-    if (m_isProject_updated || m_ProjectVersion == 11)
+    if (m_isProject_updated || m_ProjectVersion < curCombinedVer)
         wxGetFrame().SetModified();
 
     return true;

--- a/src/xml/bars_xml.xml
+++ b/src/xml/bars_xml.xml
@@ -31,55 +31,55 @@ inline const char* bars_xml = R"===(<?xml version="1.0"?>
 		<property name="var_name" type="string">m_infoBar</property>
 		<property name="show_effect" type="option"
 			help="Set the effects to use when showing the bar.">
-			<option name="wxSHOW_EFFECT_NONE"
+			<option name="no effects"
 				help="No effect, equivalent to normal wxWindow::Show() or Hide() call." />
-			<option name="wxSHOW_EFFECT_ROLL_TO_LEFT"
+			<option name="roll to left"
 				help="Roll window to the left." />
-			<option name="wxSHOW_EFFECT_ROLL_TO_RIGHT"
+			<option name="roll to right"
 				help="Roll window to the right." />
-			<option name="wxSHOW_EFFECT_ROLL_TO_TOP"
+			<option name="roll to top"
 				help="Roll window to the top." />
-			<option name="wxSHOW_EFFECT_ROLL_TO_BOTTOM"
+			<option name="roll to bottom"
 				help="Roll window to the bottom." />
-			<option name="wxSHOW_EFFECT_SLIDE_TO_LEFT"
+			<option name="slide to left"
 				help="Slide window to the left." />
-			<option name="wxSHOW_EFFECT_SLIDE_TO_RIGHT"
+			<option name="slide to right"
 				help="Slide window to the right." />
-			<option name="wxSHOW_EFFECT_SLIDE_TO_TOP"
+			<option name="slide to top"
 				help="Slide window to the top." />
-			<option name="wxSHOW_EFFECT_SLIDE_TO_BOTTOM"
+			<option name="slide to bottom"
 				help="Slide window to the bottom." />
-			<option name="wxSHOW_EFFECT_BLEND"
+			<option name="blend"
 				help="Fade in or out effect." />
-			<option name="wxSHOW_EFFECT_EXPAND"
+			<option name="expand"
 				help="Expanding or collapsing effect." />
-			wxSHOW_EFFECT_NONE
+				no effects
 		</property>
 		<property name="hide_effect" type="option"
 			help="Set the effects to use when hiding the bar. ">
-			<option name="wxSHOW_EFFECT_NONE"
+			<option name="no effects"
 				help="No effect, equivalent to normal wxWindow::Show() or Hide() call." />
-			<option name="wxSHOW_EFFECT_ROLL_TO_LEFT"
+			<option name="roll to left"
 				help="Roll window to the left." />
-			<option name="wxSHOW_EFFECT_ROLL_TO_RIGHT"
+			<option name="roll to right"
 				help="Roll window to the right." />
-			<option name="wxSHOW_EFFECT_ROLL_TO_TOP"
+			<option name="roll to top"
 				help="Roll window to the top." />
-			<option name="wxSHOW_EFFECT_ROLL_TO_BOTTOM"
+			<option name="roll to bottom"
 				help="Roll window to the bottom." />
-			<option name="wxSHOW_EFFECT_SLIDE_TO_LEFT"
+			<option name="slide to left"
 				help="Slide window to the left." />
-			<option name="wxSHOW_EFFECT_SLIDE_TO_RIGHT"
+			<option name="slide to right"
 				help="Slide window to the right." />
-			<option name="wxSHOW_EFFECT_SLIDE_TO_TOP"
+			<option name="slide to top"
 				help="Slide window to the top." />
-			<option name="wxSHOW_EFFECT_SLIDE_TO_BOTTOM"
+			<option name="slide to bottom"
 				help="Slide window to the bottom." />
-			<option name="wxSHOW_EFFECT_BLEND"
+			<option name="blend"
 				help="Fade in or out effect." />
-			<option name="wxSHOW_EFFECT_EXPAND"
+			<option name="expand"
 				help="Expanding or collapsing effect." />
-			wxSHOW_EFFECT_NONE
+				no effects
 		</property>
 		<property name="duration" type="int"
 			help="Set the duration of the animation (in milliseconds) used when showing or hiding the bar.">500</property>

--- a/src/xml/boxes_xml.xml
+++ b/src/xml/boxes_xml.xml
@@ -212,11 +212,11 @@ inline const char* boxes_xml = R"===(<?xml version="1.0"?>
 		<property name="majorDimension" type="uint"
 			help="Specifies the maximum number of rows (if style contains wxRA_SPECIFY_ROWS) or columns (if style contains wxRA_SPECIFY_COLS) for a two-dimensional radiobox. A value of zero will use as many rows or columns as there are radio buttons.">0</property>
 		<property name="style" type="option">
-			<option name="wxRA_SPECIFY_ROWS"
+			<option name="rows"
 				help="Buttons are arranged vertically (in rows)." />
-			<option name="wxRA_SPECIFY_COLS"
+			<option name="columns"
 				help="Buttons are arranged horizontally (in columns).." />
-			wxRA_SPECIFY_COLS
+			columns
 		</property>
 		<event name="wxEVT_RADIOBOX" class="wxCommandEvent"
 			help="Generated when a radio button in the box is clicked." />

--- a/src/xml/scintilla_xml.xml
+++ b/src/xml/scintilla_xml.xml
@@ -135,10 +135,10 @@ inline const char* scintilla_xml = R"===(<?xml version="1.0"?>
 			help="Set ReadOnly Mode. Disables editing if set to true.">0</property>
 		<property name="eol_mode" type="option"
 			help="Sets the characters that are added into the document when the user presses the Enter key.">
-			<option name="wxSTC_EOL_CRLF" />
-			<option name="wxSTC_EOL_CR" />
-			<option name="wxSTC_EOL_LF" />
-			wxSTC_EOL_LF
+			<option name="\r\n (CR/LF)" />
+			<option name="\r (CR)" />
+			<option name="\n (LF)" />
+			\n (LF)
 		</property>
 		<property name="left_margin_width" type="int"
 			help="Sets the width of the blank margin to the left of the text.">1</property>
@@ -148,11 +148,11 @@ inline const char* scintilla_xml = R"===(<?xml version="1.0"?>
 			help="Show end of line characters.">0</property>
 		<property name="view_whitespace" type="option"
 			help="Set whether white space is visible. Space characters appear as small centered dots and tab characters as light arrows pointing to the right.">
-			<option name="wxSTC_WS_INVISIBLE" />
-			<option name="wxSTC_WS_VISIBLEALWAYS" />
-			<option name="wxSTC_WS_VISIBLEAFTERINDENT" />
-			<option name="wxSTC_WS_VISIBLEONLYININDENT" />
-			wxSTC_WS_INVISIBLE
+			<option name="invisible" />
+			<option name="always visible" />
+			<option name="visible after indent" />
+			<option name="only indent visible" />
+			invisible
 		</property>
 		<property name="view_tab_strikeout" type="bool"
 			help="By default, if whitespace is visible, tab charcers are drawn as light arrows pointing to the right. If strikeout is checked, then tabs are drawn as a horizontal line stretching until the tabstop.">0</property>
@@ -201,18 +201,18 @@ inline const char* scintilla_xml = R"===(<?xml version="1.0"?>
 				help="Sets the background colour of the markers." />
 
 			<property name="automatic_folding" type="bitlist">
-				<option name="wxSTC_AUTOMATICFOLD_SHOW" help="Automatically show lines as needed." />
-				<option name="wxSTC_AUTOMATICFOLD_CLICK" help="Handle clicks in fold margin automatically." />
-				<option name="wxSTC_AUTOMATICFOLD_CHANGE" help="Show lines as needed when fold structure is changed." />
+				<option name="show lines as needed" help="Automatically show lines as needed." />
+				<option name="handle margin clicks" help="Handle clicks in fold margin automatically." />
+				<option name="show changes" help="Show lines as needed when fold structure is changed." />
 			</property>
 			<property name="fold_flags" type="bitlist"
 				help="In addition to showing markers in the folding margin, you can indicate folds to the user by drawing lines in the text area.">
-				<option name="wxSTC_FOLDFLAG_LINEBEFORE_EXPANDED" help="Draw above if expanded." />
-				<option name="wxSTC_FOLDFLAG_LINEBEFORE_CONTRACTED" help="Draw above if not expanded." />
-				<option name="wxSTC_FOLDFLAG_LINEAFTER_EXPANDED" help="Draw below if expanded." />
-				<option name="wxSTC_FOLDFLAG_LINEAFTER_CONTRACTED" help="Draw below if not expanded." />
-				<option name="wxSTC_FOLDFLAG_LEVELNUMBERS" help="Display hexadecimal fold levels in line margin to aid debugging of folding." />
-				<option name="wxSTC_FOLDFLAG_LINESTATE" help="Display hexadecimal line state in line margin to aid debugging of lexing and folding." />
+				<option name="before if expanded" help="Draw above if expanded." />
+				<option name="before if contracted" help="Draw above if not expanded." />
+				<option name="after if expanded" help="Draw below if expanded." />
+				<option name="after if contracted" help="Draw below if not expanded." />
+				<option name="debug hex levels" help="Display hexadecimal fold levels in line margin to aid debugging of folding." />
+				<option name="debug line state" help="Display hexadecimal line state in line margin to aid debugging of lexing and folding. Cannot be used with &quot;debug hex levels&quot;." />
 			</property>
 
 			<property name="separator_margin" type="option" help="Specify the margin you want a vertical separator line to appear in.">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR extends the support for using friendly names instead of wxWidgets constants. If a project file older then 14 is loaded, then all option and bitlist properties will have their values automatically converted to friendly names. Note that the current project version is 13, so this will handle both the beta 1 release and the current pre-beta 2 projects.

It's probable that importers are broken with this PR -- I need to make some additional code design changes before fixing the importers.