### PR TITLE
Overhaul Derived panel code generation

### DIFF
--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -150,4 +150,5 @@ private:
     bool m_NeedArtProviderHeader { false };
     bool m_NeedHeaderFunction { false };
     bool m_NeedAnimationFunction { false };
+    bool m_is_derived_class { true };
 };

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -19,7 +19,7 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 		<property name="local_pch_file" type="file"
 			help="The filename of a local precompiled header file. The file will be included in quotes." />
 		<property name="src_preamble" type="code_edit"
-			help="Code to generate at the top of the source file after the inclusion of any local precompiled header file. This can include er files, comments, macros, etc." />
+			help="Code to generate at the top of the source file after the inclusion of any local precompiled header file. This can include header files, comments, macros, etc." />
 		<property name="art_directory" type="path"
 			help="The directory containing your images (png, ico, xpm, etc.)." />
 		<property name="base_directory" type="path"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR overhauls the code generation for the Derived panel. It now always displays something, even if `derived_file` or `derived_class_name` are empty. It also now handles non-derived classes (`virtual_events` is unchecked) so that the user can copy the generated code into their own code.