### PR TITLE
Enhance wxSplitterWindow handling

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1556,7 +1556,7 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
         auto pos = parent->GetChildPosition(node) - 1;
         if (pos < parent->GetChildCount())
         {
-            parent = FindChildSizerItem(parent->GetChild(pos));
+            parent = FindChildSizerItem(parent->GetChild(pos), true);
 
             if (check_only)
                 return (parent ? true : false);
@@ -1634,15 +1634,17 @@ void MainFrame::ChangeEventHandler(NodeEvent* event, const ttlib::cstr& value)
     }
 }
 
-Node* MainFrame::FindChildSizerItem(Node* node)
+Node* MainFrame::FindChildSizerItem(Node* node, bool include_splitter)
 {
-    if (node->GetNodeDeclaration()->isSubclassOf(gen_sizer_dimension))
+    if (include_splitter && node->isGen(gen_wxSplitterWindow) && node->GetChildCount() < 2)
+        return node;
+    else if (node->GetNodeDeclaration()->isSubclassOf(gen_sizer_dimension))
         return node;
     else
     {
         for (size_t i = 0; i < node->GetChildCount(); ++i)
         {
-            auto result = FindChildSizerItem(node->GetChild(i));
+            auto result = FindChildSizerItem(node->GetChild(i), include_splitter);
             if (result)
                 return result;
         }

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1205,6 +1205,11 @@ void MainFrame::CreateToolNode(GenName name)
 
     if (!m_selected_node->CreateToolNode(name))
     {
+        if (m_selected_node->isGen(gen_wxSplitterWindow))
+        {
+            return;  // The user has already been notified of the problem
+        }
+
         wxMessageBox(ttlib::cstr() << "Unable to create " << map_GenNames[name] << " as a child of "
                                    << m_selected_node->DeclName());
     }

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -158,8 +158,9 @@ public:
     // that aligns with the PropertyGrid panel.
     void SetStatusField(const ttlib::cstr text, int position = -1);
 
-    // Search for a sizer to move the node into
-    Node* FindChildSizerItem(Node* node);
+    // Search for a sizer to move the node into.
+    // Set include_splitter to treat a splitter window like a sizer.
+    Node* FindChildSizerItem(Node* node, bool include_splitter = false);
 
     // This is the only variable length field, and therefore can hold the most text
     void SetRightStatusField(const ttlib::cstr text) { SetStatusField(text, m_posRightStatusField); }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -620,8 +620,16 @@ Node* Node::CreateChildNode(GenName name)
             auto cur_children = g_NodeCreator.CountChildrenWithSameType(this, decl->gen_type());
             if (max_children > 0 && cur_children >= static_cast<size_t>(max_children))
             {
-                wxMessageBox(ttlib::cstr() << "You can only add " << static_cast<size_t>(max_children) << ' '
-                                           << map_GenNames[name] << " as a child of " << DeclName());
+                if (isGen(gen_wxSplitterWindow))
+                {
+                    wxMessageBox("You cannot add more than two windows to a splitter window.", "Cannot add control");
+                }
+                else
+                {
+                    wxMessageBox(ttlib::cstr() << "You can only add " << static_cast<size_t>(max_children) << ' '
+                                               << map_GenNames[name] << " as a child of " << DeclName());
+                }
+
                 return nullptr;
             }
 

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -295,6 +295,7 @@ static const ParentChild lstParentChild[] = {
     { type_splitter, type_propgridman, two },
     { type_splitter, type_splitter, two },
     { type_splitter, type_treelistctrl, two },
+    { type_splitter, type_widget, two },
 
     { type_toolbar, type_tool, infinite },
     { type_toolbar, type_widget, infinite },


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes wxSplitterWindow to all all widget-type generators as a child. It also updates the warning message if the user tries to add a child to a splitter window that already has two children. Finally, it changes the Right Move command to allow moving a control into a splitter window provided the window doesn't already have two children.

Most widget types won't make sense, which is why we didn't allow this previously. For example, adding a wxStaticTextCtrl doesn't really make sense. However, combining something like a scintilla control on the left and a wxHtmlWindow control on the right would be quite useful (wxUiEditor may be doing exactly this). This PR makes this possible.