### PR TITLE
Change processing of type_path

### DIFF
--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1105,17 +1105,9 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
 
         case type_path:
             {
-                ttString newValue = property->GetValueAsString();
-                newValue.make_absolute();
-                newValue.make_relative_wx(wxGetApp().GetProjectPath());
-                newValue.backslashestoforward();
-
-                // Note that on Windows, even though we changed the property to a forward slash, it will still be displayed
-                // with a backslash. However, ModifyProperty() will save our forward slash version, so even thought the
-                // display isn't correct, it will be stored in the project file correctly.
-
-                property->SetValueFromString(newValue, 0);
-                ModifyProperty(prop, newValue);
+                m_isPropChangeSuspended = true;
+                OnPathChanged(event, prop, node);
+                m_isPropChangeSuspended = false;
             }
             break;
 

--- a/src/paths.h
+++ b/src/paths.h
@@ -9,8 +9,10 @@
 
 #include "../nodes/node_classes.h"  // Forward defintions of Node classes
 
-// Called by PropGridPanel when the user attempts to change art_directory, base_directory, or
-// derived_directory.
 void AllowDirectoryChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node);
-
 void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node);
+
+void OnPathChanged(wxPropertyGridEvent& event, NodeProperty* prop, Node* node);
+
+void ChangeDerivedDirectory(ttlib::cstr& path);
+void ChangeBaseDirectory(ttlib::cstr& path);


### PR DESCRIPTION
Handles regular paths like art_directory as well as adding special handling for base_directory and derived_directory.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds processing to base_directory and derived_directory that will change all forms that had the same original path. Unless the user had previously specified a path to a file that is different from the project's *_directory, the path will be changed when the project's directory changes.

Closes #664

This PR also fixes the bug where a directory could not be cleared.

Closes #654
