### PR TITLE
Overhaul wxTreeListCtrl

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -385,6 +385,7 @@ static std::vector<std::pair<const char*, const char*>> prefix_pair = {
     { "box", "_box" },
     { "button", "_button" },
     { "combo", "_combo" },
+    { "column", "_column" },
     { "ctrl", "_ctrl" },
     { "dialog", "_dialog" },  // stddialog becomes std_dialog
     { "double", "_double" },
@@ -398,14 +399,17 @@ static std::vector<std::pair<const char*, const char*>> prefix_pair = {
     { "notebook", "_notebook" },
     { "page", "_page" },
     { "panel", "_panel" },
-    { "pane", "_pane" },
     { "picker", "_picker" },
     { "simple", "_simple" },
     { "sizer", "_sizer" },
     { "text", "_text" },
     { "tree", "_tree" },
+    { "validator", "_validator" },
     { "view", "_view" },
     { "window", "_window" },
+
+    // Don't sort -- need to be sure "panel" is checked first
+    { "pane", "_pane" },
 
 };
 // clang-format on

--- a/src/generate/gen_initialize.cpp
+++ b/src/generate/gen_initialize.cpp
@@ -159,7 +159,7 @@ void NodeCreator::InitGenerators()
     SET_GENERATOR(gen_ribbonGalleryItem, RibbonGalleryItemGenerator)
 
     SET_GENERATOR(gen_wxTreeCtrl, TreeCtrlGenerator)
-    SET_GENERATOR(gen_wxTreeListCtrl, TreeListViewGenerator)
+    SET_GENERATOR(gen_wxTreeListCtrl, TreeListCtrlGenerator)
     SET_GENERATOR(gen_TreeListCtrlColumn, TreeListCtrlColumnGenerator)
 
     SET_GENERATOR(gen_wxDialog, DialogFormGenerator)

--- a/src/generate/tree_widgets.h
+++ b/src/generate/tree_widgets.h
@@ -20,10 +20,11 @@ public:
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };
 
-class TreeListViewGenerator : public BaseGenerator
+class TreeListCtrlGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
@@ -34,7 +35,5 @@ public:
 class TreeListCtrlColumnGenerator : public BaseGenerator
 {
 public:
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
-
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
 };

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -142,6 +142,16 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
             }
             break;
 
+        case MenuNEW_COLUMN:
+            if (m_tool_name == gen_wxTreeListCtrl)
+            {
+                if (m_child)
+                    m_child->CreateToolNode(gen_TreeListCtrlColumn);
+                else
+                    wxGetFrame().CreateToolNode(gen_TreeListCtrlColumn);
+            }
+            break;
+
         case MenuADD_TOOL_SEPARATOR:
             if (m_child)
                 m_child->CreateToolNode(gen_toolSeparator);
@@ -447,24 +457,35 @@ void NavPopupMenu::CreateNormalMenu(Node* node)
     sub_menu->Append(MenuBORDERS_VERTICAL, "Vertical only", "Borders only on top and bottom", wxITEM_CHECK);
     AppendSubMenu(sub_menu, "Borders");
 
-    AppendSeparator();
-    Append(MenuNEW_CHILD_SPACER, "Add spacer");
+    if (node->isGen(gen_wxTreeListCtrl))
+    {
+        m_tool_name = gen_wxTreeListCtrl;
+        m_child = node;
 
-    sub_menu = new wxMenu;
-    menu_item = sub_menu->Append(MenuNEW_CHILD_BOX_SIZER, "wxBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_STATIC_SIZER, "wxStaticBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_WRAP_SIZER, "wxWrapSizer");
-    menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_GRID_SIZER, "wxGridSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_FLEX_GRID_SIZER, "wxFlexGridSizer");
-    menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_GRIDBAG_SIZER, "wxGridBagSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
+        AppendSeparator();
+        Append(MenuNEW_COLUMN, "Add column");
+    }
+    else
+    {
+        AppendSeparator();
+        Append(MenuNEW_CHILD_SPACER, "Add spacer");
 
-    AppendSubMenu(sub_menu, "Add sizer");
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuNEW_CHILD_BOX_SIZER, "wxBoxSizer");
+        menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
+        menu_item = sub_menu->Append(MenuNEW_CHILD_STATIC_SIZER, "wxStaticBoxSizer");
+        menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
+        menu_item = sub_menu->Append(MenuNEW_CHILD_WRAP_SIZER, "wxWrapSizer");
+        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_CHILD_GRID_SIZER, "wxGridSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_CHILD_FLEX_GRID_SIZER, "wxFlexGridSizer");
+        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_CHILD_GRIDBAG_SIZER, "wxGridBagSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
+
+        AppendSubMenu(sub_menu, "Add sizer");
+    }
 
     sub_menu = new wxMenu;
     menu_item = sub_menu->Append(MenuNEW_PARENT_BOX_SIZER, "wxBoxSizer");
@@ -499,17 +520,20 @@ void NavPopupMenu::CreateNormalMenu(Node* node)
     Bind(wxEVT_MENU, &NavPopupMenu::OnBorders, this, MenuBORDERS_HORIZONTAL);
     Bind(wxEVT_MENU, &NavPopupMenu::OnBorders, this, MenuBORDERS_VERTICAL);
 
