### PR TITLE
Warn if multiple consecutive group radio buttons, don't allow group and single styles to be set

### DIFF
--- a/src/generate/radio_widgets.cpp
+++ b/src/generate/radio_widgets.cpp
@@ -7,6 +7,7 @@
 
 #include <wx/event.h>              // Event classes
 #include <wx/infobar.h>            // declaration of wxInfoBarBase defining common API of wxInfoBar
+#include <wx/propgrid/manager.h>   // wxPropertyGridManager
 #include <wx/propgrid/propgrid.h>  // wxPropertyGrid
 #include <wx/radiobox.h>           // wxRadioBox declaration
 #include <wx/radiobut.h>           // wxRadioButton declaration
@@ -152,6 +153,35 @@ bool RadioButtonGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeP
     else
     {
         return BaseGenerator::AllowPropertyChange(event, prop, node);
+    }
+}
+
+void RadioButtonGenerator::ChangeEnableState(wxPropertyGridManager* prop_grid, NodeProperty* changed_prop)
+{
+    if (changed_prop->isProp(prop_style))
+    {
+        if (auto pg_parent = prop_grid->GetProperty("style"); pg_parent)
+        {
+            for (unsigned int idx = 0; idx < pg_parent->GetChildCount(); ++idx)
+            {
+                if (auto pg_setting = pg_parent->Item(idx); pg_setting)
+                {
+                    auto label = pg_setting->GetLabel();
+                    if (label == "wxRB_GROUP")
+                    {
+                        pg_setting->Enable(!changed_prop->as_string().contains("wxRB_SINGLE"));
+                    }
+                    else if (label == "wxRB_SINGLE")
+                    {
+                        pg_setting->Enable(!changed_prop->as_string().contains("wxRB_GROUP"));
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        BaseGenerator::ChangeEnableState(prop_grid, changed_prop);
     }
 }
 

--- a/src/generate/radio_widgets.h
+++ b/src/generate/radio_widgets.h
@@ -20,6 +20,11 @@ public:
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
+    bool AllowPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*);
+
+private:
+    bool m_info_warning { false };
 };
 
 class RadioBoxGenerator : public BaseGenerator

--- a/src/generate/radio_widgets.h
+++ b/src/generate/radio_widgets.h
@@ -22,6 +22,7 @@ public:
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
     bool AllowPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*);
+    void ChangeEnableState(wxPropertyGridManager*, NodeProperty*);
 
 private:
     bool m_info_warning { false };

--- a/src/xml/buttons_xml.xml
+++ b/src/xml/buttons_xml.xml
@@ -55,7 +55,7 @@ inline const char* buttons_xml = R"===(<?xml version="1.0"?>
 			<option name="wxRB_GROUP"
 				help="Marks the beginning of a new group of radio buttons." />
 			<option name="wxRB_SINGLE"
-				help="Creates a radio button which is not part of any radio button group. When this style is used, no other radio buttons will be turned off automatically then this button is checked." />
+				help="Creates a radio button which is not part of any radio button group. When this style is used, no other radio buttons will be turned off automatically when this button is checked." />
 			<option name="wxALIGN_RIGHT"
 				help="Aligns the radio button to the right of the text instead of the left." />
 		</property>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR warns the user if they check wxRB_GROUP in a radio button, and the previous or next sibling is also a radio button with the group style checked. This also disables wxRB_SINGLE if wxRB_GROUP is checked and vice versa.