### PR TITLE
Add ability to build with private forked version of wxWidgets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,7 @@ else()
     set(CMAKE_CXX_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C++ Release flags" FORCE)
 endif()
 
-get_property(isMultiConfig GLOBAL
-  PROPERTY GENERATOR_IS_MULTI_CONFIG
-)
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
 if (NOT isMultiConfig)
     message("\nBecause you are using a single target generator, you MUST specify")
@@ -44,8 +42,30 @@ if (NOT isMultiConfig)
     endif()
 endif()
 
-# This will build wxCLib.lib and wxWidgets.lib
-add_subdirectory(wxSnapshot)
+option(INTERNAL_WIDGETS_SOURCES "Build with internal forked wxWidgets sources" )
+
+if (INTERNAL_WIDGETS_SOURCES)
+    # This uses a private forked version of wxWidgets containing current sources
+    message(NOTICE "Building with internal forked wxWidget libraries")
+    set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/../wxWidgets)
+    set (widget_lib_dir ${CMAKE_CURRENT_LIST_DIR}/../wxWidgets/bld/build)
+    set (widget_cmake_dir ${CMAKE_CURRENT_LIST_DIR}/../wxWidgets/bld)
+
+    # This will build wxCLib.lib and wxWidgets.lib
+    add_subdirectory(../wxWidgets/bld ${CMAKE_CURRENT_LIST_DIR}/../wxWidgets/bld/build)
+
+    # Add preprocessor definition that can be used to conditionalize code based on whether the
+    # internal wxWidgets libraries are being used.
+    add_compile_definitions(INTERNAL_WIDGETS)
+else()
+    # wxSnapshot is dev release (currently 3.1.15)
+    set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot)
+    set (widget_lib_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot/build)
+    set (widget_cmake_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot)
+
+    # This will build wxCLib.lib and wxWidgets.lib
+    add_subdirectory(${widget_cmake_dir})
+endif()
 
 add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
 
@@ -95,11 +115,11 @@ target_precompile_headers(wxUiEditor PRIVATE "src/pch.h")
 target_precompile_headers(check_build PRIVATE "src/pch.h")
 
 if (WIN32)
-    set(setup_dir wxSnapshot/win)
+    set(setup_dir ${widget_cmake_dir}/win)
 endif()
 
 target_include_directories(wxUiEditor PRIVATE
-    wxSnapshot/include
+    ${widget_dir}/include
     ${setup_dir}
     src/
     src/nodes
@@ -112,7 +132,7 @@ target_include_directories(wxUiEditor PRIVATE
 )
 
 target_include_directories(check_build PRIVATE
-    wxSnapshot/include
+    ${widget_dir}/include
     ${setup_dir}
     src/
     src/nodes

--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -120,14 +120,22 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
         if (node->HasValue(prop_bitmap) &&
             (node_parent->prop_as_bool(prop_display_images) || node_parent->isGen(gen_wxToolbook)))
         {
-            int idx_image = 0;
+            int idx_image = -1;
             bool is_image_found { false };
             for (auto& child: node_parent->GetChildNodePtrs())
             {
                 if (child.get() == node)
+                {
+                    if (idx_image < 0)
+                        idx_image = 0;
                     break;
+                }
                 if (child->HasValue(prop_bitmap))
+                {
+                    if (idx_image < 0)
+                        idx_image = 0;
                     ++idx_image;
+                }
                 if (child->GetParent()->isGen(gen_wxTreebook))
                 {
                     for (auto& grand_child: child->GetChildNodePtrs())
@@ -138,7 +146,11 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
                             break;
                         }
                         if (grand_child->isGen(gen_BookPage) && grand_child->HasValue(prop_bitmap))
+                        {
+                            if (idx_image < 0)
+                                idx_image = 0;
                             ++idx_image;
+                        }
                     }
                     if (is_image_found)
                         break;
@@ -169,13 +181,21 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
         {
             if (node->HasValue(prop_bitmap) && node_parent->prop_as_bool(prop_display_images))
             {
-                int idx_image = 0;
+                int idx_image = -1;
                 for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child)
                 {
                     if (node_parent->GetChild(idx_child) == node)
+                    {
+                        if (idx_image < 0)
+                            idx_image = 0;
                         break;
+                    }
                     if (node_parent->GetChild(idx_child)->HasValue(prop_bitmap))
+                    {
+                        if (idx_image < 0)
+                            idx_image = 0;
                         ++idx_image;
+                    }
                 }
 
                 aui_book->AddPage(widget, node->prop_as_wxString(prop_label), false, idx_image);
@@ -263,7 +283,7 @@ std::optional<ttlib::cstr> BookPageGenerator::GenConstruction(Node* node)
             (node->GetParent()->prop_as_bool(prop_display_images) || node->GetParent()->isGen(gen_wxToolbook)))
         {
             auto node_parent = node->GetParent();
-            int idx_image = 0;
+            int idx_image = -1;
             if (node_parent->isGen(gen_wxTreebook))
                 idx_image = GetTreebookImageIndex(node);
             else
@@ -271,9 +291,18 @@ std::optional<ttlib::cstr> BookPageGenerator::GenConstruction(Node* node)
                 for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child)
                 {
                     if (node_parent->GetChild(idx_child) == node)
+                    {
+                        if (idx_image < 0)
+                            idx_image = 0;
                         break;
+                    }
                     if (node_parent->GetChild(idx_child)->HasValue(prop_bitmap))
+                    {
+                        if (idx_image < 0)
+                            idx_image = 0;
+
                         ++idx_image;
+                    }
                 }
             }
             if (!node->prop_as_bool(prop_select))
@@ -304,23 +333,36 @@ wxObject* PageCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         if (node_parent->isGen(gen_wxToolbook))
         {
-            int idx_image = 0;
+            int idx_image = -1;
             for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child, ++idx_image)
             {
                 if (node_parent->GetChild(idx_child) == node)
+                {
+                    if (idx_image < 0)
+                        idx_image = 0;
                     break;
+                }
             }
             book->AddPage(wxStaticCast(widget, wxWindow), node->prop_as_wxString(prop_label), false, idx_image);
         }
         else if (node->HasValue(prop_bitmap) && node_parent->prop_as_bool(prop_display_images))
         {
-            int idx_image = 0;
+            int idx_image = -1;
             for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child)
             {
                 if (node_parent->GetChild(idx_child) == node)
+                {
+                    if (idx_image < 0)
+                        idx_image = 0;
                     break;
+                }
                 if (node_parent->GetChild(idx_child)->HasValue(prop_bitmap) || node_parent->isGen(gen_wxToolbook))
+                {
+                    if (idx_image < 0)
+                        idx_image = 0;
+
                     ++idx_image;
+                }
             }
 
             book->AddPage(wxStaticCast(widget, wxWindow), node->prop_as_wxString(prop_label), false, idx_image);
@@ -351,9 +393,18 @@ wxObject* PageCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
                 for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child)
                 {
                     if (node_parent->GetChild(idx_child) == node)
+                    {
+                        if (idx_image < 0)
+                            idx_image = 0;
+
                         break;
+                    }
                     if (node_parent->GetChild(idx_child)->HasValue(prop_bitmap))
+                    {
+                        if (idx_image < 0)
+                            idx_image = 0;
                         ++idx_image;
+                    }
                 }
 
                 aui_book->AddPage(wxStaticCast(widget, wxWindow), node->prop_as_wxString(prop_label), false, idx_image);