-    // The OnAddNew commands add to a child, so we need to "fake" the child to our parent in order to add a sibling or a
-    // child
-    m_child = node->GetParent();
+    if (!node->isGen(gen_wxTreeListCtrl))
+    {
+        // The OnAddNew commands add to a child, so we need to "fake" the child to our parent in order to add a sibling or a
+        // child
+        m_child = node->GetParent();
 
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_SPACER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_BOX_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_STATIC_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_WRAP_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRID_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_FLEX_GRID_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRIDBAG_SIZER);
+        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_SPACER);
+        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_BOX_SIZER);
+        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_STATIC_SIZER);
+        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_WRAP_SIZER);
+        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRID_SIZER);
+        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_FLEX_GRID_SIZER);
+        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRIDBAG_SIZER);
+    }
 }
 
 void NavPopupMenu::CreateProjectMenu(Node* node)

--- a/src/panels/navpopupmenu.h
+++ b/src/panels/navpopupmenu.h
@@ -82,6 +82,7 @@ protected:
         MenuNEW_CHILD_SPACER,
         MenuNEW_SIBLING_SPACER,
 
+        MenuNEW_COLUMN,
         MenuNEW_ITEM,
 
         MenuNEW_NOTEBOOK,

--- a/src/xml/trees_xml.xml
+++ b/src/xml/trees_xml.xml
@@ -60,6 +60,8 @@ inline const char* trees_xml = R"===(<?xml version="1.0"?>
 				help="Show the usual, 2 state, checkboxes for the items in the first column." />
 			<option name="wxTL_3STATE"
 				help="Show the checkboxes that can possibly be set by the program, but not the user, to a third, undetermined, state, for the items in the first column. Implies wxTL_CHECKBOX." />
+			<option name="wxTR_TWIST_BUTTONS"
+				help="Selects alternative style of +/- buttons and shows rotating (&quot;twisting&quot;) arrows instead. Currently this style is only implemented under Microsoft Windows Vista and later Windows versions and is ignored under the other platforms. Notice that under Vista this style results in the same appearance as used by the tree control in Explorer and other built-in programs and so using it may be preferable to the default style." />
 			<option name="wxTL_USER_3STATE"
 				help="Same as wxTL_3STATE but the user can also set the checkboxes to the undetermined state. Implies wxTL_3STATE." />
 			<option name="wxTL_DEFAULT_STYLE"
@@ -83,16 +85,10 @@ inline const char* trees_xml = R"===(<?xml version="1.0"?>
 	</gen>
 
 	<gen class="TreeListCtrlColumn" image="treelistctrlcolumn" type="treelistctrlcolumn">
-		<property name="var_name" type="string_escapes"
+		<property name="label" type="string_escapes"
 			help="The column label.">Column</property>
-		<property name="width" type="editoption"
-			help="The width of the column in pixels or the special wxCOL_WIDTH_AUTOSIZE value indicating that the column should adjust to its contents. Notice that the first column is special and will be always resized to fill all the space not taken by the other columns, i.e. the width specified here is ignored for it.">
-			<option name="wxCOL_WIDTH_DEFAULT"
-				help="Special value used for column width meaning unspecified or default." />
-			<option name="wxCOL_WIDTH_AUTOSIZE"
-				help="Size the column automatically to fit all values.&#10;&#10;Note:&#10;On OS X, this style is only implemented in the Cocoa build on OS X >= 10.5; it behaves identically to wxCOL_WIDTH_DEFAULT otherwise." />
-			wxCOL_WIDTH_DEFAULT
-		</property>
+		<property name="width" type="int"
+			help="The width of the column in pixels or the special -2 value indicating that the column should adjust to its contents. Notice that the first column is special and will be always resized to fill all the space not taken by the other columns, i.e. the width specified here is ignored for it.">-2</property>
 		<property name="alignment" type="option"
 			help="Alignment of both the column header and its items.">
 			<option name="wxALIGN_LEFT"
@@ -103,13 +99,13 @@ inline const char* trees_xml = R"===(<?xml version="1.0"?>
 				help="Align the item to the center." />
 			wxALIGN_LEFT
 		</property>
-		<property name="flag" type="bitlist">
+		<property name="flags" type="bitlist">
 			<option name="wxCOL_RESIZABLE"
 				help="Column can be resized (included in default flags)." />
 			<option name="wxCOL_SORTABLE"
 				help="Column can be clicked to toggle the sort order by its contents." />
 			<option name="wxCOL_REORDERABLE"
-				help="Column can be dragged to change its order (included in default)." />
+				help="Column can be dragged to change its order (included in default). Currently, this is only implemented in GTK and ignored on other platforms." />
 			<option name="wxCOL_HIDDEN"
 				help="Column is not shown at all." />
 			wxCOL_RESIZABLE


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR overhauls the **wxTreeListCtrl** generator. This primarily affects columns which were not previously working correctly.

- changed var_name to label
- changed width to an int (so the user can specify pixel size)
- fixed mockup to actually display the columns
- changed context menu to remove unusable commands and add "Add column"
