### PR TITLE
Refactor and fix Mockup Wizard code

### DIFF
--- a/src/mockup/mockup_wizard.cpp
+++ b/src/mockup/mockup_wizard.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Emulate a wxWizard, used for Mockup
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -26,85 +26,93 @@ MockupWizard::MockupWizard(wxWindow* parent, Node* node) : wxPanel(parent)
 
     m_window_sizer = new wxBoxSizer(wxVERTICAL);
     m_column_sizer = new wxBoxSizer(wxVERTICAL);
-    m_window_sizer->Add(m_column_sizer, wxSizerFlags(1).Expand());
+    m_window_sizer->Add(m_column_sizer, wxSizerFlags(1).Expand().Border());
 
-    AddBitmapRow();
-
-    m_column_sizer->Add(new wxStaticLine(this), wxSizerFlags().Expand().Border());
-    m_column_sizer->Add(0, 5, 0, wxEXPAND);
-
-    AddButtonRow();
+    CreateBmpPageRow();
+    CreateButtonRow();
 
     SetSizer(m_window_sizer);
+
+    ASSERT(m_btnPrev)
 
     m_btnPrev->Bind(wxEVT_BUTTON, &MockupWizard::OnBackOrNext, this);
     m_btnNext->Bind(wxEVT_BUTTON, &MockupWizard::OnBackOrNext, this);
 }
 
-void MockupWizard::AddBitmapRow()
+void MockupWizard::CreateBmpPageRow()
 {
-    m_sizerBmpAndPage = new wxBoxSizer(wxHORIZONTAL);
-    m_column_sizer->Add(m_sizerBmpAndPage, wxSizerFlags(1).Expand());
-    m_column_sizer->Add(0, 5, 0, wxEXPAND);
+    m_bmp_page_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_column_sizer->Add(m_bmp_page_sizer, wxSizerFlags(1).Expand().Border());
 
     if (m_wizard_node->HasValue(prop_bitmap))
     {
         m_bitmap = m_wizard_node->prop_as_wxBitmap(prop_bitmap);
         if (m_bitmap.IsOk())
         {
-            wxSize bitmapSize(wxDefaultSize);
+            wxSize bmp_size(wxDefaultSize);
             if (m_wizard_node->prop_as_int(prop_bmp_placement) > 0 && m_wizard_node->prop_as_int(prop_bmp_min_width) > 0)
             {
                 ResizeBitmap(m_bitmap);
-                bitmapSize.x = m_wizard_node->prop_as_int(prop_bmp_min_width);
+                bmp_size.x = m_wizard_node->prop_as_int(prop_bmp_min_width);
             }
-            m_statbmp = new wxStaticBitmap(this, wxID_ANY, m_bitmap, wxDefaultPosition, bitmapSize);
-            m_sizerBmpAndPage->Add(m_statbmp, wxSizerFlags());
-            m_sizerBmpAndPage->Add(5, 0, 0, wxEXPAND);
+            m_static_bitmap = new wxStaticBitmap(this, wxID_ANY, m_bitmap, wxDefaultPosition, bmp_size);
+            m_bmp_page_sizer->Add(m_static_bitmap, wxSizerFlags());
+            m_bmp_page_sizer->Add(wxSizerFlags::GetDefaultBorder(), 0);
 
             m_size_bmp = m_bitmap.GetSize();
-            m_size_bmp.IncBy(5);  // add border size
+            m_size_bmp.IncBy(wxSizerFlags::GetDefaultBorder());  // add border size
         }
     }
 
     m_sizerPage = new wxBoxSizer(wxHORIZONTAL);
-    m_sizerBmpAndPage->Add(m_sizerPage, wxSizerFlags());
-
-    // REVIEW: [KeyWorks - 05-18-2021] This should work, but unfortunately it can truncate one or more pages. Worse, it
-    // causes the button row to sometimes shift locations when switching between pages.
-
-    // m_sizerBmpAndPage->Add(m_sizerPage, wxSizerFlags(1).Border(wxALL, m_border));
+    m_bmp_page_sizer->Add(m_sizerPage, wxSizerFlags(1).Expand());
 }
 
