### PR TITLE
Code gen

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,48 @@
+# Images
+
+Most Windows applications store their images in the resource file which then gets linked into the executable. While **wxWidgets** does support reading these images, it only works on Windows, so you have to conditionalize the code if you want your app to be cross-platform. **wxUiEditor** takes a different approach. By default, when you specify an image file, that file will be converted into an unsigned character array, and placed into the first class source file that uses it. This allows the image to be compiled directly into your executable, which works on all platforms.
+
+# wxBitmapBundle
+
+**wxUiEditor** supports the **wxBitmapBundle** class introduced in **wxWidgets** 3.1.6. If your project settings specify a **wxWidgets** 3.1 version, then all bitmap code will be generated in conditionals so that it will use **wxBitmapBundle** if you compile with **wxWidgets** 3.1.6 or later, and the regular **wxImage/wxBitmap** code if you are compiling using an earlier version of **wxWidgets**.
+
+The exception to the above paragraph is if you specify a SVG file for a bitmap -- since these images require **wxWidgets** 3.1.6 or later, the entire class will be marked as requiring **wxWidgets** 3.1.6 or later (if you use 3.1 as your project wxWidgets library setting), and will not compile if you use an earlier version of **wxWidgets**.
+
+Multiple images will be added automatically if you using one of the following suffixes:
+
+```
+    basename + _1_5x
+    basename + @1_5x
+    basename + _2x
+    basename + @2x
+```
+
+Example:
+
+```
+    my_bitmap.png
+
+    // will also add the following if they exist
+
+    my_bitmap_1_5x.png
+    my_bitmap_2x.png
+```
+
+If the basename contains the suffix `_16x16` then a search will also be made for files with the suffix `_24x24` and `_32x32`. If the basename contains the suffix `_24x24`, then a search will also be made for files with the suffix `_36x36` and `_48x48`.
+
+Example:
+
+```
+    my_bitmap_16x16.png
+
+    // will also add the following if they exist
+
+    my_bitmap_24x24.png
+    my_bitmap_32x32.png
+```
+
+# SVG images
+
+Starting with **wxWidgets** 3.1.6, many SVG images can be used as bitmaps that will accuratele scale to any dimension. Support for SVG is somewhat limited, so it's generally a good idea to preview the image before you build you application execting the SVG images to work. If you are adding it to a control inside **wxUiEditor** you can simply check how it looks in the Mockup panel. Otherwise, you can use the Preview SVG command under the Tools menu to see what it looks at (this will also allow you to see it at different scaling sizes).
+
+When you specify an SVG file, **wxUiEdiutor** will read the file, strip out some content that **wxWidgets** won't use, compress it, and then store it as an unsigned character array in one of your source files. This will typically reduce the size of the image in your executable file by 80%. When your program runs, the generated code that displays the image will automatically decompress the data and pass it to **wxBitMapBundle**.

--- a/src/debugging/msg_logging.cpp
+++ b/src/debugging/msg_logging.cpp
@@ -249,7 +249,7 @@ void MsgLogging::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogR
 #if defined(_DEBUG)
 void MsgLogging::OnNodeSelected()
 {
-    if (m_msgFrame)
+    if (!m_bDestroyed && m_msgFrame)
     {
         m_msgFrame->OnNodeSelected();
     }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1477,6 +1477,7 @@ void BaseCodeGenerator::GenConstruction(Node* node)
 
     if (auto generator = declaration->GetGenerator(); generator)
     {
+        bool need_closing_brace = false;
         if (auto result = generator->GenConstruction(node); result)
         {
             // Don't add blank lines when adding tools to a toolbar
@@ -1490,6 +1491,10 @@ void BaseCodeGenerator::GenConstruction(Node* node)
                                                  ttlib::is_found(result.value().find("\n\t\t"))) ?
                                                     indent::none :
                                                     indent::auto_no_whitespace);
+            if (result.value().is_sameprefix("\t{"))
+            {
+                need_closing_brace = true;
+            }
         }
         GenSettings(node);
 
