### PR TITLE
Initial commit to support bitmap bundles

### DIFF
--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -42,6 +42,7 @@ Files:
     cstm_event.cpp        # Custom Event handling
     frame_status_bar.cpp  # MainFrame status bar functions
     gen_enums.cpp         # Enumerations for generators
+    image_bundle.cpp      # Functions for working with wxBitmapBundle
     lambdas.cpp           # Functions for formatting and storage of lamda events
     paths.cpp             # Handles *_directory properties
     pjtsettings.cpp       # Hold data for currently loaded project

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -11,6 +11,7 @@ set (file_list
     ${CMAKE_CURRENT_LIST_DIR}/cstm_event.cpp        # Custom Event handling
     ${CMAKE_CURRENT_LIST_DIR}/frame_status_bar.cpp  # MainFrame status bar functions
     ${CMAKE_CURRENT_LIST_DIR}/gen_enums.cpp         # Enumerations for generators
+    ${CMAKE_CURRENT_LIST_DIR}/image_bundle.cpp      # Functions for working with wxBitmapBundle
     ${CMAKE_CURRENT_LIST_DIR}/lambdas.cpp           # Functions for formatting and storage of lamda events
     ${CMAKE_CURRENT_LIST_DIR}/paths.cpp             # Handles *_directory properties
     ${CMAKE_CURRENT_LIST_DIR}/pjtsettings.cpp       # Hold data for currently loaded project

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -1,0 +1,495 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Functions for working with wxBitmapBundle
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#if wxCHECK_VERSION(3, 1, 6)
+    #include <filesystem>
+    #include <fstream>
+    #include <thread>
+
+    #include <wx/artprov.h>   // wxArtProvider class
+    #include <wx/bmpbndl.h>   // includes wx/bitmap.h, wxBitmapBundle class interface
+    #include <wx/mstream.h>   // Memory stream classes
+    #include <wx/wfstream.h>  // File stream classes
+
+    #include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
+
+    #include "image_bundle.h"
+
+    #include "mainapp.h"      // compiler_standard -- Main application class
+    #include "node.h"         // Node class
+    #include "pjtsettings.h"  // ProjectSettings -- Hold data for currently loaded project
+    #include "utils.h"        // Utility functions that work with properties
+
+bool isConvertibleMime(const ttString& suffix);  // declared in embedimg.cpp
+
+void ProjectSettings::ParseBundles()
+{
+    FinishThreads();
+
+    m_collect_bundle_thread = new std::thread(&ProjectSettings::CollectBundles, this);
+}
+
+void ProjectSettings::CollectBundles()
+{
+    std::unique_lock<std::mutex> add_lock(m_mutex_init_bundles);
+
+    // We need the shared ptr rather than the raw pointer because we can't let the pointer become invalid while we're still
+    // processing nodes.
+    auto project = wxGetApp().GetProjectPtr();
+
+    for (size_t pos = 0; pos < project->GetChildCount(); ++pos)
+    {
+        if (m_is_terminating || m_cancel_collection)
+            return;
+
+        auto form = project->GetChildPtr(pos);
+
+        for (auto& iter: form->GetChildNodePtrs())
+        {
+            if (m_is_terminating || m_cancel_collection)
+                return;
+            CollectNodeBundles(iter.get(), form.get());
+        }
+    }
+}
+
+void ProjectSettings::CollectNodeBundles(Node* node, Node* form)
+{
+    for (auto& iter: node->get_props_vector())
+    {
+        if (iter.type() == type_image || iter.type() == type_animation)
+        {
+            if (!iter.HasValue())
+                continue;
+            auto& value = iter.as_string();
+            if (value.is_sameprefix("Embed"))
+            {
+                if (m_is_terminating || m_cancel_collection)
+                    return;
+
+                ttlib::multiview parts(value, BMP_PROP_SEPARATOR, tt::TRIM::both);
+                if (parts[IndexImage].size())
+                {
+                    if (auto result = m_map_embedded.find(parts[IndexImage].filename()); result == m_map_embedded.end())
+                    {
+                        if (m_is_terminating)
+                            return;
+
+                        if (iter.type() == type_animation)
+                        {
+                            AddEmbeddedImage(parts[IndexImage], form);
+                        }
+                        else
+                        {
+                            AddNewEmbeddedBundle(value, parts[IndexImage], form);
+                        }
+
+                        if (m_is_terminating)
+                            return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void ProjectSettings::AddNewEmbeddedBundle(const ttlib::cstr& description, ttlib::cstr path, Node* form)
+{
+    ImageBundle img_bundle;
+
+    if (!path.file_exists())
+    {
+        if (wxGetApp().GetProject()->HasValue(prop_art_directory))
+        {
+            ttlib::cstr art_path = wxGetApp().GetProject()->prop_as_string(prop_art_directory);
+            art_path.append_filename(path);
+            if (!art_path.file_exists())
+            {
+                m_bundles[description] = img_bundle;
+                return;
+            }
+            path = std::move(art_path);
+        }
+        else
+        {
+            m_bundles[description] = img_bundle;
+            return;
+        }
+    }
+
+    if (!AddEmbeddedBundleImage(path, form))
+    {
+        m_bundles[description] = img_bundle;
+        return;
+    }
+
+    img_bundle.lst_filenames.emplace_back(path);
+
+    /*
+
+        Look for suffix combinations -- it's fine if one of them doesn't exist
+
+            _16x16, _24x24, _32x32
+            _24x24, _36x36, _48x48
+            any, _1_5x, _2x
+
+    */
+
+    if (auto pos = path.find_last_of('.'); ttlib::is_found(pos))
+    {
+        if (path.contains("_16x16."))
+        {
+            path.Replace("_16x16.", "_24x24.");
+            if (path.file_exists())
+            {
+                if (auto added = AddEmbeddedBundleImage(path, form); added)
+                {
+                    img_bundle.lst_filenames.emplace_back(path);
+                }
+            }
+            path.Replace("_24x24.", "_32x32.");
+            if (path.file_exists())
+            {
+                if (auto added = AddEmbeddedBundleImage(path, form); added)
+                {
+                    img_bundle.lst_filenames.emplace_back(path);
+                }
+            }
+        }
+        else if (path.contains("_24x24."))
+        {
+            path.Replace("_24x24.", "_36x36.");
+            if (path.file_exists())
+            {
+                if (auto added = AddEmbeddedBundleImage(path, form); added)
+                {
+                    img_bundle.lst_filenames.emplace_back(path);
+                }
+            }
+            path.Replace("_36x36.", "_48x48.");
+            if (path.file_exists())
+            {
+                if (auto added = AddEmbeddedBundleImage(path, form); added)
+                {
+                    img_bundle.lst_filenames.emplace_back(path);
+                }
+            }
+        }
+        else
+        {
+            path.insert(pos, "_1_5x");
+            if (path.file_exists())
+            {
+                if (auto added = AddEmbeddedBundleImage(path, form); added)
+                {
+                    img_bundle.lst_filenames.emplace_back(path);
+                }
+            }
+            path.Replace("_1_5x", "_2x");
+            if (path.file_exists())
+            {
+                if (auto added = AddEmbeddedBundleImage(path, form); added)
+                {
+                    img_bundle.lst_filenames.emplace_back(path);
+                }
+            }
+        }
+    }
+
+    if (img_bundle.lst_filenames.size() == 1)
+    {
+        if (auto embed = GetEmbeddedImage(img_bundle.lst_filenames[0]); embed)
+        {
+            wxMemoryInputStream stream(embed->array_data.get(), embed->array_size);
+            wxImage image;
+            image.LoadFile(stream);
+            img_bundle.bundle = wxBitmapBundle::FromBitmap(image);
+        }
+    }
+    else
+    {
+        wxVector<wxBitmap> bitmaps;
+        for (auto& iter: img_bundle.lst_filenames)
+        {
+            if (auto embed = GetEmbeddedImage(iter); embed)
+            {
+                wxMemoryInputStream stream(embed->array_data.get(), embed->array_size);
+                wxImage image;
+                image.LoadFile(stream);
+                ASSERT(image.IsOk())
+                bitmaps.push_back(image);
+            }
+        }
+        img_bundle.bundle = wxBitmapBundle::FromBitmaps(bitmaps);
+    }
+
+    m_bundles[description] = std::move(img_bundle);
+}
+
+bool ProjectSettings::AddEmbeddedBundleImage(ttlib::cstr path, Node* form)
+{
+    wxFFileInputStream stream(path.wx_str());
+    if (!stream.IsOk())
+    {
+        return false;
+    }
+
+    wxImageHandler* handler;
+    auto& list = wxImage::GetHandlers();
+    for (auto node = list.GetFirst(); node; node = node->GetNext())
+    {
+        handler = (wxImageHandler*) node->GetData();
+        if (handler->CanRead(stream))
+        {
+            wxImage image;
+            if (handler->LoadFile(&image, stream))
+            {
+                m_map_embedded[path.filename().c_str()] = std::make_unique<EmbededImage>();
+                auto embed = m_map_embedded[path.filename().c_str()].get();
+                embed->array_name = path.filename();
+                embed->array_name.Replace(".", "_", true);
+                embed->form = form;
+
+                // If possible, convert the file to a PNG -- even if the original file is a PNG, since we might end up with
+                // better compression.
+
+                if (isConvertibleMime(handler->GetMimeType()))
+                {
+                    embed->type = wxBITMAP_TYPE_PNG;
+
+                    wxMemoryOutputStream save_stream;
+
+                    // Maximize compression
+                    image.SetOption(wxIMAGE_OPTION_PNG_COMPRESSION_LEVEL, 9);
+                    image.SetOption(wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL, 9);
+                    image.SaveFile(save_stream, "image/png");
+
+                    auto read_stream = save_stream.GetOutputStreamBuffer();
+                    stream.SeekI(0);
+                    if (read_stream->GetBufferSize() <= static_cast<size_t>(stream.GetLength()))
+                    {
+                        embed->array_size = read_stream->GetBufferSize();
+                        embed->array_data = std::make_unique<unsigned char[]>(embed->array_size);
+                        memcpy(embed->array_data.get(), read_stream->GetBufferStart(), embed->array_size);
+                    }
+                    else
+                    {
+    #if defined(_DEBUG)
+                        auto org_size = static_cast<size_t>(stream.GetLength());
+                        auto png_size = read_stream->GetBufferSize();
+                        ttlib::cstr size_comparison;
+                        size_comparison.Format("Original: %ku, new: %ku", org_size, png_size);
+    #endif  // _DEBUG
+
+                        embed->type = handler->GetType();
+                        embed->array_size = stream.GetSize();
+                        embed->array_data = std::make_unique<unsigned char[]>(embed->array_size);
+                        stream.Read(embed->array_data.get(), embed->array_size);
+                    }
+                }
+                else
+                {
+                    embed->type = handler->GetType();
+
+                    stream.SeekI(0);
+                    embed->array_size = stream.GetSize();
+                    embed->array_data = std::make_unique<unsigned char[]>(embed->array_size);
+                    stream.Read(embed->array_data.get(), embed->array_size);
+                }
+
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+ImageBundle* ProjectSettings::ProcessBundleProperty(const ttlib::cstr& description, Node* node)
+{
+    ASSERT_MSG(m_bundles.find(description) == m_bundles.end(),
+               "ProcessBundleProperty should not be called if bundle already exists!")
+
+    ttlib::multistr parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
+
+    if (parts[IndexImage].empty())
+    {
+        return nullptr;
+    }
+
+    ImageBundle img_bundle;
+
+    if (parts[IndexType].contains("Art"))
+    {
+        if (parts[IndexArtID].contains("|"))
+        {
+            ttlib::multistr id_client(parts[IndexArtID], '|');
+            img_bundle.bundle = wxArtProvider::GetBitmapBundle(id_client[0], wxART_MAKE_CLIENT_ID_FROM_STR(id_client[1]));
+        }
+        else
+        {
+            img_bundle.bundle =
+                wxArtProvider::GetBitmapBundle(parts[IndexArtID].wx_str(), wxART_MAKE_CLIENT_ID_FROM_STR("wxART_OTHER"));
+        }
+
+        m_bundles[description] = std::move(img_bundle);
+        return &m_bundles[description];
+    }
+    else if (parts[IndexType].contains("Embed"))
+    {
+        AddNewEmbeddedBundle(description, parts[IndexImage], node->GetForm());
+        return &m_bundles[description];
+    }
+
+    auto image_first = wxGetApp().GetProjectSettings()->GetPropertyBitmap(description, false, false);
+    if (!image_first.IsOk())
+    {
+        return nullptr;
+    }
+
+    img_bundle.lst_filenames.emplace_back(parts[IndexImage]);
+
+    if (auto pos = parts[IndexImage].find_last_of('.'); ttlib::is_found(pos))
+    {
+        if (parts[IndexImage].contains("_16x16."))
+        {
+            ttlib::cstr path(parts[IndexImage]);
+            path.Replace("_16x16.", "_24x24.");
+            if (!path.file_exists())
+            {
+                if (wxGetApp().GetProjectPtr()->HasValue(prop_art_directory))
+                {
+                    path = wxGetApp().GetProjectPtr()->prop_as_string(prop_art_directory);
+                    path.append_filename(parts[IndexImage]);
+                    path.Replace("_16x16.", "_24x24.");
+                    if (path.file_exists())
+                    {
+                        img_bundle.lst_filenames.emplace_back(path);
+                    }
+                }
+            }
+            else
+            {
+                img_bundle.lst_filenames.emplace_back(path);
+            }
+
+            // Note that path may now contain the prop_art_directory prefix
+            path.Replace("_24x24.", "_32x32.");
+            if (path.file_exists())
+            {
+                img_bundle.lst_filenames.emplace_back(path);
+            }
+        }
+        else if (parts[IndexImage].contains("_24x24."))
+        {
+            ttlib::cstr path(parts[IndexImage]);
+            path.Replace("_24x24.", "_36x36.");
+            if (!path.file_exists())
+            {
+                if (wxGetApp().GetProjectPtr()->HasValue(prop_art_directory))
+                {
+                    path = wxGetApp().GetProjectPtr()->prop_as_string(prop_art_directory);
+                    path.append_filename(parts[IndexImage]);
+                    path.Replace("_24x24.", "_36x36.");
+                    if (path.file_exists())
+                    {
+                        img_bundle.lst_filenames.emplace_back(path);
+                    }
+                }
+            }
+            else
+            {
+                img_bundle.lst_filenames.emplace_back(path);
+            }
+
+            // Note that path may now contain the prop_art_directory prefix
+            path.Replace("_36x36.", "_48x48.");
+            if (path.file_exists())
+            {
+                img_bundle.lst_filenames.emplace_back(path);
+            }
+        }
+        else
+        {
+            ttlib::cstr path(parts[IndexImage]);
+            path.insert(pos, "_1_5x");
+            if (!path.file_exists())
+            {
+                if (wxGetApp().GetProjectPtr()->HasValue(prop_art_directory))
+                {
+                    ttlib::cstr tmp_path = wxGetApp().GetProjectPtr()->prop_as_string(prop_art_directory);
+                    tmp_path.append_filename(path);
+                    if (tmp_path.file_exists())
+                    {
+                        img_bundle.lst_filenames.emplace_back(tmp_path);
+                    }
+                }
+            }
+            else
+            {
+                img_bundle.lst_filenames.emplace_back(path);
+            }
+
+            path = parts[IndexImage];
+            path.Replace("_1_5x", "_2x");
+            if (!path.file_exists())
+            {
+                if (wxGetApp().GetProjectPtr()->HasValue(prop_art_directory))
+                {
+                    ttlib::cstr tmp_path = wxGetApp().GetProjectPtr()->prop_as_string(prop_art_directory);
+                    tmp_path.append_filename(path);
+                    if (tmp_path.file_exists())
+                    {
+                        img_bundle.lst_filenames.emplace_back(tmp_path);
+                    }
+                }
+            }
+            else
+            {
+                img_bundle.lst_filenames.emplace_back(path);
+            }
+        }
+    }
+
+    ASSERT_MSG(img_bundle.lst_filenames.size() > 0, "image_first must always have it's filename added.")
+
+    if (img_bundle.lst_filenames.size() == 1)
+    {
+        img_bundle.bundle = wxBitmapBundle::FromBitmap(image_first);
+    }
+    else
+    {
+        wxVector<wxBitmap> bitmaps;
+        bitmaps.push_back(image_first);
+        ttlib::cstr new_description;
+        new_description << parts[IndexType] << ';';
+        new_description << img_bundle.lst_filenames[1];
+        auto image_second = GetPropertyBitmap(new_description, false, false);
+        if (image_second.IsOk())
+        {
+            bitmaps.push_back(image_second);
+        }
+
+        if (img_bundle.lst_filenames.size() > 2)
+        {
+            new_description.clear();
+            new_description << parts[IndexType] << ';';
+            new_description << img_bundle.lst_filenames[1];
+            auto image_third = GetPropertyBitmap(new_description, false, false);
+            if (image_third.IsOk())
+            {
+                bitmaps.push_back(image_third);
+            }
+        }
+
+        img_bundle.bundle = wxBitmapBundle::FromBitmaps(bitmaps);
+    }
+
+    m_bundles[description] = std::move(img_bundle);
+    return &m_bundles[description];
+}
+
+#endif

--- a/src/image_bundle.h
+++ b/src/image_bundle.h
@@ -1,0 +1,20 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Functions for working with wxBitmapBundle
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#if !wxCHECK_VERSION(3, 1, 6)
+    #error "Don't include this file unless compiling with 3.1.6 or later."
+#endif
+
+#include <wx/bmpbndl.h>  // includes wx/bitmap.h, wxBitmapBundle class interface
+
+struct ImageBundle
+{
+    wxBitmapBundle bundle;
+    std::vector<ttlib::cstr> lst_filenames;
+};

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -258,12 +258,12 @@ wxImage App::GetImage(const ttlib::cstr& description)
 }
 
 #if wxCHECK_VERSION(3, 1, 6)
-wxBitmapBundle App::GetImageBundle(const ttlib::cstr& description)
+wxBitmapBundle App::GetBitmapBundle(const ttlib::cstr& description, Node* node)
 {
     if (description.is_sameprefix("Embed;") || description.is_sameprefix("XPM;") || description.is_sameprefix("Header;") ||
         description.is_sameprefix("Art;"))
     {
-        return m_pjtSettings->GetPropertyBitmapBundle(description);
+        return m_pjtSettings->GetPropertyBitmapBundle(description, node);
     }
     else
         return GetInternalImage("unknown");

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -9,6 +9,12 @@
 
 #include <wx/app.h>  // wxAppBase class and macros used for declaration of wxApp
 
+#if wxCHECK_VERSION(3, 1, 6)
+    #include <wx/bmpbndl.h>
+#else
+    #include <wx/bitmap.h>
+#endif
+
 #include "node_classes.h"  // Forward defintions of Node classes
 
 namespace pugi
@@ -71,9 +77,9 @@ public:
 
     wxImage GetImage(const ttlib::cstr& description);
 #if wxCHECK_VERSION(3, 1, 6)
-    wxBitmapBundle GetImageBundle(const ttlib::cstr& description);
+    wxBitmapBundle GetBitmapBundle(const ttlib::cstr& description, Node* node);
 #else
-    wxBitmap GetImageBundle(const ttlib::cstr& description);
+    wxBitmap GetBitmapBundle(const ttlib::cstr& description);
 #endif
 
     ProjectSettings* GetProjectSettings() { return m_pjtSettings; };

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -298,11 +298,20 @@ wxBitmap NodeProperty::as_bitmap() const
 #if wxCHECK_VERSION(3, 1, 6)
 wxBitmapBundle NodeProperty::as_bitmap_bundle() const
 {
-    auto bundle = wxGetApp().GetImageBundle(m_value);
+    auto bundle = wxGetApp().GetBitmapBundle(m_value, m_node);
     if (!bundle.IsOk())
         return wxNullBitmap;
     else
         return bundle;
+}
+
+const ImageBundle* NodeProperty::as_image_bundle() const
+{
+    auto bundle_ptr = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(m_value);
+    if (!bundle_ptr || !bundle_ptr->bundle.IsOk())
+        return nullptr;
+    else
+        return bundle_ptr;
 }
 #endif
 

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -7,7 +7,11 @@
 
 #pragma once
 
-#include <wx/bitmap.h>  // wxBitmap class interface
+#if wxCHECK_VERSION(3, 1, 6)
+    #include "image_bundle.h"  // Functions for working with wxBitmapBundle
+#else
+    #include <wx/bitmap.h>  // wxBitmap class interface
+#endif
 
 #include "font_prop.h"     // FontProperty class
 #include "node_classes.h"  // Forward defintions of Node classes
@@ -56,6 +60,7 @@ public:
 
 #if wxCHECK_VERSION(3, 1, 6)
     wxBitmapBundle as_bitmap_bundle() const;
+    const ImageBundle* as_image_bundle() const;
 #else
     wxBitmap as_bitmap_bundle() const { return as_bitmap(); }
 #endif

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -11,7 +11,11 @@
 #include <mutex>
 #include <thread>
 
-#include <wx/bitmap.h>
+#if wxCHECK_VERSION(3, 1, 6)
+    #include "image_bundle.h"  // Functions for working with wxBitmapBundle
+#else
+    #include <wx/bitmap.h>
+#endif
 
 class Node;
 class wxAnimation;
@@ -58,14 +62,24 @@ public:
     wxImage GetPropertyBitmap(const ttlib::cstr& description, bool want_scaled = true, bool check_image = true);
 
 #if wxCHECK_VERSION(3, 1, 6)
-    wxBitmapBundle GetPropertyBitmapBundle(const ttlib::cstr& description);
+    wxBitmapBundle GetPropertyBitmapBundle(const ttlib::cstr& description, Node* node);
+
+    // ImageBundle contains the filenames of each image in the bundle, needed to generate the
+    // code for the bundle.
+    const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description);
+
+    // This will finish any current thread and then launch a new thread to start collecting
+    // all the image bundles in the project (initializes m_bundles)
+    void ProjectSettings::ParseBundles();
+
+    ImageBundle* ProcessBundleProperty(const ttlib::cstr& description, Node* node);
 #endif
 
     // This takes the full animation property description and uses that to determine the image
     // to load. The image is cached for as long as the project is open.
     wxAnimation GetPropertyAnimation(const ttlib::cstr& description);
 
-    bool AddEmbeddedImage(ttlib::cstr path, Node* form);
+    bool AddEmbeddedImage(ttlib::cstr path, Node* form, bool is_animation = false);
     EmbededImage* GetEmbeddedImage(ttlib::sview path);
 
     // This will finish any current thread and then launch a new thread to start collecting
@@ -77,6 +91,17 @@ protected:
     void CollectEmbeddedImages();
     void CollectNodeImages(Node* node, Node* form);
 
+#if wxCHECK_VERSION(3, 1, 6)
+    void CollectBundles();
+    void CollectNodeBundles(Node* node, Node* form);
+    void AddNewEmbeddedBundle(const ttlib::cstr& description, ttlib::cstr path, Node* form);
+
+    // Reads the image and stores it in m_map_embedded
+    bool AddEmbeddedBundleImage(ttlib::cstr path, Node* form);
+#endif
+
+    bool AddNewEmbeddedImage(ttlib::cstr path, Node* form, std::unique_lock<std::mutex>& add_lock);
+
 private:
     ttlib::cstr m_projectFile;
     ttlib::cstr m_projectPath;
@@ -85,11 +110,16 @@ private:
     std::mutex m_mutex_embed_retrieve;
 
     std::map<std::string, wxImage> m_images;
-#if wxCHECK_VERSION(3, 1, 6)
-    std::map<std::string, wxBitmapBundle> m_bundles;
-#endif
 
     std::thread* m_collect_thread { nullptr };
+#if wxCHECK_VERSION(3, 1, 6)
+    std::mutex m_mutex_init_bundles;
+
+    std::map<std::string, ImageBundle> m_bundles;
+
+    bool m_cancel_collection { false };
+    std::thread* m_collect_bundle_thread { nullptr };
+#endif
 
     std::map<std::string, std::unique_ptr<EmbededImage>, std::less<>> m_map_embedded;
 


### PR DESCRIPTION
This fully implements reading multiple images marked as Embed:, XPM:, or
Header:, initializing the m_bundles and m_map_embedded maps.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR expands **wxBitmapBundle** support to include all of our supported image types. Note that this does _not_ complete the work needed to fully support **wxBitmapBundle**. This just adds the necessary code to create and store bundle information.

If an image name contains a `_16x16` suffix, then a check will also be made for the same base image name but with a `_24x24` suffix as well as a `_32x32` suffix.

If an image name contains a `_24x24` suffix, then a check will also be made for the same base image name but with a `_36x364` suffix as well as a `_48x48` suffix.

If neither of the above suffixes is specified, then a check will be made for both a `_1_5x` and `_2x` suffix -- and images with the same base name but with those suffixes will be added to the bundle.

Because of the higher complexity of creating bundles from multiple files, the thread for parsing all images will not allow any re-entry into bundles until the entire thread has completed. This is a change from the previous code, which would allow access to embedded images even while the thread was continuing to run.
