### PR TITLE
Overhaul Navigation Panel context menu

### DIFF
--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -95,6 +95,7 @@ Files:
     generate/misc_widgets.cpp      # Miscellaneous generation classes
     generate/panel_widgets.cpp     # Panel generation classes
     generate/picker_widgets.cpp    # Picker generation classes
+    generate/project.cpp           # Project generator
     generate/radio_widgets.cpp     # Radio button and Radio box generation classes
     generate/ribbon_widgets.cpp    # Ribbon generation classes
     generate/sizer_widgets.cpp     # Sizer generation classes

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -30,7 +30,7 @@ bool isClipboardDataAvailable()
     return false;
 }
 
-NodeSharedPtr GetClipboardNode()
+NodeSharedPtr GetClipboardNode(bool warn_if_problems)
 {
     SmartClipboard clip;
     if (clip.IsOpened())
@@ -62,7 +62,8 @@ NodeSharedPtr GetClipboardNode()
 
         if (!result)
         {
-            wxMessageBox("Unable to parse the object in the clipboard", "Paste Clipboard");
+            if (warn_if_problems)
+                wxMessageBox("Unable to parse the object in the clipboard", "Paste Clipboard");
             return {};
         }
 
@@ -76,7 +77,7 @@ NodeSharedPtr GetClipboardNode()
         {
             FormBuilder fb;
             auto new_node = fb.CreateFbpNode(root, nullptr);
-            if (fb.GetErrors().size())
+            if (fb.GetErrors().size() && warn_if_problems)
             {
                 ttlib::cstr errMsg("Not everything from the wxFormBuilder object could be converted:\n\n");
                 for (auto& iter: fb.GetErrors())
@@ -95,7 +96,7 @@ NodeSharedPtr GetClipboardNode()
             auto child = root.first_child();
             WxSmith smith;
             auto new_node = smith.CreateXrcNode(child, nullptr);
-            if (smith.GetErrors().size())
+            if (smith.GetErrors().size() && warn_if_problems)
             {
                 ttlib::cstr errMsg("Not everything from the wxSmith object could be converted:\n\n");
                 for (auto& iter: smith.GetErrors())

--- a/src/clipboard.h
+++ b/src/clipboard.h
@@ -14,8 +14,13 @@ constexpr const char* txt_OurClipboardFormat = "wxUiEditor";
 class Node;
 using NodeSharedPtr = std::shared_ptr<Node>;
 
+// Declared in clipboard.h. Returns true if the external clipboard condtains data that we can
+// paste. This will either be from a different instance of wxUiEditor, or from wxFormBuilder
+// or wxSmith.
 bool isClipboardDataAvailable();
-NodeSharedPtr GetClipboardNode();
+
+// Pass false as the parameter to prevent any error messages
+NodeSharedPtr GetClipboardNode(bool warn_if_problems = true);
 
 class wxUtf8DataObject : public wxDataObjectSimple
 {

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -68,6 +68,7 @@ set (file_list
     ${CMAKE_CURRENT_LIST_DIR}/generate/misc_widgets.cpp      # Miscellaneous generation classes
     ${CMAKE_CURRENT_LIST_DIR}/generate/panel_widgets.cpp     # Panel generation classes
     ${CMAKE_CURRENT_LIST_DIR}/generate/picker_widgets.cpp    # Picker generation classes
+    ${CMAKE_CURRENT_LIST_DIR}/generate/project.cpp           # Project generator
     ${CMAKE_CURRENT_LIST_DIR}/generate/radio_widgets.cpp     # Radio button and Radio box generation classes
     ${CMAKE_CURRENT_LIST_DIR}/generate/ribbon_widgets.cpp    # Ribbon generation classes
     ${CMAKE_CURRENT_LIST_DIR}/generate/sizer_widgets.cpp     # Sizer generation classes

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -398,7 +398,7 @@ static std::vector<std::pair<const char*, const char*>> prefix_pair = {
     { "menu", "_menu" },
     { "notebook", "_notebook" },
     { "page", "_page" },
-    { "panel", "_panel" },
+    { "pane", "_pane" },
     { "picker", "_picker" },
     { "simple", "_simple" },
     { "sizer", "_sizer" },
@@ -407,9 +407,6 @@ static std::vector<std::pair<const char*, const char*>> prefix_pair = {
     { "validator", "_validator" },
     { "view", "_view" },
     { "window", "_window" },
-
-    // Don't sort -- need to be sure "panel" is checked first
-    { "pane", "_pane" },
 
 };
 // clang-format on
@@ -498,10 +495,21 @@ static const auto parentless_types = {
     type_dataviewlistcolumn,
     type_embed_image,
     type_images,
+    type_menu,
+    type_menubar,
+    type_menubar_form,
+    type_menuitem,
     type_page,
+    type_ribbonbar,
+    type_ribbonbar_form,
     type_ribbonbutton,
+    type_ribbonbuttonbar,
+    type_ribbongallery,
     type_ribbongalleryitem,
+    type_ribbonpage,
+    type_ribbonpanel,
     type_ribbontool,
+    type_ribbontoolbar,
     type_tool,
     type_wizardpagesimple
 

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -486,3 +486,42 @@ ttlib::cstr BaseGenerator::GetHelpURL(Node* node)
 
     return ttlib::cstr();
 }
+
+// clang-format off
+
+// These are the control types that cannot have their parent changed
+static const auto parentless_types = {
+
+    type_bookpage,
+    type_ctx_menu,
+    type_dataviewcolumn,
+    type_dataviewlistcolumn,
+    type_embed_image,
+    type_images,
+    type_page,
+    type_ribbonbutton,
+    type_ribbongalleryitem,
+    type_ribbontool,
+    type_tool,
+    type_wizardpagesimple
+
+};
+// clang-format on
+
+bool BaseGenerator::CanChangeParent(Node* node)
+{
+    if (node->IsForm())
+    {
+        return false;
+    }
+
+    for (auto& iter: parentless_types)
+    {
+        if (node->isType(iter))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -112,4 +112,9 @@ public:
     // If true, a control can be move left or right or into a new sizer. Override and return
     // false if the control can't do this (such as a book page).
     virtual bool CanChangeParent(Node* node);
+
+    // Return true to automatically add submenu command to add child sizers.
+    //
+    // You will need to Bind to any commands you add.
+    virtual bool PopupMenuAddCommands(NavPopupMenu*, Node*) { return false; }
 };

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -15,6 +15,7 @@
 
 class BaseCodeGenerator;
 class MockupParent;
+class NavPopupMenu;
 class WriteCode;
 class wxMouseEvent;
 class wxObject;
@@ -107,4 +108,8 @@ public:
     // flags. Returns true if a change was made. Note that the change is *not* pushed to the
     // undo stack.
     virtual bool VerifyProperty(NodeProperty*);
+
+    // If true, a control can be move left or right or into a new sizer. Override and return
+    // false if the control can't do this (such as a book page).
+    virtual bool CanChangeParent(Node* node);
 };

--- a/src/generate/gen_initialize.cpp
+++ b/src/generate/gen_initialize.cpp
@@ -24,6 +24,7 @@
 #include "misc_widgets.h"      // Miscellaneous component classes
 #include "panel_widgets.h"     // Panel component classes
 #include "picker_widgets.h"    // DatePickerCtrlGenerator -- Picker component classes
+#include "project.h"           // Project generator
 #include "radio_widgets.h"     // RadioButtonGenerator -- Radio button and Radio box component classes
 #include "ribbon_widgets.h"    // RibbonBarGenerator -- Ribbon component classes
 #include "sizer_widgets.h"     // Sizer component classes
@@ -181,6 +182,8 @@ void NodeCreator::InitGenerators()
     SET_GENERATOR(gen_TextSizer, TextSizerGenerator)
 
     SET_GENERATOR(gen_CustomControl, CustomControl)
+
+    SET_GENERATOR(gen_Project, ProjectGenerator)
 
     AddAllConstants();
 }

--- a/src/generate/project.cpp
+++ b/src/generate/project.cpp
@@ -1,0 +1,85 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Project generator
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include <wx/propgrid/propgrid.h>  // wxPropertyGrid
+
+#include "gen_base.h"   // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
+#include "mainframe.h"  // MainFrame -- Main window frame
+#include "node.h"       // Node class
+#include "node_prop.h"  // NodeProperty -- NodeProperty class
+#include "undo_cmds.h"  // InsertNodeAction -- Undoable command classes derived from UndoAction
+
+#include "newdialog_base.h"  // NewDialog -- Dialog for creating a new project dialog
+#include "newframe_base.h"   // NewFrame -- Dialog for creating a new project wxFrame
+#include "newwizard_base.h"  // NewWizard -- Dialog for creating a new wizard
+
+#include "../panels/navpopupmenu.h"  // NavPopupMenu -- Context-menu for Navigation Panel
+
+#include "project.h"
+
+bool ProjectGenerator::PopupMenuAddCommands(NavPopupMenu* menu, Node* /* node */)
+{
+    menu->Append(NavPopupMenu::MenuPROJECT_ADD_DIALOG, "Add new dialog...");
+    menu->Append(NavPopupMenu::MenuPROJECT_ADD_WINDOW, "Add new window...");
+    menu->Append(NavPopupMenu::MenuPROJECT_ADD_WIZARD, "Add new wizard...");
+    menu->AppendSeparator();
+    menu->Append(NavPopupMenu::MenuPROJECT_SORT_FORMS, "Sort Forms");
+
+    menu->Bind(
+        wxEVT_MENU,
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().PasteNode(wxGetApp().GetProject());
+        },
+        wxID_PASTE);
+
+    menu->Bind(
+        wxEVT_MENU,
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().PushUndoAction(std::make_shared<SortProjectAction>());
+        },
+        NavPopupMenu::MenuPROJECT_SORT_FORMS);
+
+    menu->Bind(
+        wxEVT_MENU,
+        [](wxCommandEvent&)
+        {
+            NewDialog dlg(wxGetFrame().GetWindow());
+            if (dlg.ShowModal() == wxID_OK)
+            {
+                dlg.CreateNode();
+            }
+        },
+        NavPopupMenu::MenuPROJECT_ADD_DIALOG);
+
+    menu->Bind(
+        wxEVT_MENU,
+        [](wxCommandEvent&)
+        {
+            NewFrame dlg(wxGetFrame().GetWindow());
+            if (dlg.ShowModal() == wxID_OK)
+            {
+                dlg.CreateNode();
+            }
+        },
+        NavPopupMenu::MenuPROJECT_ADD_WINDOW);
+
+    menu->Bind(
+        wxEVT_MENU,
+        [](wxCommandEvent&)
+        {
+            NewWizard dlg(wxGetFrame().GetWindow());
+            if (dlg.ShowModal() == wxID_OK)
+            {
+                dlg.CreateNode();
+            }
+        },
+        NavPopupMenu::MenuPROJECT_ADD_WIZARD);
+
+    return true;
+}

--- a/src/generate/project.h
+++ b/src/generate/project.h
@@ -1,0 +1,16 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Project generator
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "base_generator.h"  // BaseGenerator -- Base Generator class
+
+class ProjectGenerator : public BaseGenerator
+{
+public:
+    bool PopupMenuAddCommands(NavPopupMenu*, Node*) override;
+};

--- a/src/generate/wizard_form.cpp
+++ b/src/generate/wizard_form.cpp
@@ -12,6 +12,7 @@
 #include "utils.h"       // Utility functions that work with properties
 
 #include "../mockup/mockup_wizard.h"  // WizardPageSimple
+#include "../panels/navpopupmenu.h"   // NavPopupMenu -- Context-menu for Navigation Panel
 
 #include "wizard_form.h"
 
@@ -195,6 +196,20 @@ std::optional<ttlib::cstr> WizardFormGenerator::GetHint(NodeProperty* prop)
     }
 }
 
+bool WizardFormGenerator::PopupMenuAddCommands(NavPopupMenu* menu, Node* node)
+{
+    menu->Append(NavPopupMenu::MenuADD_WIZARD_PAGE, "Add Page");
+    menu->Bind(
+        wxEVT_MENU,
+        [=](wxCommandEvent&)
+        {
+            node->CreateToolNode(gen_wxWizardPageSimple);
+        },
+        NavPopupMenu::MenuADD_WIZARD_PAGE);
+
+    return true;
+}
+
 //////////////////////////////////////////  WizardPageGenerator  //////////////////////////////////////////
 
 wxObject* WizardPageGenerator::CreateMockup(Node* node, wxObject* parent)
@@ -223,4 +238,23 @@ std::optional<ttlib::cstr> WizardPageGenerator::GenConstruction(Node* node)
     code << ");";
 
     return code;
+}
+
+bool WizardPageGenerator::PopupMenuAddCommands(NavPopupMenu* menu, Node* node)
+{
+    menu->Append(NavPopupMenu::MenuADD_WIZARD_PAGE, "Add Page");
+    menu->Bind(
+        wxEVT_MENU,
+        [=](wxCommandEvent&)
+        {
+            node->CreateToolNode(gen_wxWizardPageSimple);
+        },
+        NavPopupMenu::MenuADD_WIZARD_PAGE);
+
+    if (node->GetChildCount() && node->GetChild(0)->IsSizer())
+    {
+        menu->MenuAddChildSizerCommands(node->GetChild(0));
+    }
+
+    return true;
 }

--- a/src/generate/wizard_form.h
+++ b/src/generate/wizard_form.h
@@ -12,14 +12,16 @@
 class WizardFormGenerator : public BaseGenerator
 {
 public:
-    wxObject* CreateMockup(Node* /*node*/, wxObject* parent) override;
+    wxObject* CreateMockup(Node*, wxObject* parent) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
-    std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
+    std::optional<ttlib::cstr> GenConstruction(Node*) override;
+    std::optional<ttlib::cstr> GenEvents(NodeEvent*, const std::string& class_name) override;
+    std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node*) override;
+
+    bool GetIncludes(Node*, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
     std::optional<ttlib::cstr> GetHint(NodeProperty*) override;
-
-    bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+    bool PopupMenuAddCommands(NavPopupMenu*, Node*) override;
 
     std::vector<Node*> GetChildPanes(Node* parent);
 };
@@ -27,7 +29,9 @@ public:
 class WizardPageGenerator : public BaseGenerator
 {
 public:
-    wxObject* CreateMockup(Node* /*node*/, wxObject* parent) override;
+    wxObject* CreateMockup(Node*, wxObject* parent) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    std::optional<ttlib::cstr> GenConstruction(Node*) override;
+
+    bool PopupMenuAddCommands(NavPopupMenu*, Node*) override;
 };

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -874,10 +874,10 @@ GenEnum::PropName WxCrafter::UnknownProperty(Node* node, const Value& value, ttl
             if (value["m_selection"].IsNumber())
             {
                 index = value["m_selection"].GetInt();
-                if (index)
+                if (index > 0)
                 {
                     auto list_effects = GetStringVector(FindValue(value, "m_options"));
-                    if (index < list_effects.size())
+                    if (static_cast<size_t>(index) < list_effects.size())
                     {
                         bool found = false;
                         for (auto& friendly_pair: g_friend_constant)

--- a/src/import/import_wxcrafter.h
+++ b/src/import/import_wxcrafter.h
@@ -49,11 +49,11 @@ protected:
 
     // Called when prop_name is a valid property. This will set the property's value after
     // any possible additional processing.
-    void WxCrafter::KnownProperty(Node* node, const rapidjson::Value& value, GenEnum::PropName prop_name);
+    void KnownProperty(Node* node, const rapidjson::Value& value, GenEnum::PropName prop_name);
 
     // Called to handle prop_value which may get converted to a different property before
     // saving.
-    void WxCrafter::ValueProperty(Node* node, const rapidjson::Value& value);
+    void ValueProperty(Node* node, const rapidjson::Value& value);
 
 private:
     ttlib::cstr m_output_name;

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -584,6 +584,8 @@ void MainFrame::OnClose(wxCloseEvent& event)
     m_FileHistory.Save(*config);
     m_property_panel->SaveDescBoxHeight();
 
+    // REVIEW: [KeyWorks - 01-24-2022] m_has_clipboard_data is never set to true
+
     // If we have clipboard data, ensure it persists after we exit
     if (m_has_clipboard_data)
         wxTheClipboard->Flush();

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -42,6 +42,11 @@ class ChangeParentAction;
 class ChangePositionAction;
 class ModifyProperties;
 
+// Declared in clipboard.h. Returns true if the external clipboard condtains data that we can
+// paste. This will either be from a different instance of wxUiEditor, or from wxFormBuilder
+// or wxSmith.
+bool isClipboardDataAvailable();
+
 // Warning! This MUST be at least 3!
 constexpr const size_t StatusPanels = 3;
 
@@ -111,6 +116,7 @@ public:
     Node* GetSelectedNode() { return (m_selected_node ? m_selected_node.get() : nullptr); };
     Node* GetSelectedForm();
 
+    NodeSharedPtr GetClipboardPtr() { return (m_clipboard ? m_clipboard : nullptr); }
     Node* GetClipboard() { return (m_clipboard ? m_clipboard.get() : nullptr); }
     size_t GetClipHash() { return (m_clipboard ? m_clip_hash : 0); }
 
@@ -173,7 +179,13 @@ public:
     void PasteNode(Node* parent);
 
     bool CanCopyNode();
+
+    // Returns true if there is a selected node, and there is data in either the internal or
+    // external clipboard.
     bool CanPasteNode();
+
+    // Returns true if there is data in either the internal or external clipboard.
+    bool isPasteAvailable() { return (m_clipboard.get() || isClipboardDataAvailable()); }
 
     // This does not use the internal clipboard
     void DuplicateNode(Node* node);

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -1,15 +1,18 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Context-menu for Navigation Panel
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include <wx/artprov.h>
+#include <wx/artprov.h>   // wxArtProvider class
+#include <wx/wupdlock.h>  // wxWindowUpdateLocker prevents window redrawing
 
 #include "navpopupmenu.h"  // NavPopupMenu
 
+#include "base_generator.h"  // BaseGenerator -- Base widget generator class
 #include "bitmaps.h"         // Contains various images handling functions
+#include "clipboard.h"       // Handles reading and writing OS clipboard data
 #include "mainframe.h"       // MainFrame -- Main window frame
 #include "mainframe_base.h"  // contains all the wxue_img namespace embedded images
 #include "nav_panel.h"       // NavigationPanel -- Navigation Panel
@@ -20,35 +23,7 @@
 
 #include "newdialog_base.h"  // NewDialog -- Dialog for creating a new project dialog
 #include "newframe_base.h"   // NewFrame -- Dialog for creating a new project wxFrame
-
-// clang-format off
-static const auto lstBarGenerators = {
-
-    gen_wxStatusBar,
-    gen_wxMenuBar,
-    gen_wxToolBar,
-    gen_tool,
-
-    gen_MenuBar,  // form version of wxMenuBar
-    gen_RibbonBar,  // form version of wxRibbonBar
-    gen_ToolBar,  // form version of wxToolBar
-
-    gen_wxRibbonBar,
-    gen_wxRibbonPage,
-    gen_wxRibbonPanel,
-    gen_wxRibbonToolBar,
-    gen_ribbonTool,
-
-};
-
-static const auto lstContainerGenerators = {
-
-    gen_BookPage,
-    gen_wxPanel,
-    gen_wxWizardPageSimple,
-
-};
-// clang-format on
+#include "newwizard_base.h"  // NewWizard -- Dialog for creating a new wizard
 
 NavPopupMenu::NavPopupMenu(Node* node) : m_node(node)
 {
@@ -58,74 +33,14 @@ NavPopupMenu::NavPopupMenu(Node* node) : m_node(node)
         return;  // theoretically impossible, but don't crash if it happens
     }
 
-    for (auto& iter: lstBarGenerators)
-    {
-        if (node->isGen(iter))
-        {
-            CreateBarMenu(node);
-            return;
-        }
-    }
-
-    if (node->isGen(gen_PopupMenu))
-    {
-        CreateMenuMenu(node);
-        return;
-    }
-
-    if (node->IsForm())
-    {
-        CreateFormMenu(node);
-        return;
-    }
-
-    for (auto& iter: lstContainerGenerators)
-    {
-        if (node->isGen(iter))
-        {
-            CreateContainerMenu(node);
-            return;
-        }
-    }
-
-    if (node->IsContainer() && node->DeclName().contains("book", tt::CASE::either))
-    {
-        CreateBookMenu(node);
-        return;
-    }
-
-    if (node->isType(type_project))
-    {
-        CreateProjectMenu(node);
-        return;
-    }
-
-    if (node->DeclName().is_sameprefix("wxMenu") || node->isGen(gen_separator) || node->isGen(gen_submenu))
-    {
-        CreateMenuMenu(node);
-        return;
-    }
-
-    if (node->isGen(gen_wxWizard))
-    {
-        CreateWizardMenu(node);
-        return;
-    }
-
     if (node->IsSizer())
     {
-        if (node->GetParent()->IsForm() || node->GetParent()->IsContainer())
-        {
-            CreateTopSizerMenu(node);
-        }
-        else
-        {
-            CreateSizerMenu(node);
-        }
-        return;
+        CreateSizerMenu(node);
     }
-
-    CreateNormalMenu(node);
+    else
+    {
+        CreateCommonMenu(node);
+    }
 }
 
 void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
@@ -135,6 +50,14 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
         case MenuNEW_ITEM:
             if (m_tool_name < gen_name_array_size)
             {
+                if (m_node->isType(type_bookpage) || m_node->isType(type_wizardpagesimple))
+                {
+                    if (m_child && m_child->IsSizer())
+                    {
+                        m_child = m_child->GetParent();
+                    }
+                }
+
                 if (m_child)
                     m_child->CreateToolNode(m_tool_name);
                 else
@@ -150,6 +73,82 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
                 else
                     wxGetFrame().CreateToolNode(gen_TreeListCtrlColumn);
             }
+            break;
+
+        case MenuNEW_SIBLING_BOX_SIZER:
+            m_node->GetParent()->CreateToolNode(gen_wxBoxSizer);
+            break;
+
+        case MenuNEW_SIBLING_STATIC_SIZER:
+            m_node->GetParent()->CreateToolNode(gen_wxStaticBoxSizer);
+            break;
+
+        case MenuNEW_SIBLING_WRAP_SIZER:
+            m_node->GetParent()->CreateToolNode(gen_wxWrapSizer);
+            break;
+
+        case MenuNEW_SIBLING_GRID_SIZER:
+            m_node->GetParent()->CreateToolNode(gen_wxGridSizer);
+            break;
+
+        case MenuNEW_SIBLING_FLEX_GRID_SIZER:
+            m_node->GetParent()->CreateToolNode(gen_wxFlexGridSizer);
+            break;
+
+        case MenuNEW_SIBLING_GRIDBAG_SIZER:
+            m_node->GetParent()->CreateToolNode(gen_wxGridBagSizer);
+            break;
+
+        case MenuNEW_SIBLING_STD_DIALG_BTNS:
+            m_node->GetParent()->CreateToolNode(gen_wxStdDialogButtonSizer);
+            break;
+
+        case MenuNEW_SIBLING_SPACER:
+            m_node->GetParent()->CreateToolNode(gen_spacer);
+            break;
+
+        case MenuNEW_CHILD_BOX_SIZER:
+            m_sizer_node->CreateToolNode(gen_wxBoxSizer);
+            break;
+
+        case MenuNEW_CHILD_STATIC_SIZER:
+            m_sizer_node->CreateToolNode(gen_wxStaticBoxSizer);
+            break;
+
+        case MenuNEW_CHILD_WRAP_SIZER:
+            m_sizer_node->CreateToolNode(gen_wxWrapSizer);
+            break;
+
+        case MenuNEW_CHILD_GRID_SIZER:
+            m_sizer_node->CreateToolNode(gen_wxGridSizer);
+            break;
+
+        case MenuNEW_CHILD_FLEX_GRID_SIZER:
+            m_sizer_node->CreateToolNode(gen_wxFlexGridSizer);
+            break;
+
+        case MenuNEW_CHILD_GRIDBAG_SIZER:
+            m_sizer_node->CreateToolNode(gen_wxGridBagSizer);
+            break;
+
+        case MenuNEW_CHILD_STD_DIALG_BTNS:
+            wxGetFrame().CreateToolNode(gen_wxStdDialogButtonSizer);
+            break;
+
+        case MenuNEW_CHILD_SPACER:
+            wxGetFrame().CreateToolNode(gen_spacer);
+            break;
+
+        case MenuNEW_TOOLBAR:
+            wxGetFrame().CreateToolNode(gen_wxToolBar);
+            break;
+
+        case MenuNEW_INFOBAR:
+            wxGetFrame().CreateToolNode(gen_wxInfoBar);
+            break;
+
+        case MenuADD_MENU:
+            wxGetFrame().CreateToolNode(gen_wxMenu);
             break;
 
         case MenuADD_TOOL_SEPARATOR:
@@ -240,28 +239,12 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
             ChangeSizer(gen_wxWrapSizer);
             break;
 
-        case MenuRESET_ID:
-            m_node->ModifyProperty("id", "wxID_ANY");
-            break;
-
-        case MenuRESET_SIZE:
-            m_node->ModifyProperty("size", "-1,-1");
-            break;
-
-        case MenuRESET_MIN_SIZE:
-            m_node->ModifyProperty(prop_minimum_size, "-1,-1");
-            break;
-
-        case MenuRESET_MAX_SIZE:
-            m_node->ModifyProperty("maximum_size", "-1,-1");
-            break;
-
         case MenuADD_PAGE:
             if (m_node->isGen(gen_BookPage))
             {
                 m_node->GetParent()->CreateToolNode(gen_BookPage);
             }
-            if (m_node->isGen(gen_wxWizardPageSimple))
+            else if (m_node->isGen(gen_wxWizardPageSimple))
             {
                 m_node->GetParent()->CreateToolNode(gen_wxWizardPageSimple);
             }
@@ -288,28 +271,6 @@ void NavPopupMenu::OnUpdateEvent(wxUpdateUIEvent& event)
                 event.Enable(wxGetFrame().CanCopyNode());
             break;
 
-        case wxID_PASTE:
-            event.Enable(wxGetFrame().CanPasteNode());
-            break;
-
-        case MenuBORDERS_ALL:
-            event.Check(m_node->prop_as_string(prop_borders).contains("wxALL"));
-            break;
-
-        case MenuBORDERS_NONE:
-            event.Check(m_node->prop_as_string(prop_borders).empty());
-            break;
-
-        case MenuBORDERS_HORIZONTAL:
-            event.Check(m_node->prop_as_string(prop_borders) == "wxLEFT|wxRIGHT" ||
-                        m_node->prop_as_string(prop_borders) == "wxRIGHT|wxLEFT|");
-            break;
-
-        case MenuBORDERS_VERTICAL:
-            event.Check(m_node->prop_as_string(prop_borders) == "wxTOP|wxBOTTOM" ||
-                        m_node->prop_as_string(prop_borders) == "wxBOTTOM|wxTOP|");
-            break;
-
         case MenuMOVE_UP:
             Enable(MenuMOVE_UP, wxGetFrame().MoveNode(m_node, MoveDirection::Up, true));
             break;
@@ -325,6 +286,437 @@ void NavPopupMenu::OnUpdateEvent(wxUpdateUIEvent& event)
         case MenuMOVE_RIGHT:
             Enable(MenuMOVE_RIGHT, wxGetFrame().MoveNode(m_node, MoveDirection::Right, true));
             break;
+    }
+}
+
+void NavPopupMenu::CreateSizerMenu(Node* node)
+{
+    // This needs to be added first to cover all menu ids that aren't specically bound to an id.
+    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
+    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
+
+    m_sizer_node = node;
+
+    bool isTopSizer = (node->GetParent()->IsForm() || node->GetParent()->IsContainer());
+    wxMenuItem* menu_item;
+    wxMenu* sub_menu;
+
+    sub_menu = new wxMenu;
+    menu_item = sub_menu->Append(MenuNEW_CHILD_BOX_SIZER, "wxBoxSizer");
+    menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_STATIC_SIZER, "wxStaticBoxSizer");
+    menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_WRAP_SIZER, "wxWrapSizer");
+    menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_GRID_SIZER, "wxGridSizer");
+    menu_item->SetBitmap(GetInternalImage("grid_sizer"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_FLEX_GRID_SIZER, "wxFlexGridSizer");
+    menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_GRIDBAG_SIZER, "wxGridBagSizer");
+    menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
+
+    AppendSubMenu(sub_menu, "Add child sizer");
+
+    if (!isTopSizer)
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuNEW_SIBLING_BOX_SIZER, "wxBoxSizer");
+        menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
+        menu_item = sub_menu->Append(MenuNEW_SIBLING_STATIC_SIZER, "wxStaticBoxSizer");
+        menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
+        menu_item = sub_menu->Append(MenuNEW_SIBLING_WRAP_SIZER, "wxWrapSizer");
+        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_SIBLING_GRID_SIZER, "wxGridSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_SIBLING_FLEX_GRID_SIZER, "wxFlexGridSizer");
+        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_SIBLING_GRIDBAG_SIZER, "wxGridBagSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
+        AppendSubMenu(sub_menu, "Add sibling sizer");
+
+        AppendSeparator();
+        MenuAddMoveCommands(node);
+    }
+
+    if (node->isGen(gen_wxBoxSizer))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_FLEX_GRID_SIZER, "wxFlexGridSizer");
+        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
+        menu_item = sub_menu->Append(MenuChangeTo_GRID_SIZER, "wxGridSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
+        menu_item = sub_menu->Append(MenuChangeTo_STATIC_SIZER, "wxStaticBoxSizer");
+        menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
+        menu_item = sub_menu->Append(MenuChangeTo_WRAP_SIZER, "wxWrapSizer");
+        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
+
+        AppendSubMenu(sub_menu, "Change Sizer To");
+    }
+    else if (node->isGen(gen_wxGridSizer))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_FLEX_GRID_SIZER, "wxFlexGridSizer");
+        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
+        menu_item = sub_menu->Append(MenuChangeTo_WRAP_SIZER, "wxWrapSizer");
+        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
+
+        AppendSubMenu(sub_menu, "Change Sizer To");
+    }
+    else if (node->isGen(gen_wxFlexGridSizer))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_GRID_SIZER, "wxGridSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
+        menu_item = sub_menu->Append(MenuChangeTo_WRAP_SIZER, "wxWrapSizer");
+        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
+
+        AppendSubMenu(sub_menu, "Change Sizer To");
+    }
+    else if (node->isGen(gen_wxWrapSizer))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_FLEX_GRID_SIZER, "wxFlexGridSizer");
+        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
+        menu_item = sub_menu->Append(MenuChangeTo_GRID_SIZER, "wxGridSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
+
+        AppendSubMenu(sub_menu, "Change Sizer To");
+    }
+
+    AppendSeparator();
+    MenuAddStandardCommands(node);
+}
+
+void NavPopupMenu::CreateCommonMenu(Node* node)
+{
+    // This needs to be added first to cover all menu ids that aren't specically bound to an id.
+    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
+    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
+
+    MenuAddCommands(node);
+    MenuAddMoveCommands(node);
+    AppendSeparator();
+    MenuAddStandardCommands(node);
+}
+
+void NavPopupMenu::MenuAddCommands(Node* node)
+{
+    if (node->IsForm())
+    {
+        if (!node->isGen(gen_wxWizard))
+        {
+            return;
+        }
+    }
+
+    if (node->isGen(gen_wxStatusBar))
+    {
+        return;
+    }
+
+    if (auto gen = node->GetGenerator(); gen)
+    {
+        if (gen->PopupMenuAddCommands(this, node))
+        {
+            AppendSeparator();
+            return;
+        }
+    }
+
+    bool add_sizer = true;
+
+    switch (node->gen_name())
+    {
+        case gen_wxAuiNotebook:
+        case gen_wxChoicebook:
+        case gen_wxListbook:
+        case gen_wxNotebook:
+        case gen_wxSimplebook:
+        case gen_wxToolbook:
+        case gen_wxTreebook:
+            add_sizer = false;
+            Append(MenuADD_PAGE, "Add Page");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_BookPage);
+                },
+                MenuADD_PAGE);
+            break;
+
+        case gen_wxRibbonBar:
+        case gen_RibbonBar:
+            add_sizer = false;
+            Append(MenuADD_RIBBON_PAGE, "Add Page");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_wxRibbonPage);
+                },
+                MenuADD_RIBBON_PAGE);
+            break;
+
+        case gen_wxRibbonPage:
+            add_sizer = false;
+            Append(MenuADD_RIBBON_PANEL, "Add Panel");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_wxRibbonPanel);
+                },
+                MenuADD_RIBBON_PANEL);
+            break;
+
+        case gen_wxRibbonPanel:
+            if (node->GetChildCount())
+            {
+                return;
+            }
+            else
+            {
+                Append(MenuADD_RIBBON_BUTTONBAR, "Add Button Bar");
+                Bind(
+                    wxEVT_MENU,
+                    [](wxCommandEvent&)
+                    {
+                        wxGetFrame().CreateToolNode(gen_wxRibbonButtonBar);
+                    },
+                    MenuADD_RIBBON_BUTTONBAR);
+
+                Append(MenuADD_RIBBON_TOOLBAR, "Add Tool Bar");
+                Bind(
+                    wxEVT_MENU,
+                    [](wxCommandEvent&)
+                    {
+                        wxGetFrame().CreateToolNode(gen_wxRibbonToolBar);
+                    },
+                    MenuADD_RIBBON_TOOLBAR);
+
+                Append(MenuADD_RIBBON_GALLERY, "Add Gallery");
+                Bind(
+                    wxEVT_MENU,
+                    [](wxCommandEvent&)
+                    {
+                        wxGetFrame().CreateToolNode(gen_wxRibbonGallery);
+                    },
+                    MenuADD_RIBBON_GALLERY);
+            }
+            break;
+
+        case gen_wxToolBar:
+        case gen_ToolBar:
+        case gen_tool:
+        case gen_toolSeparator:
+            add_sizer = false;
+            Append(MenuADD_TOOL, "Add Tool");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_tool);
+                },
+                MenuADD_TOOL);
+
+            Append(MenuADD_TOOL_SEPARATOR, "Add Separator");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_toolSeparator);
+                },
+                MenuADD_TOOL_SEPARATOR);
+            break;
+
+        case gen_wxMenuBar:
+        case gen_MenuBar:
+            add_sizer = false;
+            Append(MenuADD_MENU, "Add Menu");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_wxMenu);
+                },
+                MenuADD_MENU);
+            break;
+
+        case gen_wxMenu:
+        case gen_wxMenuItem:
+        case gen_submenu:
+        case gen_separator:
+            add_sizer = false;
+            Append(MenuADD_MENUITEM, "Add Menu Item");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_wxMenuItem);
+                },
+                MenuADD_MENUITEM);
+
+            Append(MenuADD_SUBMENU, "Add Submenu");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_submenu);
+                },
+                MenuADD_SUBMENU);
+
+            Append(MenuADD_MENU_SEPARATOR, "Add Separator");
+            Bind(
+                wxEVT_MENU,
+                [](wxCommandEvent&)
+                {
+                    wxGetFrame().CreateToolNode(gen_separator);
+                },
+                MenuADD_MENU_SEPARATOR);
+
+            break;
+
+        default:
+            Append(MenuNEW_CHILD_SPACER, "Add spacer");
+            break;
+    }
+
+    if (add_sizer)
+    {
+        MenuAddChildSizerCommands(node);
+    }
+
+    if (!node->isGen(gen_Project))
+    {
+        AppendSeparator();
+    }
+}
+
+void NavPopupMenu::MenuAddChildSizerCommands(Node* child)
+{
+    m_sizer_node = child;
+    auto sub_menu = new wxMenu;
+    auto menu_item = sub_menu->Append(MenuNEW_CHILD_BOX_SIZER, "wxBoxSizer");
+    menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_STATIC_SIZER, "wxStaticBoxSizer");
+    menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_WRAP_SIZER, "wxWrapSizer");
+    menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_GRID_SIZER, "wxGridSizer");
+    menu_item->SetBitmap(GetInternalImage("grid_sizer"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_FLEX_GRID_SIZER, "wxFlexGridSizer");
+    menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
+    menu_item = sub_menu->Append(MenuNEW_CHILD_GRIDBAG_SIZER, "wxGridBagSizer");
+    menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
+
+    if (child->isParent(gen_wxDialog))
+    {
+        sub_menu->AppendSeparator();
+        menu_item = sub_menu->Append(MenuNEW_CHILD_STD_DIALG_BTNS, "wxStdDialogButtonSizer");
+        menu_item->SetBitmap(GetInternalImage("stddialogbuttonsizer"));
+    }
+
+    AppendSubMenu(sub_menu, "Add sizer");
+}
+
+void NavPopupMenu::MenuAddMoveCommands(Node* node)
+{
+    if (node->isGen(gen_Project))
+    {
+        return;
+    }
+
+    wxMenuItem* menu_item;
+    wxMenu* sub_menu;
+
+    sub_menu = new wxMenu;
+    menu_item = sub_menu->Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
+    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
+    menu_item = sub_menu->Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
+    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
+
+    auto gen = node->GetGenerator();
+    if (gen && gen->CanChangeParent(node))
+    {
+        menu_item = sub_menu->Append(MenuMOVE_LEFT, "Left\tAlt+Left", "Moves selected item left");
+        menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveleft_png, sizeof(wxue_img::nav_moveleft_png)));
+        menu_item = sub_menu->Append(MenuMOVE_RIGHT, "Right\tAlt+Right", "Moves selected item right");
+        menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveleft_png, sizeof(wxue_img::nav_moveleft_png)));
+    }
+    AppendSubMenu(sub_menu, "Move");
+
+    if (gen && gen->CanChangeParent(node))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuNEW_PARENT_BOX_SIZER, "wxBoxSizer");
+        menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
+        menu_item = sub_menu->Append(MenuNEW_PARENT_STATIC_SIZER, "wxStaticBoxSizer");
+        menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
+        menu_item = sub_menu->Append(MenuNEW_PARENT_WRAP_SIZER, "wxWrapSizer");
+        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_PARENT_GRID_SIZER, "wxGridSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_PARENT_FLEX_GRID_SIZER, "wxFlexGridSizer");
+        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
+        menu_item = sub_menu->Append(MenuNEW_PARENT_GRIDBAG_SIZER, "wxGridBagSizer");
+        menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
+
+        AppendSubMenu(sub_menu, "&Move into new sizer");
+    }
+}
+
+void NavPopupMenu::MenuAddStandardCommands(Node* node)
+{
+    m_isPasteAllowed = false;
+
+    if (!node->isGen(gen_wxStatusBar))
+    {
+        auto clip_node = GetClipboardNode(false);
+        if (!clip_node)
+        {
+            clip_node = wxGetFrame().GetClipboardPtr();
+        }
+
+        if (node->isGen(gen_Project))
+        {
+            auto paste_menu_item = Append(wxID_PASTE);
+            paste_menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
+
+            if (!clip_node || !clip_node->IsForm())
+            {
+                paste_menu_item->Enable(false);
+                m_isPasteAllowed = false;
+            }
+
+            // There are no other standard commands for a project
+            return;
+        }
+        m_isPasteAllowed = (clip_node ? true : false);
+    }
+
+    wxMenuItem* menu_item;
+    menu_item = Append(wxID_CUT);
+    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU));
+    menu_item = Append(wxID_COPY);
+    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
+
+    if (!node->isGen(gen_wxStatusBar))
+    {
+        auto paste_menu_item = Append(wxID_PASTE);
+        paste_menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
+
+        if (!m_isPasteAllowed)
+        {
+            paste_menu_item->Enable(false);
+        }
+    }
+    menu_item = Append(wxID_DELETE);
+    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_DELETE, wxART_MENU));
+
+    if (!node->isGen(gen_wxStatusBar))
+    {
+        Append(MenuDUPLICATE, "Duplicate");
     }
 }
 