@@ -1533,6 +1538,10 @@ void BaseCodeGenerator::GenConstruction(Node* node)
                 }
                 else
                 {
+                    if (need_closing_brace)
+                    {
+                        code << "\t";
+                    }
                     code << node->GetParent()->get_node_name() << "->Add(" << node->get_node_name() << ", ";
                 }
 
@@ -1562,7 +1571,15 @@ void BaseCodeGenerator::GenConstruction(Node* node)
                 }
             }
 
-            m_source->writeLine(code);
+            if (need_closing_brace)
+            {
+                m_source->writeLine(code, indent::auto_keep_whitespace);
+                m_source->writeLine("\t}");
+            }
+            else
+            {
+                m_source->writeLine(code);
+            }
         }
         else if (parent->IsToolBar() && !node->isType(type_tool))
         {

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -77,6 +77,22 @@ void GenerateWindowSettings(Node* node, ttlib::cstr& code);
 ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description, bool is_bitmapbundle = false,
                                const ttlib::cstr* pDpiWindow = nullptr);
 
+// If a wxVector() is required to create the wxBitmapBundle, this will generate the opening
+// brace and the vector code and returns true with code filled in.
+//
+// Call this before calling GenerateBundleCode()
+bool GenerateVectorCode(const ttlib::cstr& description, ttlib::cstr& code);
+
+// Generates the code necessary to create a wxBitmapBundle used to pass as an argument to a
+// function.
+//
+// Returns "wxNullBitmap" if description is empty
+ttlib::cstr GenerateBundleCode(const ttlib::cstr& description);
+
+// If a wxVector() is required to create the wxBitmapBundle, this will generate the opening
+// brace and the vector code and returns true with code filled in.
+bool GenerateVectorCode(const ttlib::cstr& description, ttlib::cstr& code);
+
 ttlib::cstr GenEventCode(NodeEvent* event, const std::string& class_name);
 
 // Will generate "wxDefaultPosition" if prop_pos is -1;-1

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -89,10 +89,6 @@ bool GenerateVectorCode(const ttlib::cstr& description, ttlib::cstr& code);
 // Returns "wxNullBitmap" if description is empty
 ttlib::cstr GenerateBundleCode(const ttlib::cstr& description);
 
-// If a wxVector() is required to create the wxBitmapBundle, this will generate the opening
-// brace and the vector code and returns true with code filled in.
-bool GenerateVectorCode(const ttlib::cstr& description, ttlib::cstr& code);
-
 ttlib::cstr GenEventCode(NodeEvent* event, const std::string& class_name);
 
 // Will generate "wxDefaultPosition" if prop_pos is -1;-1

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -50,7 +50,7 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
             m_image_name->SetLabel(wxEmptyString);
         }
 
-        auto bmp = node->prop_as_wxBitmap(prop_bitmap);
+        auto bmp = node->prop_as_wxBitmapBundle(prop_bitmap);
         ASSERT(bmp.IsOk());
         if (!bmp.IsOk())
         {
@@ -60,9 +60,10 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
         else
         {
             m_bitmap->SetBitmap(bmp);
+            auto default_size = bmp.GetDefaultSize();
 
-            ttlib::cstr info("Dimensions: ");
-            info << bmp.GetWidth() << "(w) x " << bmp.GetHeight() << "(h)  Bit depth: " << bmp.GetDepth();
+            ttlib::cstr info("Default wxSize: ");
+            info << default_size.GetWidth() << " x " << default_size.GetHeight();
             m_text_info->SetLabel(info);
         }
     }

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Embedded images generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -14,9 +14,11 @@
 
 #include "images_form.h"
 
-#include "bitmaps.h"    // Contains various images handling functions
-#include "mainframe.h"  // MainFrame -- Main window frame
-#include "node.h"       // Node class
+#include "bitmaps.h"      // Contains various images handling functions
+#include "mainapp.h"      // compiler_standard -- Main application class
+#include "mainframe.h"    // MainFrame -- Main window frame
+#include "node.h"         // Node class
+#include "pjtsettings.h"  // ProjectSettings -- Hold data for currently loaded project
 
 #include "ui_images.h"
 
