### PR TITLE
Overhaul code generation panels, change how current node is indicated in code panel

### DIFF
--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -165,27 +165,6 @@ void WriteCode::write(ttlib::sview code, bool auto_indent)
     }
 }
 
-//////////////////////////////////////////// PanelCodeWriter class /////////////////////////////////////////////
-
-// PanelCodeWriter ctor and methods are implemented here, rather than in header filr to avoid having to include
-// wx/stc/stc.h in every app that includes the write_code.h header file.
-
-PanelCodeWriter::PanelCodeWriter(wxStyledTextCtrl* scintilla)
-{
-    ASSERT(scintilla);
-    m_Scintilla = scintilla;
-};
-
-void PanelCodeWriter::Clear()
-{
-    m_Scintilla->ClearAll();
-}
-
-void PanelCodeWriter::doWrite(ttlib::sview code)
-{
-    m_Scintilla->AddTextRaw(code.data(), static_cast<int>(code.length()));
-}
-
 //////////////////////////////////////////// FileCodeWriter class /////////////////////////////////////////////
 
 int FileCodeWriter::WriteFile(bool test_only)

--- a/src/generate/write_code.h
+++ b/src/generate/write_code.h
@@ -61,22 +61,6 @@ private:
     bool m_IsLastLineBlank { false };
 };
 
-class wxStyledTextCtrl;
-
-class PanelCodeWriter : public WriteCode
-{
-public:
-    PanelCodeWriter(wxStyledTextCtrl* scintilla);
-
-    void Clear() override;
-
-protected:
-    void doWrite(ttlib::sview code) override;
-
-private:
-    wxStyledTextCtrl* m_Scintilla;
-};
-
 class FileCodeWriter : public WriteCode
 {
 public:

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -666,9 +666,6 @@ void MainFrame::OnNodeSelected(CustomEvent& event)
         }
     }
 
-    // If a code generation panel is open, then attempt to locate the node's name in that panel
-    FindItemName(sel_node);
-
 #if defined(_DEBUG)
     g_pMsgLogging->OnNodeSelected();
 #endif
@@ -1140,23 +1137,6 @@ void MainFrame::UpdateMoveMenu()
     m_menuEdit->Enable(id_MoveDown, MoveNode(node, MoveDirection::Down, true));
     m_menuEdit->Enable(id_MoveLeft, MoveNode(node, MoveDirection::Left, true));
     m_menuEdit->Enable(id_MoveRight, MoveNode(node, MoveDirection::Right, true));
-}
-
-void MainFrame::FindItemName(Node* node)
-{
-    if (auto& value = node->prop_as_string(prop_var_name); value.size())
-    {
-        m_generatedPanel->FindItemName(value);
-        return;
-    }
-
-    if (node->DeclName().is_sameprefix("ribbon"))
-    {
-        if (auto& value = node->prop_as_string(prop_id); value.size())
-        {
-            m_generatedPanel->FindItemName(value);
-        }
-    }
 }
 
 Node* MainFrame::GetSelectedForm()

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -73,6 +73,7 @@ public:
     PropGridPanel* GetPropPanel() { return m_property_panel; }
     NavigationPanel* GetNavigationPanel() { return m_nav_panel; }
     RibbonPanel* GetRibbonPanel() { return m_ribbon_panel; }
+    BasePanel* GetGeneratedPanel() { return m_generatedPanel; }
 
     void AddCustomEventHandler(wxEvtHandler* handler) { m_custom_event_handlers.push_back(handler); }
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -177,8 +177,6 @@ public:
     // This does not use the internal clipboard
     void DuplicateNode(Node* node);
 
-    void FindItemName(Node* node);
-
     void setStatusText(const ttlib::cstr& txt, int pane = 1);
     wxStatusBar* OnCreateStatusBar(int number, long style, wxWindowID id, const wxString& name) override;
 

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -172,9 +172,14 @@ void BasePanel::GenerateBaseClass()
         codegen.GenerateBaseClass(project, m_cur_form, panel_type);
 
     if (panel_type == CPP_PANEL)
+    {
         m_cppPanel->CodeGenerationComplete();
+        m_cppPanel->OnNodeSelected(wxGetFrame().GetSelectedNode());
+    }
     else
+    {
         m_hPanel->CodeGenerationComplete();
+    }
 
     Thaw();
 }

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -124,25 +124,6 @@ void BasePanel::OnFind(wxFindDialogEvent& event)
     }
 }
 