@@ -386,845 +778,6 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
 
 void NavPopupMenu::ChangeSizer(GenEnum::GenName new_sizer_gen)
 {
-    wxGetFrame().Freeze();
+    wxWindowUpdateLocker freeze(wxGetFrame().GetWindow());
     wxGetFrame().PushUndoAction(std::make_shared<ChangeSizerType>(m_node, new_sizer_gen));
-    wxGetFrame().Thaw();
-}
-
-void NavPopupMenu::OnBorders(wxCommandEvent& event)
-{
-    ttlib::cstr value;
-
-    switch (event.GetId())
-    {
-        case MenuBORDERS_ALL:
-            value = "wxALL";
-            break;
-
-        case MenuBORDERS_NONE:
-            // It's already cleared, so nothing to do
-            break;
-
-        case MenuBORDERS_HORIZONTAL:
-            value = "wxLEFT|wxRIGHT";
-            break;
-
-        case MenuBORDERS_VERTICAL:
-            value = "wxTOP|wxBOTTOM";
-            break;
-    }
-
-    m_node->ModifyProperty(prop_borders, value);
-}
-
-void NavPopupMenu::CreateNormalMenu(Node* node)
-{
-    wxMenuItem* menu_item;
-    menu_item = Append(wxID_CUT);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU));
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-    menu_item = Append(wxID_PASTE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-
-    menu_item = Append(wxID_DELETE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_DELETE, wxART_MENU));
-    Append(MenuDUPLICATE, "Duplicate");
-    AppendSeparator();
-
-    auto sub_menu = new wxMenu;
-    menu_item = sub_menu->Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
-    menu_item = sub_menu->Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
-    menu_item = sub_menu->Append(MenuMOVE_LEFT, "Left\tAlt+Left", "Moves selected item left");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveleft_png, sizeof(wxue_img::nav_moveleft_png)));
-    menu_item = sub_menu->Append(MenuMOVE_RIGHT, "Right\tAlt+Right", "Moves selected item right");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveleft_png, sizeof(wxue_img::nav_moveleft_png)));
-    AppendSubMenu(sub_menu, "Move");
-
-    sub_menu = new wxMenu;
-    sub_menu->Append(MenuRESET_ID, "ID", "Changes id to wxANY");
-    sub_menu->Append(MenuRESET_SIZE, "Size", "Changes size to -1, -1");
-    sub_menu->Append(MenuRESET_MIN_SIZE, "Minimum size", "Changes minimum size to -1, -1");
-    sub_menu->Append(MenuRESET_MAX_SIZE, "Maximum size", "Changes maximum size to -1, -1");
-    AppendSubMenu(sub_menu, "Reset");
-
-    sub_menu = new wxMenu;
-    sub_menu->Append(MenuBORDERS_ALL, "All", "Borders on all sides", wxITEM_CHECK);
-    sub_menu->Append(MenuBORDERS_NONE, "None", "No borders", wxITEM_CHECK);
-    sub_menu->Append(MenuBORDERS_HORIZONTAL, "Horizontal only", "Borders only on left and right", wxITEM_CHECK);
-    sub_menu->Append(MenuBORDERS_VERTICAL, "Vertical only", "Borders only on top and bottom", wxITEM_CHECK);
-    AppendSubMenu(sub_menu, "Borders");
-
-    if (node->isGen(gen_wxTreeListCtrl))
-    {
-        m_tool_name = gen_wxTreeListCtrl;
-        m_child = node;
-
-        AppendSeparator();
-        Append(MenuNEW_COLUMN, "Add column");
-    }
-    else
-    {
-        AppendSeparator();
-        Append(MenuNEW_CHILD_SPACER, "Add spacer");
-
-        sub_menu = new wxMenu;
-        menu_item = sub_menu->Append(MenuNEW_CHILD_BOX_SIZER, "wxBoxSizer");
-        menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_STATIC_SIZER, "wxStaticBoxSizer");
-        menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_WRAP_SIZER, "wxWrapSizer");
-        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_GRID_SIZER, "wxGridSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_FLEX_GRID_SIZER, "wxFlexGridSizer");
-        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_GRIDBAG_SIZER, "wxGridBagSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
-
-        AppendSubMenu(sub_menu, "Add sizer");
-    }
-
-    sub_menu = new wxMenu;
-    menu_item = sub_menu->Append(MenuNEW_PARENT_BOX_SIZER, "wxBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-    menu_item = sub_menu->Append(MenuNEW_PARENT_STATIC_SIZER, "wxStaticBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-    menu_item = sub_menu->Append(MenuNEW_PARENT_WRAP_SIZER, "wxWrapSizer");
-    menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_PARENT_GRID_SIZER, "wxGridSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_PARENT_FLEX_GRID_SIZER, "wxFlexGridSizer");
-    menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_PARENT_GRIDBAG_SIZER, "wxGridBagSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
-
-    AppendSubMenu(sub_menu, "&Move into new sizer");
-
-    if (node->DeclName().contains("book"))
-    {
-        AppendSeparator();
-        Append(MenuADD_PAGE, "Add page");
-    }
-
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
-
-    // Bind() uses the equivalent of a LIFO stack, so we can Bind() to wxID_ANY first, then Bind() to any specific ids as
-    // needed
-
-    Bind(wxEVT_MENU, &NavPopupMenu::OnBorders, this, MenuBORDERS_ALL);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnBorders, this, MenuBORDERS_NONE);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnBorders, this, MenuBORDERS_HORIZONTAL);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnBorders, this, MenuBORDERS_VERTICAL);
-
-    if (!node->isGen(gen_wxTreeListCtrl))
-    {
-        // The OnAddNew commands add to a child, so we need to "fake" the child to our parent in order to add a sibling or a
-        // child
-        m_child = node->GetParent();
-
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_SPACER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_BOX_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_STATIC_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_WRAP_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRID_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_FLEX_GRID_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRIDBAG_SIZER);
-    }
-}
-
-void NavPopupMenu::CreateProjectMenu(Node* node)
-{
-    if (wxGetFrame().GetClipboard())
-    {
-        auto clipboard = wxGetFrame().GetClipboard();
-
-        // The selected node is a container, so there aren't very many things you can paste into it.
-
-        if (clipboard->IsForm() || clipboard->IsContainer() || (clipboard->IsSizer() && node->GetChildCount() == 0))
-        {
-            auto menu_item = Append(wxID_PASTE);
-            menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-            AppendSeparator();
-
-            Bind(
-                wxEVT_MENU,
-                [](wxCommandEvent&)
-                {
-                    wxGetFrame().PasteNode(wxGetApp().GetProject());
-                },
-                wxID_PASTE);
-        }
-    }
-
-    Append(MenuPROJECT_ADD_DIALOG, "Add new dialog...");
-    Append(MenuPROJECT_ADD_WINDOW, "Add new window...");
-    Append(MenuPROJECT_ADD_WIZARD, "Add new wizard");
-    AppendSeparator();
-    Append(MenuPROJECT_SORT_FORMS, "Sort Forms");
-
-    Bind(wxEVT_MENU, &NavPopupMenu::OnCreateNewDialog, this, MenuPROJECT_ADD_DIALOG);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnCreateNewFrame, this, MenuPROJECT_ADD_WINDOW);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnSortForms, this, MenuPROJECT_SORT_FORMS);
-
-    Bind(
-        wxEVT_MENU,
-        [](wxCommandEvent&)
-        {
-            wxGetFrame().CreateToolNode(gen_wxWizard);
-        },
-        MenuPROJECT_ADD_WIZARD);
-}
-
-void NavPopupMenu::OnAddNew(wxCommandEvent& event)
-{
-    if (m_tool_name < gen_name_array_size)
-    {
-        if (m_child)
-            m_child->CreateToolNode(m_tool_name);
-        else
-            wxGetFrame().CreateToolNode(m_tool_name);
-        return;
-    }
-
-    switch (event.GetId())
-    {
-        case MenuNEW_SIBLING_BOX_SIZER:
-            m_child->CreateToolNode(gen_wxBoxSizer);
-            break;
-
-        case MenuNEW_SIBLING_STATIC_SIZER:
-            m_child->CreateToolNode(gen_wxStaticBoxSizer);
-            break;
-
-        case MenuNEW_SIBLING_WRAP_SIZER:
-            m_child->CreateToolNode(gen_wxWrapSizer);
-            break;
-
-        case MenuNEW_SIBLING_GRID_SIZER:
-            m_child->CreateToolNode(gen_wxGridSizer);
-            break;
-
-        case MenuNEW_SIBLING_FLEX_GRID_SIZER:
-            m_child->CreateToolNode(gen_wxFlexGridSizer);
-            break;
-
-        case MenuNEW_SIBLING_GRIDBAG_SIZER:
-            m_child->CreateToolNode(gen_wxGridBagSizer);
-            break;
-
-        case MenuNEW_SIBLING_STD_DIALG_BTNS:
-            m_child->CreateToolNode(gen_wxStdDialogButtonSizer);
-            break;
-
-        case MenuNEW_SIBLING_SPACER:
-            m_child->CreateToolNode(gen_spacer);
-            break;
-
-        case MenuNEW_CHILD_BOX_SIZER:
-            wxGetFrame().CreateToolNode(gen_wxBoxSizer);
-            break;
-
-        case MenuNEW_CHILD_STATIC_SIZER:
-            wxGetFrame().CreateToolNode(gen_wxStaticBoxSizer);
-            break;
-
-        case MenuNEW_CHILD_WRAP_SIZER:
-            wxGetFrame().CreateToolNode(gen_wxWrapSizer);
-            break;
-
-        case MenuNEW_CHILD_GRID_SIZER:
-            wxGetFrame().CreateToolNode(gen_wxGridSizer);
-            break;
-
-        case MenuNEW_CHILD_FLEX_GRID_SIZER:
-            wxGetFrame().CreateToolNode(gen_wxFlexGridSizer);
-            break;
-
-        case MenuNEW_CHILD_GRIDBAG_SIZER:
-            wxGetFrame().CreateToolNode(gen_wxGridBagSizer);
-            break;
-
-        case MenuNEW_CHILD_STD_DIALG_BTNS:
-            wxGetFrame().CreateToolNode(gen_wxStdDialogButtonSizer);
-            break;
-
-        case MenuNEW_CHILD_SPACER:
-            wxGetFrame().CreateToolNode(gen_spacer);
-            break;
-
-        case MenuNEW_TOOLBAR:
-            wxGetFrame().CreateToolNode(gen_wxToolBar);
-            break;
-
-        case MenuNEW_INFOBAR:
-            wxGetFrame().CreateToolNode(gen_wxInfoBar);
-            break;
-
-        case MenuADD_MENU:
-            wxGetFrame().CreateToolNode(gen_wxMenu);
-            break;
-
-        default:
-            break;
-    }
-}
-
-void NavPopupMenu::CreateContainerMenu(Node* node)
-{
-    wxMenuItem* menu_item;
-
-    menu_item = Append(wxID_CUT);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU));
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-    auto paste_item = Append(wxID_PASTE);
-    paste_item->Enable(false);
-    paste_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-    menu_item = Append(wxID_DELETE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_DELETE, wxART_MENU));
-    Append(MenuDUPLICATE, "Duplicate");
-
-    if (auto clipboard = wxGetFrame().GetClipboard(); clipboard)
-    {
-        // The selected node is a container, so there aren't very many things you can paste into it.
-
-        if (clipboard->IsForm() || clipboard->IsContainer() || (clipboard->IsSizer() && node->GetChildCount() == 0))
-        {
-            paste_item->Enable(true);
-        }
-    }
-    AppendSeparator();
-
-    auto sub_menu = new wxMenu;
-    menu_item = sub_menu->Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
-    menu_item = sub_menu->Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
-    AppendSubMenu(sub_menu, "Move");
-
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-
-    if (node->isGen(gen_BookPage))
-    {
-        if (!node->GetChildCount())
-        {
-            sub_menu = new wxMenu;
-            menu_item = sub_menu->Append(MenuNEW_CHILD_BOX_SIZER, "wxBoxSizer");
-            menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-            menu_item = sub_menu->Append(MenuNEW_CHILD_STATIC_SIZER, "wxStaticBoxSizer");
-            menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-            menu_item = sub_menu->Append(MenuNEW_CHILD_WRAP_SIZER, "wxWrapSizer");
-            menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-            menu_item = sub_menu->Append(MenuNEW_CHILD_GRID_SIZER, "wxGridSizer");
-            menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-            menu_item = sub_menu->Append(MenuNEW_CHILD_FLEX_GRID_SIZER, "wxFlexGridSizer");
-            menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-            menu_item = sub_menu->Append(MenuNEW_CHILD_GRIDBAG_SIZER, "wxGridBagSizer");
-            menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
-            AppendSubMenu(sub_menu, "Add sizer");
-        }
-        Append(MenuADD_PAGE, "Add Page\tCtrl+P");
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_ITEM);
-
-        if (!node->GetChildCount())
-        {
-            Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_BOX_SIZER);
-            Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_STATIC_SIZER);
-            Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_WRAP_SIZER);
-            Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRID_SIZER);
-            Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_FLEX_GRID_SIZER);
-            Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRIDBAG_SIZER);
-        }
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_ITEM);
-    }
-    else if (node->GetChildCount())
-    {
-        m_child = node->GetChild(0);
-
-        AppendSeparator();
-        sub_menu = new wxMenu;
-        menu_item = sub_menu->Append(MenuNEW_SIBLING_BOX_SIZER, "wxBoxSizer");
-        menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-        menu_item = sub_menu->Append(MenuNEW_SIBLING_STATIC_SIZER, "wxStaticBoxSizer");
-        menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-        menu_item = sub_menu->Append(MenuNEW_SIBLING_WRAP_SIZER, "wxWrapSizer");
-        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_SIBLING_GRID_SIZER, "wxGridSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_SIBLING_FLEX_GRID_SIZER, "wxFlexGridSizer");
-        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_SIBLING_GRIDBAG_SIZER, "wxGridBagSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
-        if (node->isGen(gen_wxDialog))
-        {
-            sub_menu->AppendSeparator();
-            menu_item = sub_menu->Append(MenuNEW_SIBLING_STD_DIALG_BTNS, "wxStdDialogButtonSizer");
-            menu_item->SetBitmap(GetInternalImage("stddialogbuttonsizer"));
-        }
-        AppendSubMenu(sub_menu, "&Add new sizer");
-
-        if (node->isGen(gen_wxWizardPageSimple))
-        {
-            Append(MenuADD_PAGE, "Add Page\tCtrl+P");
-            Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, MenuADD_PAGE);
-        }
-
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_BOX_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_STATIC_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_WRAP_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_GRID_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_FLEX_GRID_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_GRIDBAG_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_STD_DIALG_BTNS);
-    }
-
-    else if (node->isGen(gen_wxWizardPageSimple))
-    {
-        sub_menu = new wxMenu;
-        menu_item = sub_menu->Append(MenuNEW_CHILD_BOX_SIZER, "wxBoxSizer");
-        menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_STATIC_SIZER, "wxStaticBoxSizer");
-        menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_WRAP_SIZER, "wxWrapSizer");
-        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_GRID_SIZER, "wxGridSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_FLEX_GRID_SIZER, "wxFlexGridSizer");
-        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-        menu_item = sub_menu->Append(MenuNEW_CHILD_GRIDBAG_SIZER, "wxGridBagSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
-        AppendSubMenu(sub_menu, "Add sizer");
-
-        Append(MenuADD_PAGE, "Add Page\tCtrl+P");
-
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_BOX_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_STATIC_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_WRAP_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRID_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_FLEX_GRID_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRIDBAG_SIZER);
-        Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, MenuADD_PAGE);
-    }
-}
-
-void NavPopupMenu::CreateFormMenu(Node* node)
-{
-    m_node = node;
-
-    wxMenuItem* menu_item;
-
-    menu_item = Append(wxID_CUT);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU));
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-
-    AppendSeparator();
-    menu_item = Append(MenuEXPAND_ALL, "Expand All");
-
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-}
-
-void NavPopupMenu::CreateTopSizerMenu(Node* node)
-{
-    wxMenuItem* menu_item;
-
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-    menu_item = Append(wxID_PASTE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-    AppendSeparator();
-
-    // Many of the OnAddNew commands add to a child, so we need to "fake" the child to ourselves
-    m_child = node;
-
-    auto sub_menu = new wxMenu;
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_BOX_SIZER, "wxBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_STATIC_SIZER, "wxStaticBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_WRAP_SIZER, "wxWrapSizer");
-    menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_GRID_SIZER, "wxGridSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_FLEX_GRID_SIZER, "wxFlexGridSizer");
-    menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_GRIDBAG_SIZER, "wxGridBagSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
-
-    if (node->isParent(gen_wxDialog))
-    {
-        sub_menu->AppendSeparator();
-        menu_item = sub_menu->Append(MenuNEW_SIBLING_STD_DIALG_BTNS, "wxStdDialogButtonSizer");
-        menu_item->SetBitmap(GetInternalImage("stddialogbuttonsizer"));
-    }
-    AppendSubMenu(sub_menu, "&Add new sizer");
-
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_PASTE);
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-}
-
-void NavPopupMenu::CreateSizerMenu(Node* node)
-{
-    wxMenuItem* menu_item;
-    menu_item = Append(wxID_CUT);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU));
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-    menu_item = Append(wxID_PASTE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-
-    menu_item = Append(wxID_DELETE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_DELETE, wxART_MENU));
-    Append(MenuDUPLICATE, "Duplicate");
-    AppendSeparator();
-
-    auto sub_menu = new wxMenu;
-    menu_item = sub_menu->Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
-    menu_item = sub_menu->Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
-    menu_item = sub_menu->Append(MenuMOVE_LEFT, "Left\tAlt+Left", "Moves selected item left");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveleft_png, sizeof(wxue_img::nav_moveleft_png)));
-    menu_item = sub_menu->Append(MenuMOVE_RIGHT, "Right\tAlt+Right", "Moves selected item right");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveleft_png, sizeof(wxue_img::nav_moveleft_png)));
-    AppendSubMenu(sub_menu, "Move");
-
-    AppendSeparator();
-    sub_menu = new wxMenu;
-    menu_item = sub_menu->Append(MenuNEW_CHILD_BOX_SIZER, "wxBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_STATIC_SIZER, "wxStaticBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_WRAP_SIZER, "wxWrapSizer");
-    menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_GRID_SIZER, "wxGridSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_FLEX_GRID_SIZER, "wxFlexGridSizer");
-    menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_CHILD_GRIDBAG_SIZER, "wxGridBagSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
-
-    AppendSubMenu(sub_menu, "Add child sizer");
-
-    sub_menu = new wxMenu;
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_BOX_SIZER, "wxBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("sizer_horizontal"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_STATIC_SIZER, "wxStaticBoxSizer");
-    menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_WRAP_SIZER, "wxWrapSizer");
-    menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_GRID_SIZER, "wxGridSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_FLEX_GRID_SIZER, "wxFlexGridSizer");
-    menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-    menu_item = sub_menu->Append(MenuNEW_SIBLING_GRIDBAG_SIZER, "wxGridBagSizer");
-    menu_item->SetBitmap(GetInternalImage("grid_bag_sizer"));
-
-    // The OnAddNew commands add to a child, so we need to "fake" the child to our parent in order to add a sibling or a
-    // child
-    m_child = node->GetParent();
-
-    AppendSubMenu(sub_menu, "Add sibling sizer");
-
-    ASSERT_MSG(!node->GetParent()->IsForm() && !node->GetParent()->IsContainer(),
-               "This popup menu should never be called if parent is a form or container!");
-
-    if (node->isGen(gen_wxBoxSizer))
-    {
-        sub_menu = new wxMenu;
-        menu_item = sub_menu->Append(MenuChangeTo_FLEX_GRID_SIZER, "wxFlexGridSizer");
-        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-        menu_item = sub_menu->Append(MenuChangeTo_GRID_SIZER, "wxGridSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-        menu_item = sub_menu->Append(MenuChangeTo_STATIC_SIZER, "wxStaticBoxSizer");
-        menu_item->SetBitmap(GetInternalImage("wxStaticBoxSizer"));
-        menu_item = sub_menu->Append(MenuChangeTo_WRAP_SIZER, "wxWrapSizer");
-        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-
-        AppendSubMenu(sub_menu, "Change Sizer To");
-    }
-    else if (node->isGen(gen_wxGridSizer))
-    {
-        sub_menu = new wxMenu;
-        menu_item = sub_menu->Append(MenuChangeTo_FLEX_GRID_SIZER, "wxFlexGridSizer");
-        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-        menu_item = sub_menu->Append(MenuChangeTo_WRAP_SIZER, "wxWrapSizer");
-        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-
-        AppendSubMenu(sub_menu, "Change Sizer To");
-    }
-    else if (node->isGen(gen_wxFlexGridSizer))
-    {
-        sub_menu = new wxMenu;
-        menu_item = sub_menu->Append(MenuChangeTo_GRID_SIZER, "wxGridSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-        menu_item = sub_menu->Append(MenuChangeTo_WRAP_SIZER, "wxWrapSizer");
-        menu_item->SetBitmap(GetInternalImage("wrap_sizer"));
-
-        AppendSubMenu(sub_menu, "Change Sizer To");
-    }
-    else if (node->isGen(gen_wxWrapSizer))
-    {
-        sub_menu = new wxMenu;
-        menu_item = sub_menu->Append(MenuChangeTo_FLEX_GRID_SIZER, "wxFlexGridSizer");
-        menu_item->SetBitmap(GetInternalImage("flex_grid_sizer"));
-        menu_item = sub_menu->Append(MenuChangeTo_GRID_SIZER, "wxGridSizer");
-        menu_item->SetBitmap(GetInternalImage("grid_sizer"));
-
-        AppendSubMenu(sub_menu, "Change Sizer To");
-    }
-
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
-
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_BOX_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_STATIC_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_WRAP_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_GRID_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_FLEX_GRID_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_GRIDBAG_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_SIBLING_SPACER);
-
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_BOX_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_STATIC_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_WRAP_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRID_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_FLEX_GRID_SIZER);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuNEW_CHILD_GRIDBAG_SIZER);
-}
-
-void NavPopupMenu::CreateMenuMenu(Node* /* node */)
-{
-    wxMenuItem* menu_item;
-
-    menu_item = Append(wxID_CUT);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU));
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-    menu_item = Append(wxID_PASTE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-    menu_item = Append(wxID_DELETE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_DELETE, wxART_MENU));
-
-    AppendSeparator();
-    menu_item = Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
-    menu_item = Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
-
-    AppendSeparator();
-    Append(MenuADD_MENUITEM, "Add Menu &Item\tCtrl+I");
-    Append(MenuADD_SUBMENU, "Add &Submenu &Item\tCtrl+S");
-    Append(MenuADD_MENU_SEPARATOR, "Add S&eparator\tCtrl+E");
-
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this);
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-
-    Bind(
-        wxEVT_MENU,
-        [](wxCommandEvent&)
-        {
-            wxGetFrame().CreateToolNode(gen_wxMenuItem);
-        },
-        MenuADD_MENUITEM);
-
-    Bind(
-        wxEVT_MENU,
-        [](wxCommandEvent&)
-        {
-            wxGetFrame().CreateToolNode(gen_submenu);
-        },
-        MenuADD_SUBMENU);
-
-    Bind(
-        wxEVT_MENU,
-        [](wxCommandEvent&)
-        {
-            wxGetFrame().CreateToolNode(gen_separator);
-        },
-        MenuADD_MENU_SEPARATOR);
-}
-
-void NavPopupMenu::CreateBarMenu(Node* node)
-{
-    m_node = node;
-
-    wxMenuItem* menu_item;
-
-    menu_item = Append(wxID_CUT);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU));
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-
-    if (!node->isGen(gen_wxStatusBar))
-    {
-        menu_item = Append(wxID_PASTE);
-        menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-    }
-
-    if (node->isGen(gen_wxRibbonPanel) || node->isGen(gen_wxRibbonPage) || node->isGen(gen_ribbonTool) ||
-        node->isGen(gen_tool))
-    {
-        menu_item = Append(wxID_DELETE);
-        menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_DELETE, wxART_MENU));
-        Append(MenuDUPLICATE, "Duplicate");
-    }
-
-    if (node->isGen(gen_wxRibbonBar) || node->isGen(gen_RibbonBar))
-    {
-        AppendSeparator();
-        menu_item = Append(MenuEXPAND_ALL, "Expand All");
-    }
-
-    if (node->isGen(gen_wxRibbonPanel) || node->isGen(gen_wxRibbonPage) || node->isGen(gen_ribbonTool))
-    {
-        AppendSeparator();
-        menu_item = Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
-        menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
-        menu_item = Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
-        menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
-    }
-
-    if (node->isGen(gen_wxMenuBar) || node->isGen(gen_MenuBar))
-    {
-        AppendSeparator();
-        Append(MenuADD_MENU, "Add Menu\tCtrl+M");
-    }
-    else if (node->isGen(gen_wxToolBar) || node->isGen(gen_ToolBar))
-    {
-        AppendSeparator();
-        m_tool_name = gen_tool;
-        Append(MenuNEW_ITEM, "Add Tool");
-        Append(MenuADD_TOOL_SEPARATOR, "Add Separator");
-    }
-    else if (node->isGen(gen_tool))
-    {
-        AppendSeparator();
-        menu_item = Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
-        menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
-        menu_item = Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
-        menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
-
-        m_child = node->GetParent();
-        AppendSeparator();
-        m_tool_name = gen_tool;
-        Append(MenuNEW_ITEM, "Add Tool");
-        Append(MenuADD_TOOL_SEPARATOR, "Add Separator");
-    }
-    else if (node->isGen(gen_wxRibbonBar) || node->isGen(gen_RibbonBar))
-    {
-        AppendSeparator();
-        m_tool_name = gen_wxRibbonPage;
-        Append(MenuNEW_ITEM, "Add Page");
-    }
-    else if (node->isGen(gen_wxRibbonPage))
-    {
-        AppendSeparator();
-        m_tool_name = gen_wxRibbonPanel;
-        Append(MenuNEW_ITEM, "Add Panel");
-    }
-    else if (node->isGen(gen_wxRibbonToolBar))
-    {
-        AppendSeparator();
-        m_tool_name = gen_ribbonTool;
-        Append(MenuNEW_ITEM, "Add Tool");
-    }
-    else if (node->isGen(gen_ribbonTool))
-    {
-        // This differs from the above gen_wxRibbonPanel by setting the child node to add the tool to
-        m_child = node->GetParent();
-        AppendSeparator();
-        m_tool_name = gen_ribbonTool;
-        Append(MenuNEW_ITEM, "Add Tool");
-    }
-
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
-
-    if (node->isGen(gen_wxMenuBar) || node->isGen(gen_MenuBar))
-    {
-        Bind(wxEVT_MENU, &NavPopupMenu::OnAddNew, this, MenuADD_MENU);
-    }
-}
-
-void NavPopupMenu::CreateWizardMenu(Node* /* node */)
-{
-    wxMenuItem* menu_item;
-
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-    menu_item = Append(wxID_PASTE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-    AppendSeparator();
-    menu_item = Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
-    menu_item = Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
-
-    AppendSeparator();
-    m_tool_name = gen_wxWizardPageSimple;
-    Append(MenuNEW_ITEM, "Add Page\tCtrl+P");
-
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
-}
-
-void NavPopupMenu::CreateBookMenu(Node* /* node */)
-{
-    wxMenuItem* menu_item;
-
-    menu_item = Append(wxID_COPY);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU));
-    menu_item = Append(wxID_PASTE);
-    menu_item->SetBitmap(wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU));
-    AppendSeparator();
-    menu_item = Append(MenuMOVE_UP, "Up\tAlt+Up", "Moves selected item up");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_moveup_png, sizeof(wxue_img::nav_moveup_png)));
-    menu_item = Append(MenuMOVE_DOWN, "Down\tAlt+Down", "Moves selected item down");
-    menu_item->SetBitmap(GetImageFromArray(wxue_img::nav_movedown_png, sizeof(wxue_img::nav_movedown_png)));
-
-    AppendSeparator();
-    m_tool_name = gen_BookPage;
-    Append(MenuNEW_ITEM, "Add Page");
-    AppendSeparator();
-
-    auto sub_menu = new wxMenu;
-    sub_menu->Append(MenuBORDERS_ALL, "All", "Borders on all sides", wxITEM_CHECK);
-    sub_menu->Append(MenuBORDERS_NONE, "None", "No borders", wxITEM_CHECK);
-    sub_menu->Append(MenuBORDERS_HORIZONTAL, "Horizontal only", "Borders only on left and right", wxITEM_CHECK);
-    sub_menu->Append(MenuBORDERS_VERTICAL, "Vertical only", "Borders only on top and bottom", wxITEM_CHECK);
-    AppendSubMenu(sub_menu, "Borders");
-
-    Bind(wxEVT_UPDATE_UI, &NavPopupMenu::OnUpdateEvent, this);
-    Bind(wxEVT_MENU, &NavPopupMenu::OnMenuEvent, this, wxID_ANY);
-}
-
-void NavPopupMenu::OnCreateNewDialog(wxCommandEvent& WXUNUSED(event))
-{
-    NewDialog dlg(wxGetFrame().GetWindow());
-    if (dlg.ShowModal() == wxID_OK)
-    {
-        dlg.CreateNode();
-    }
-}
-
-void NavPopupMenu::OnCreateNewFrame(wxCommandEvent& WXUNUSED(event))
-{
-    NewFrame dlg(wxGetFrame().GetWindow());
-    if (dlg.ShowModal() == wxID_OK)
-    {
-        dlg.CreateNode();
-    }
-}
-
-void NavPopupMenu::OnSortForms(wxCommandEvent& WXUNUSED(event))
-{
-    wxGetFrame().PushUndoAction(std::make_shared<SortProjectAction>());
 }

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -409,7 +409,7 @@ void NavPopupMenu::MenuAddCommands(Node* node)
         }
     }
 