@@ -39,11 +41,29 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
     auto node = wxGetFrame().GetSelectedNode();
     if (node->isGen(gen_embedded_image))
     {
+        auto bundle = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(node->prop_as_string(prop_bitmap));
+
         ttlib::multiview mstr(node->prop_as_string(prop_bitmap), ';');
 
         if (mstr.size() > 1)
         {
-            m_image_name->SetLabel(mstr[1].wx_str());
+            if (bundle && bundle->lst_filenames.size())
+            {
+                ttlib::cstr list;
+                for (auto& iter: bundle->lst_filenames)
+                {
+                    if (list.size())
+                    {
+                        list << '\n';
+                    }
+                    list << iter;
+                }
+                m_image_name->SetLabel(list.wx_str());
+            }
+            else
+            {
+                m_image_name->SetLabel(mstr[1].wx_str());
+            }
         }
         else
         {

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -367,30 +367,86 @@ wxObject* StaticBitmapGenerator::CreateMockup(Node* node, wxObject* parent)
 std::optional<ttlib::cstr> StaticBitmapGenerator::GenConstruction(Node* node)
 {
     ttlib::cstr code;
-    if (node->IsLocal())
-        code << "auto ";
-
-    bool use_generic_version = (node->prop_as_string(prop_scale_mode) != "None");
-    if (use_generic_version)
-        code << node->get_node_name() << " = new wxGenericStaticBitmap(";
-    else
-        code << node->get_node_name() << " = new wxStaticBitmap(";
-
-    code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", ";
     if (node->HasValue(prop_bitmap))
     {
-        if (use_generic_version)
+        auto& description = node->prop_as_string(prop_bitmap);
+        bool is_vector_code = GenerateVectorCode(description, code);
+
+        if (is_vector_code)
         {
-            // wxGenericStaticBitmap expects a wxBitmap, so it's fine to pass it a wxImage
-            code << GenerateBitmapCode(node->prop_as_string(prop_bitmap), true);
+            code << "\t\t";
+        }
+
+        if (node->IsLocal())
+            code << "auto ";
+
+        bool use_generic_version = (node->prop_as_string(prop_scale_mode) != "None");
+        if (use_generic_version)
+            code << node->get_node_name() << " = new wxGenericStaticBitmap(";
+        else
+            code << node->get_node_name() << " = new wxStaticBitmap(";
+
+        code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", ";
+
+        if (!is_vector_code)
+        {
+            if (wxGetProject().prop_as_string(prop_wxWidgets_version) != "3.1")
+            {
+                code << GenerateBundleCode(description);
+            }
+            else
+            {
+                if (wxGetProject().prop_as_string(prop_wxWidgets_version) == "3.1")
+                {
+                    code.insert(0, "\t");
+                    code << "\n#if wxCHECK_VERSION(3, 1, 6)\n\t\t";
+                    code << GenerateBundleCode(description);
+                    GeneratePosSizeFlags(node, code);
+                }
+
+                code << "\n#else\n\t\t";
+                if (use_generic_version)
+                {
+                    // wxGenericStaticBitmap expects a wxBitmap, so it's fine to pass it a wxImage
+                    code << GenerateBitmapCode(description, true);
+                }
+                else
+                {
+                    // wxStaticBitmap requires a wxGDIImage for the bitmap, and that won't accept a wxImage.
+                    code << "wxBitmap(" << GenerateBitmapCode(description) << ")";
+                }
+                GeneratePosSizeFlags(node, code);
+                code << "\n#endif";
+                return code;
+            }
         }
         else
         {
-            // REVIEW: [KeyWorks - 02-25-2022] GenerateBitmapCode may return a wxBitmapBundle under 3.1.6, so if that's the
-            // case, we can't had it to a wxBitmap.
+            if (wxGetProject().prop_as_string(prop_wxWidgets_version) != "3.1")
+            {
+                code << "wxBitmapBundle::FromBitmaps(bitmaps)";
+            }
+            else
+            {
+                code << "\n#if wxCHECK_VERSION(3, 1, 6)\n\t\t\t";
+                code << "wxBitmapBundle::FromBitmaps(bitmaps)";
+                GeneratePosSizeFlags(node, code);
 
-            // wxStaticBitmap requires a wxGDIImage for the bitmap, and that won't accept a wxImage.
-            code << "wxBitmap(" << GenerateBitmapCode(node->prop_as_string(prop_bitmap)) << ")";
+                code << "\n#else\n\t\t\t";
+                if (use_generic_version)
+                {
+                    // wxGenericStaticBitmap expects a wxBitmap, so it's fine to pass it a wxImage
+                    code << GenerateBitmapCode(description, true);
+                }
+                else
+                {
+                    // wxStaticBitmap requires a wxGDIImage for the bitmap, and that won't accept a wxImage.
+                    code << "wxBitmap(" << GenerateBitmapCode(description) << ")";
+                }
+                GeneratePosSizeFlags(node, code);
+                code << "\n#endif";
+                return code;
+            }
         }
     }
     else

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -33,6 +33,8 @@
 const char* suffixes[] = {
     "_1_5x",
     "_2x",
+    "@1_5x",
+    "@2x",
 };
 
 bool isConvertibleMime(const ttString& suffix);  // declared in embedimg.cpp
@@ -312,8 +314,7 @@ bool ProjectSettings::AddEmbeddedBundleImage(ttlib::cstr path, Node* form)
             {
                 m_map_embedded[path.filename().c_str()] = std::make_unique<EmbeddedImage>();
                 auto embed = m_map_embedded[path.filename().c_str()].get();
-                embed->array_name = path.filename();
-                embed->array_name.Replace(".", "_", true);
+                InitializeArrayName(embed, path.filename());
                 embed->form = form;
 
                 // If possible, convert the file to a PNG -- even if the original file is a PNG, since we might end up with
@@ -573,8 +574,7 @@ bool ProjectSettings::AddSvgBundleImage(const ttlib::cstr& description, ttlib::c
     wxZlibOutputStream save_strem(memory_stream, wxZ_BEST_COMPRESSION);
     m_map_embedded[path.filename().c_str()] = std::make_unique<EmbeddedImage>();
     auto embed = m_map_embedded[path.filename().c_str()].get();
-    embed->array_name = path.filename();
-    embed->array_name.Replace(".", "_", true);
+    InitializeArrayName(embed, path.filename());
     embed->form = form;
 
     size_t org_size = (stream.GetLength() & 0xFFFFFFFF);

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -34,6 +34,7 @@
 #include "node_decl.h"       // NodeDeclaration class
 #include "node_prop.h"       // NodeProperty -- NodeProperty class
 #include "paths.h"           // Handles *_directory properties
+#include "pjtsettings.h"     // ProjectSettings -- Hold data for currently loaded project
 #include "prop_decl.h"       // PropChildDeclaration and PropDeclaration classes
 #include "utils.h"           // Utility functions that work with properties
 
@@ -1089,7 +1090,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                 else
                 {
                     // This ensures that all images from a bitmap bundle get added
-                    wxGetApp().GetBitmapBundle(value, prop->GetNode());
+                    wxGetApp().GetProjectSettings()->UpdateBundle(value, prop->GetNode());
                 }
 
                 modifyProperty(prop, value);

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1083,7 +1083,15 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                 ttlib::multistr parts(value, BMP_PROP_SEPARATOR);
                 // If the image field is empty, then the entire property needs to be cleared
                 if (parts.size() > IndexImage && parts[IndexImage].empty())
+                {
                     value.clear();
+                }
+                else
+                {
+                    // This ensures that all images from a bitmap bundle get added
+                    wxGetApp().GetBitmapBundle(value, prop->GetNode());
+                }
+
                 modifyProperty(prop, value);
             }
             break;

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -63,6 +63,9 @@ public:
 
     ImageBundle* ProcessBundleProperty(const ttlib::cstr& description, Node* node);
 
+    // This adds the bundle if new, or updates the embed->form if the node has changed
+    void UpdateBundle(const ttlib::cstr& description, Node* node);
+
     // This takes the full animation property description and uses that to determine the image
     // to load. The image is cached for as long as the project is open.
     wxAnimation GetPropertyAnimation(const ttlib::cstr& description);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates the Image file to correctly add all sub-bitmap files so that the code for them will be generated in this file rather than other form files. It also now generates the code for creating bitmap bundles when there are three files used (requires using a wxVector).
