### PR TITLE
Remove indentation before #if, #else and #endif

### DIFF
--- a/src/debugging/debug_dialogs.wxui
+++ b/src/debugging/debug_dialogs.wxui
@@ -6,57 +6,6 @@
     art_directory="../art_src">
     <node
       class="wxDialog"
-      base_file="..\debugging\nodeinfo_base"
-      class_name="NodeInfoBase"
-      derived_class_name="NodeInfo"
-      derived_file="../debugging/nodeinfo"
-      title="Node Information">
-      <node
-        class="wxBoxSizer"
-        orientation="wxVERTICAL"
-        var_name="parent_sizer"
-        flags="wxEXPAND">
-        <node
-          class="wxStaticBoxSizer"
-          label="Selected Node"
-          var_name="static_box_2">
-          <node
-            class="wxStaticText"
-            label="Name:"
-            var_name="m_txt_generator" />
-          <node
-            class="wxStaticText"
-            label="Type:"
-            var_name="m_txt_type" />
-          <node
-            class="wxStaticText"
-            label="Memory:"
-            var_name="m_txt_memory" />
-        </node>
-        <node
-          class="wxStaticBoxSizer"
-          label="Memory Usage"
-          flags="wxEXPAND">
-          <node
-            class="wxStaticText"
-            label="Project:"
-            var_name="m_txt_project" />
-          <node
-            class="wxStaticText"
-            label="Clipboard:"
-            var_name="m_txt_clipboard" />
-        </node>
-        <node
-          class="wxStdDialogButtonSizer"
-          Cancel="false"
-          Close="true"
-          OK="false"
-          default_button="Close"
-          flags="wxEXPAND" />
-      </node>
-    </node>
-    <node
-      class="wxDialog"
       base_file="debugsettingsBase"
       class_name="DebugSettingsBase"
       derived_class_name="DebugSettings"

--- a/src/debugging/msgframe_base.cpp
+++ b/src/debugging/msgframe_base.cpp
@@ -35,11 +35,11 @@ MsgFrameBase::MsgFrameBase(wxWindow* parent, wxWindowID id, const wxString& titl
 
     auto menu_item_saveas = new wxMenuItem(menu_file, wxID_SAVEAS, wxEmptyString);
     menu_item_saveas->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE_AS, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_FILE_SAVE_AS, wxART_MENU)
-    #endif
+#endif
     );
     menu_file->Append(menu_item_saveas);
 
@@ -47,11 +47,11 @@ MsgFrameBase::MsgFrameBase(wxWindow* parent, wxWindowID id, const wxString& titl
 
     auto menu_item_clear = new wxMenuItem(menu_file, wxID_CLEAR, wxEmptyString);
     menu_item_clear->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_CUT, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU)
-    #endif
+#endif
     );
     menu_file->Append(menu_item_clear);
 
@@ -65,33 +65,33 @@ MsgFrameBase::MsgFrameBase(wxWindow* parent, wxWindowID id, const wxString& titl
     m_menu_item_warnings = new wxMenuItem(menu_view, id_warning_msgs, "Warnings",
         wxEmptyString, wxITEM_CHECK);
     m_menu_item_warnings->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_WARNING, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_WARNING, wxART_MENU)
-    #endif
+#endif
     );
     menu_view->Append(m_menu_item_warnings);
 
     m_menu_item_events = new wxMenuItem(menu_view, id_event_msgs, "Events",
         wxEmptyString, wxITEM_CHECK);
     m_menu_item_events->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_TIP, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_TIP, wxART_MENU)
-    #endif
+#endif
     );
     menu_view->Append(m_menu_item_events);
 
     m_menu_item_info = new wxMenuItem(menu_view, wxID_INFO, wxEmptyString,
         wxEmptyString, wxITEM_CHECK);
     m_menu_item_info->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_INFORMATION, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_INFORMATION, wxART_MENU)
-    #endif
+#endif
     );
     menu_view->Append(m_menu_item_info);
     menubar->Append(menu_view, "&View");