-    if (node->isGen(gen_wxStatusBar))
+    if (node->isGen(gen_wxStatusBar) || node->isGen(gen_embedded_image))
     {
         return;
     }

--- a/src/panels/navpopupmenu.h
+++ b/src/panels/navpopupmenu.h
@@ -19,28 +19,10 @@ class NavPopupMenu : public wxMenu
 public:
     NavPopupMenu(Node* node);
 
-protected:
-    void OnAddNew(wxCommandEvent& event);
-    void OnBorders(wxCommandEvent& event);
-    void OnCreateNewDialog(wxCommandEvent& event);
-    void OnCreateNewFrame(wxCommandEvent& event);
-    void OnMenuEvent(wxCommandEvent& event);
-    void OnSortForms(wxCommandEvent& WXUNUSED(event));
-    void OnUpdateEvent(wxUpdateUIEvent& event);
-
-    void CreateBarMenu(Node* node);
-    void CreateBookMenu(Node* node);
-    void CreateContainerMenu(Node* node);
-    void CreateFormMenu(Node* node);
-    void CreateMenuMenu(Node* node);
-    void CreateNormalMenu(Node* node);
-    void CreateProjectMenu(Node* node);
-    void CreateSizerMenu(Node* node);
-    void CreateTopSizerMenu(Node* node);
-    void CreateWizardMenu(Node* node);
-
-    void ChangeSizer(GenEnum::GenName new_sizer_gen);
-    void CreateSizerParent(Node* node, ttlib::cview widget);
+    // Call this from a generator if adding commands via PopupMenuAddCommands().
+    //
+    // The child parameter is the node that child sizers should be added to.
+    void MenuAddChildSizerCommands(Node* child);
 
     enum
     {
@@ -89,22 +71,24 @@ protected:
         MenuNEW_TOOLBAR,
         MenuNEW_INFOBAR,
 
-        MenuRESET_ID,
-        MenuRESET_SIZE,
-        MenuRESET_MIN_SIZE,
-        MenuRESET_MAX_SIZE,
-
         MenuBORDERS_ALL,
         MenuBORDERS_NONE,
         MenuBORDERS_HORIZONTAL,
         MenuBORDERS_VERTICAL,
 
         MenuADD_PAGE,
+        MenuADD_RIBBON_PAGE,
+        MenuADD_RIBBON_PANEL,
+        MenuADD_RIBBON_BUTTONBAR,
+        MenuADD_RIBBON_TOOLBAR,
+        MenuADD_RIBBON_GALLERY,
 
         MenuADD_MENU,
         MenuADD_MENUITEM,
         MenuADD_SUBMENU,
         MenuADD_MENU_SEPARATOR,
+
+        MenuADD_TOOL,
         MenuADD_TOOL_SEPARATOR,
 
         MenuADD_WIZARD_PAGE,
@@ -120,10 +104,35 @@ protected:
         MenuDEBUG_KEYHH,
     };
 