@@ -407,13 +458,23 @@ std::optional<ttlib::cstr> PageCtrlGenerator::GenConstruction(Node* node)
         (node->GetParent()->prop_as_bool(prop_display_images) || node->isParent(gen_wxToolbook)))
     {
         auto node_parent = node->GetParent();
-        int idx_image = 0;
+        int idx_image = -1;
         for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child)
         {
             if (node_parent->GetChild(idx_child) == node)
+            {
+                if (idx_image < 0)
+                    idx_image = 0;
+
                 break;
+            }
             if (node_parent->GetChild(idx_child)->HasValue(prop_bitmap))
+            {
+                if (idx_image < 0)
+                    idx_image = 0;
+
                 ++idx_image;
+            }
         }
 
         if (!node->prop_as_bool(prop_select))

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1031,13 +1031,13 @@ wxWindow* MainFrame::CreateNoteBook(wxWindow* parent)
 
     m_mockupPanel = new MockupParent(m_notebook, this);
 
-    m_notebook->AddPage(m_mockupPanel, "Mock Up", false, 0);
+    m_notebook->AddPage(m_mockupPanel, "Mock Up", false, wxWithImages::NO_IMAGE);
 
     m_generatedPanel = new BasePanel(m_notebook, this, false);
-    m_notebook->AddPage(m_generatedPanel, "Generated", false, 1);
+    m_notebook->AddPage(m_generatedPanel, "Generated", false, wxWithImages::NO_IMAGE);
 
     m_derivedPanel = new BasePanel(m_notebook, this, true);
-    m_notebook->AddPage(m_derivedPanel, "Derived", false, 1);
+    m_notebook->AddPage(m_derivedPanel, "Derived", false, wxWithImages::NO_IMAGE);
 
     return m_notebook;
 }

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -43,10 +43,10 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, bool GenerateDerivedCod
     m_notebook->SetArtProvider(new wxAuiGenericTabArt());
 
     m_cppPanel = new CodeDisplay(m_notebook);
-    m_notebook->AddPage(m_cppPanel, "source", false, 0);
+    m_notebook->AddPage(m_cppPanel, "source", false, wxWithImages::NO_IMAGE);
 
     m_hPanel = new CodeDisplay(m_notebook);
-    m_notebook->AddPage(m_hPanel, "header", false, 1);
+    m_notebook->AddPage(m_hPanel, "header", false, wxWithImages::NO_IMAGE);
 
     top_sizer->Add(m_notebook, wxSizerFlags(1).Expand());
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -77,8 +77,8 @@ PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(paren
     m_event_grid = new wxPropertyGridManager(m_notebook_parent, EVENT_ID, wxDefaultPosition, wxDefaultSize,
                                              wxPG_BOLD_MODIFIED | wxPG_SPLITTER_AUTO_CENTER | wxPG_DESCRIPTION);
 
-    m_notebook_parent->AddPage(m_prop_grid, "Properties", false, 0);
-    m_notebook_parent->AddPage(m_event_grid, "Events", false, 1);
+    m_notebook_parent->AddPage(m_prop_grid, "Properties", false, wxWithImages::NO_IMAGE);
+    m_notebook_parent->AddPage(m_event_grid, "Events", false, wxWithImages::NO_IMAGE);
 
     RestoreDescBoxHeight();
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability to build a private internal version that uses a forked version of the current wxWidgets sources. This requires setting a configuration option in the CMake gui, so it shouldn't affect anyone else.

Trying this out revealed some problems with the way book pages are added when building with wxWIdgets 3.1.16, so the rest of the PR fixes those.