### PR TITLE
Property validation overhaul

### DIFF
--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -39,6 +39,7 @@ Files:
     frame_status_bar.cpp  # MainFrame status bar functions
     gen_enums.cpp         # Enumerations for generators
     lambdas.cpp           # Functions for formatting and storage of lamda events
+    paths.cpp             # Handles *_directory properties
     pjtsettings.cpp       # Hold data for currently loaded project
     startup_dlg.cpp       # Startup dialog
     undo_cmds.cpp         # Undoable command classes derived from UndoStackCmd

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -12,12 +12,14 @@ set (file_list
     ${CMAKE_CURRENT_LIST_DIR}/frame_status_bar.cpp  # MainFrame status bar functions
     ${CMAKE_CURRENT_LIST_DIR}/gen_enums.cpp         # Enumerations for generators
     ${CMAKE_CURRENT_LIST_DIR}/lambdas.cpp           # Functions for formatting and storage of lamda events
+    ${CMAKE_CURRENT_LIST_DIR}/paths.cpp             # Handles *_directory properties
     ${CMAKE_CURRENT_LIST_DIR}/pjtsettings.cpp       # Hold data for currently loaded project
     ${CMAKE_CURRENT_LIST_DIR}/startup_dlg.cpp       # Startup dialog
     ${CMAKE_CURRENT_LIST_DIR}/undo_cmds.cpp         # Undoable command classes derived from UndoStackCmd
     ${CMAKE_CURRENT_LIST_DIR}/undo_stack.cpp        # Maintain an undo and redo stack
     ${CMAKE_CURRENT_LIST_DIR}/wakatime.cpp          # Updates WakaTime metrics
     ${CMAKE_CURRENT_LIST_DIR}/xpm.cpp               # All xpm files
+
 
     ${CMAKE_CURRENT_LIST_DIR}/customprops/code_string_prop.cpp   # Derived wxStringProperty class for code
     ${CMAKE_CURRENT_LIST_DIR}/customprops/custom_colour_prop.cpp # Property editor for colour

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -52,14 +52,14 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
         {
             if (parent && parent->IsSizer() && parent->prop_as_string(prop_orientation).contains("wxVERTICAL"))
             {
-                wxMessageBox("You can't set vertical alignment when the parent sizer is oriented vertically.",
-                             "Invalid alignment");
+                event->SetValidationFailureMessage(
+                    "You can't set vertical alignment when the parent sizer is oriented vertically.");
                 event->Veto();
                 return false;
             }
             else if (node->prop_as_string(prop_flags).contains("wxEXPAND"))
             {
-                wxMessageBox("You can't set vertical alignment if the wxEXPAND flag is set.", "Invalid alignment");
+                event->SetValidationFailureMessage("You can't set vertical alignment if the wxEXPAND flag is set.");
                 event->Veto();
                 return false;
             }
@@ -68,14 +68,14 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
         {
             if (parent && parent->IsSizer() && parent->prop_as_string(prop_orientation).contains("wxHORIZONTAL"))
             {
-                wxMessageBox("You can't set horizontal alignment when the parent sizer is oriented horizontally.",
-                             "Invalid alignment");
+                event->SetValidationFailureMessage(
+                    "You can't set horizontal alignment when the parent sizer is oriented horizontally.");
                 event->Veto();
                 return false;
             }
             else if (node->prop_as_string(prop_flags).contains("wxEXPAND"))
             {
-                wxMessageBox("You can't set horizontal alignment if the wxEXPAND flag is set.", "Invalid alignment");
+                event->SetValidationFailureMessage("You can't set horizontal alignment if the wxEXPAND flag is set.");
                 event->Veto();
                 return false;
             }
@@ -107,8 +107,9 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
                     alignment.contains("wxALIGN_CENTER_HORIZONTAL") || alignment.contains("wxALIGN_TOP") ||
                     alignment.contains("wxALIGN_BOTTOM") || alignment.contains("wxALIGN_CENTER_VERTICAL"))
                 {
-                    wxMessageBox("You can't set the wxEXPAND flag if you have either horizontal or vertical alignment set.",
-                                 "Invalid alignment");
+                    event->SetValidationFailureMessage(
+                        "You can't set the wxEXPAND flag if you have either horizontal or vertical alignment set.");
+                    event->Veto();
                     return false;
                 }
             }
@@ -176,9 +177,9 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
 
         if (is_duplicate)
         {
-            wxMessageBox("The name you have chosen is already in use by another variable.", "Duplicate name");
+            event->SetValidationFailureMessage("The name you have chosen is already in use by another variable.");
             event->Veto();
-            event->GetProperty()->SetValue(newValue.wx_str());
+            wxGetFrame().SetStatusField("Either change the name, or press ESC to restore the original value.");
             return false;
         }
 
@@ -203,9 +204,9 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
             }
             else if (iter.get()->prop_as_string(prop_class_name).is_sameas(newValue))
             {
-                wxMessageBox("The name you have chosen is already in use by another class.", "Duplicate class name");
+                event->SetValidationFailureMessage("The name you have chosen is already in use by another class.");
                 event->Veto();
-                event->GetProperty()->SetValue(newValue.wx_str());
+                wxGetFrame().SetStatusField("Either change the name, or press ESC to restore the original value.");
                 return false;
             }
         }