+protected:
+    void OnMenuEvent(wxCommandEvent& event);
+    void OnUpdateEvent(wxUpdateUIEvent& event);
+
+    // Create menu for use when the current node is a sizer
+    void CreateSizerMenu(Node* node);
+
+    // Creates menu for all non-sizer nodes
+    void CreateCommonMenu(Node* node);
+
+    // Adds menu commands at the top of the menu. Calls node's generator to override the
+    // default add commands as needed.
+    void MenuAddCommands(Node* node);
+
+    // Cut, Copy, Paste, Delete, Duplicate
+    void MenuAddStandardCommands(Node* node);
+
+    // This always adds up/down, and depending on the node, it also adds left/right and move
+    // into new sizer.
+    void MenuAddMoveCommands(Node* node);
+
+    void ChangeSizer(GenEnum::GenName new_sizer_gen);
+    void CreateSizerParent(Node* node, ttlib::cview widget);
+
 private:
     Node* m_node { nullptr };
     Node* m_child { nullptr };
-    GenEnum::GenName m_tool_name {
-        GenEnum::GenName::gen_name_array_size
-    };  // used by MenuNEW_ITEM -> wxGetApp().CreateToolNode(m_tool_name)
+    Node* m_sizer_node { nullptr };  // node to add child sizers to
+    GenEnum::GenName m_tool_name { GenEnum::GenName::gen_name_array_size };
+
+    bool m_isPasteAllowed { true };
 };

