### PR TITLE
Import wxCrafter property grid items

### DIFF
--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -14,9 +14,9 @@
 
 #include "images_form.h"
 
-#include "bitmaps.h"      // Contains various images handling functions
-#include "mainframe.h"    // MainFrame -- Main window frame
-#include "node.h"         // Node class
+#include "bitmaps.h"    // Contains various images handling functions
+#include "mainframe.h"  // MainFrame -- Main window frame
+#include "node.h"       // Node class
 
 #include "ui_images.h"
 

--- a/src/import/import_crafter_maps.cpp
+++ b/src/import/import_crafter_maps.cpp
@@ -86,23 +86,23 @@ std::map<int, GenEnum::GenName> g_map_id_generator = {
     { 4479, gen_wxWebView },               // verified
     { 4484, gen_wxPopupTransientWindow },  // no way for wxCrafter to create this
     { 4485, gen_wxPropertyGridManager },   // verified
-    { 4486, gen_propGridItem },
-    { 4488, gen_wxRibbonBar },        // verified
-    { 4489, gen_wxRibbonPage },       // verified
-    { 4490, gen_wxRibbonPanel },      // verified
-    { 4491, gen_wxRibbonButtonBar },  // verified
-    { 4492, gen_ribbonButton },       // normal button
-    { 4493, gen_ribbonButton },       // hybrid button
-    { 4494, gen_ribbonButton },       // dropdown button
-    { 4495, gen_ribbonButton },       // toggle button
-    { 4496, gen_wxRibbonGallery },    // verified
-    { 4497, gen_ribbonGalleryItem },  // verified
-    { 4498, gen_wxRibbonToolBar },    // verified
-    { 4499, gen_ribbonTool },         // normal tool
-    { 4500, gen_ribbonTool },         // hybrid tool
-    { 4501, gen_ribbonTool },         // dropdown tool
-    { 4502, gen_ribbonTool },         // toggle tool
-    { 4503, gen_ribbonSeparator },    // verified
+    { 4486, gen_propGridItem },            // verified
+    { 4488, gen_wxRibbonBar },             // verified
+    { 4489, gen_wxRibbonPage },            // verified
+    { 4490, gen_wxRibbonPanel },           // verified
+    { 4491, gen_wxRibbonButtonBar },       // verified
+    { 4492, gen_ribbonButton },            // normal button
+    { 4493, gen_ribbonButton },            // hybrid button
+    { 4494, gen_ribbonButton },            // dropdown button
+    { 4495, gen_ribbonButton },            // toggle button
+    { 4496, gen_wxRibbonGallery },         // verified
+    { 4497, gen_ribbonGalleryItem },       // verified
+    { 4498, gen_wxRibbonToolBar },         // verified
+    { 4499, gen_ribbonTool },              // normal tool
+    { 4500, gen_ribbonTool },              // hybrid tool
+    { 4501, gen_ribbonTool },              // dropdown tool
+    { 4502, gen_ribbonTool },              // toggle tool
+    { 4503, gen_ribbonSeparator },         // verified
     { 4504, gen_toolSeparator },
     { 4509, gen_wxTreeListCtrl },      // verified
     { 4510, gen_TreeListCtrlColumn },  // verified

--- a/src/ui/embedimg.cpp
+++ b/src/ui/embedimg.cpp
@@ -23,10 +23,10 @@
 
 #include "embedimg.h"  // auto-generated: embedimg_base.h and embedimg_base.cpp
 
-#include "bitmaps.h"      // Map of bitmaps accessed by name
-#include "mainframe.h"    // MainFrame -- Main window frame
-#include "node.h"         // Node class
-#include "utils.h"        // Utility functions that work with properties
+#include "bitmaps.h"    // Map of bitmaps accessed by name
+#include "mainframe.h"  // MainFrame -- Main window frame
+#include "node.h"       // Node class
+#include "utils.h"      // Utility functions that work with properties
 
 #include "ui_images.h"
 

--- a/src/xml/propgrid_xml.xml
+++ b/src/xml/propgrid_xml.xml
@@ -138,7 +138,7 @@ inline const char* propgrid_xml = R"===(<?xml version="1.0"?>
 		<property name="var_name" type="string"
 			help="Instance name.">m_propertyGridPage</property>
 		<property name="label" type="string_escapes"
-			help="Label shown as a tooltip of the manager's tool button.">Page</property>
+			help="Label shown as a tooltip of the manager's tool button." />
 		<property name="bitmap" type="image"
 			help="Bitmap shown in the property manager's header." />
 	</gen>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This needed special handling because wxCrafter doesn't allow pages to be added, which will cause **wxPropertyGridManager::Clear()** to fail to delete the properties.