### PR TITLE
Reduce SVG image size

### DIFF
--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -21,6 +21,7 @@ using namespace wxue_img;
 
 #include "bitmaps.h"      // Contains various images handling functions
 #include "mainapp.h"      // Main application class
+#include "mainframe.h"    // MainFrame -- Main window frame
 #include "node.h"         // Node -- Node class
 #include "pjtsettings.h"  // ProjectSettings -- Hold data for currently loaded project
 #include "utils.h"        // Utility functions that work with properties
@@ -120,10 +121,14 @@ void PropertyGrid_Image::RefreshChildren()
                 }
                 else
                 {
-                    auto img = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(m_img_props.CombineValues());
-                    if (img->bundle.IsOk())
+                    if (auto img = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(m_img_props.CombineValues(),
+                                                                                           wxGetFrame().GetSelectedNode());
+                        img)
                     {
-                        bundle = img->bundle;
+                        if (img->bundle.IsOk())
+                        {
+                            bundle = img->bundle;
+                        }
                     }
                 }
             }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -315,7 +315,7 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
 
     thrd_collect_img_headers.join();
     std::sort(m_embedded_images.begin(), m_embedded_images.end(),
-              [](const EmbededImage* a, const EmbededImage* b)
+              [](const EmbeddedImage* a, const EmbeddedImage* b)
               {
                   return (a->array_name.compare(b->array_name) < 0);
               });

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -18,7 +18,7 @@ class NodeCreator;
 class WriteCode;
 class wxWindow;
 
-struct EmbededImage;
+struct EmbeddedImage;
 
 using EventVector = std::vector<NodeEvent*>;
 
@@ -143,7 +143,7 @@ private:
     ttlib::cstr m_baseFullPath;
     EventVector m_CtxMenuEvents;
 
-    std::vector<const EmbededImage*> m_embedded_images;
+    std::vector<const EmbeddedImage*> m_embedded_images;
     std::set<wxBitmapType> m_type_generated;
 
     Node* m_form_node;

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -25,7 +25,7 @@
 #include "utils.h"        // Utility functions that work with properties
 
 bool isConvertibleMime(const ttString& suffix);  // declared in embedimg.cpp
