### PR TITLE
Generate conditionalized code when necessary

### DIFF
--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -601,7 +601,7 @@ const std::unordered_map<std::string, const char*> s_EventNames = {
     { "wxEVT_WEBVIEW_ERROR", "OnWebViewError" },
     { "wxEVT_WEBVIEW_NEWWINDOW", "OnWebViewWindow" },
     { "wxEVT_WEBVIEW_TITLE_CHANGED", "OnWebViewTitleChanged" },
-    { "EVT_WEBVIEW_FULL_SCREEN_CHANGED", "OnFullScreen" },
+    { "wxEVT_WEBVIEW_FULL_SCREEN_CHANGED", "OnFullScreen" },
     { "wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED", "OnScriptMessage" },
 
     { "ApplyButtonClicked", "OnApply" },

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -380,6 +380,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_window_style, "window_style" },
     { prop_wrap, "wrap" },
     { prop_wrap_flags, "wrap_flags" },
+    { prop_wxWidgets_version, "wxWidgets_version" },
 
 };
 std::map<std::string_view, GenEnum::PropName, std::less<>> GenEnum::rmap_PropNames;

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -101,6 +101,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_caption, "caption" },
     { prop_caption_visible, "caption_visible" },
     { prop_cell_bg, "cell_bg" },
+    { prop_cell_fit, "cell_fit" },
     { prop_cell_font, "cell_font" },
     { prop_cell_horiz_alignment, "cell_horiz_alignment" },
     { prop_cell_text, "cell_text" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -382,6 +382,7 @@ namespace GenEnum
         prop_window_style,
         prop_wrap,
         prop_wrap_flags,
+        prop_wxWidgets_version,
 
         // This must always be the last item as it is used to calculate the array size needed to store all items
         prop_name_array_size,

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -100,6 +100,7 @@ namespace GenEnum
         prop_caption,
         prop_caption_visible,
         prop_cell_bg,
+        prop_cell_fit,
         prop_cell_font,
         prop_cell_horiz_alignment,
         prop_cell_text,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -626,15 +626,33 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
                     continue;
                 }
             }
-
-            if (m_form_node->prop_as_bool(prop_use_derived_class))
+            if ((event->get_name() == "wxEVT_WEBVIEW_FULL_SCREEN_CHANGED" ||
+                 event->get_name() == "wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED") &&
+                wxGetProject().prop_as_string(prop_wxWidgets_version) == "3.1")
             {
-                code << "virtual void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class()
-                     << "& event) { event.Skip(); }";
+                code << "\n#if wxCHECK_VERSION(3, 1, 5)\n";
+                if (m_form_node->prop_as_bool(prop_use_derived_class))
+                {
+                    code << "virtual void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class()
+                         << "& event) { event.Skip(); }";
+                }
+                else
+                {
+                    code << "void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class() << "& event);";
+                }
+                code << "\n#endif";
             }
             else
             {
-                code << "void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class() << "& event);";
+                if (m_form_node->prop_as_bool(prop_use_derived_class))
+                {
+                    code << "virtual void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class()
+                         << "& event) { event.Skip(); }";
+                }
+                else
+                {
+                    code << "void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class() << "& event);";
+                }
             }
             code_lines.insert(code);
         }

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -317,8 +317,20 @@ std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenConstruction(Node
         }
     }
 
-    code << node->get_node_name() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY, ";
-    code << node->prop_as_string(prop_checkbox_var_name) << "), " << node->prop_as_string(prop_orientation) << ");";
+    code << node->get_node_name() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY,";
+    if (wxGetProject().prop_as_string(prop_wxWidgets_version) == "3.1")
+    {
+        code << "\n#if wxCHECK_VERSION(3, 1, 1)\n\t";
+        code << node->prop_as_string(prop_checkbox_var_name) << "),";
+        code << "\n#else\n\t";
+        code << "wxEmptyString),";
+        code << "\n#endif\n";
+        code << node->prop_as_string(prop_orientation) << ");";
+    }
+    else
+    {
+        code << node->prop_as_string(prop_checkbox_var_name) << "), " << node->prop_as_string(prop_orientation) << ");";
+    }
 
     auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)
@@ -449,8 +461,20 @@ std::optional<ttlib::cstr> StaticRadioBtnBoxSizerGenerator::GenConstruction(Node
         }
     }
 
-    code << node->get_node_name() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY, ";
-    code << node->prop_as_string(prop_radiobtn_var_name) << "), " << node->prop_as_string(prop_orientation) << ");";
+    code << node->get_node_name() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY,";
+    if (wxGetProject().prop_as_string(prop_wxWidgets_version) == "3.1")
+    {
+        code << "\n#if wxCHECK_VERSION(3, 1, 1)\n\t";
+        code << node->prop_as_string(prop_radiobtn_var_name) << "),";
+        code << "\n#else\n\t";
+        code << "wxEmptyString),";
+        code << "\n#endif\n";
+        code << node->prop_as_string(prop_orientation) << ");";
+    }
+    else
+    {
+        code << node->prop_as_string(prop_radiobtn_var_name) << "), " << node->prop_as_string(prop_orientation) << ");";
+    }
 
     auto min_size = node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)

