### PR TITLE
Add undo command for changing multiple properties at once

### DIFF
--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -22,6 +22,7 @@ wxDEFINE_EVENT(EVT_NodeDeleted, CustomEvent);
 wxDEFINE_EVENT(EVT_NodeSelected, CustomEvent);
 
 wxDEFINE_EVENT(EVT_NodePropChange, CustomEvent);
+wxDEFINE_EVENT(EVT_MultiPropChange, CustomEvent);
 
 wxDEFINE_EVENT(EVT_GridBagAction, CustomEvent);
 
@@ -66,6 +67,15 @@ void MainFrame::FireDeletedEvent(Node* node)
 void MainFrame::FirePropChangeEvent(NodeProperty* prop)
 {
     CustomEvent node_event(EVT_NodePropChange, prop);
+    for (auto handler: m_custom_event_handlers)
+    {
+        handler->ProcessEvent(node_event);
+    }
+}
+
+void MainFrame::FireMultiPropEvent(ModifyProperties* undo_cmd)
+{
+    CustomEvent node_event(EVT_MultiPropChange, undo_cmd);
     for (auto handler: m_custom_event_handlers)
     {
         handler->ProcessEvent(node_event);

--- a/src/cstm_event.h
+++ b/src/cstm_event.h
@@ -45,5 +45,6 @@ wxDECLARE_EVENT(EVT_NodeDeleted, CustomEvent);
 wxDECLARE_EVENT(EVT_NodeSelected, CustomEvent);
 
 wxDECLARE_EVENT(EVT_NodePropChange, CustomEvent);
+wxDECLARE_EVENT(EVT_MultiPropChange, CustomEvent);
 
 wxDECLARE_EVENT(EVT_GridBagAction, CustomEvent);

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1669,6 +1669,15 @@ void MainFrame::RemoveFileFromHistory(ttString file)
     }
 }
 
+void MainFrame::PushUndoAction(UndoActionPtr cmd, bool add_to_stack)
+{
+    m_isProject_modified = true;
+    if (!add_to_stack)
+        cmd->Change();
+    else
+        m_undo_stack.Push(cmd);
+}
+
 #if defined(_DEBUG)
 
     #include "debugging/dbg_code_diff.h"  // DbgCodeDiff -- Compare code generation

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -40,6 +40,7 @@ class RibbonPanel;
 
 class ChangeParentAction;
 class ChangePositionAction;
+class ModifyProperties;
 
 // Warning! This MUST be at least 3!
 constexpr const size_t StatusPanels = 3;
@@ -84,6 +85,7 @@ public:
     void FireProjectLoadedEvent();
     void FireProjectUpdatedEvent();
     void FirePropChangeEvent(NodeProperty* prop);
+    void FireMultiPropEvent(ModifyProperties* undo_cmd);
     void FireSelectedEvent(Node* node);
 
     // These are just here for convenience so you don't have to remember whether you have the raw pointer or the shared
@@ -96,11 +98,7 @@ public:
     void ChangeEventHandler(NodeEvent* event, const ttlib::cstr& value);
 
     // This will first call cmd->Change() and then push cmd onto the undo stack.
-    inline void PushUndoAction(UndoActionPtr cmd)
-    {
-        m_isProject_modified = true;
-        m_undo_stack.Push(cmd);
-    }
+    void PushUndoAction(UndoActionPtr cmd, bool add_to_stack = true);
 
     void Undo();
     void Redo();

--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -114,6 +114,11 @@ MockupParent::MockupParent(wxWindow* parent, MainFrame* frame) : wxScrolled<wxPa
          {
              CreateContent();
          });
+    Bind(EVT_MultiPropChange,
+         [this](CustomEvent&)
+         {
+             CreateContent();
+         });
 
     frame->AddCustomEventHandler(GetEventHandler());
 }

