### PR TITLE
Add initial support for wxBitmapBundle

### DIFF
--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -140,7 +140,7 @@ void PropertyGrid_Image::RefreshChildren()
 
     Item(IndexType)->SetValue(m_img_props.type.wx_str());
     Item(IndexImage)->SetValue(m_img_props.image.wx_str());
-#if 0   // See https://github.com/KeyWorksRW/wxUiEditor/issues/683
+#if 0  // See https://github.com/KeyWorksRW/wxUiEditor/issues/683
     if (!m_isEmbeddedImage)
     {
         Item(IndexScale)->SetValue(m_img_props.CombineScale());

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -58,11 +58,13 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
 
     AddPrivateChild(new wxEnumProperty("type", wxPG_LABEL, types, 0));
     AddPrivateChild(new ImageStringProperty("image", m_img_props));
+#if 0  // See https://github.com/KeyWorksRW/wxUiEditor/issues/683
     if (!m_isEmbeddedImage)
     {
         AddPrivateChild(new CustomPointProperty("scale size", prop, CustomPointProperty::type_scale));
         Item(IndexScale)->SetHelpString("Scale the image to this size.");
     }
+#endif
 }
 
 void PropertyGrid_Image::RefreshChildren()
@@ -138,10 +140,12 @@ void PropertyGrid_Image::RefreshChildren()
 
     Item(IndexType)->SetValue(m_img_props.type.wx_str());
     Item(IndexImage)->SetValue(m_img_props.image.wx_str());
+#if 0   // See https://github.com/KeyWorksRW/wxUiEditor/issues/683
     if (!m_isEmbeddedImage)
     {
         Item(IndexScale)->SetValue(m_img_props.CombineScale());
     }
+#endif
 }
 
 void PropertyGrid_Image::SetAutoComplete()
@@ -235,6 +239,7 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
             }
             break;
 
+#if 0  // See https://github.com/KeyWorksRW/wxUiEditor/issues/683
         case IndexScale:
             {
                 auto u8_value = childValue.GetString().utf8_string();
@@ -243,6 +248,7 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
                 img_props.SetHeight(mstr[1].atoi());
             }
             break;
+#endif
     }
 
     value = img_props.CombineValues().wx_str();

--- a/src/generate/btn_widgets.cpp
+++ b/src/generate/btn_widgets.cpp
@@ -38,19 +38,19 @@ wxObject* ButtonGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_bitmap))
     {
-        widget->SetBitmap(node->prop_as_wxBitmap(prop_bitmap));
+        widget->SetBitmap(node->prop_as_wxBitmapBundle(prop_bitmap));
 
         if (node->HasValue(prop_disabled_bmp))
-            widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));
+            widget->SetBitmapDisabled(node->prop_as_wxBitmapBundle(prop_disabled_bmp));
 
         if (node->HasValue(prop_pressed_bmp))
-            widget->SetBitmapPressed(node->prop_as_wxBitmap(prop_pressed_bmp));
+            widget->SetBitmapPressed(node->prop_as_wxBitmapBundle(prop_pressed_bmp));
 
         if (node->HasValue(prop_focus_bmp))
-            widget->SetBitmapFocus(node->prop_as_wxBitmap(prop_focus_bmp));
+            widget->SetBitmapFocus(node->prop_as_wxBitmapBundle(prop_focus_bmp));
 
         if (node->HasValue(prop_current))
-            widget->SetBitmapCurrent(node->prop_as_wxBitmap(prop_current));
+            widget->SetBitmapCurrent(node->prop_as_wxBitmapBundle(prop_current));
 
         if (node->HasValue(prop_position))
             widget->SetBitmapPosition(static_cast<wxDirection>(node->prop_as_int(prop_position)));
@@ -249,19 +249,19 @@ wxObject* ToggleButtonGenerator::CreateMockup(Node* node, wxObject* parent)
     widget->SetValue((node->prop_as_bool(prop_pressed)));
 
     if (node->HasValue(prop_bitmap))