--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -36,9 +36,14 @@ void WriteCode::WriteCodeLine(ttlib::sview code, size_t indentation)
     {
         if (indentation != indent::none)
         {
-            for (int i = 0; i < m_indent; ++i)
+            // Don't indent #if, #else or #endif
+            if (code[0] != '#' ||
+                !(code.is_sameprefix("#if") || code.is_sameprefix("#else") || code.is_sameprefix("#endif")))
             {
-                doWrite("    ");
+                for (int i = 0; i < m_indent; ++i)
+                {
+                    doWrite("    ");
+                }
             }
         }
         m_isLineWriting = true;

--- a/src/ui/colourprop_base.cpp
+++ b/src/ui/colourprop_base.cpp
@@ -44,11 +44,11 @@ bool ColourPropBase::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     m_radio_custom = new wxRadioButton(this, wxID_ANY, "Custom Colour");
     m_staticbox_custom = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY,
-    #if wxCHECK_VERSION(3, 1, 1)
+#if wxCHECK_VERSION(3, 1, 1)
     m_radio_custom),
-    #else
+#else
     wxEmptyString),
-    #endif
+#endif
     wxVERTICAL);
     m_staticbox_custom->GetStaticBox()->Enable(false);
     dlg_sizer->Add(m_staticbox_custom, wxSizerFlags().Expand().Border(wxALL));
@@ -62,11 +62,11 @@ bool ColourPropBase::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     m_radio_system = new wxRadioButton(this, wxID_ANY, "System Colour");
     m_staticbox_system = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY,
-    #if wxCHECK_VERSION(3, 1, 1)
+#if wxCHECK_VERSION(3, 1, 1)
     m_radio_system),
-    #else
+#else
     wxEmptyString),
-    #endif
+#endif
     wxVERTICAL);
     m_staticbox_system->GetStaticBox()->Enable(false);
     dlg_sizer->Add(m_staticbox_system, wxSizerFlags().Expand().Border(wxALL));

--- a/src/ui/eventhandlerdlg_base.cpp
+++ b/src/ui/eventhandlerdlg_base.cpp
@@ -29,11 +29,11 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     m_radio_use_function = new wxRadioButton(this, wxID_ANY, "Use function");
     m_function_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY,
-    #if wxCHECK_VERSION(3, 1, 1)
+#if wxCHECK_VERSION(3, 1, 1)
     m_radio_use_function),
-    #else
+#else
     wxEmptyString),
-    #endif
+#endif
     wxVERTICAL);
     box_sizer->Add(m_function_box, wxSizerFlags().Expand().Border(wxALL));
 
@@ -44,11 +44,11 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     m_radio_use_lambda = new wxRadioButton(this, wxID_ANY, "Use lambda");
     m_lambda_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY,
-    #if wxCHECK_VERSION(3, 1, 1)
+#if wxCHECK_VERSION(3, 1, 1)
     m_radio_use_lambda),
-    #else
+#else
     wxEmptyString),
-    #endif
+#endif
     wxVERTICAL);
     box_sizer->Add(m_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
 

--- a/src/ui/fontpropdlg_base.cpp
+++ b/src/ui/fontpropdlg_base.cpp
@@ -18,11 +18,11 @@ bool FontPropDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& ti
 
     m_radioSystem = new wxRadioButton(this, wxID_ANY, "Default GUI Font");
     m_system_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY,
-    #if wxCHECK_VERSION(3, 1, 1)
+#if wxCHECK_VERSION(3, 1, 1)
     m_radioSystem),
-    #else
+#else
     wxEmptyString),
-    #endif
+#endif
     wxVERTICAL);
     dlg_sizer->Add(m_system_box, wxSizerFlags().Expand().DoubleBorder(wxALL));
 
@@ -79,11 +79,11 @@ bool FontPropDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& ti
 
     m_radioCustom = new wxRadioButton(this, wxID_ANY, "Custom Font");
     m_custom_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY,
-    #if wxCHECK_VERSION(3, 1, 1)
+#if wxCHECK_VERSION(3, 1, 1)
     m_radioCustom),
-    #else
+#else
     wxEmptyString),
-    #endif
+#endif
     wxVERTICAL);
     dlg_sizer->Add(m_custom_box, wxSizerFlags().Expand().DoubleBorder(wxALL));
 

--- a/src/ui/mainframe_base.cpp
+++ b/src/ui/mainframe_base.cpp
@@ -45,11 +45,11 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     auto menuItem2 = new wxMenuItem(m_menuFile, id_OpenProject, "&Open Project...\tCtrl+O",
         "Open a project", wxITEM_NORMAL);
     menuItem2->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_MENU)
-    #endif
+#endif
     );
     m_menuFile->Append(menuItem2);
 
@@ -69,11 +69,11 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     auto menu_item2 = new wxMenuItem(m_menuFile, id_SaveProjectAs, "Save &As...\tCtrl-Shift+S",
         "Save current project to a different filename", wxITEM_NORMAL);
     menu_item2->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE_AS, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_FILE_SAVE_AS, wxART_MENU)