--- a/src/generate/text_widgets.cpp
+++ b/src/generate/text_widgets.cpp
@@ -486,7 +486,19 @@ std::optional<ttlib::cstr> WebViewGenerator::GenConstruction(Node* node)
 
 std::optional<ttlib::cstr> WebViewGenerator::GenEvents(NodeEvent* event, const std::string& class_name)
 {
-    return GenEventCode(event, class_name);
+    if ((event->get_name() == "wxEVT_WEBVIEW_FULL_SCREEN_CHANGED" ||
+         event->get_name() == "wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED") &&
+        wxGetProject().prop_as_string(prop_wxWidgets_version) == "3.1")
+    {
+        ttlib::cstr code("\n#if wxCHECK_VERSION(3, 1, 5)\n");
+        code << GenEventCode(event, class_name);
+        code << "\n#endif";
+        return code;
+    }
+    else
+    {
+        return GenEventCode(event, class_name);
+    }
 }
 
 bool WebViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)

--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -8,9 +8,9 @@
 #include <cstring>
 #include <fstream>
 
-#include <wx/file.h>     // wxFile - encapsulates low-level "file descriptor"
-#include <wx/stc/stc.h>  // Scintilla
-#include <wx/filename.h> // wxFileName - encapsulates a file path
+#include <wx/file.h>      // wxFile - encapsulates low-level "file descriptor"
+#include <wx/filename.h>  // wxFileName - encapsulates a file path
+#include <wx/stc/stc.h>   // Scintilla
 
 #include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
 

--- a/src/xml/grid_xml.xml
+++ b/src/xml/grid_xml.xml
@@ -32,7 +32,7 @@ inline const char* grid_xml = R"===(<?xml version="1.0"?>
 			<option name="wxGridSelectRowsOrColumns"
 				help="Select either the entire columns or the entire rows but not individual cells nor blocks." />
 			<option name="wxGridSelectNone"
-				help="No selections can be made. The user won't be able to select any cells in this mode. Available since dgets 3.1.5" />
+				help="No selections can be made. The user won't be able to select any cells in this mode. Available since wxWidgets 3.1.5" />
 			wxGridSelectCells
 		</property>
 
@@ -52,6 +52,13 @@ inline const char* grid_xml = R"===(<?xml version="1.0"?>
 		<category name="Cells">
 			<property name="cell_bg" type="wxColour"
 				help="Default cell background color." />
+			<property name="cell_fit" type="option"
+				help="Specifies the default behaviour of the cell contents if it doesn't fit into the available space. Available since wxWidgets 3.1.4.">
+				<option name="clip" />
+				<option name="ellipsize" />
+				<option name="overflow" />
+				overflow
+			</property>
 			<property name="cell_font" type="wxFont"
 				help="Default cell font." />
 			<property name="cell_text" type="wxColour"

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -21,6 +21,11 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 			<option name="C++ 20" />
 			C++ 11
 		</property>
+		<property name="wxWidgets_version" type="option" help="If you specify a control or property that requires a wxWidgets version later than this number, then the code will be generated within a conditional block.">
+			<option name="3.1" />
+			<option name="3.2" />
+			3.1
+		</property>
 	</gen>
 
 	<gen class="Project" type="project" image="project">

--- a/src/xml/sizers_xml.xml
+++ b/src/xml/sizers_xml.xml
@@ -66,7 +66,7 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 			help="" />
 	</gen>
 
-	<gen class="StaticCheckboxBoxSizer" image="wxStaticCheckBoxSizer" type="sizer">
+	<gen class="StaticCheckboxBoxSizer" image="wxStaticCheckBoxSizer" type="sizer" help="Available since wxWidgets 3.1.1">
 		<inherits class="sizer_dimension" />
 		<inherits class="sizer_child" />
 		<inherits class="Boolean Validator" />

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -443,10 +443,10 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 			help="Generated when a new window is created." />
 		<event name="wxEVT_WEBVIEW_TITLE_CHANGED" class="wxWebViewEvent"
 			help="Generated when the page title changes." />
-		<event name="EVT_WEBVIEW_FULL_SCREEN_CHANGED" class="wxWebViewEvent"
-			help="Generated when the page wants to enter or leave fullscreen." />
+		<event name="wxEVT_WEBVIEW_FULL_SCREEN_CHANGED" class="wxWebViewEvent"
+			help="Generated when the page wants to enter or leave fullscreen. Available since wxWidgets 3.1.5" />
 		<event name="wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED" class="wxWebViewEvent"
-			help="Only available in wxWidgets 3.1.5 or later." />
+			help="Available since wxWidgets 3.1.5" />
 	</gen>
 
 	<gen class="wxCalendarCtrl" image="calendar" type="widget">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a wxWidgets_version property, and generates conditional code for controls/properties that required a specific version unless the user selects a higher version. Currently, I'm just going with major releases (3.1 and 3.2) since 3.2 should be released this year (probably summer).

I looked at release notes and full-text search through the CHM file, so I *think* I have most if not all of the properties and events that need conditionalizing up through 3.1.5.