--- a/src/ui/newwizard_base.cpp
+++ b/src/ui/newwizard_base.cpp
@@ -66,7 +66,6 @@ bool NewWizard::Create(wxWindow *parent, wxWindowID id, const wxString &title,
     m_spinCtrlTabs = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
             wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 7, 3);
     m_spinCtrlTabs->SetValidator(wxGenericValidator(&m_num_pages));
-    m_spinCtrlTabs->Enable(false);
     box_sizer_4->Add(m_spinCtrlTabs, wxSizerFlags().Center().Border(wxALL));
 
     auto stdBtn = CreateStdDialogButtonSizer(wxOK|wxCANCEL);

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -2178,7 +2178,6 @@
               min="1"
               var_name="m_spinCtrlTabs"
               validator_variable="m_num_pages"
-              disabled="true"
               alignment="wxALIGN_CENTER_VERTICAL" />
           </node>
         </node>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR overhauls the Context menu used in the Navigation pane. Instead of having multiple menu functions for mutliple types of controls, there are only two top level menu creation functions. Each of those functions may call sub functions.

This also removes the `OnAddMenu` event handler -- now all menu commands that aren't bound to a lambda will go through `OnMenuEvent`.

The `MenuAddCommands()` is where controls can customize the menu. A generator can implement a `PopupMenuAddCommands()` function to add whatever menu commands it needs. If it's not implemented, then a switch statement is used to determine what menu commands to add.

A new generator function `CanChangeParent()` has been added that determines whether the control can change it's parent. This is used to determine whether menu commands for moving left or right are added, and whether the "Move into new sizer" sub-menu is added. The `BaseGenerator` class covers most cases by checking the node's type, but generators can override this if needed.

`gen_Project` now has it's own generator. This allows for override functions like `PopupMenuAddCommands`.