### PR TITLE
Filename

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -340,11 +340,16 @@ std::optional<ttlib::cstr> BaseGenerator::GetHint(NodeProperty* prop)
     if (prop->isProp(prop_derived_class_name) && !prop->HasValue())
     {
         // Note that once set, this won't change until the property grid gets recreated.
-        return ttlib::cstr(!prop->GetNode()->prop_as_bool(prop_virtual_events) ? "requires virtual events" : "");
+        return ttlib::cstr(!prop->GetNode()->prop_as_bool(prop_virtual_events) ? "requires virtual events" :
+                                                                                 "change class_name first");
     }
     else if (prop->isProp(prop_derived_file) && !prop->HasValue())
     {
         return ttlib::cstr(!prop->GetNode()->prop_as_bool(prop_virtual_events) ? "requires virtual events" : "");
+    }
+    else if (prop->isProp(prop_base_file) && !prop->HasValue())
+    {
+        return ttlib::cstr("change class_name first");
     }
     else
     {

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -187,6 +187,30 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
 
         event->GetProperty()->SetValueFromString(newValue, 0);
     }
+    else if (prop->isProp(prop_class_name) && prop->GetNode()->IsForm())
+    {
+        auto property = wxStaticCast(event->GetProperty(), wxStringProperty);
+        auto variant = event->GetPropertyValue();
+        ttlib::cstr newValue = property->ValueToString(variant).utf8_string();
+        if (newValue.empty())
+            return true;
+
+        for (auto& iter: wxGetApp().GetProject()->GetChildNodePtrs())
+        {
+            if (iter.get() == prop->GetNode())
+            {
+                continue;
+            }
+            else if (iter.get()->prop_as_string(prop_class_name).is_sameas(newValue))
+            {
+                wxMessageBox("The name you have chosen is already in use by another class.", "Duplicate class name");
+                event->Veto();
+                event->GetProperty()->SetValue(newValue.wx_str());
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 
@@ -298,41 +322,43 @@ void BaseGenerator::ChangeEnableState(wxPropertyGridManager* prop_grid, NodeProp
 
 bool BaseGenerator::VerifyProperty(NodeProperty* prop)
 {
-    if (!prop->isProp(prop_alignment))
-        return false;
+    bool result = false;
 
-    bool is_modified = false;
-    auto value = prop->as_raw_ptr();
-    if (value->contains("wxALIGN_LEFT") &&
-        (value->contains("wxALIGN_RIGHT") || value->contains("wxALIGN_CENTER_HORIZONTAL")))
+    if (prop->isProp(prop_alignment))
     {
-        value->Replace("wxALIGN_LEFT|", "");
-        is_modified = true;
-    }
-    if (value->contains("wxALIGN_TOP") && (value->contains("wxALIGN_BOTTOM") || value->contains("wxALIGN_CENTER_VERTICAL")))
-    {
-        value->Replace("wxALIGN_TOP|", "");
-        is_modified = true;
-    }
-    if (value->contains("wxALIGN_RIGHT") && value->contains("wxALIGN_CENTER_HORIZONTAL"))
-    {
-        value->Replace("wxALIGN_RIGHT|", "");
-        is_modified = true;
-    }
-    if (value->contains("wxALIGN_BOTTOM") && value->contains("wxALIGN_CENTER_VERTICAL"))
-    {
-        value->Replace("wxALIGN_BOTTOM|", "");
-        is_modified = true;
+        auto value = prop->as_raw_ptr();
+        if (value->contains("wxALIGN_LEFT") &&
+            (value->contains("wxALIGN_RIGHT") || value->contains("wxALIGN_CENTER_HORIZONTAL")))
+        {
+            value->Replace("wxALIGN_LEFT|", "");
+            result = true;
+        }
+        if (value->contains("wxALIGN_TOP") &&
+            (value->contains("wxALIGN_BOTTOM") || value->contains("wxALIGN_CENTER_VERTICAL")))
+        {
+            value->Replace("wxALIGN_TOP|", "");
+            result = true;
+        }
+        if (value->contains("wxALIGN_RIGHT") && value->contains("wxALIGN_CENTER_HORIZONTAL"))
+        {
+            value->Replace("wxALIGN_RIGHT|", "");
+            result = true;
+        }
+        if (value->contains("wxALIGN_BOTTOM") && value->contains("wxALIGN_CENTER_VERTICAL"))
+        {
+            value->Replace("wxALIGN_BOTTOM|", "");
+            result = true;
+        }
+
+        // wxALIGN_CENTER can't be combined with anything
+        if (value->contains("wxALIGN_CENTER|"))
+        {
+            value->Replace("wxALIGN_CENTER|", "");
+            result = true;
+        }
     }
 
-    // wxALIGN_CENTER can't be combined with anything
-    if (value->contains("wxALIGN_CENTER|"))
-    {
-        value->Replace("wxALIGN_CENTER|", "");
-        is_modified = true;
-    }
-
-    return is_modified;
+    return result;
 }
 
 std::optional<ttlib::cstr> BaseGenerator::GetHint(NodeProperty* prop)

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -267,9 +267,19 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
         header_ext = hdr_extension;
     }
 
-    file.replace_extension(header_ext);
-    m_source->writeLine();
-    m_source->writeLine(ttlib::cstr() << "#include \"" << file.filename() << "\"");
+    if (file.empty())
+    {
+        m_source->writeLine();
+        m_source->writeLine("// Specify the filename to use in the base_file property");
+        m_source->writeLine("#include \"Your filename here\"");
+    }
+    else
+    {
+        file.replace_extension(header_ext);
+        m_source->writeLine();
+        m_source->writeLine(ttlib::cstr() << "#include \"" << file.filename() << "\"");
+    }
+
     m_source->writeLine();
 
     thrd_collect_img_headers.join();

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -52,13 +52,10 @@ int WriteCMakeFile(bool test_only)
 
     for (auto& iter: project->GetChildNodePtrs())
     {
-        ttlib::cstr base_file = iter->prop_as_string(prop_base_file);
-        // "filename_base" is the default filename given to all form files. Unless it's changed, no code will be
-        // generated.
-        if (base_file == "filename_base")
+        if (!iter->HasValue(prop_base_file))
             continue;
 
-        base_files.emplace(base_file);
+        base_files.emplace(iter->prop_as_string(prop_base_file));
     }
 
     for (auto base_file: base_files)

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -57,6 +57,7 @@ public:
 
     Node* LocateAncestorType(GenEnum::GenType type) const noexcept;
     Node* FindParentForm() const noexcept;
+    Node* GetForm() const noexcept { return FindParentForm(); }  // alias
 
     // Equivalent to AddChild(child); child->SetParent(this);
     // Returns false if child is not allowed for this node.

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -59,9 +59,9 @@ protected:
     void AddProperties(ttlib::cview name, Node* node, NodeCategory& category, PropNameSet& prop_set,
                        bool is_child_cat = false);
 
-    void ReplaceDrvName(const wxString& formName, NodeProperty* propType);
+    void ReplaceDerivedName(const wxString& formName, NodeProperty* propType);
     void ReplaceBaseFile(const wxString& formName, NodeProperty* propType);
-    void ReplaceDrvFile(const wxString& formName, NodeProperty* propType);
+    void ReplaceDerivedFile(const wxString& formName, NodeProperty* propType);
 
     wxPGProperty* CreatePGProperty(NodeProperty* prop);
 

--- a/src/xml/interface_xml.xml
+++ b/src/xml/interface_xml.xml
@@ -122,7 +122,7 @@ inline const char* interface_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="Code Generation" type="interface">
 		<property name="base_file" type="file"
-			help="The filename of the base class.">filename_base</property>
+			help="The filename of the base class." />
 		<property name="base_src_includes" type="code_edit"
 			help="This preamble is added in addition to any src_preamble specified for the entire project. It will be placed unchanged at the top of the generated base src file after any (optional) precompiled header file. It is typically used to add header files needed for lambdas used as event handlers." />
 		<property name="base_hdr_includes" type="code_edit"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes `filename_base` as the default filename for the `base_file` property. Instead, the field is left blank, though now both `base_file` and `derived_class_name` have hints that state "change class_name first".

When the base class name is changed, there is a verification check to prevent creating a duplicate class name. If the check passes, then `base_file` gets filled in with a suggested name, including the `base_directory` path, if specified. If `virtual_events` is checked, then `derived_class_name` and `derived_file` are also filled in. The algorithms for all of these has been updated to cover more cases of what the user might choose for a filename.

Both the Generated and Derived panels have been updated to handle empty filenames, indicating to the user which property needs to be changed to get an actual filename instead of a placeholder.

This PR is related to #605.