--- a/src/newdialogs/new_dialog.cpp
+++ b/src/newdialogs/new_dialog.cpp
@@ -102,6 +102,53 @@ void NewDialog::CreateNode()
 
     auto pos = parent->FindInsertionPos(parent);
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), parent, undo_str, pos));
+
+    if (form_node->prop_as_string(prop_class_name) != form_node->prop_default_value(prop_class_name))
+    {
+        bool is_base_class = false;
+        ttString baseName = form_node->prop_as_wxString(prop_class_name);
+        if (baseName.Right(4) == "Base")
+        {
+            baseName.Replace("Base", wxEmptyString);
+            is_base_class = true;
+        }
+        baseName.MakeLower();
+        baseName << "_base";
+        if (wxGetApp().GetProject()->HasValue(prop_base_directory))
+            baseName.insert(0, wxGetApp().GetProject()->prop_as_wxString(prop_base_directory) << '/');
+
+        form_node->prop_set_value(prop_base_file, baseName);
+        if (is_base_class)
+        {
+            form_node->prop_set_value(prop_base_file, baseName);
+
+            wxString class_name = form_node->prop_as_wxString(prop_class_name);
+            if (class_name.Right(4) == "Base")
+            {
+                class_name.Replace("Base", wxEmptyString);
+            }
+            else
+            {
+                class_name << "Derived";
+            }
+            form_node->prop_set_value(prop_derived_class_name, class_name);
+
+            ttString drvName = form_node->prop_as_wxString(prop_derived_class_name);
+            if (drvName.Right(7) == "Derived")
+                drvName.Replace("Derived", "_derived");
+            else if (!is_base_class)
+            {
+                drvName << "_derived";
+            }
+
+            drvName.MakeLower();
+            if (wxGetApp().GetProject()->HasValue(prop_base_directory))
+                drvName.insert(0, wxGetApp().GetProject()->prop_as_wxString(prop_base_directory) << '/');
+
+            form_node->prop_set_value(prop_derived_file, drvName);
+        }
+    }
+
     wxGetFrame().FireCreatedEvent(form_node);
     wxGetFrame().SelectNode(form_node, true, true);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -429,6 +429,18 @@ ttlib::cstr* Node::prop_as_raw_ptr(PropName name)
         return nullptr;
 }
 
+const ttlib::cstr& Node::prop_default_value(PropName name)
+{
+    auto prop = get_prop_ptr(name);
+
+    ASSERT_MSG(prop, ttlib::cstr(get_node_name()) << " doesn't have the property " << map_PropNames[name]);
+
+    if (prop)
+        return prop->GetDefaultValue();
+    else
+        return tt_empty_cstr;
+}
+
 const ttlib::cstr& Node::get_node_name() const
 {
     if (auto it = m_prop_indices.find(prop_var_name); it != m_prop_indices.end())

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -192,6 +192,8 @@ public:
     // Returns nullptr if the property doesn't exist.
     ttlib::cstr* prop_as_raw_ptr(PropName name);
 
+    const ttlib::cstr& prop_default_value(PropName name);
+
     // This will convert the string from UTF8 to UTF16 on Windows
     wxString prop_as_wxString(PropName name) const;
 

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -79,6 +79,7 @@ public:
     operator wxSize() const { return as_size(); }
 
     bool IsDefaultValue() const;
+    const ttlib::cstr& GetDefaultValue() const noexcept { return m_declaration->GetDefaultValue(); }
 
     // Returns false if the property is empty. For size, point, and Bitmap properties,
     // returns false if the default value is used.

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -98,6 +98,11 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, bool GenerateDerivedCod
          {
              GenerateBaseClass();
          });
+    Bind(EVT_MultiPropChange,
+         [this](wxEvent&)
+         {
+             GenerateBaseClass();
+         });
 
     Bind(EVT_NodeSelected, &BasePanel::OnNodeSelected, this);
 

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -75,6 +75,7 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
     Bind(wxEVT_TREE_END_DRAG, &NavigationPanel::OnEndDrag, this);
 
     Bind(EVT_NodePropChange, &NavigationPanel::OnNodePropChange, this);
+    Bind(EVT_MultiPropChange, &NavigationPanel::OnMultiPropChange, this);
     Bind(EVT_NodeSelected, &NavigationPanel::OnNodeSelected, this);
     Bind(EVT_ParentChanged, &NavigationPanel::OnParentChange, this);
     Bind(EVT_PositionChanged, &NavigationPanel::OnPositionChange, this);
@@ -521,6 +522,16 @@ void NavigationPanel::OnNodeSelected(CustomEvent& event)
                  << node->DeclName() << "\n\tName: " << node->prop_as_string(prop_var_name).wx_str());
         BETA_ERROR(ttlib::cstr("\nThere is no tree item associated with this object.\n\tClass: ")
                    << node->DeclName() << "\n\tName: " << node->prop_as_string(prop_var_name).wx_str());