--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -285,9 +285,9 @@ bool FrameFormGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodePro
             if (style.contains("wxDEFAULT_FRAME_STYLE") || style.contains("wxMINIMIZE_BOX") ||
                 style.contains("wxMINIMIZE_BOX"))
             {
-                wxMessageBox("You can't add a context help button if there is a minimize or maximize button "
-                             "(wxDEFAULT_FRAME_STYLE contains these).",
-                             "Invalid button");
+                event->SetValidationFailureMessage(
+                    "You can't add a context help button if there is a minimize or maximize button "
+                    "(wxDEFAULT_FRAME_STYLE contains these).");
                 event->Veto();
                 return false;
             }

--- a/src/generate/spin_widgets.cpp
+++ b/src/generate/spin_widgets.cpp
@@ -187,9 +187,8 @@ bool SpinCtrlDoubleGenerator::AllowPropertyChange(wxPropertyGridEvent* event, No
         auto newValue = event->GetValue();
         if (newValue.GetInteger() > 20)
         {
-            wxMessageBox("You can't specify more than 20 digits.", "Invalid digts");
+            event->SetValidationFailureMessage("You can't specify more than 20 digits.");
             event->Veto();
-            event->GetProperty()->SetValue(0, 0);
             return false;
         }
         return true;

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -35,9 +35,6 @@ public:
     void RestoreDescBoxHeight();
     void SaveDescBoxHeight();
 
-    // Returns true if a validation failure message has already been displayed to the user
-    bool WasFailureHandled() { return m_failure_handled; }
-
     // Prevents creation of node's properties until UnLock() is called.
     void Lock() { m_locked = true; }
 
@@ -83,11 +80,6 @@ protected:
 
     int GetBitlistValue(const wxString& strVal, wxPGChoices& bit_flags);
 
-    // The VerifyChange...() functions are called when a property is changing. The function is used to verify that the change
-    // is valid, and if not, the user is warned and the wxEVT_PG_CHANGING event is vetoed.
-
-    void VerifyChangeFile(wxPropertyGridEvent& event, NodeProperty* prop, Node* node);
-
     // Event handlers
 
     void OnEventGridChanged(wxPropertyGridEvent& event);
@@ -124,9 +116,6 @@ private:
     wxArrayString m_astr_wx_decorations;
 
     bool m_isPropChangeSuspended { false };
-
-    // Set to true if a VerifyChangeFile() function already disaplayed a message to the user.
-    bool m_failure_handled { false };
 
     bool m_locked { false };
 };

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -1,0 +1,101 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Functions for directory and file properties
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+// This module handles changes to art_directory, base_directory, and derived_directory
+
+#include "ttstr.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
+
+#include "paths.h"
+
+#include "mainapp.h"    // Main application class
+#include "mainframe.h"  // MainFrame -- Main window frame
+#include "node.h"       // Node class
+
+void AllowDirectoryChange(wxPropertyGridEvent& event, NodeProperty* /* prop */, Node* /* node */)
+{
+    ttString newValue = event.GetPropertyValue().GetString();
+    if (newValue.empty())
+        return;
+
+    newValue.make_absolute();
+    newValue.make_relative_wx(wxGetApp().GetProjectPath());
+    newValue.backslashestoforward();
+
+    if (!newValue.dir_exists())
+    {
+        // Displaying the message box can cause a focus change event which will call validation again in the OnIdle()
+        // processing. Preserve the focus to avoid validating twice.
+        auto focus = wxWindow::FindFocus();
+
+        auto result = wxMessageBox(ttlib::cstr() << "The directory \"" << newValue.wx_str()
+                                                 << "\" does not exist. Do you want to use this name anyway?",
+                                   "Directory doesn't exist", wxYES_NO | wxICON_WARNING, wxGetApp().GetMainFrame());
+        if (focus)
+        {
+            focus->SetFocus();
+        }
+
+        if (result != wxYES)
+        {
+            event.Veto();
+            event.SetValidationFailureBehavior(wxPG_VFB_MARK_CELL | wxPG_VFB_STAY_IN_PROPERTY);
+            wxGetFrame().SetStatusField("Either change the directory, or press ESC to restore the original value.");
+            return;
+        }
+    }
+
+    // If the event was previously veto'd, and the user corrected the file, then we have to set it here,
+    // otherwise it will revert back to the original name before the Veto.
+
+    event.GetProperty()->SetValueFromString(newValue, 0);
+}
+
+// Unlike the AllowDirectoryChange() above, this will *not* allow a duplicate prop_base_file filename since the generated code will create a linker error due to the duplicate filenames (and the risk of overwriting an already generated file for a different class).
+
+void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node)
+{
+    if (prop->isProp(prop_base_file))
+    {
+        ttString newValue = event.GetPropertyValue().GetString();
+        if (newValue.empty())
+            return;
+
+        newValue.make_absolute();
+        newValue.make_relative_wx(wxGetApp().GetProjectPath());
+        newValue.backslashestoforward();
+
+        auto filename = newValue.sub_cstr();
+        auto project = wxGetApp().GetProject();
+        for (size_t child_idx = 0; child_idx < project->GetChildCount(); ++child_idx)
+        {
+            if (project->GetChild(child_idx) == node)
+                continue;
+            if (project->GetChild(child_idx)->prop_as_string(prop_base_file).filename() == filename)
+            {
+                auto focus = wxWindow::FindFocus();
+
+                wxMessageBox(wxString() << "The base filename \"" << filename << "\" is already in use by "
+                                        << project->GetChild(child_idx)->prop_as_string(prop_class_name)
+                                        << "\n\nEither change the name, or press ESC to restore the original name.", "Duplicate base filename", wxICON_STOP);
+                if (focus)
+                {
+                    focus->SetFocus();
+                }
+
+                event.Veto();
+                event.SetValidationFailureBehavior(wxPG_VFB_MARK_CELL | wxPG_VFB_STAY_IN_PROPERTY);
+                wxGetFrame().SetStatusField("Either change the name, or press ESC to restore the original value.");
+                return;
+            }
+        }
+
+        // If the event was previously veto'd, and the user corrected the file, then we have to set it here,
+        // otherwise it will revert back to the original name before the Veto.
+
+        event.GetProperty()->SetValueFromString(newValue, 0);
+    }
+}

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -54,7 +54,9 @@ void AllowDirectoryChange(wxPropertyGridEvent& event, NodeProperty* /* prop */, 
     event.GetProperty()->SetValueFromString(newValue, 0);
 }
 
