### PR TITLE
Add play option to wxAnimationCtrl

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -277,6 +277,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_persist, "persist" },
     { prop_persist_name, "persist_name" },
     { prop_pin_button, "pin_button" },
+    { prop_play, "play" },
     { prop_pos, "pos" },
     { prop_position, "position" },
     { prop_pressed, "pressed" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -279,6 +279,7 @@ namespace GenEnum
         prop_persist,
         prop_persist_name,
         prop_pin_button,
+        prop_play,
         prop_pos,
         prop_position,
         prop_pressed,

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -117,6 +117,20 @@ std::optional<ttlib::cstr> AnimationGenerator::GenConstruction(Node* node)
     return code;
 }
 
+std::optional<ttlib::cstr> AnimationGenerator::GenSettings(Node* node, size_t& /* auto_indent */)
+{
+    if (node->prop_as_bool(prop_play))
+    {
+        ttlib::cstr code;
+        code << node->get_node_name() << "->Play();";
+        return code;
+    }
+    else
+    {
+        return {};
+    }
+}
+
 bool AnimationGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/animate.h>", set_src, set_hdr);

--- a/src/generate/misc_widgets.h
+++ b/src/generate/misc_widgets.h
@@ -25,6 +25,7 @@ class AnimationGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };
 

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -22,6 +22,7 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		</inherits>
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_animation_ctrl</property>
+		<property name="play" type="bool" help="If checked, Play() will be called as soon as the control is created." />
 		<property name="style" type="bitlist">
 			<option name="wxAC_DEFAULT_STYLE"
 				help="The default style: wxBORDER_NONE." />


### PR DESCRIPTION
If checked this generates Play() in the generator's GenSettings() function.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `play` property to the **wxAnimationCtrl**. I personally think calling `Play()` in the constructor for a dialog is a bad idea. However, all the other designers do this and if we don't support it, then our imported generated UI works differently which is technically a bug.