### PR TITLE
Finish using wxBitmapBundle instead of wxBitmap

### DIFF
--- a/src/generate/btn_widgets.cpp
+++ b/src/generate/btn_widgets.cpp
@@ -443,16 +443,16 @@ wxObject* CommandLinkBtnGenerator::CreateMockup(Node* node, wxObject* parent)
         widget->SetBitmap(node->prop_as_wxBitmapBundle(prop_bitmap));
 
         if (node->HasValue(prop_disabled_bmp))
-            widget->SetBitmapDisabled(node->prop_as_wxBitmap(prop_disabled_bmp));
+            widget->SetBitmapDisabled(node->prop_as_wxBitmapBundle(prop_disabled_bmp));
 
         if (node->HasValue(prop_pressed_bmp))
-            widget->SetBitmapPressed(node->prop_as_wxBitmap(prop_pressed_bmp));
+            widget->SetBitmapPressed(node->prop_as_wxBitmapBundle(prop_pressed_bmp));
 
         if (node->HasValue(prop_focus_bmp))
-            widget->SetBitmapFocus(node->prop_as_wxBitmap(prop_focus_bmp));
+            widget->SetBitmapFocus(node->prop_as_wxBitmapBundle(prop_focus_bmp));
 
         if (node->HasValue(prop_current))
-            widget->SetBitmapCurrent(node->prop_as_wxBitmap(prop_current));
+            widget->SetBitmapCurrent(node->prop_as_wxBitmapBundle(prop_current));
     }
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -124,23 +124,22 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
 
             if (menu_item->HasValue(prop_bitmap))
             {
-                wxBitmap unchecked = wxNullBitmap;
+#ifdef __WXMSW__
                 if (menu_item->HasValue(prop_unchecked_bitmap))
                 {
-                    unchecked = menu_item->prop_as_wxBitmap(prop_unchecked_bitmap);
+                    auto unchecked = menu_item->prop_as_wxBitmapBundle(prop_unchecked_bitmap);
+                    item->SetBitmaps(menu_item->prop_as_wxBitmapBundle(prop_bitmap), unchecked);
                 }
-#ifdef __WXMSW__
-                item->SetBitmaps(menu_item->prop_as_wxBitmapBundle(prop_bitmap), unchecked);
-#else
-                item->SetBitmap(menu_item->prop_as_wxBitmapBundle(prop_bitmap));
+                else
 #endif
+                    item->SetBitmap(menu_item->prop_as_wxBitmapBundle(prop_bitmap));
             }
 #ifdef __WXMSW__
             else
             {
                 if (menu_item->HasValue(prop_unchecked_bitmap))
                 {
-                    item->SetBitmaps(wxNullBitmap, menu_item->prop_as_wxBitmap(prop_unchecked_bitmap));
+                    item->SetBitmaps(wxNullBitmap, menu_item->prop_as_wxBitmapBundle(prop_unchecked_bitmap));
                 }
             }
 #endif

--- a/src/generate/ribbon_widgets.cpp
+++ b/src/generate/ribbon_widgets.cpp
@@ -193,7 +193,7 @@ bool RibbonBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 wxObject* RibbonPageGenerator::CreateMockup(Node* node, wxObject* parent)
 {
     auto bmp = node->HasValue(prop_bitmap) ? node->prop_as_wxBitmap(prop_bitmap) : wxNullBitmap;
-    // REVIEW: [KeyWorks - 02-25-2022] This is still a bitmap rather then a bundle as of 2/25/22
+    // REVIEW: This is still a bitmap rather then a bundle as of the 3.1.6 release
     auto widget = new wxRibbonPage((wxRibbonBar*) parent, wxID_ANY, node->prop_as_wxString(prop_label), bmp, 0);
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);
@@ -337,6 +337,7 @@ void RibbonButtonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxp
         if (!bmp.IsOk())
             bmp = GetInternalImage("default");
 
+        // REVIEW: This is still a bitmap rather then a bundle as of the 3.1.6 release
         btn_bar->AddButton(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, childObj->prop_as_wxString(prop_help),
                            (wxRibbonButtonKind) childObj->prop_as_int(prop_kind));
     }
@@ -440,6 +441,7 @@ void RibbonToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpar
             auto bmp = childObj->prop_as_wxBitmap(prop_bitmap);
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
+            // REVIEW: This is still a bitmap rather then a bundle as of the 3.1.6 release
             btn_bar->AddTool(wxID_ANY, bmp, childObj->prop_as_wxString(prop_help),
                              (wxRibbonButtonKind) childObj->prop_as_int(prop_kind));
         }
@@ -559,6 +561,7 @@ void RibbonGalleryGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpar
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
 
+            // REVIEW: This is still a bitmap rather then a bundle as of the 3.1.6 release
             gallery->Append(bmp, wxID_ANY);
         }
     }

--- a/src/mockup/mockup_wizard.cpp
+++ b/src/mockup/mockup_wizard.cpp
@@ -46,7 +46,8 @@ void MockupWizard::CreateBmpPageRow()
 
     if (m_wizard_node->HasValue(prop_bitmap))
     {
-        m_bitmap = m_wizard_node->prop_as_wxBitmap(prop_bitmap);
+        auto bundle = m_wizard_node->prop_as_wxBitmapBundle(prop_bitmap);
+        m_bitmap = bundle.GetBitmap(bundle.GetPreferredBitmapSizeFor(this));
         if (m_bitmap.IsOk())
         {
             wxSize bmp_size(wxDefaultSize);
@@ -302,5 +303,8 @@ bool MockupWizard::ResizeBitmap(wxBitmap& bmp)
 MockupWizardPage::MockupWizardPage(Node* node, wxObject* parent) : wxPanel(wxStaticCast(parent, wxWindow))
 {
     if (node->HasValue(prop_bitmap))
-        m_bitmap = node->prop_as_wxBitmap(prop_bitmap);
+    {
+        auto bundle = node->prop_as_wxBitmapBundle(prop_bitmap);
+        m_bitmap = bundle.GetBitmap(bundle.GetPreferredBitmapSizeFor(this));
+    }
 }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -380,6 +380,7 @@ wxAnimation Node::prop_as_wxAnimation(PropName name) const
         return wxNullAnimation;
 }
 
+// This is still required, even for 3.1.6 since wxRibbon pages still use bitmaps instead of bundles
 wxBitmap Node::prop_as_wxBitmap(PropName name) const
 {
     if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Now supported by everything that wxWidgets supports (wxRibbon still uses wxBitmap).