-// Unlike the AllowDirectoryChange() above, this will *not* allow a duplicate prop_base_file filename since the generated code will create a linker error due to the duplicate filenames (and the risk of overwriting an already generated file for a different class).
+// Unlike the AllowDirectoryChange() above, this will *not* allow a duplicate prop_base_file filename since the generated
+// code will create a linker error due to the duplicate filenames (and the risk of overwriting an already generated file for
+// a different class).
 
 void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node)
 {
@@ -80,7 +82,8 @@ void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node)
 
                 wxMessageBox(wxString() << "The base filename \"" << filename << "\" is already in use by "
                                         << project->GetChild(child_idx)->prop_as_string(prop_class_name)
-                                        << "\n\nEither change the name, or press ESC to restore the original name.", "Duplicate base filename", wxICON_STOP);
+                                        << "\n\nEither change the name, or press ESC to restore the original name.",
+                             "Duplicate base filename", wxICON_STOP);
                 if (focus)
                 {
                     focus->SetFocus();

--- a/src/paths.h
+++ b/src/paths.h
@@ -1,0 +1,16 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Functions for directory and file properties
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include <wx/propgrid/manager.h>  // wxPropertyGridManager
+
+#include "../nodes/node_classes.h"  // Forward defintions of Node classes
+
+// Called by PropGridPanel when the user attempts to change art_directory, base_directory, or
+// derived_directory.
+void AllowDirectoryChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node);
+
+void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR overhauls the way invalid property entries are handled. `CustomPropertyGrid::DoOnValidationFailure()` now saves and restores the focus window if a message box is displayed. Fixing this meant the workaround in our `PropGridPanel` class could be removed.

With the above fix, it now makes more sense in most cases to just set the failure message and let `DoOnValidationFailure()` handle displaying it. In some cases we also set the status bar text, since unfortunately `wxPropertyGrid` doesn't allow you to set the status bar text independently from the regular text message.

A new `paths.cpp` module has been added. Eventually this will handle global path changes like `art_directory` and `base_directory`. For now, it just has functions for verifying a valid directory, and for not allowing a duplicate `prop_base_file`.