-    #endif
+#endif
     );
     m_menuFile->Append(menu_item2);
 
@@ -116,11 +116,11 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_quit = new wxMenuItem(m_menuFile, wxID_EXIT, wxEmptyString);
     menu_quit->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_QUIT, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_QUIT, wxART_MENU)
-    #endif
+#endif
     );
     m_menuFile->Append(menu_quit);
     m_menubar->Append(m_menuFile, "&File");
@@ -129,21 +129,21 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_undo = new wxMenuItem(m_menuEdit, wxID_UNDO, wxEmptyString);
     menu_undo->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_UNDO, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_UNDO, wxART_MENU)
-    #endif
+#endif
     );
     m_menuEdit->Append(menu_undo);
 
     auto menu_redo = new wxMenuItem(m_menuEdit, wxID_REDO, wxEmptyString);
     menu_redo->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_REDO, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_REDO, wxART_MENU)
-    #endif
+#endif
     );
     m_menuEdit->Append(menu_redo);
 
@@ -151,42 +151,42 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_cut = new wxMenuItem(m_menuEdit, wxID_CUT, wxEmptyString);
     menu_cut->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_CUT, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_CUT, wxART_MENU)
-    #endif
+#endif
     );
     m_menuEdit->Append(menu_cut);
 
     auto menu_copy = new wxMenuItem(m_menuEdit, wxID_COPY, wxEmptyString);
     menu_copy->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_COPY, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_COPY, wxART_MENU)
-    #endif
+#endif
     );
     m_menuEdit->Append(menu_copy);
 
     auto menu_paste = new wxMenuItem(m_menuEdit, wxID_PASTE, wxEmptyString);
     menu_paste->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_PASTE, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_PASTE, wxART_MENU)
-    #endif
+#endif
     );
     m_menuEdit->Append(menu_paste);
 
     auto menu_delete = new wxMenuItem(m_menuEdit, wxID_DELETE, wxEmptyString,
         "Delete selected object without using clipboard.", wxITEM_NORMAL);
     menu_delete->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_DELETE, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_DELETE, wxART_MENU)
-    #endif
+#endif
     );
     m_menuEdit->Append(menu_delete);
 
@@ -199,22 +199,22 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     auto menu_find = new wxMenuItem(m_menuEdit, wxID_FIND, wxEmptyString,
         "Find text in the active code viewer.", wxITEM_NORMAL);
     menu_find->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_FIND, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_FIND, wxART_MENU)
-    #endif
+#endif
     );
     m_menuEdit->Append(menu_find);
 
     auto menu_insert_widget = new wxMenuItem(m_menuEdit, id_insert_widget, "&Insert widget...",
         "Find text in the active code viewer.", wxITEM_NORMAL);
     menu_insert_widget->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_EDIT, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_EDIT, wxART_MENU)
-    #endif
+#endif
     );
     m_menuEdit->Append(menu_insert_widget);
 
@@ -330,11 +330,11 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto menu_help = new wxMenuItem(m_menuHelp, wxID_ABOUT, wxEmptyString);
     menu_help->SetBitmap(
-    #if wxCHECK_VERSION(3, 1, 6)
+#if wxCHECK_VERSION(3, 1, 6)
     wxArtProvider::GetBitmapBundle(wxART_HELP, wxART_MENU)
-    #else
+#else
     wxArtProvider::GetBitmap(wxART_HELP, wxART_MENU)
-    #endif
+#endif
     );
     m_menuHelp->Append(menu_help);
 

--- a/src/ui/newframe_base.cpp
+++ b/src/ui/newframe_base.cpp
@@ -45,11 +45,11 @@ bool NewFrame::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     m_checkBox_mainframe = new wxCheckBox(this, wxID_ANY, "Main Frame Window");
     m_checkBox_mainframe->SetValidator(wxGenericValidator(&m_has_mainframe));
     auto static_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY,
-    #if wxCHECK_VERSION(3, 1, 1)
+#if wxCHECK_VERSION(3, 1, 1)
     m_checkBox_mainframe),
-    #else
+#else
     wxEmptyString),
-    #endif
+#endif
     wxVERTICAL);
     box_sizer->Add(static_box, wxSizerFlags().Expand().DoubleBorder(wxALL));
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes code generation, remove indentation before `#if`, `#else` and `#endif` to make the conditionals easier to see.