### PR TITLE
Update Image property

### DIFF
--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -7,10 +7,11 @@
 
 #include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
 
-#include "img_props.h"  // ImageProperties
-#include "mainapp.h"    // App -- Main application class
-#include "node.h"       // Node -- Node class
-#include "utils.h"      // Utility functions that work with properties
+#include "img_props.h"    // ImageProperties
+#include "mainapp.h"      // App -- Main application class
+#include "node.h"         // Node -- Node class
+#include "pjtsettings.h"  // ProjectSettings -- Hold data for currently loaded project
+#include "utils.h"        // Utility functions that work with properties
 
 void ImageProperties::InitValues(const char* value)
 {
@@ -31,8 +32,16 @@ void ImageProperties::InitValues(const char* value)
         }
         else
         {
-            m_size.x = -1;
-            m_size.y = -1;
+            auto img_bundle = wxGetApp().GetPropertyImageBundle(value);
+            if (img_bundle)
+            {
+                m_size = img_bundle->bundle.GetDefaultSize();
+            }
+            else
+            {
+                m_size.x = -1;
+                m_size.y = -1;
+            }
         }
     }
 }
@@ -54,10 +63,10 @@ ttlib::cstr ImageProperties::CombineValues()
     }
 
     ttlib::cstr value;
-
-    // REVIEW: [KeyWorks - 03-11-2022] Why are we still adding the size? That's only used for SVG images.
-
-    value << type << ';' << image << ";[" << m_size.x << ',' << m_size.y << "]";
+    image.backslashestoforward();
+    value << type << ';' << image;
+    if (type == "SVG")
+        value << ";[" << m_size.x << ',' << m_size.y << "]";
     return value;
 }
 

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -61,11 +61,8 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
     AddPrivateChild(new wxEnumProperty("type", wxPG_LABEL, types, 0));
     AddPrivateChild(new ImageStringProperty("image", m_img_props));
 
-    if (!m_isEmbeddedImage)
-    {
-        AddPrivateChild(new CustomPointProperty("default size for SVG", prop, CustomPointProperty::type_SVG));
-        Item(IndexSize)->SetHelpString("Sets the default size to pass to wxBitmapBundle. Only used by SVG files.");
-    }
+    AddPrivateChild(new CustomPointProperty("Size", prop, CustomPointProperty::type_SVG));
+    Item(IndexSize)->SetHelpString("Default size -- ignored unless it's a SVG file.");
 }
 
 void PropertyGrid_Image::RefreshChildren()
@@ -156,10 +153,7 @@ void PropertyGrid_Image::RefreshChildren()
 
     Item(IndexType)->SetValue(m_img_props.type.wx_str());
     Item(IndexImage)->SetValue(m_img_props.image.wx_str());
-    if (!m_isEmbeddedImage)
-    {
-        Item(IndexSize)->SetValue(m_img_props.CombineDefaultSize());
-    }
+    Item(IndexSize)->SetValue(m_img_props.CombineDefaultSize());
 }
 
 void PropertyGrid_Image::SetAutoComplete()
@@ -263,7 +257,6 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
             break;
 
         case IndexSize:
