### PR TITLE
Improve Insert Widget dialog

### DIFF
--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -557,12 +557,26 @@ Node* Node::CreateChildNode(GenName name)
 
     if (!new_node)
     {
-        if ((IsForm() || IsContainer()) && GetChildCount() && GetChild(0)->isGen(gen_wxBoxSizer))
+        if ((IsForm() || IsContainer()) && GetChildCount())
         {
-            new_node = g_NodeCreator.CreateNode(name, GetChild(0));
-            if (!new_node)
-                return nullptr;
-            parent = GetChild(0);
+            if (GetChild(0)->gen_type() == type_sizer || GetChild(0)->gen_type() == type_gbsizer)
+            {
+                new_node = g_NodeCreator.CreateNode(name, GetChild(0));
+                if (!new_node)
+                    return nullptr;
+                parent = GetChild(0);
+            }
+
+            if (parent->gen_type() == type_gbsizer)
+            {
+                GridBag grid_bag(parent);
+                if (grid_bag.InsertNode(parent, new_node.get()))
+                    return new_node.get();
+                else
+                {
+                    return nullptr;
+                }
+            }
         }
     }
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -184,6 +184,37 @@ bool Node::AddChild(size_t idx, Node* node)
     return false;
 }
 
+bool Node::IsChildAllowed(NodeDeclaration* child)
+{
+    ASSERT(child);
+
+    auto max_children = m_declaration->GetAllowableChildren(child->gen_type());
+
+    if (max_children == child_count::none)
+        return false;
+
+    if (max_children == child_count::infinite)
+        return true;
+
+    if (isGen(gen_wxSplitterWindow))
+        return (GetChildCount() < 2);
+
+    // Because m_children contains shared_ptrs, we don't want to use an iteration loop which will get/release the shared
+    // ptr. Using an index into the vector lets us access the raw pointer.
+
+    int_t children = 0;
+    for (size_t i = 0; i < m_children.size() && children <= max_children; ++i)
+    {
+        if (GetChild(i)->gen_type() == child->gen_type())
+            ++children;
+    }
+
+    if (children >= max_children)
+        return false;
+
+    return true;
+}
+
 bool Node::IsChildAllowed(Node* child)
 {
     ASSERT(child);

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -207,6 +207,14 @@ bool Node::IsChildAllowed(NodeDeclaration* child)
     {
         if (GetChild(i)->gen_type() == child->gen_type())
             ++children;
+
+        // treat type-sizer and type_gbsizer as the same since forms and contains can only have one of them as the top level
+        // sizer.
+
+        else if (child->gen_type() == type_sizer && GetChild(i)->gen_type() == type_gbsizer)
+            ++children;
+        else if (child->gen_type() == type_gbsizer && GetChild(i)->gen_type() == type_sizer)
+            ++children;
     }
 
     if (children >= max_children)
@@ -219,32 +227,7 @@ bool Node::IsChildAllowed(Node* child)
 {
     ASSERT(child);
 
-    auto child_type = child->gen_type();
-    auto max_children = m_declaration->GetAllowableChildren(child_type);
-
-    if (max_children == child_count::none)
-        return false;
-
-    if (max_children == child_count::infinite)
-        return true;
-
-    if (isGen(gen_wxSplitterWindow))
-        return (GetChildCount() < 2);
-
-    // Because m_children contains shared_ptrs, we don't want to use an iteration loop which will get/release the shared
-    // ptr. Using an index into the vector lets us access the raw pointer.
-
-    int_t children = 0;
-    for (size_t i = 0; i < m_children.size() && children <= max_children; ++i)
-    {
-        if (GetChild(i)->gen_type() == child_type)
-            ++children;
-    }
-
-    if (children >= max_children)
-        return false;
-
-    return true;
+    return IsChildAllowed(child->GetNodeDeclaration());
 }
 
 void Node::RemoveChild(NodeSharedPtr node)

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -84,6 +84,7 @@ public:
     auto GetChildCount() const { return m_children.size(); }
 
     bool IsChildAllowed(Node* child);
+    bool IsChildAllowed(NodeDeclaration* child);
     bool IsChildAllowed(NodeSharedPtr child) { return IsChildAllowed(child.get()); }
 
     auto gen_type() const { return m_declaration->gen_type(); }

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -83,6 +83,14 @@ size_t NodeCreator::CountChildrenWithSameType(Node* parent, GenType type)
     {
         if (type == parent->GetChild(i)->gen_type())
             ++count;
+
+        // treat type-sizer and type_gbsizer as the same since forms and contains can only have one of them as the top level
+        // sizer.
+
+        else if (type == type_sizer && parent->GetChild(i)->gen_type() == type_gbsizer)
+            ++count;
+        else if (type == type_gbsizer && parent->GetChild(i)->gen_type() == type_sizer)
+            ++count;
     }
 
     return count;
@@ -165,15 +173,23 @@ NodeSharedPtr NodeCreator::CreateNode(GenName name, Node* parent)
     {
         if (node_decl->isType(type_sizer))
         {
-            node = NewNode(node_decl);
-            if (name == gen_VerticalBoxSizer)
+            auto count = CountChildrenWithSameType(parent, node_decl->gen_type());
+            if (count < static_cast<size_t>(max_children))
             {
-                node->prop_set_value(prop_orientation, "wxVERTICAL");
+                node = NewNode(node_decl);
+                if (name == gen_VerticalBoxSizer)
+                {
+                    node->prop_set_value(prop_orientation, "wxVERTICAL");
+                }
             }
         }
         else if (node_decl->isType(type_gbsizer))
         {
-            node = NewNode(node_decl);
+            auto count = CountChildrenWithSameType(parent, node_decl->gen_type());
+            if (count < static_cast<size_t>(max_children))
+            {
+                node = NewNode(node_decl);
+            }
         }
         else if (parent->isGen(gen_wxSplitterWindow))
         {

--- a/src/ui/insertwidget_base.cpp
+++ b/src/ui/insertwidget_base.cpp
@@ -24,7 +24,16 @@ bool InsertWidget::Create(wxWindow *parent, wxWindowID id, const wxString &title
     box_sizer_2->Add(staticText, wxSizerFlags().Center().Border(wxALL));
 
     m_text_name = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
+    m_text_name->SetHint("type a portion of the name to filter the list");
+    m_text_name->SetToolTip("Use Up/Down arrows to change list selection");
     box_sizer_2->Add(m_text_name, wxSizerFlags(1).Border(wxALL));
+
+    auto box_sizer_4 = new wxBoxSizer(wxHORIZONTAL);
+    box_sizer->Add(box_sizer_4, wxSizerFlags().Border(wxALL));
+
+    auto staticText_2 = new wxStaticText(this, wxID_ANY, "Only widgets that can be a child of the currently selected widget are shown. If the list is empty, no children can be added.");
+    staticText_2->Wrap(300);
+    box_sizer_4->Add(staticText_2, wxSizerFlags().Border(wxALL));
 
     auto box_sizer_3 = new wxBoxSizer(wxHORIZONTAL);
     box_sizer->Add(box_sizer_3, wxSizerFlags(1).Expand().Border(wxALL));

--- a/src/ui/insertwidget_base.h
+++ b/src/ui/insertwidget_base.h
@@ -18,14 +18,14 @@ class InsertWidget : public wxDialog
 {
 public:
     InsertWidget() {}
-    InsertWidget(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "Insert widget",
+    InsertWidget(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "Insert Widget",
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
     {
         Create(parent, id, title, pos, size, style, name);
     }
 
-    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "Insert widget",
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "Insert Widget",
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -997,7 +997,7 @@
       inserted_hdr_code="ttlib::cstr GetWidget() { return m_widget; }@@@@private:@@ttlib::cstr m_widget;"
       minimum_size="-1,-1"
       private_members="true"
-      title="Insert widget"
+      title="Insert Widget"
       use_derived_class="false"
       wxEVT_INIT_DIALOG="OnInit">
       <node
@@ -1017,10 +1017,22 @@
             alignment="wxALIGN_CENTER_VERTICAL" />
           <node
             class="wxTextCtrl"
+            hint="type a portion of the name to filter the list"
             var_name="m_text_name"
+            tooltip="Use Up/Down arrows to change list selection"
             proportion="1"
             wxEVT_TEXT="OnNameText"
             wxEVT_KEY_DOWN="OnKeyDown" />
+        </node>
+        <node
+          class="wxBoxSizer"
+          var_name="box_sizer_4">
+          <node
+            class="wxStaticText"
+            class_access="none"
+            label="Only widgets that can be a child of the currently selected widget are shown. If the list is empty, no children can be added."
+            var_name="staticText_2"
+            wrap="300" />
         </node>
         <node
           class="wxBoxSizer"

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -290,7 +290,10 @@ void ChangeSizerType::Change()
     m_parent->RemoveChild(m_old_node);
     m_old_node->SetParent(NodeSharedPtr());
     m_parent->Adopt(m_node);
-    m_parent->FindParentForm()->FixDuplicateNodeNames();
+    if (auto parent_form = m_parent->FindParentForm(); parent_form)
+    {
+        parent_form->FixDuplicateNodeNames();
+    }
     m_parent->ChangeChildPosition(m_node, pos);
 
     wxGetFrame().FireDeletedEvent(m_old_node.get());


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the Insert Widget dialog so that it only shows widgets that can be added to the currently selected node. It adds Hint text to indicate how to filter this list, tooltip text to indicate how to change which list item is selected, and static text to explain why the list might be empty (the current selection doesn't allow any children).

Closes #653

In the process of adding this, a bug was uncovered that allowed adding both a box sizer and a gridbag sizer as a form's parent -- this would cause all kinds of problems with code generation, so I fixed the problem by changing the code to consider type_sizer and type_gbsizer as the same.

In testing this out, I also removed the restriction on form's only allowing the user to add a widget if the parent sizer was a wxBoxSizer -- it can now be any type of sizer. That in turn uncovered a bug when changing the parent sizer to a different type -- it didn't check that a form returned nullptr as it's parent.