### PR TITLE
Imagelist

### DIFF
--- a/src/customprops/art_prop_dlg.cpp
+++ b/src/customprops/art_prop_dlg.cpp
@@ -42,27 +42,28 @@ ArtBrowserDialog::ArtBrowserDialog(wxWindow* parent, const ImageProperties& img_
 
 void ArtBrowserDialog::ChangeClient()
 {
-    auto img_list = new wxImageList(16, 16);
-    int index = 0;
-
+    // Save the current selection before all items are deleted. Restore the selection after the new items have been added.
     auto sel = m_list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
     if (sel < 0)
         sel = 0;
 
     m_list->DeleteAllItems();
+
+    int index = 0;
+    wxVector<wxBitmapBundle> bitmap_bundles;
     for (auto& iter: set_art_ids)
     {
-        auto bmp = wxArtProvider::GetBitmap(iter, wxART_MAKE_CLIENT_ID_FROM_STR(m_client), wxSize(16, 16));
-        if (bmp.IsOk())
+        if (auto bundle = wxArtProvider::GetBitmapBundle(iter, wxART_MAKE_CLIENT_ID_FROM_STR(m_client), wxSize(16, 16));
+            bundle.IsOk())
         {
-            m_list->InsertItem(index, iter, img_list->Add(bmp));
+            bitmap_bundles.push_back(bundle);
+            m_list->InsertItem(index, iter, static_cast<int>(bitmap_bundles.size() - 1));
             m_list->SetItemPtrData(index++, reinterpret_cast<wxUIntPtr>(iter.c_str()));
         }
     }
+    m_list->SetSmallImages(bitmap_bundles);
 
-    m_list->AssignImageList(img_list, wxIMAGE_LIST_SMALL);
     m_list->SetColumnWidth(0, wxLIST_AUTOSIZE);
-
     m_list->SetItemState(sel, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
 }
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -208,7 +208,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_hover_color, "hover_color" },
     { prop_icon, "icon" },
     { prop_id, "id" },
-    { prop_image_size, "image_size" },
+    { prop_image_size, "image_size" },  // currently unused
     { prop_inactive_bitmap, "inactive_bitmap" },
     { prop_inc, "inc" },
     { prop_include_advanced, "include_advanced" },

--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -26,10 +26,6 @@
 
 #include "book_widgets.h"
 
-// These dimensions match the default size in containers.xml -- if you change them here, then you must also change every
-// "image_size" property in containers.xml. Doing so will break any project that has these values as the default, so you will
-// also need to do a project version increase and convert down-level projects. Bottom line: don't change these values!
-
 constexpr const int DEF_TAB_IMG_WIDTH = 16;
 constexpr const int DEF_TAB_IMG_HEIGHT = 16;
 
@@ -532,13 +528,6 @@ std::optional<ttlib::cstr> NotebookGenerator::GenEvents(NodeEvent* event, const 
 bool NotebookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/notebook.h>", set_src, set_hdr);
-    auto size = node->prop_as_wxSize(prop_bitmapsize);
-    if (size.x != -1 || size.y != -1)
-    {
-        InsertGeneratorInclude(node, "#include <wx/imaglist.h>", set_src, set_hdr);
-        InsertGeneratorInclude(node, "#include <wx/image.h>", set_src, set_hdr);
-    }
-
     if (node->HasValue(prop_persist_name))
     {
         set_src.insert("#include <wx/persist/bookctrl.h>");
@@ -619,13 +608,6 @@ std::optional<ttlib::cstr> AuiNotebookGenerator::GenEvents(NodeEvent* event, con
 bool AuiNotebookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/aui/auibook.h>", set_src, set_hdr);
-    auto size = node->prop_as_wxSize(prop_bitmapsize);
-    if (size.x != -1 || size.y != -1)
-    {
-        InsertGeneratorInclude(node, "#include <wx/imaglist.h>", set_src, set_hdr);
-        InsertGeneratorInclude(node, "#include <wx/image.h>", set_src, set_hdr);
-    }
-
     if (node->HasValue(prop_persist_name))
     {
         set_src.insert("#include <wx/persist/bookctrl.h>");
@@ -730,13 +712,6 @@ std::optional<ttlib::cstr> ListbookGenerator::GenEvents(NodeEvent* event, const 
 bool ListbookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/listbook.h>", set_src, set_hdr);
-    auto size = node->prop_as_wxSize(prop_bitmapsize);
-    if (size != wxDefaultSize)
-    {
-        InsertGeneratorInclude(node, "#include <wx/imaglist.h>", set_src, set_hdr);
-        InsertGeneratorInclude(node, "#include <wx/image.h>", set_src, set_hdr);
-    }
-
     if (node->HasValue(prop_persist_name))
     {
         set_src.insert("#include <wx/persist/bookctrl.h>");

--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   Book component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -752,38 +752,16 @@ wxObject* ToolbookGenerator::CreateMockup(Node* node, wxObject* parent)
     auto widget = new wxToolbook(wxStaticCast(parent, wxWindow), wxID_ANY, DlgPoint(parent, node, prop_pos),
                                  DlgSize(parent, node, prop_size), GetStyleInt(node));
 
-    // A toolbook always has images, so we can't use AddBookImageList
-
-    auto size = node->prop_as_wxSize(prop_bitmapsize);
-    if (size.GetWidth() == -1)
-    {
-        size.SetWidth(DEF_TAB_IMG_WIDTH);
-    }
-    if (size.GetHeight() == -1)
-    {
-        size.SetHeight(DEF_TAB_IMG_HEIGHT);
-    }
-
-    auto img_list = new wxImageList(size.x, size.y);
-
+    wxBookCtrlBase::Images bundle_list;
     for (size_t idx_child = 0; idx_child < node->GetChildCount(); ++idx_child)
     {
         if (node->GetChild(idx_child)->HasValue(prop_bitmap))
         {
-            auto img = wxGetApp().GetImage(node->GetChild(idx_child)->prop_as_string(prop_bitmap));
-            ASSERT(img.IsOk());
-            img_list->Add(img.Scale(size.x, size.y));
-        }
-        else
-        {
-            auto img = GetInternalImage("unknown");
-            ASSERT(img.IsOk());
-            img_list->Add(img.Scale(size.x, size.y));
+            bundle_list.push_back(node->GetChild(idx_child)->prop_as_wxBitmapBundle(prop_bitmap));
         }
     }
-
     auto book = wxStaticCast(widget, wxBookCtrlBase);
-    book->AssignImageList(img_list);
+    book->SetImages(bundle_list);
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
     widget->Bind(wxEVT_TOOLBOOK_PAGE_CHANGED, &ToolbookGenerator::OnPageChanged, this);

--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -26,9 +26,6 @@
 
 #include "book_widgets.h"
 
-constexpr const int DEF_TAB_IMG_WIDTH = 16;
-constexpr const int DEF_TAB_IMG_HEIGHT = 16;
-
 // Walks up the parent tree until it finds a Book and returns whether or not the book is
 // supposed to display images. This function will handle wxTreeBook with any depth of sub
 // pages.
@@ -40,8 +37,9 @@ static bool isBookHasImage(Node* node);
 
 static void AddBookImageList(Node* node_book, wxObject* widget);
 static void BookCtorAddImagelist(ttlib::cstr& code, Node* node);
-static void AddTreebookSubImages(Node* node, wxImageList* img_list, wxSize& size);
-static void AddTreebookImageCode(ttlib::cstr& code, Node* node, size_t& image_index, wxSize& size);
+static void AddTreebookSubImages(Node* node, wxImageList* img_list);
+static void AddTreebookSubImages(Node* node, wxBookCtrlBase::Images& bundle_list);
+static void AddTreebookImageCode(ttlib::cstr& code, Node* node, size_t& image_index);
 static int GetTreebookImageIndex(Node* node);
 
 //////////////////////////////////////////  BookPageGenerator  //////////////////////////////////////////
@@ -911,16 +909,26 @@ static void AddBookImageList(Node* node_book, wxObject* widget)
 {
     if (isBookDisplayImages(node_book) && isBookHasImage(node_book))
     {
-        auto size = node_book->prop_as_wxSize(prop_bitmapsize);
-        if (size.x == -1)
+#if 1
+        wxBookCtrlBase::Images bundle_list;
+        for (auto& child_node: node_book->GetChildNodePtrs())
         {
-            size.x = DEF_TAB_IMG_WIDTH;
+            if (child_node->HasValue(prop_bitmap))
+            {
+                bundle_list.push_back(child_node->prop_as_wxBitmapBundle(prop_bitmap));
+            }
+
+            if (node_book->isGen(gen_wxTreebook))
+            {
+                AddTreebookSubImages(child_node.get(), bundle_list);
+            }
         }
-        if (size.y == -1)
-        {
-            size.y = DEF_TAB_IMG_HEIGHT;
-        }
-        wxImageList* img_list = new wxImageList(size.x, size.y);
+        auto book = wxStaticCast(widget, wxBookCtrlBase);
+        book->SetImages(bundle_list);
+#else
+        // Don't remove this section -- we need to use it to compare with our code generation for pre-3.1.6 code
+
+        wxImageList* img_list = nullptr;
 
         for (auto& child_node: node_book->GetChildNodePtrs())
         {
@@ -928,17 +936,28 @@ static void AddBookImageList(Node* node_book, wxObject* widget)
             {
                 auto img = wxGetApp().GetImage(child_node->prop_as_string(prop_bitmap));
                 ASSERT(img.IsOk());
-                img_list->Add(img.Scale(size.x, size.y));
+                if (!img_list)
+                {
+                    img_list = new wxImageList(img.GetWidth(), img.GetHeight());
+                    img_list->Add(img);
+                }
+                else
+                {
+                    auto size = img_list->GetSize();
+                    // If the image is already the desired size, then Scale() will return immediately without doing anything
+                    img_list->Add(img.Scale(size.x, size.y));
+                }
             }
 
-            if (node_book->isGen(gen_wxTreebook))
+            if (node_book->isGen(gen_wxTreebook) && img_list)
             {
-                AddTreebookSubImages(child_node.get(), img_list, size);
+                AddTreebookSubImages(child_node.get(), img_list);
             }
         }
 
         auto book = wxStaticCast(widget, wxBookCtrlBase);
         book->AssignImageList(img_list);
+#endif
     }
 }
 
@@ -947,22 +966,12 @@ static void BookCtorAddImagelist(ttlib::cstr& code, Node* node)
     if ((node->prop_as_bool(prop_display_images) || node->isGen(gen_wxToolbook)) && isBookHasImage(node))
     {
         code.insert(0, "\t");
-        auto size = node->prop_as_wxSize(prop_bitmapsize);
-        if (size.x == -1)
-        {
-            size.x = DEF_TAB_IMG_WIDTH;
-        }
-        if (size.y == -1)
-        {
-            size.y = DEF_TAB_IMG_HEIGHT;
-        }
 
         // Enclose the code in braces to allow using "img_list" and "bmp" as variable names, as well as making the
         // code more readable.
 
         code << "\n\t{";
-        code << "\n\t\tauto img_list = new wxImageList(";
-        code << size.x << ", " << size.y << ");";
+        code << "\n\t\tauto img_list = new wxImageList;";
 
         size_t image_index = 0;
         for (auto& child_node: node->GetChildNodePtrs())
@@ -978,13 +987,13 @@ static void BookCtorAddImagelist(ttlib::cstr& code, Node* node)
                 code << "\n\t\timg_list->Add(img_" << image_index;
                 if (child_node->prop_as_string(prop_bitmap).is_sameprefix("Art;"))
                     code << ".ConvertToImage()";
-                code << ".Scale(" << size.x << ", " << size.y << "));";
+                code << ");";
                 ++image_index;
             }
             if (node->isGen(gen_wxTreebook))
             {
                 // This is a recursive function that will handle unlimited nesting
-                AddTreebookImageCode(code, child_node.get(), image_index, size);
+                AddTreebookImageCode(code, child_node.get(), image_index);
             }
         }
         code << "\n\t\t" << node->get_node_name() << "->AssignImageList(img_list);";
@@ -1031,8 +1040,11 @@ static bool isBookHasImage(Node* node)
     return false;
 }
 
-static void AddTreebookSubImages(Node* node, wxImageList* img_list, wxSize& size)
+static void AddTreebookSubImages(Node* node, wxImageList* img_list)
 {
+    if (!img_list)
+        return;
+
     for (auto& child_node: node->GetChildNodePtrs())
     {
         if (child_node->isGen(gen_BookPage))
@@ -1041,14 +1053,32 @@ static void AddTreebookSubImages(Node* node, wxImageList* img_list, wxSize& size
             {
                 auto img = wxGetApp().GetImage(child_node->prop_as_string(prop_bitmap));
                 ASSERT(img.IsOk());
+
+                auto size = img_list->GetSize();
+                // If the image is already the desired size, then Scale() will return immediately without doing anything
                 img_list->Add(img.Scale(size.x, size.y));
             }
-            AddTreebookSubImages(child_node.get(), img_list, size);
+            AddTreebookSubImages(child_node.get(), img_list);
         }
     }
 }
 
-static void AddTreebookImageCode(ttlib::cstr& code, Node* child_node, size_t& image_index, wxSize& size)
+static void AddTreebookSubImages(Node* node, wxBookCtrlBase::Images& bundle_list)
+{
+    for (auto& child_node: node->GetChildNodePtrs())
+    {
+        if (child_node->isGen(gen_BookPage))
+        {
+            if (child_node->HasValue(prop_bitmap))
+            {
+                bundle_list.push_back(child_node->prop_as_wxBitmapBundle(prop_bitmap));
+            }
+            AddTreebookSubImages(child_node.get(), bundle_list);
+        }
+    }
+}
+
+static void AddTreebookImageCode(ttlib::cstr& code, Node* child_node, size_t& image_index)
 {
     for (auto& grand_child: child_node->GetChildNodePtrs())
     {
@@ -1059,9 +1089,9 @@ static void AddTreebookImageCode(ttlib::cstr& code, Node* child_node, size_t& im
             code << "\n\t\timg_list->Add(img_" << image_index;
             if (grand_child->prop_as_string(prop_bitmap).is_sameprefix("Art;"))
                 code << ".ConvertToImage()";
-            code << ".Scale(" << size.x << ", " << size.y << "));";
+            code << ");";
             ++image_index;
-            AddTreebookImageCode(code, grand_child.get(), image_index, size);
+            AddTreebookImageCode(code, grand_child.get(), image_index);
         }
     }
 }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1701,7 +1701,9 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
                 {
                     for (auto& idx_image: bundle->lst_filenames)
                     {
-                        embedset.insert(ttlib::cstr() << "#include \"" << idx_image << "\"");
+                        ttlib::cstr path(idx_image);
+                        path.backslashestoforward();
+                        embedset.insert(ttlib::cstr() << "#include \"" << path << "\"");
                     }
                 }
 

--- a/src/xml/aui_xml.xml
+++ b/src/xml/aui_xml.xml
@@ -8,8 +8,6 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 		<property name="var_name" type="string">m_notebook</property>
 		<property name="display_images" type="bool"
 			help="If true, will display an image on the tab in addition to any text.">0</property>
-		<property name="image_size" type="wxSize"
-			help="All tab images will be scaled to this size.">16, 16</property>
 		<property name="persist_name" type="string"
 			help="If a name is specified, wxPersistenceManager will be used to save/restore the currently selected page." />
 		<property name="art_provider" type="option">

--- a/src/xml/books_xml.xml
+++ b/src/xml/books_xml.xml
@@ -34,8 +34,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<property name="var_name" type="string">m_listbook</property>
 		<property name="display_images" type="bool"
 			help="If true, will display an image on the tab in addition to any text.">0</property>
-		<property name="image_size" type="wxSize"
-			help="All tab images will be scaled to this size.">16, 16</property>
 		<property name="persist_name" type="string"
 			help="If a name is specified, wxPersistenceManager will be used to save/restore the currently selected page." />
 		<property name="style" type="option">
@@ -64,8 +62,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<property name="var_name" type="string">m_notebook</property>
 		<property name="display_images" type="bool"
 			help="If true, will display an image on the tab in addition to any text.">0</property>
-		<property name="image_size" type="wxSize"
-			help="All tab images will be scaled to this size.">16, 16</property>
 		<property name="persist_name" type="string"
 			help="If a name is specified, wxPersistenceManager will be used to save/restore the currently selected page." />
 		<property name="tab_position" type="option">
@@ -100,8 +96,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_toolbook</property>
-		<property name="image_size" type="wxSize"
-			help="All tool images will be scaled to this size.">16, 16</property>
 		<property name="style" type="bitlist">
 			<option name="wxTBK_HORZ_LAYOUT"
 				help="Shows the text and the icons alongside, not vertically stacked (only implement under Windows and GTK 2 platforms as it relies on wxTB_HORZ_LAYOUT flag support)." />
@@ -119,8 +113,6 @@ inline const char* books_xml = R"===(<?xml version="1.0"?>
 		<property name="var_name" type="string">m_treebook</property>
 		<property name="display_images" type="bool"
 			help="If true, will display an image on the tab in addition to any text.">0</property>
-		<property name="image_size" type="wxSize"
-			help="All tab images will be scaled to this size.">16, 16</property>
 		<property name="persist_name" type="string"
 			help="If a name is specified, wxPersistenceManager will be used to save/restore the currently selected page and the expand/collapse state of sub pages." />
 		<property name="tab_position" type="option">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR switches the Mockup code to use wxBitmapBundle instead of wxImageList for displaying Books. It removes the `image_size` property from books and the call to Scale() in the code generation. Previously, all images were forced to 16x16, this change will allow images of any size.

Because the call to .Scale() was removed, all images _must_ be the same size. If not, the Mockup will display correctly, but the users generated code will not. This is because wxBitmapBundle can handle images of different sizes, but wxImageList cannot. See issue #692. This will need to be fixed when the code generation is updated to handle wxBitmapBundle.