+    }
+}
+
+void NavigationPanel::OnMultiPropChange(CustomEvent& event)
+{
+    auto& vector = static_cast<ModifyProperties*>(event.GetUndoCmd())->GetVector();
+    for (auto& iter: vector)
+    {
+        CustomEvent prop_event(EVT_NodePropChange, iter.property);
+        OnNodePropChange(prop_event);
     }
 }
 

--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -67,6 +67,7 @@ protected:
     void OnNodeCreated(CustomEvent& event);
     void OnNodeSelected(CustomEvent& event);
     void OnNodePropChange(CustomEvent& event);
+    void OnMultiPropChange(CustomEvent& event);
     void OnParentChange(CustomEvent& event);
     void OnPositionChange(CustomEvent& event);
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -106,6 +106,11 @@ PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(paren
          {
              Create();
          });
+    Bind(EVT_MultiPropChange,
+         [this](CustomEvent&)
+         {
+             Create();
+         });
 
     frame->AddCustomEventHandler(GetEventHandler());
 }

--- a/src/ui/newdialog_base.cpp
+++ b/src/ui/newdialog_base.cpp
@@ -20,12 +20,28 @@ bool NewDialog::Create(wxWindow *parent, wxWindowID id, const wxString &title,
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
-    auto box_sizer_3 = new wxBoxSizer(wxHORIZONTAL);
+    auto box_sizer_3 = new wxBoxSizer(wxVERTICAL);
     parent_sizer->Add(box_sizer_3, wxSizerFlags().Border(wxALL));
 
     auto staticText_3 = new wxStaticText(this, wxID_ANY, "These are initial values -- all of them can be changed after the dialog is created.");
     staticText_3->Wrap(300);
     box_sizer_3->Add(staticText_3, wxSizerFlags().Border(wxALL));
+
+    m_infoBar = new wxInfoBar(this);
+    m_infoBar->SetShowHideEffects(wxSHOW_EFFECT_NONE, wxSHOW_EFFECT_NONE);
+    box_sizer_3->Add(m_infoBar, wxSizerFlags().Expand().Border(wxALL));
+
+    auto box_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
+    parent_sizer->Add(box_sizer_2, wxSizerFlags().Expand().Border(wxALL));
+
+    auto staticText = new wxStaticText(this, wxID_ANY, "&Base class name:");
+    staticText->SetToolTip("Change this to something unique to your project.");
+    box_sizer_2->Add(staticText, wxSizerFlags().Center().Border(wxALL));
+
+    m_classname = new wxTextCtrl(this, wxID_ANY, "MyDialogBase");
+    m_classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_base_class));
+    m_classname->SetToolTip("Change this to something unique to your project.");
+    box_sizer_2->Add(m_classname, wxSizerFlags(1).Border(wxALL));
 
     auto box_sizer__2 = new wxBoxSizer(wxHORIZONTAL);
     parent_sizer->Add(box_sizer__2, wxSizerFlags().Expand().Border(wxALL));
@@ -37,16 +53,6 @@ bool NewDialog::Create(wxWindow *parent, wxWindowID id, const wxString &title,
     m_textCtrl_title->SetValidator(wxTextValidator(wxFILTER_NONE, &m_title));
     box_sizer__2->Add(m_textCtrl_title, wxSizerFlags(1).Border(wxALL));
 
-    auto box_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
-    parent_sizer->Add(box_sizer_2, wxSizerFlags().Expand().Border(wxALL));
-
-    auto staticText = new wxStaticText(this, wxID_ANY, "&Base class name:");
-    box_sizer_2->Add(staticText, wxSizerFlags().Center().Border(wxALL));
-
-    auto classname = new wxTextCtrl(this, wxID_ANY, "MyDialogBase");
-    classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_base_class));
-    box_sizer_2->Add(classname, wxSizerFlags(1).Border(wxALL));
-
     auto box_sizer = new wxBoxSizer(wxVERTICAL);
     parent_sizer->Add(box_sizer, wxSizerFlags().Border(wxALL));
 
