### PR TITLE
Complete support for books with bitmaps for pages

### DIFF
--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -820,7 +820,7 @@ ttlib::cstr GenerateBundleCode(const ttlib::cstr& description)
 
                 if (parts[IndexType].is_sameprefix("Embed"))
                 {
-                    auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(bundle->lst_filenames[1]);
+                    auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(bundle->lst_filenames[0]);
                     if (embed)
                     {
                         name = "wxue_img::" + embed->array_name;
@@ -844,7 +844,11 @@ ttlib::cstr GenerateBundleCode(const ttlib::cstr& description)
             }
             else
             {
-                code << "\n\t\t[] {\n\t\t\twxVector<wxBitmap> bitmaps;\n";
+                // Caller will need to check for a return that starts with a { and use the bitmaps local variable as well as
+                // adding the closing brace. It's a bit of a hack, but unless the caller knows how many sub-images there are,
+                // it's the only way.
+
+                code << "{\n\t\t\twxVector<wxBitmap> bitmaps;\n";
                 for (auto& iter: bundle->lst_filenames)
                 {
                     ttlib::cstr name(iter.filename());
@@ -860,8 +864,6 @@ ttlib::cstr GenerateBundleCode(const ttlib::cstr& description)
                     }
                     code << "\t\t\tbitmaps.push_back(GetImageFromArray(" << name << ", sizeof(" << name << ")));\n";
                 }
-
-                code << "\t\t\treturn wxBitmapBundle::FromBitmaps(bitmaps);\n\t\t}";
             }
         }
         else

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -77,7 +77,7 @@ void GenerateWindowSettings(Node* node, ttlib::cstr& code);
 ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description, bool is_bitmapbundle = false,
                                const ttlib::cstr* pDpiWindow = nullptr);
 
-// If a wxVector() is required to create the wxBitmapBundle, this will generate the opening
+// If a wxVector is required to create the wxBitmapBundle, this will generate the opening
 // brace and the vector code and returns true with code filled in.
 //
 // Call this before calling GenerateBundleCode()
@@ -86,7 +86,7 @@ bool GenerateVectorCode(const ttlib::cstr& description, ttlib::cstr& code);
 // Generates the code necessary to create a wxBitmapBundle used to pass as an argument to a
 // function.
 //
-// Returns "wxNullBitmap" if description is empty
+// If the returned string starts with a '{' character, then a wxVector was generated,
 ttlib::cstr GenerateBundleCode(const ttlib::cstr& description);
 
 ttlib::cstr GenEventCode(NodeEvent* event, const std::string& class_name);


### PR DESCRIPTION
See PR description for more details

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds support for wxBitmapBundle to books that use bitmaps for the various pages. The common function `GenerateBundleCode(...)` has been changed to support this.

The change to `GenerateBundleCode(...)` provides an alternative to calling `GenerateVectorCode(...)` first -- the generated code contains the same local variable `wxVector<wxBitmap> bitmaps` but does not include any `#if wxCHECK_VERSION(3, 1, 6)` code. This makes it appropriate for when the entire code block is surronded by conditionals.
