### PR TITLE
WinRes Import: Create PopupMenu

### DIFF
--- a/src/winres/winres_form.h
+++ b/src/winres/winres_form.h
@@ -187,6 +187,8 @@ private:
 
     WinResource* m_pWinResource;
 
+    bool m_is_popup_menu { false };
+
 #if defined(_DEBUG)
     // Makes it easier to know exactly which form we're looking at in the debugger
     ttlib::cstr m_form_id;


### PR DESCRIPTION
If there is only one POPUP directive, and it doesn't contain an accelerator,
assume it is a popup menu rather than a menu bar.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
In a Windows Resource file, there isn't any directive indicating that a menu will be used as a popup menu, or attached to a window. With wxWidgets, it matters because you create a **wxMenu** for a popup, or a **wxMenuBar** to attach to a window.

This PR attempts to differentiate between the two by assuming a single POPUP directive that doesn't have an accelerator means it will be used for a popup menu. Unfortunately, it's perfectly normal to have nested Popups in either type of menu. So this change will work for a popup menu with no sub-menus, but will still create the wrong type if it's supposed to be a popup menu with sub menus.