@@ -55,7 +61,7 @@ bool NewDialog::Create(wxWindow *parent, wxWindowID id, const wxString &title,
 
     m_check_tabs = new wxCheckBox(this, wxID_ANY, "Tabbed &Dialog");
     m_check_tabs->SetValidator(wxGenericValidator(&m_has_tabs));
-    box_sizer_4->Add(m_check_tabs, wxSizerFlags().Border(wxALL));
+    box_sizer_4->Add(m_check_tabs, wxSizerFlags().Center().Border(wxALL));
 
     auto staticText_4 = new wxStaticText(this, wxID_ANY, "Tab&s:");
     box_sizer_4->Add(staticText_4, wxSizerFlags().Center().Border(wxLEFT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
@@ -64,7 +70,7 @@ bool NewDialog::Create(wxWindow *parent, wxWindowID id, const wxString &title,
             wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 7, 3);
     m_spinCtrlTabs->SetValidator(wxGenericValidator(&m_num_tabs));
     m_spinCtrlTabs->Enable(false);
-    box_sizer_4->Add(m_spinCtrlTabs, wxSizerFlags().Border(wxALL));
+    box_sizer_4->Add(m_spinCtrlTabs, wxSizerFlags().Center().Border(wxALL));
 
     auto checkBox_2 = new wxCheckBox(this, wxID_ANY, "&Standard Buttons");
     checkBox_2->SetValue(true);
@@ -79,6 +85,8 @@ bool NewDialog::Create(wxWindow *parent, wxWindowID id, const wxString &title,
 
     // Event handlers
     Bind(wxEVT_INIT_DIALOG, &NewDialog::OnInit, this);
+    m_classname->Bind(wxEVT_TEXT, &NewDialog::OnClassName, this);
+    m_textCtrl_title->Bind(wxEVT_TEXT, &NewDialog::OnClassName, this);
     m_check_tabs->Bind(wxEVT_CHECKBOX,
         [this](wxCommandEvent&)
         {

--- a/src/ui/newdialog_base.h
+++ b/src/ui/newdialog_base.h
@@ -10,6 +10,7 @@
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
+#include <wx/infobar.h>
 #include <wx/spinctrl.h>
 #include <wx/textctrl.h>
 
@@ -17,23 +18,28 @@ class NewDialog : public wxDialog
 {
 public:
     NewDialog() {}
-    NewDialog(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "New Dialog",
+    NewDialog(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "Create New Dialog",
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
     {
         Create(parent, id, title, pos, size, style, name);
     }
 
-    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "New Dialog",
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "Create New Dialog",
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
     void CreateNode();
+    void VerifyClassName();
+
+private:
+    bool m_is_info_shown { false };
 
 protected:
 
     // Event handlers
 
+    void OnClassName(wxCommandEvent& event);
     void OnInit(wxInitDialogEvent& event);
 
 private:
@@ -49,6 +55,8 @@ private:
     // Class member variables
 
     wxCheckBox* m_check_tabs;
+    wxInfoBar* m_infoBar;
     wxSpinCtrl* m_spinCtrlTabs;
+    wxTextCtrl* m_classname;
     wxTextCtrl* m_textCtrl_title;
 };

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -880,7 +880,7 @@
       inserted_hdr_code="const ttlib::cstr&amp; GetRcFilename() { return m_rcFilename; }@@std::vector&lt;ttlib::cstr>&amp; GetDlgNames() { return m_dialogs; }@@@@protected:@@void ReadRcFile();@@@@private:@@ttlib::cstr m_rcFilename;@@std::vector&lt;ttlib::cstr> m_dialogs;"
       private_members="true"
       title="Import Windows Resource Dialogs"
-      virtual_events="false"
+      use_derived_class="false"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -950,7 +950,7 @@
       minimum_size="-1,-1"
       private_members="true"
       title="Insert widget"
-      virtual_events="false"
+      use_derived_class="false"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -1683,10 +1683,10 @@
       class="wxDialog"
       base_file="newdialog_base"
       class_name="NewDialog"
-      inserted_hdr_code="void CreateNode();"
+      inserted_hdr_code="void CreateNode();@@void VerifyClassName();@@@@private:@@bool m_is_info_shown { false };"
       private_members="true"
-      title="New Dialog"
-      virtual_events="false"
+      title="Create New Dialog"
+      use_derived_class="false"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"
@@ -1695,6 +1695,7 @@
         flags="wxEXPAND">
         <node
           class="wxBoxSizer"
+          orientation="wxVERTICAL"
           var_name="box_sizer_3">
           <node
             class="wxStaticText"
@@ -1702,6 +1703,29 @@
             label="These are initial values -- all of them can be changed after the dialog is created."
             var_name="staticText_3"
             wrap="300" />
+          <node
+            class="wxInfoBar"
+            flags="wxEXPAND" />
+        </node>
+        <node
+          class="wxBoxSizer"
+          var_name="box_sizer_2"
+          flags="wxEXPAND">
+          <node
+            class="wxStaticText"
+            class_access="none"
+            label="&amp;Base class name:"
+            var_name="staticText"
+            tooltip="Change this to something unique to your project."
+            alignment="wxALIGN_CENTER_VERTICAL" />
+          <node
+            class="wxTextCtrl"
+            value="MyDialogBase"
+            var_name="m_classname"
+            validator_variable="m_base_class"
+            tooltip="Change this to something unique to your project."
+            proportion="1"
+            wxEVT_TEXT="OnClassName" />
         </node>
         <node
           class="wxBoxSizer"
@@ -1717,25 +1741,8 @@
             class="wxTextCtrl"
             var_name="m_textCtrl_title"
             validator_variable="m_title"
-            proportion="1" />
-        </node>
-        <node
-          class="wxBoxSizer"
-          var_name="box_sizer_2"
-          flags="wxEXPAND">
-          <node
-            class="wxStaticText"
-            class_access="none"
-            label="&amp;Base class name:"
-            var_name="staticText"
-            alignment="wxALIGN_CENTER_VERTICAL" />
-          <node
-            class="wxTextCtrl"
-            class_access="none"
-            value="MyDialogBase"
-            var_name="classname"
-            validator_variable="m_base_class"
-            proportion="1" />
+            proportion="1"
+            wxEVT_TEXT="OnClassName" />
         </node>
         <node
           class="wxBoxSizer"
@@ -1749,6 +1756,7 @@
               label="Tabbed &amp;Dialog"
               var_name="m_check_tabs"
               validator_variable="m_has_tabs"
+              alignment="wxALIGN_CENTER_VERTICAL"
               wxEVT_CHECKBOX="[this](wxCommandEvent&amp;)@@{@@m_spinCtrlTabs->Enable(m_check_tabs->GetValue());@@}" />
             <node
               class="wxStaticText"
@@ -1764,7 +1772,8 @@
               min="1"
               var_name="m_spinCtrlTabs"
               validator_variable="m_num_tabs"
-              disabled="true" />
+              disabled="true"
+              alignment="wxALIGN_CENTER_VERTICAL" />
           </node>
           <node
             class="wxCheckBox"
@@ -1786,7 +1795,7 @@
       inserted_hdr_code="void CreateNode();@@"
       private_members="true"
       title="New wxFrame window"
-      virtual_events="false"
+      use_derived_class="false"
       wxEVT_INIT_DIALOG="[this](wxInitDialogEvent&amp; event)@@{@@m_classname->SetFocus();@@event.Skip();@@}">
       <node
         class="wxBoxSizer"
@@ -1868,7 +1877,7 @@
       inserted_hdr_code="// Checks current selected node to see if it accepts a wxRibbonBar as a child@@bool IsCreatable(bool notify_user = true);@@@@void WantFormVersion() { m_is_form = true; }@@void CreateNode();@@@@private:@@bool m_is_form { false };@@"
       private_members="true"
       title="New Ribbon Bar"
-      virtual_events="false">
+      use_derived_class="false">
       <node
         class="wxBoxSizer"
         orientation="wxVERTICAL"
@@ -3431,7 +3440,7 @@
       inserted_hdr_code="enum : size_t@@{@@    START_MRU,@@    START_CONVERT,@@    START_OPEN,@@    START_EMPTY,@@};@@@@auto GetCommandType() const { return m_cmdType; }@@ttString&amp; GetProjectFile() { return m_value; }@@@@protected:@@void OnHyperlink(wxHyperlinkEvent&amp; event);@@@@private:@@ttString m_value;@@size_t m_cmdType { START_EMPTY };"
       private_members="true"
       title="Open, Import, or Create Project"
-      virtual_events="false"
+      use_derived_class="false"
       wxEVT_INIT_DIALOG="OnInit">
       <node
         class="wxBoxSizer"

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -145,6 +145,53 @@ void ModifyPropertyAction::Revert()
     wxGetFrame().FirePropChangeEvent(m_property);
 }
 
+///////////////////////////////// ModifyProperties ////////////////////////////////////
+
+ModifyProperties::ModifyProperties(ttlib::cview undo_string, bool fire_events) : UndoAction(undo_string)
+{
+    m_fire_events = fire_events;
+    m_RedoEventGenerated = true;
+    m_UndoEventGenerated = true;
+}
+
+void ModifyProperties::AddProperty(NodeProperty* prop, ttlib::cview value)
+{
+    auto& entry = m_properties.emplace_back();
+    entry.property = prop;
+    entry.change_value = value;
+    entry.revert_value = prop->as_string();
+}
+
+void ModifyProperties::AddProperty(NodeProperty* prop, int value)
+{
+    auto& entry = m_properties.emplace_back();
+    entry.property = prop;
+    entry.change_value << value;
+    entry.revert_value = prop->as_string();
+}
+
+void ModifyProperties::Change()
+{
+    for (auto& iter: m_properties)
+    {
+        iter.property->set_value(iter.change_value);
+    }
+
+    if (m_fire_events)
+        wxGetFrame().FireMultiPropEvent(this);
+}
+
+void ModifyProperties::Revert()
+{
+    for (auto& iter: m_properties)
+    {
+        iter.property->set_value(iter.revert_value);
+    }
+
+    if (m_fire_events)
+        wxGetFrame().FireMultiPropEvent(this);
+}
+
 ///////////////////////////////// ModifyEventAction ////////////////////////////////////
 
 ModifyEventAction::ModifyEventAction(NodeEvent* event, ttlib::cview value) : m_event(event), m_change_value(value)

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -11,6 +11,7 @@
 #include "node_classes.h"  // Forward defintions of Node classes
 #include "undo_stack.h"    // UndoAction -- Maintain a undo and redo stack
 
+// Specify node, parent node, undo string, and optional position
 class InsertNodeAction : public UndoAction
 {
 public:
@@ -30,6 +31,7 @@ private:
     bool m_fix_duplicate_names { true };
 };
 
+// Specify node, undo string, and whether or not to add to the clipboard.
 class RemoveNodeAction : public UndoAction
 {
 public:
@@ -49,6 +51,7 @@ private:
     bool m_AddToClipboard;
 };
 
+// Specify property and value (string or int).
 class ModifyPropertyAction : public UndoAction
 {
 public:
@@ -63,6 +66,35 @@ private:
     ttlib::cstr m_change_value;
 };
 
+// Used to modify multiple properties as a single undo/redo command.
+//
+// Specify undo string, and whether or not to fire events.
+class ModifyProperties : public UndoAction
+{
+public:
+    ModifyProperties(ttlib::cview undo_string, bool fire_events = true);
+
+    void AddProperty(NodeProperty* prop, ttlib::cview value);
+    void AddProperty(NodeProperty* prop, int value);
+
+    void Change() override;
+    void Revert() override;
+
+    struct MULTI_PROP
+    {
+        NodeProperty* property;
+        // All properties are stored as a string, no matter what their original data type
+        ttlib::cstr revert_value;
+        ttlib::cstr change_value;
+    };
+    auto& GetVector() { return m_properties; }
+
+private:
+    std::vector<MULTI_PROP> m_properties;
+    bool m_fire_events { true };
+};
+
+// Specify event and value.
 class ModifyEventAction : public UndoAction
 {
 public:
@@ -76,6 +108,7 @@ private:
     ttlib::cstr m_change_value;
 };
 
+// Specify node and position.
 class ChangePositionAction : public UndoAction
 {
 public:
@@ -93,6 +126,7 @@ private:
     size_t m_revert_pos;
 };
 
+// Specify node and parent node.
 class ChangeParentAction : public UndoAction
 {
 public:
@@ -114,6 +148,7 @@ private:
     int m_revert_col;
 };
 
+// Specify node and new sizer gen_ name.
 class ChangeSizerType : public UndoAction
 {
 public:
@@ -131,6 +166,7 @@ private:
     GenEnum::GenName m_new_gen_sizer;
 };
 
+// Specify node and parent node, and optional position
 class AppendGridBagAction : public UndoAction
 {
 public:
@@ -150,6 +186,8 @@ private:
 
 // Use this when the entire wxGridBagSizer node needs to be saved. You *MUST* call Update()
 // or the Navigation Panel will be frozen!
+//
+// Specify gridbag sizer node and undo string
 class GridBagAction : public UndoAction
 {
 public:


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `ModifyProperties` undo command that can be used to modify multiple properties at once and have all of them tied into a single undo/redo. It also adds a `EVT_MultiPropChange` custom event that will be fired when the undo `Change()` or `Revert()` method is called.

Initially, this was planned for the `NewDialog` dialog, but that dialog doesn't actually need it, so the code is implemented but not tested.

Changes were made to the `NewDialog` dialog to prevent creating a duplicate class name, and to set the base filename and possibly the derived class name and derived filename (depending on the base class name). This is related to issue #605.