### PR TITLE
Expand node and all children in InsertNode

### DIFF
--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -353,6 +353,7 @@ void NavigationPanel::InsertNode(Node* node)
     if (node->GetChildCount())
     {
         AddAllChildren(node);
+        ExpandAllNodes(node);
     }
 }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds `ExpandAllNodes(node)` to the `InsertNode(node)` function in the Navigation Panel. This results in several types of operations automatically expanding all the node's children: paste, change parent, drag/drop.

This _will_ sometimes change the expansion so that it no longer matches what the user had. Moving a collapsed sizer will cause it to expand. Previously, moving it caused it to collapse.

Closes #633