-        widget->SetBitmap(node->prop_as_wxBitmap(prop_bitmap));
+        widget->SetBitmap(node->prop_as_wxBitmapBundle(prop_bitmap));
 
     if (node->HasValue(prop_disabled_bmp))
-        widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));
+        widget->SetBitmapDisabled(node->prop_as_wxBitmapBundle(prop_disabled_bmp));
 
     if (node->HasValue(prop_pressed_bmp))
-        widget->SetBitmapPressed(node->prop_as_wxBitmap(prop_pressed_bmp));
+        widget->SetBitmapPressed(node->prop_as_wxBitmapBundle(prop_pressed_bmp));
 
     if (node->HasValue(prop_focus_bmp))
-        widget->SetBitmapFocus(node->prop_as_wxBitmap(prop_focus_bmp));
+        widget->SetBitmapFocus(node->prop_as_wxBitmapBundle(prop_focus_bmp));
 
     if (node->HasValue(prop_current))
-        widget->SetBitmapCurrent(node->prop_as_wxBitmap(prop_current));
+        widget->SetBitmapCurrent(node->prop_as_wxBitmapBundle(prop_current));
 
     if (node->HasValue(prop_position))
         widget->SetBitmapPosition(static_cast<wxDirection>(node->prop_as_int(prop_position)));
@@ -438,7 +438,7 @@ wxObject* CommandLinkBtnGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_bitmap))
     {
-        widget->SetBitmap(node->prop_as_wxBitmap(prop_bitmap));
+        widget->SetBitmap(node->prop_as_wxBitmapBundle(prop_bitmap));
 
         if (node->HasValue(prop_disabled_bmp))
             widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));

--- a/src/generate/grid_widgets.cpp
+++ b/src/generate/grid_widgets.cpp
@@ -461,7 +461,7 @@ void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /
         if (childObj->isGen(gen_propGridPage))
         {
             wxPropertyGridPage* page =
-                pgm->AddPage(childObj->prop_as_wxString(prop_label), childObj->prop_as_wxBitmap(prop_bitmap));
+                pgm->AddPage(childObj->prop_as_wxString(prop_label), childObj->prop_as_wxBitmapBundle(prop_bitmap));
 
             for (size_t j = 0; j < childObj->GetChildCount(); ++j)
             {

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -96,7 +96,7 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
             auto result = MakeSubMenu(menu_item.get());
             auto item = sub_menu->AppendSubMenu(result, menu_item->prop_as_wxString(prop_label));
             if (menu_item->HasValue(prop_bitmap))
-                item->SetBitmap(menu_item->prop_as_wxBitmap(prop_bitmap));
+                item->SetBitmap(menu_item->prop_as_wxBitmapBundle(prop_bitmap));
         }
         else if (menu_item->isGen(gen_separator))
         {
@@ -130,9 +130,9 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
                     unchecked = menu_item->prop_as_wxBitmap(prop_unchecked_bitmap);
                 }
 #ifdef __WXMSW__
-                item->SetBitmaps(menu_item->prop_as_wxBitmap(prop_bitmap), unchecked);
+                item->SetBitmaps(menu_item->prop_as_wxBitmapBundle(prop_bitmap), unchecked);
 #else
-                item->SetBitmap(menu_item->GetPropertyAsBitmap(prop_bitmap));
+                item->SetBitmap(menu_item->prop_as_wxBitmapBundle(prop_bitmap));
 #endif
             }
 #ifdef __WXMSW__

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -111,7 +111,7 @@ std::optional<ttlib::cstr> AnimationGenerator::GenConstruction(Node* node)
     if (node->HasValue(prop_inactive_bitmap))
     {
         code << "\n\t" << node->get_node_name() << "->SetInactiveBitmap(";
-        code << GenerateBitmapCode(node->prop_as_string(prop_inactive_bitmap)) << ");";
+        code << GenerateBitmapCode(node->prop_as_string(prop_inactive_bitmap), true) << ");";
     }
 
     return code;