-void MockupWizard::AddButtonRow()
+void MockupWizard::CreateButtonRow()
 {
+    auto static_line = new wxStaticLine(this);
+    m_column_sizer->Add(static_line, wxSizerFlags().Expand().Border());
+
     wxBoxSizer* buttonRow = new wxBoxSizer(wxHORIZONTAL);
 
-    m_column_sizer->Add(buttonRow, 0, wxALIGN_RIGHT);
-
-    if (m_wizard_node->prop_as_string(prop_extra_style).contains("wxWIZARD_EX_HELPBUTTON"))
-    {
-        buttonRow->Add(new wxButton(this, wxID_HELP, "&Help"), 0, wxALL, 5);
-#ifdef __WXMAC__
-        // Put stretchable space between help button and others
-        buttonRow->Add(0, 0, 1, wxALIGN_CENTRE, 0);
-#endif
-    }
+    m_column_sizer->Add(buttonRow, wxSizerFlags().Right());
 
     m_btnPrev = new wxButton(this, wxID_BACKWARD, "< &Back");
     m_btnNext = new wxButton(this, wxID_FORWARD, "&Next >");
 
     wxBoxSizer* backNextPair = new wxBoxSizer(wxHORIZONTAL);
-    buttonRow->Add(backNextPair, 0, wxALL, 5);
-    backNextPair->Add(m_btnPrev);
-    backNextPair->Add(10, 0, 0, wxEXPAND);
-    backNextPair->Add(m_btnNext);
+    buttonRow->Add(backNextPair, wxSizerFlags().Border());
 
-    buttonRow->Add(new wxButton(this, wxID_CANCEL, "&Cancel"), 0, wxALL, 5);
+    if (m_wizard_node->prop_as_string(prop_extra_style).contains("wxWIZARD_EX_HELPBUTTON"))
+    {
+        backNextPair->Add(new wxButton(this, wxID_HELP, "&Help"));
+#ifdef __WXMAC__
+        // Put stretchable space between help button and others
+        backNextPair->Add(0, 0, 1, wxALIGN_CENTRE, 0);
+#else
+        backNextPair->Add(wxSizerFlags::GetDefaultBorder() * 2, 0, 0, wxEXPAND);
+#endif
+    }
+    backNextPair->Add(m_btnPrev);
+    backNextPair->Add(wxSizerFlags::GetDefaultBorder() * 2, 0, 0, wxEXPAND);
+    backNextPair->Add(m_btnNext);
+    backNextPair->Add(wxSizerFlags::GetDefaultBorder() * 2, 0, 0, wxEXPAND);
+    backNextPair->Add(new wxButton(this, wxID_CANCEL, "&Cancel"));
+
+    m_button_row_size = m_btnPrev->GetSize();
+    m_button_row_size.IncBy(0, static_line->GetSize().y);
+
+    // Add border for static line and buttons
+    m_button_row_size.IncBy(0, wxSizerFlags::GetDefaultBorder() * 2);
 }
 
 void MockupWizard::SetSelection(size_t pageIndex)
 {
+    if (m_pages.empty())
+    {
+        return;
+    }
+
     wxWindowUpdateLocker(this);
 
     auto old_pageIndex = m_cur_page_index;
@@ -138,7 +146,7 @@ void MockupWizard::SetSelection(size_t pageIndex)
             bmpPrev = m_bitmap;
 
         if (!bmp.IsSameAs(bmpPrev))
-            m_statbmp->SetBitmap(bmp);
+            m_static_bitmap->SetBitmap(bmp);
 
         m_pages[old_pageIndex]->Hide();
         m_pages[pageIndex]->Show();
@@ -173,7 +181,7 @@ void MockupWizard::OnBackOrNext(wxCommandEvent& event)
         bmpPrev = m_bitmap;
 
     if (!bmp.IsSameAs(bmpPrev))
-        m_statbmp->SetBitmap(bmp);
+        m_static_bitmap->SetBitmap(bmp);
 
     m_pages[m_cur_page_index]->Show();
 
@@ -194,7 +202,7 @@ void MockupWizard::AddPage(MockupWizardPage* page)
     if (auto page_sizer = page->GetSizer(); page_sizer)
     {
         auto min_size = page_sizer->GetMinSize();
-        min_size.IncBy(5);
+        min_size.IncBy(wxSizerFlags::GetDefaultBorder());
         m_largest_nonbmp_page.IncTo(min_size);
 
         auto bmp = page->GetBitmapPtr();
@@ -202,17 +210,17 @@ void MockupWizard::AddPage(MockupWizardPage* page)
             bmp = &m_bitmap;
         if (bmp->IsOk())
         {
-            min_size.IncBy(bmp->GetScaledSize());
+            auto bmp_size = bmp->GetScaledSize();
             if (m_wizard_node->prop_as_int(prop_bmp_min_width) > 0 &&
-                min_size.x < m_wizard_node->prop_as_int(prop_bmp_min_width))
+                bmp_size.x < m_wizard_node->prop_as_int(prop_bmp_min_width))
             {
-                min_size.x = m_wizard_node->prop_as_int(prop_bmp_min_width);
+                bmp_size.x = m_wizard_node->prop_as_int(prop_bmp_min_width);
             }
-            // Add bitmap borders
-            min_size.IncBy(5);
+            min_size.IncBy(bmp_size.x, 0);
         }
 
         m_largest_page.IncTo(min_size);
+        m_largest_page.IncBy(0, m_button_row_size.y);
         m_window_sizer->SetMinSize(m_largest_page);
     }
 