-void BasePanel::FindItemName(const wxString& name)
-{
-    if (!IsShown())
-        return;
-
-    auto notebook = wxStaticCast(m_cppPanel->GetParent(), wxAuiNotebook);
-    ASSERT(notebook);
-
-    auto text = notebook->GetPageText(notebook->GetSelection());
-    if (text == "source")
-    {
-        m_cppPanel->FindItemName(name);
-    }
-    else if (text == "header")
-    {
-        m_hPanel->FindItemName(name);
-    }
-}
-
 void BasePanel::GenerateBaseClass()
 {
     if (!IsShown())

--- a/src/panels/base_panel.h
+++ b/src/panels/base_panel.h
@@ -29,9 +29,9 @@ public:
 
     void OnFind(wxFindDialogEvent& event);
 
-protected:
     void OnNodeSelected(CustomEvent& event);
 
+protected:
 private:
     CodeDisplay* m_cppPanel;
     CodeDisplay* m_hPanel;

--- a/src/panels/base_panel.h
+++ b/src/panels/base_panel.h
@@ -14,7 +14,6 @@
 class CodeDisplay;
 class CustomEvent;
 class MainFrame;
-class PanelCodeWriter;
 
 class wxAuiNotebook;
 class wxFindDialogEvent;
@@ -39,9 +38,6 @@ private:
     CodeDisplay* m_hPanel;
     wxAuiNotebook* m_notebook;
     Node* m_cur_form { nullptr };
-
-    std::unique_ptr<PanelCodeWriter> m_hdr_display;
-    std::unique_ptr<PanelCodeWriter> m_src_display;
 
     bool m_GenerateDerivedCode;
 };

--- a/src/panels/base_panel.h
+++ b/src/panels/base_panel.h
@@ -28,7 +28,6 @@ public:
     void GenerateBaseClass();
 
     void OnFind(wxFindDialogEvent& event);
-    void FindItemName(const wxString& name);
 
 protected:
     void OnNodeSelected(CustomEvent& event);

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -10,9 +10,10 @@
 
 #include "code_display.h"  // auto-generated: ../ui/codedisplay_base.h and ../ui/codedisplay_base.cpp
 
-#include "mainframe.h"     // MainFrame -- Main window frame
-#include "node.h"          // Node class
-#include "node_creator.h"  // NodeCreator -- Class used to create nodes
+#include "mainframe.h"       // MainFrame -- Main window frame
+#include "node.h"            // Node class
+#include "node_creator.h"    // NodeCreator -- Class used to create nodes
+#include "propgrid_panel.h"  // PropGridPanel -- PropertyGrid class for node properties and events
 
 #ifndef SCI_SETKEYWORDS
     #define SCI_SETKEYWORDS 4005
@@ -145,12 +146,29 @@ void CodeDisplay::OnNodeSelected(Node* node)
     if (!node->HasProp(prop_var_name))
         return;  // probably a form, spacer, or image
 
+    auto is_event = wxGetFrame().GetPropPanel()->IsEventPageShowing();
+
     // Find where the node is created.
 
     ttlib::cstr name(" ");
     name << node->prop_as_string(prop_var_name);
-    name << " = ";
-    int line = static_cast<int>(m_view.FindLineContaining(name));
+    int line = 0;
+    if (is_event)
+    {
+        name << "->Bind";
+        line = static_cast<int>(m_view.FindLineContaining(name));
+        if (!ttlib::is_found(line))
+        {
+            name.Replace("->Bind", " = ");
+            line = static_cast<int>(m_view.FindLineContaining(name));
+        }
+    }
+    else
+    {
+        name << " = ";
+        line = static_cast<int>(m_view.FindLineContaining(name));
+    }
+
     if (!ttlib::is_found(line))
         return;
 

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -149,7 +149,7 @@ void CodeDisplay::OnNodeSelected(Node* node)
 
     ttlib::cstr name(" ");
     name << node->prop_as_string(prop_var_name);
-    name << " = new";
+    name << " = ";
     int line = static_cast<int>(m_view.FindLineContaining(name));
     if (!ttlib::is_found(line))
         return;

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -9,14 +9,33 @@
 
 #include <wx/panel.h>
 
+#include "tttextfile.h"  // ttlib::viewfile
+
 #include "../ui/codedisplay_base.h"
 
-class wxFindDialogEvent;
+#include "write_code.h"  // WriteCode -- Write code to Scintilla or file
 
