### PR TITLE
Generate code for reading a compressed SVG image

### DIFF
--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -156,7 +156,10 @@ void PropertyGrid_Image::RefreshChildren()
 
     Item(IndexType)->SetValue(m_img_props.type.wx_str());
     Item(IndexImage)->SetValue(m_img_props.image.wx_str());
-    Item(IndexSize)->SetValue(m_img_props.CombineDefaultSize());
+    if (!m_isEmbeddedImage)
+    {
+        Item(IndexSize)->SetValue(m_img_props.CombineDefaultSize());
+    }
 }
 
 void PropertyGrid_Image::SetAutoComplete()

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -514,7 +514,7 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
                 }
                 m_source->writeLine();
                 ttlib::cstr code;
-                code.reserve(142);  // loosely based on a line length of 140
+                code.reserve(96);  // loosely based on a line length of 80
                 if (wxGetApp().GetCompilerVersion() != compiler_standard::c11)
                 {
                     code << "inline ";
@@ -529,8 +529,8 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
                 while (pos < max_pos)
                 {
                     code.clear();
-                    // Using 132 will generate lines up to 140 characters long (4 indent + max 3 chars for number + comma)
-                    for (; pos < max_pos && code.size() < 132; ++pos)
+                    // Using 72 will generate lines up to 80 characters long (4 indent + max 3 chars for number + comma)
+                    for (; pos < max_pos && code.size() < 72; ++pos)
                     {
                         code << static_cast<int>(iter_array->array_data[pos]) << ',';
                     }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -26,6 +26,12 @@
 #include "utils.h"         // Utility functions that work with properties
 #include "write_code.h"    // Write code to Scintilla or file
 
+// This determines the longest line when generating embedded images. Do *not* use constexpr for this -- at some point we may
+// want to allow the user to set maximum line length of all generated code, and if so, this will need to reflect the user's
+// preference.
+
+static int max_image_line_length { 125 };
+
 using namespace GenEnum;
 
 // clang-format off
@@ -514,7 +520,7 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
                 }
                 m_source->writeLine();
                 ttlib::cstr code;
-                code.reserve(96);  // loosely based on a line length of 80
+                code.reserve(max_image_line_length + 16);
                 if (wxGetApp().GetCompilerVersion() != compiler_standard::c11)
                 {
                     code << "inline ";
@@ -529,8 +535,8 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
                 while (pos < max_pos)
                 {
                     code.clear();
-                    // Using 72 will generate lines up to 80 characters long (4 indent + max 3 chars for number + comma)
-                    for (; pos < max_pos && code.size() < 72; ++pos)
+                    // -8 to account for 4 indent + max 3 chars for number + comma
+                    for (; pos < max_pos && code.size() < (max_image_line_length - 8); ++pos)
                     {
                         code << static_cast<int>(iter_array->array_data[pos]) << ',';
                     }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1793,6 +1793,11 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
 
                 // TODO: [KeyWorks - 03-12-2022] Need to support SVG images
             }
+            else
+            {
+                MSG_WARNING(ttlib::cstr("Unable to locate ") << iter.as_string())
+            }
+
         }
 
         else if (iter.type() == type_animation)

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -150,8 +150,11 @@ private:
 
     PANEL_TYPE m_panel_type { NOT_PANEL };
 
+    bool m_is_derived_class { true };
+
+    // These are also initialized whenever GenerateBaseClass() is called
     bool m_NeedArtProviderHeader { false };
     bool m_NeedHeaderFunction { false };
     bool m_NeedAnimationFunction { false };
-    bool m_is_derived_class { true };
+    bool m_NeedSVGFunction { false };
 };

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -62,7 +62,7 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
             m_bitmap->SetBitmap(bmp);
 
             ttlib::cstr info("Dimensions: ");
-            info << bmp.GetWidth() << "(w) x " << bmp.GetHeight() << "(w)  Bit depth: " << bmp.GetDepth();
+            info << bmp.GetWidth() << "(w) x " << bmp.GetHeight() << "(h)  Bit depth: " << bmp.GetDepth();
             m_text_info->SetLabel(info);
         }
     }

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -599,8 +599,9 @@ bool ProjectSettings::AddSvgBundleImage(const ttlib::cstr& description, ttlib::c
     {
         auto file_size = file_original.Length();
         ttlib::cstr size_comparison;
-        int percent = (100 - (100 / (file_size / compressed_size)));
-        size_comparison.Format("%s -- Original: %ku, compressed: %ku, %u percent", path.filename().c_str(), file_size, compressed_size, percent);
+        int percent = static_cast<int>(100 - (100 / (file_size / compressed_size)));
+        size_comparison.Format("%s -- Original: %ku, compressed: %ku, %u percent", path.filename().c_str(), file_size,
+                               compressed_size, percent);
         MSG_INFO(size_comparison)
     }
 #endif

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -40,6 +40,14 @@ void ProjectSettings::CollectBundles()
         {
             CollectNodeBundles(iter.get(), form);
         }
+
+        if (form->HasProp(prop_icon) && form->HasValue(prop_icon))
+        {
+            if (m_bundles.find(form->prop_as_string(prop_icon)) == m_bundles.end())
+            {
+                ProcessBundleProperty(form->prop_as_string(prop_icon), form);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability to generate the code necessary to read a compressed SVG image. The rest of the commits are primarly tweaks and bug fixes from testing on an actual app.