-wxBitmapBundle LoadSVG(EmbededImage* embed);
+wxBitmapBundle LoadSVG(EmbeddedImage* embed);
 
 void ProjectSettings::CollectBundles()
 {
@@ -263,7 +263,7 @@ static bool CopyStreamData(wxInputStream* inputStream, wxOutputStream* outputStr
     return true;
 }
 
-wxBitmapBundle LoadSVG(EmbededImage* embed)
+wxBitmapBundle LoadSVG(EmbeddedImage* embed)
 {
     size_t org_size = (embed->array_size >> 32);
     auto str = std::make_unique<char[]>(org_size);
@@ -302,7 +302,7 @@ bool ProjectSettings::AddEmbeddedBundleImage(ttlib::cstr path, Node* form)
 
         wxMemoryOutputStream memory_stream;
         wxZlibOutputStream save_strem(memory_stream, wxZ_BEST_COMPRESSION);
-        m_map_embedded[path.filename().c_str()] = std::make_unique<EmbededImage>();
+        m_map_embedded[path.filename().c_str()] = std::make_unique<EmbeddedImage>();
         auto embed = m_map_embedded[path.filename().c_str()].get();
         embed->array_name = path.filename();
         embed->array_name.Replace(".", "_", true);
@@ -341,7 +341,7 @@ bool ProjectSettings::AddEmbeddedBundleImage(ttlib::cstr path, Node* form)
             wxImage image;
             if (handler->LoadFile(&image, stream))
             {
-                m_map_embedded[path.filename().c_str()] = std::make_unique<EmbededImage>();
+                m_map_embedded[path.filename().c_str()] = std::make_unique<EmbeddedImage>();
                 auto embed = m_map_embedded[path.filename().c_str()].get();
                 embed->array_name = path.filename();
                 embed->array_name.Replace(".", "_", true);

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -354,7 +354,7 @@ bool ProjectSettings::AddNewEmbeddedImage(ttlib::cstr path, Node* form, std::uni
             wxImage image;
             if (handler->LoadFile(&image, stream))
             {
-                m_map_embedded[path.filename().c_str()] = std::make_unique<EmbededImage>();
+                m_map_embedded[path.filename().c_str()] = std::make_unique<EmbeddedImage>();
                 auto embed = m_map_embedded[path.filename().c_str()].get();
                 embed->array_name = path.filename();
                 embed->array_name.Replace(".", "_", true);
@@ -422,7 +422,7 @@ bool ProjectSettings::AddNewEmbeddedImage(ttlib::cstr path, Node* form, std::uni
     return false;
 }
 
-EmbededImage* ProjectSettings::GetEmbeddedImage(ttlib::sview path)
+EmbeddedImage* ProjectSettings::GetEmbeddedImage(ttlib::sview path)
 {
     std::unique_lock<std::mutex> add_lock(m_mutex_embed_add);
 

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -188,11 +188,15 @@ wxBitmapBundle ProjectSettings::GetPropertyBitmapBundle(const ttlib::cstr& descr
     return GetInternalImage("unknown");
 }
 
-const ImageBundle* ProjectSettings::GetPropertyImageBundle(const ttlib::cstr& description)
+const ImageBundle* ProjectSettings::GetPropertyImageBundle(const ttlib::cstr& description, Node* node)
 {
     if (auto result = m_bundles.find(description); result != m_bundles.end())
     {
         return &result->second;
+    }
+    else if (node)
+    {
+        return ProcessBundleProperty(description, node);
     }
     else
     {

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -59,7 +59,7 @@ public:
 
     // ImageBundle contains the filenames of each image in the bundle, needed to generate the
     // code for the bundle.
-    const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description);
+    const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description, Node* node = nullptr);
 
     ImageBundle* ProcessBundleProperty(const ttlib::cstr& description, Node* node);
 

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -21,6 +21,8 @@ struct EmbeddedImage
     Node* form;  // the form node the image is declared in
     ttlib::cstr array_name;
     size_t array_size;
+    int size_x { 16 };  // currently x and y are only used for SVG images
+    int size_y { 16 };
     std::unique_ptr<unsigned char[]> array_data;
     wxBitmapType type;
 };
@@ -80,6 +82,9 @@ protected:
 
     // Reads the image and stores it in m_map_embedded
     bool AddEmbeddedBundleImage(ttlib::cstr path, Node* form);
+
+    // Reads the image and stores it in m_map_embedded
+    bool AddSvgBundleImage(const ttlib::cstr& description, ttlib::cstr path, Node* form);
 
     bool AddNewEmbeddedImage(ttlib::cstr path, Node* form, std::unique_lock<std::mutex>& add_lock);
 

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -16,7 +16,7 @@
 class Node;
 class wxAnimation;
 
-struct EmbededImage
+struct EmbeddedImage
 {
     Node* form;  // the form node the image is declared in
     ttlib::cstr array_name;
@@ -66,7 +66,7 @@ public:
     wxAnimation GetPropertyAnimation(const ttlib::cstr& description);
 
     bool AddEmbeddedImage(ttlib::cstr path, Node* form, bool is_animation = false);
-    EmbededImage* GetEmbeddedImage(ttlib::sview path);
+    EmbeddedImage* GetEmbeddedImage(ttlib::sview path);
 
     // This will collect bundles for the entire project -- it initializes
     // std::map<std::string, ImageBundle> m_bundles for every image.
@@ -96,5 +96,5 @@ private:
     std::map<std::string, ImageBundle> m_bundles;
 
     // std::string is parts[IndexImage].filename()
-    std::map<std::string, std::unique_ptr<EmbededImage>, std::less<>> m_map_embedded;
+    std::map<std::string, std::unique_ptr<EmbeddedImage>, std::less<>> m_map_embedded;
 };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how SVG images are loaded. Instead of using wxBitmapBundle::FromSVGFile, the code now uses pugixml to load and parse the file. It then strips out information that isn't needed, and writes the entire file to a single string, removing any line breaks and leading whitespace. Next it compresses the string using wxZlibOutputStream and then stores the data into the embedded images array. Converting the compressed data is done by using wxZlibInputStream to decompress the data into a string and then calling wxBitmapBundle::FromSVG().

I tried this out on a couple of small **inkscape** files, and it reduced the file size by 80%, making the size only slightly larger than the same image as a PNG file.