### PR TITLE
Fix handling of a missing project file

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1642,6 +1642,21 @@ void MainFrame::UpdateWakaTime(bool FileSavedEvent)
     }
 }
 
+void MainFrame::RemoveFileFromHistory(ttString file)
+{
+    if (file.empty())
+        return;
+
+    for (size_t idx = 0; idx < m_FileHistory.GetCount(); ++idx)
+    {
+        if (file == m_FileHistory.GetHistoryFile(idx))
+        {
+            m_FileHistory.RemoveFileFromHistory(idx);
+            break;
+        }
+    }
+}
+
 #if defined(_DEBUG)
 
     #include "debugging/dbg_code_diff.h"  // DbgCodeDiff -- Compare code generation

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -150,6 +150,10 @@ public:
 
     wxFileHistory& GetFileHistory() { return m_FileHistory; }
 
+    // This does an exact comparison, so file needs to be identical to what was added to the
+    // history.
+    void RemoveFileFromHistory(ttString file);
+
     // Display the text in a specific field of the status bar -- the default is the field
     // that aligns with the PropertyGrid panel.
     void SetStatusField(const ttlib::cstr text, int position = -1);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a bug related to #601, and changes when the main window is shown.

Previously, the code attempted to import a file if it didn't exist, which failed without checking the result. Now there is an outer loop that keeps popping up the Startup dialog if the file doesn't exist or cannot be loaded or imported. That dialog will continue to pop up until the user cancels it or a project is created, loaded, or imported.

Note that #601 is left open because we still need to remove a non-existent file from the MRU history, and we can't do that until the startup dialog gets overhauled (see #608).