### PR TITLE
Complete Importing wxStyledTextCtrl from wxCrafter and wxFormBuilder

### DIFF
--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -413,7 +413,7 @@ wxObject* StyledTextGenerator::CreateMockup(Node* node, wxObject* parent)
     }
 
     scintilla->SetViewEOL(node->prop_as_bool(prop_view_eol));
-    if (node->isPropValue(prop_view_whitespace, "invisible"))
+    if (!node->isPropValue(prop_view_whitespace, "invisible"))
     {
         scintilla->SetViewWhiteSpace(node->prop_as_mockup(prop_view_whitespace, "stc_"));
     }

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -334,6 +334,15 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
                     if (!xml_prop.text().empty())
                         BitmapProperty(xml_prop, prop_ptr);
                 }
+                else if (wxue_prop == prop_view_whitespace)
+                {
+                    // There are 4 possible values, but wxFormBuilder only supports this as a bool
+                    if (xml_prop.text().as_bool())
+                    {
+                        prop_ptr->set_value("always visible");
+                    }
+                    continue;
+                }
                 else if (wxue_prop == prop_bitmapsize)
                 {
                     if (class_name.contains("book"))
@@ -816,6 +825,22 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
             }
         }
     }
+    else if (prop_name.is_sameas("folding"))
+    {
+        if (xml_prop.text().as_bool())
+        {
+            newobject->prop_set_value(prop_fold_margin, "1");
+            newobject->prop_set_value(prop_fold_width, "16");
+        }
+    }
+    else if (prop_name.is_sameas("line_numbers"))
+    {
+        if (xml_prop.text().as_bool())
+        {
+            newobject->prop_set_value(prop_line_margin, "1");
+        }
+    }
+
     else
     {
         if (xml_prop.text().as_cview().size())

--- a/src/import/import_wxcrafter.h
+++ b/src/import/import_wxcrafter.h
@@ -32,6 +32,7 @@ public:
     NodeSharedPtr CreateFbpNode(pugi::xml_node& xml_prop, Node* parent, Node* sizeritem = nullptr);
 
 protected:
+    bool ProcessedScintillaProperty(Node* node, const rapidjson::Value& object);
     void ProcessSizerFlags(Node* node, const rapidjson::Value& array);
     void ProcessProperties(Node* node, const rapidjson::Value& array);
     void ProcessChild(Node* parent, const rapidjson::Value& object);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR completes importing wxStyledTextCtrl from wxCrafter and wxFormbuilder. wxGlade, wxSmith, and XRC don't support the control at all. wxWidgets 3.1.16 does add a very limited version to XRC, though neither wxFormBuilder or wxCrafter export it as a named class.