-            if (img_props.type == "SVG")
             {
                 auto u8_value = childValue.GetString().utf8_string();
                 ttlib::multiview mstr(u8_value, ',');

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -42,7 +42,7 @@ wxBitmapBundle LoadSVG(EmbeddedImage* embed);
 
 inline ttlib::cstr ConvertToLookup(const ttlib::cstr& description)
 {
-    ttlib::multistr parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
+    ttlib::multiview parts(description, ';', tt::TRIM::both);
     ASSERT(parts.size() > 1)
 
     ttlib::cstr lookup_str;

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -268,6 +268,11 @@ wxBitmapBundle App::GetBitmapBundle(const ttlib::cstr& description, Node* node)
         return GetInternalImage("unknown");
 }
 
+const ImageBundle* App::GetPropertyImageBundle(const ttlib::cstr& description, Node* node)
+{
+    return m_pjtSettings->GetPropertyImageBundle(description, node);
+}
+
 ttString App::GetArtDirectory()
 {
     if (m_project->HasValue(prop_art_directory))

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -21,6 +21,7 @@ namespace pugi
 class MainFrame;
 class ProjectSettings;
 class ImportXML;
+struct ImageBundle;
 
 // Current version of wxUiEditor project files
 constexpr const auto curWxuiMajorVer = 1;
@@ -62,6 +63,7 @@ public:
 
     wxImage GetImage(const ttlib::cstr& description);
     wxBitmapBundle GetBitmapBundle(const ttlib::cstr& description, Node* node);
+    const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description, Node* node = nullptr);
 
     ProjectSettings* GetProjectSettings() { return m_pjtSettings; };
 

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -185,7 +185,13 @@ wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool 
 
 void ProjectSettings::UpdateBundle(const ttlib::cstr& description, Node* node)
 {
-    auto lookup_str = ConvertToLookup(description);
+    ttlib::multiview parts(description, ';', tt::TRIM::both);
+    if (parts.size() < 2)
+        return;
+
+    ttlib::cstr lookup_str;
+    lookup_str << parts[0] << ';' << parts[1].filename();
+
     auto result = m_bundles.find(lookup_str);
     if (result == m_bundles.end())
     {
@@ -217,6 +223,15 @@ void ProjectSettings::UpdateBundle(const ttlib::cstr& description, Node* node)
 
 wxBitmapBundle ProjectSettings::GetPropertyBitmapBundle(const ttlib::cstr& description, Node* node)
 {
+    ttlib::multiview parts(description, ';', tt::TRIM::both);
+    if (parts.size() < 2)
+    {
+        return GetInternalImage("unknown");
+    }
+
+    ttlib::cstr lookup_str;
+    lookup_str << parts[0] << ';' << parts[1].filename();
+
     if (auto result = m_bundles.find(ConvertToLookup(description)); result != m_bundles.end())
     {
         return result->second.bundle;
@@ -232,7 +247,16 @@ wxBitmapBundle ProjectSettings::GetPropertyBitmapBundle(const ttlib::cstr& descr
 
 const ImageBundle* ProjectSettings::GetPropertyImageBundle(const ttlib::cstr& description, Node* node)
 {
-    if (auto result = m_bundles.find(ConvertToLookup(description)); result != m_bundles.end())
+    ttlib::multiview parts(description, ';', tt::TRIM::both);
+    if (parts.size() < 2)
+    {
+        return nullptr;
+    }
+
+    ttlib::cstr lookup_str;
+    lookup_str << parts[0] << ';' << parts[1].filename();
+
+    if (auto result = m_bundles.find(lookup_str); result != m_bundles.end())
     {
         return &result->second;
     }

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -302,6 +302,24 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
                             }
                             break;
 
+                        case type_image:
+                            {
+                                ttlib::multistr parts(iter.value(), ';', tt::TRIM::both);
+                                if (parts.size() < 3)
+                                {
+                                    prop->set_value(iter.value());
+                                }
+                                else
+                                {
+                                    parts[1].backslashestoforward();
+                                    ttlib::cstr description(parts[0]);
+                                    description << ';' << parts[1];
+                                    if (parts[0].is_sameprefix("SVG"))
+                                        description << ';' << parts[2];
+                                    prop->set_value(description);
+                                }
+                            }
+
                         default:
                             prop->set_value(iter.value());
                     }

--- a/src/project/saveproject.cpp
+++ b/src/project/saveproject.cpp
@@ -1,9 +1,11 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   Save a wxUiEditor project file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
+
+#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
 
 #include "mainapp.h"    // App -- Main application class
 #include "node.h"       // Node class
@@ -42,7 +44,30 @@ void Node::AddNodeToDoc(pugi::xml_node& node)
             if (iter.type() == type_bool)
                 attr.set_value(iter.as_bool());
             else
-                attr.set_value(value.c_str());
+            {
+                if (iter.isType(type_image) || iter.isType(type_animation))
+                {
+                    // Normalize using forward slashes, no spaces after ';' and no size info unless it is an SVG file
+
+                    ttlib::multistr parts(value, ';', tt::TRIM::both);
+                    if (parts.size() < 2)
+                        continue;
+
+                    ttlib::cstr description(parts[0]);
+                    parts[1].backslashestoforward();
+                    description << ';' << parts[1];
+
+                    if (parts.size() > 2 && parts[0].is_sameprefix("SVG"))
+                    {
+                        description << ';' << parts[2];
+                    }
+                    attr.set_value(description.c_str());
+                }
+                else
+                {
+                    attr.set_value(value.c_str());
+                }
+            }
         }
         else
         {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes loading, saving, and display of type_image properties. Load/Save now standardizes using forward slashes in paths, no space after a semi-colon, and no size information unless it is a SVG image. Display will show the size from `wxBitmapBundle::GetDefaultSize()` if available for non-SVG images. Only SVG images will allow the user to change the size.