@@ -232,7 +240,7 @@ void MockupWizard::AllChildrenAdded()
         {
             if (ResizeBitmap(m_bitmap))
             {
-                m_statbmp->SetBitmap(m_bitmap);
+                m_static_bitmap->SetBitmap(m_bitmap);
             }
         }
     }

--- a/src/mockup/mockup_wizard.h
+++ b/src/mockup/mockup_wizard.h
@@ -45,33 +45,34 @@ public:
 
 protected:
     void OnBackOrNext(wxCommandEvent& event);
-    void AddBitmapRow();
-    void AddButtonRow();
+    void CreateBmpPageRow();
+    void CreateButtonRow();
 
     bool ResizeBitmap(wxBitmap& bmp);
 
 private:
     wxBoxSizer* m_window_sizer;  // Top level sizer for entire window
     wxBoxSizer* m_column_sizer;  // Contains bitmap row, static line, and buttons
-    wxBoxSizer* m_sizerBmpAndPage;
+    wxBoxSizer* m_bmp_page_sizer;
     wxBoxSizer* m_sizerPage { nullptr };
 
-    wxButton* m_btnPrev;
-    wxButton* m_btnNext;
+    wxButton* m_btnPrev { nullptr };
+    wxButton* m_btnNext { nullptr };
 
     size_t m_cur_page_index { tt::npos };
 
-    Node* m_wizard_node;
+    Node* m_wizard_node;  // set in constructor
 
     wxSize m_largest_page { 0, 0 };
     wxSize m_largest_nonbmp_page { 0, 0 };
+    wxSize m_button_row_size;
 
     wxSize m_size_bmp { 0, 0 };
     wxBitmap m_bitmap { wxNullBitmap };
-    wxStaticBitmap* m_statbmp { nullptr };
+    wxStaticBitmap* m_static_bitmap { nullptr };
 
     std::vector<MockupWizardPage*> m_pages;
 
     int m_bmp_placement;
-    int m_border { 5 };
+    int m_border;  // set in constructor
 };

--- a/src/ui/newwizard_base.cpp
+++ b/src/ui/newwizard_base.cpp
@@ -64,7 +64,7 @@ bool NewWizard::Create(wxWindow *parent, wxWindowID id, const wxString &title,
     box_sizer_4->Add(staticText_4, wxSizerFlags().Center().Border(wxLEFT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     m_spinCtrlTabs = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
-            wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 7, 3);
+            wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 7, 3);
     m_spinCtrlTabs->SetValidator(wxGenericValidator(&m_num_pages));
     box_sizer_4->Add(m_spinCtrlTabs, wxSizerFlags().Center().Border(wxALL));
 

--- a/src/ui/wxUiEditor.wxui
+++ b/src/ui/wxUiEditor.wxui
@@ -2187,7 +2187,6 @@
               class="wxSpinCtrl"
               initial="3"
               max="7"
-              min="1"
               var_name="m_spinCtrlTabs"
               validator_variable="m_num_pages"
               alignment="wxALIGN_CENTER_VERTICAL" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors the `MockupWizard` class code both to make the code easier to read and to maintain. I also changed the sizing calculations to more accurately determine how big the client area needs to be. The end result is that the button row no longer gets clipped, and the Mockup display looks much closer to what the final _real_ wizard will look like.