-class CodeDisplay : public CodeDisplayBase
+class wxFindDialogEvent;
+class Node;
+
+// CodeDisplayBase creates and initializes a wxStyledTextCtrl (scintilla) control, and places it in a sizer.
+//
+// WriteCode expects a class to override the doWrite() method, which in this case sends the text to the scinitilla control
+// created by CodeDisplayBase.
+
+class CodeDisplay : public CodeDisplayBase, public WriteCode
 {
 public:
     CodeDisplay(wxWindow* parent);
+
+    // Clears scintilla and internal buffer, removes read-only flag in scintilla
+    void Clear() override;
+
+    // Transfers code from buffer to scintilla, sets scintilla markers to current node, marks
+    // scintilla as read-only
+    void CodeGenerationComplete();
+
+    void OnNodeSelected(Node* node);
 
     void FindItemName(const wxString& name);
 
@@ -24,4 +43,11 @@ public:
 
 protected:
     void OnFind(wxFindDialogEvent& event);
+
+    // The following two functions are required to inherit from WriteCode
+
+    void doWrite(ttlib::sview code) override;
+
+private:
+    ttlib::viewfile m_view;
 };

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -37,8 +37,6 @@ public:
 
     void OnNodeSelected(Node* node);
 
-    void FindItemName(const wxString& name);
-
     wxStyledTextCtrl* GetTextCtrl() { return m_scintilla; };
 
 protected:

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -24,6 +24,7 @@
 #include "appoptions.h"      // AppOptions -- Application-wide options
 #include "auto_freeze.h"     // AutoFreeze -- Automatically Freeze/Thaw a window
 #include "base_generator.h"  // BaseGenerator -- Base widget generator class
+#include "base_panel.h"      // BasePanel -- Code generation panel
 #include "bitmaps.h"         // Map of bitmaps accessed by name
 #include "category.h"        // NodeCategory class
 #include "cstm_event.h"      // CustomEvent -- Custom Event class
@@ -112,6 +113,8 @@ PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(paren
          {
              Create();
          });
+
+    m_notebook_parent->Bind(wxEVT_AUINOTEBOOK_PAGE_CHANGED, &PropGridPanel::OnAuiNotebookPageChanged, this);
 
     frame->AddCustomEventHandler(GetEventHandler());
 }
@@ -1736,4 +1739,20 @@ void PropGridPanel::OnPostPropChange(CustomEvent& event)
             wxGetFrame().GetPropInfoBar()->Dismiss();
         }
     }
+}
+
+bool PropGridPanel::IsEventPageShowing()
+{
+    if (auto page = m_notebook_parent->GetCurrentPage(); page)
+    {
+        return (page == m_event_grid);
+    }
+    return false;
+}
+
+void PropGridPanel::OnAuiNotebookPageChanged(wxAuiNotebookEvent& /* event */)
+{
+    CustomEvent custom_event(EVT_NodeSelected, wxGetFrame().GetSelectedNode());
+
+    wxGetFrame().GetGeneratedPanel()->OnNodeSelected(custom_event);
 }

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -30,6 +30,8 @@ class PropGridPanel : public wxPanel
 public:
     PropGridPanel(wxWindow* parent, MainFrame* frame);
 
+    bool IsEventPageShowing();
+
     void RestoreDescBoxHeight();
     void SaveDescBoxHeight();
 
@@ -97,6 +99,7 @@ protected:
     void OnPropertyGridItemSelected(wxPropertyGridEvent& event);
     void OnNodePropChange(CustomEvent& event);
     void OnReCreateGrid(wxCommandEvent& event);
+    void OnAuiNotebookPageChanged(wxAuiNotebookEvent& event);
 
 private:
     std::map<wxPGProperty*, NodeProperty*> m_property_map;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR overhauls the code display panels. Originally, a `PanelCodeWriter` was created to write to scintilla, `CodeDisplay` simply created the scintilla control, and handled finding a node or user-text Find request. `BasePanel` used pointers to call each class to change the scintilla control -- which meant calling multiple functions twice (once for the src and once for the header).

The `PanelCodeWriter` class is removed, and instead `CodeDisplay` uses multiple inheritence. Special handling of the scintilla control has been moved from `BasePanel` to `CodeDisplay`.

The second part of the PR changes the way the current node is indicated in the code generation panels. Instead of selecting text, it now uses a bookmark in the selection column. It will scroll, if needed to display the bookmarked line. If the Event property grid panel is open and an event handler has been declared, then the bookmark will be set to the `->Bind` for the node instead. Switching back to the Properties panel will switch the bookmark back to where the node is created.