### PR TITLE
Add ability for generators to set Hint and Help text

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -270,6 +270,13 @@ void BaseGenerator::ChangeEnableState(wxPropertyGridManager* prop_grid, NodeProp
             }
         }
     }
+    else if (changed_prop->isProp(prop_var_comment))
+    {
+        if (auto pg_setting = prop_grid->GetProperty("var_comment"); pg_setting)
+        {
+            pg_setting->Enable(!changed_prop->GetNode()->isPropValue(prop_class_access, "none"));
+        }
+    }
 }
 
 bool BaseGenerator::VerifyProperty(NodeProperty* prop)

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -97,6 +97,12 @@ public:
     // property.
     virtual void ChangeEnableState(wxPropertyGridManager*, NodeProperty*);
 
+    // Call this to retrieve hint text for the property
+    virtual std::optional<ttlib::cstr> GetHint(NodeProperty*) { return {}; }
+
+    // Call this to use different help text then GetPropDeclaration()->GetDescription()
+    virtual std::optional<ttlib::cstr> GetPropertyDescription(NodeProperty*) { return {}; }
+
     // Call this to convert wxWidgets constants to friendly names, and to fix conflicting bit
     // flags. Returns true if a change was made. Note that the change is *not* pushed to the
     // undo stack.

--- a/src/generate/picker_widgets.cpp
+++ b/src/generate/picker_widgets.cpp
@@ -175,7 +175,8 @@ std::optional<ttlib::cstr> FilePickerGenerator::GetPropertyDescription(NodePrope
 {
     if (prop->isProp(prop_message))
     {
-        return (ttlib::cstr() << "Title bar text for the file picker dialog. If not specified, \"Select a file\" will be used.");
+        return (
+            ttlib::cstr() << "Title bar text for the file picker dialog. If not specified, \"Select a file\" will be used.");
     }
     else
     {

--- a/src/generate/picker_widgets.cpp
+++ b/src/generate/picker_widgets.cpp
@@ -171,6 +171,18 @@ bool FilePickerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
     return true;
 }
 
+std::optional<ttlib::cstr> FilePickerGenerator::GetPropertyDescription(NodeProperty* prop)
+{
+    if (prop->isProp(prop_message))
+    {
+        return (ttlib::cstr() << "Title bar text for the file picker dialog. If not specified, \"Select a file\" will be used.");
+    }
+    else
+    {
+        return {};
+    }
+}
+
 //////////////////////////////////////////  DirPickerGenerator  //////////////////////////////////////////
 
 wxObject* DirPickerGenerator::CreateMockup(Node* node, wxObject* parent)

--- a/src/generate/picker_widgets.h
+++ b/src/generate/picker_widgets.h
@@ -38,6 +38,7 @@ public:
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
+    std::optional<ttlib::cstr> GetPropertyDescription(NodeProperty*) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };

--- a/src/generate/wizard_form.cpp
+++ b/src/generate/wizard_form.cpp
@@ -183,6 +183,18 @@ std::vector<Node*> WizardFormGenerator::GetChildPanes(Node* parent)
     return panes;
 }
 
+std::optional<ttlib::cstr> WizardFormGenerator::GetHint(NodeProperty* prop)
+{
+    if (prop->isProp(prop_title) && !prop->GetNode()->HasValue(prop_title))
+    {
+        return (ttlib::cstr() << "Title bar text");
+    }
+    else
+    {
+        return {};
+    }
+}
+
 //////////////////////////////////////////  WizardPageGenerator  //////////////////////////////////////////
 
 wxObject* WizardPageGenerator::CreateMockup(Node* node, wxObject* parent)

--- a/src/generate/wizard_form.h
+++ b/src/generate/wizard_form.h
@@ -17,6 +17,7 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
+    std::optional<ttlib::cstr> GetHint(NodeProperty*) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -240,7 +240,7 @@ int PropGridPanel::GetBitlistValue(const wxString& strVal, wxPGChoices& bit_flag
     return value;
 }
 
-wxPGProperty* PropGridPanel::GetProperty(NodeProperty* prop)
+wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
 {
     auto type = prop->type();
 
@@ -503,7 +503,7 @@ void PropGridPanel::AddProperties(ttlib::cview name, Node* node, NodeCategory& c
                 continue;
 
             auto propInfo = prop->GetPropDeclaration();
-            auto pg = m_prop_grid->Append(GetProperty(prop));
+            auto pg = m_prop_grid->Append(CreatePGProperty(prop));
             auto propType = prop->type();
             if (propType != type_option)
             {
@@ -1511,7 +1511,7 @@ void PropGridPanel::CreateLayoutCategory(Node* node)
             if (!prop)
                 continue;
 
-            auto id_prop = m_prop_grid->Append(GetProperty(prop));
+            auto id_prop = m_prop_grid->Append(CreatePGProperty(prop));
 
             auto propInfo = prop->GetPropDeclaration();
             m_prop_grid->SetPropertyHelpString(id_prop, propInfo->GetDescription());
@@ -1525,7 +1525,7 @@ void PropGridPanel::CreateLayoutCategory(Node* node)
 
         if (auto prop = node->get_prop_ptr(prop_proportion); prop)
         {
-            auto id_prop = m_prop_grid->Append(GetProperty(prop));
+            auto id_prop = m_prop_grid->Append(CreatePGProperty(prop));
 
             auto propInfo = prop->GetPropDeclaration();
             m_prop_grid->SetPropertyHelpString(id_prop, propInfo->GetDescription());
@@ -1541,7 +1541,7 @@ void PropGridPanel::CreateLayoutCategory(Node* node)
             if (!prop)
                 continue;
 
-            auto id_prop = m_prop_grid->Append(GetProperty(prop));
+            auto id_prop = m_prop_grid->Append(CreatePGProperty(prop));
 
             auto propInfo = prop->GetPropDeclaration();
             m_prop_grid->SetPropertyHelpString(id_prop, propInfo->GetDescription());

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -508,6 +508,20 @@ void PropGridPanel::AddProperties(ttlib::cview name, Node* node, NodeCategory& c
             if (propType != type_option)
             {
                 m_prop_grid->SetPropertyHelpString(pg, propInfo->GetDescription());
+                if (auto gen = node->GetGenerator(); gen)
+                {
+                    if (auto result = gen->GetPropertyDescription(prop); result)
+                    {
+                        wxString help_test(result->wx_str());
+                        m_prop_grid->SetPropertyHelpString(pg, help_test);
+                    }
+
+                    if (auto result = gen->GetHint(prop); result)
+                    {
+                        m_prop_grid->SetPropertyAttribute(pg, wxPG_ATTR_HINT, result->wx_str());
+                    }
+                }
+
                 if (propType == type_id)
                 {
                     if (prop->isProp(prop_id))

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -63,7 +63,7 @@ protected:
     void ReplaceBaseFile(const wxString& formName, NodeProperty* propType);
     void ReplaceDrvFile(const wxString& formName, NodeProperty* propType);
 
-    wxPGProperty* GetProperty(NodeProperty* prop);
+    wxPGProperty* CreatePGProperty(NodeProperty* prop);
 
     // Called after a property has been modified, this checks to see if various property
     // items need to be enabled or disabled based on the current value of the changed


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds methods to the `BaseGenerator` class that allow generators to set Hint text to display in an empty property, and to override the Help Description to display for a property.

Closes #617