@@ -346,7 +346,7 @@ bool StatusBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 wxObject* StaticBitmapGenerator::CreateMockup(Node* node, wxObject* parent)
 {
     auto widget =
-        new wxGenericStaticBitmap(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxBitmap(prop_bitmap),
+        new wxGenericStaticBitmap(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxBitmapBundle(prop_bitmap),
                                   DlgPoint(parent, node, prop_pos), DlgSize(parent, node, prop_size), GetStyleInt(node));
     if (auto value = node->prop_as_string(prop_scale_mode); value != "None")
     {

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -146,7 +146,7 @@ wxObject* BannerWindowGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_bitmap))
     {
-        widget->SetBitmap(node->prop_as_wxBitmap(prop_bitmap));
+        widget->SetBitmap(node->prop_as_wxBitmapBundle(prop_bitmap));
     }
 
     else if (node->HasValue(prop_start_colour) && node->HasValue(prop_end_colour))

--- a/src/generate/ribbon_widgets.cpp
+++ b/src/generate/ribbon_widgets.cpp
@@ -193,6 +193,7 @@ bool RibbonBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 wxObject* RibbonPageGenerator::CreateMockup(Node* node, wxObject* parent)
 {
     auto bmp = node->HasValue(prop_bitmap) ? node->prop_as_wxBitmap(prop_bitmap) : wxNullBitmap;
+    // REVIEW: [KeyWorks - 02-25-2022] This is still a bitmap rather then a bundle as of 2/25/22
     auto widget = new wxRibbonPage((wxRibbonBar*) parent, wxID_ANY, node->prop_as_wxString(prop_label), bmp, 0);
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);

--- a/src/generate/toolbar_widgets.cpp
+++ b/src/generate/toolbar_widgets.cpp
@@ -61,7 +61,7 @@ void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparen
         auto child = GetMockup()->GetChild(wxobject, i);
         if (childObj->isGen(gen_tool))
         {
-            auto bmp = childObj->prop_as_wxBitmap(prop_bitmap);
+            auto bmp = childObj->prop_as_wxBitmapBundle(prop_bitmap);
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
 
@@ -216,7 +216,7 @@ void ToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
         auto child = GetMockup()->GetChild(wxobject, i);
         if (childObj->isGen(gen_tool))
         {
-            auto bmp = childObj->prop_as_wxBitmap(prop_bitmap);
+            auto bmp = childObj->prop_as_wxBitmapBundle(prop_bitmap);
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
 
@@ -424,7 +424,7 @@ void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent
         auto child = GetMockup()->GetChild(wxobject, i);
         if (childObj->isGen(gen_auitool))
         {
-            auto bmp = childObj->prop_as_wxBitmap(prop_bitmap);
+            auto bmp = childObj->prop_as_wxBitmapBundle(prop_bitmap);
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -257,6 +257,19 @@ wxImage App::GetImage(const ttlib::cstr& description)
         return GetInternalImage("unknown");
 }
 
+#if wxCHECK_VERSION(3, 1, 6)
+wxBitmapBundle App::GetImageBundle(const ttlib::cstr& description)
+{
+    if (description.is_sameprefix("Embed;") || description.is_sameprefix("XPM;") || description.is_sameprefix("Header;") ||
+        description.is_sameprefix("Art;"))
+    {
+        return m_pjtSettings->GetPropertyBitmapBundle(description);
+    }
+    else
+        return GetInternalImage("unknown");
+}
+#endif
+
 ttString App::GetArtDirectory()
 {
     if (m_project->HasValue(prop_art_directory))

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -70,6 +70,11 @@ public:
     ttString GetDerivedDirectory();
 
     wxImage GetImage(const ttlib::cstr& description);
+#if wxCHECK_VERSION(3, 1, 6)
+    wxBitmapBundle GetImageBundle(const ttlib::cstr& description);
+#else
+    wxBitmap GetImageBundle(const ttlib::cstr& description);
+#endif
 
     ProjectSettings* GetProjectSettings() { return m_pjtSettings; };
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -387,6 +387,16 @@ wxBitmap Node::prop_as_wxBitmap(PropName name) const
         return wxNullBitmap;
 }
 
+#if wxCHECK_VERSION(3, 1, 6)
+wxBitmapBundle Node::prop_as_wxBitmapBundle(PropName name) const
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_bitmap_bundle();
+    else
+        return wxNullBitmap;
+}
+#endif
+
 wxArrayString Node::prop_as_wxArrayString(PropName name) const
 {
     if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -182,6 +182,12 @@ public:
     wxBitmap prop_as_wxBitmap(PropName name) const;
     wxArrayString prop_as_wxArrayString(PropName name) const;
 
+#if wxCHECK_VERSION(3, 1, 6)
+    wxBitmapBundle prop_as_wxBitmapBundle(PropName name) const;
+#else
+    wxBitmap prop_as_wxBitmapBundle(PropName name) const { return prop_as_wxBitmap(name); }
+#endif
+
     FontProperty prop_as_font_prop(PropName name) const;
     double prop_as_double(PropName name) const;
 

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -295,6 +295,17 @@ wxBitmap NodeProperty::as_bitmap() const
         return image;
 }
 
+#if wxCHECK_VERSION(3, 1, 6)
+wxBitmapBundle NodeProperty::as_bitmap_bundle() const
+{
+    auto bundle = wxGetApp().GetImageBundle(m_value);
+    if (!bundle.IsOk())
+        return wxNullBitmap;
+    else
+        return bundle;
+}
+#endif
+
 wxAnimation NodeProperty::as_animation() const
 {
     return wxGetApp().GetProjectSettings()->GetPropertyAnimation(m_value);

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -54,6 +54,12 @@ public:
     auto as_wxString() const { return m_value.wx_str(); }
     wxArrayString as_wxArrayString() const;
 
+#if wxCHECK_VERSION(3, 1, 6)
+    wxBitmapBundle as_bitmap_bundle() const;
+#else
+    wxBitmap as_bitmap_bundle() const { return as_bitmap(); }
+#endif
+
     const ttlib::cstr& as_string() const { return m_value; }
 
     // Converts friendly name to wxWidgets constant

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -53,7 +53,13 @@ public:
 
     // This takes the full bitmap property description and uses that to determine the image
     // to load. The image is cached for as long as the project is open.
-    wxImage GetPropertyBitmap(const ttlib::cstr& description, bool want_scaled = true);
+    //
+    // If check_image is true, and !image.IsOK(), GetInternalImage() is returned
+    wxImage GetPropertyBitmap(const ttlib::cstr& description, bool want_scaled = true, bool check_image = true);
+
+#if wxCHECK_VERSION(3, 1, 6)
+    wxBitmapBundle GetPropertyBitmapBundle(const ttlib::cstr& description);
+#endif
 
     // This takes the full animation property description and uses that to determine the image
     // to load. The image is cached for as long as the project is open.
@@ -79,6 +85,9 @@ private:
     std::mutex m_mutex_embed_retrieve;
 
     std::map<std::string, wxImage> m_images;
+#if wxCHECK_VERSION(3, 1, 6)
+    std::map<std::string, wxBitmapBundle> m_bundles;
+#endif
 
     std::thread* m_collect_thread { nullptr };
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds initial support for wxBitmapBundle -- all mockups except for ribbons now call prop_as_wxBitmapBundle() which will return a wxBitmap under 3.1.5 and wxBitmapBundler under 3.1.6. Ribbons don't support wxBitmapBundle yet, so that still calls the older prop_as_wxBitmap() function.

ProjectSettings::GetPropertyBitmapBundle() handles retrieving two bitmaps: the first named normally, and the second with either a `_2x` or `@2x` suffix which matches what `wxBitmapBundle::FromFiles()` does.

Note that support for wxBitmapBundle is not complete with this PR, this is just the first step so that mockup works as expected.