### PR TITLE
Change code generation for Image forms

### DIFF
--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -7,8 +7,6 @@
 
 #include <unordered_map>
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "eventhandler_dlg.h"  // auto-generated: eventhandlerdlg_base.h and eventhandlerdlg_base.cpp
 
 #include "../nodes/node.h"        // Node class

--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -5,8 +5,6 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "img_props.h"    // ImageProperties
 #include "mainapp.h"      // App -- Main application class
 #include "node.h"         // Node -- Node class

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -47,6 +47,7 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
     if (prop->GetNode()->isGen(gen_embedded_image))
     {
         types.Add(s_type_names[1]);  // Embed
+        types.Add(s_type_names[3]);  // SVG
         m_isEmbeddedImage = true;
     }
     else
@@ -221,7 +222,15 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
         case IndexType:
             if (auto index = childValue.GetLong(); index >= 0)
             {
-                img_props.type = s_type_names[index];
+                if (m_isEmbeddedImage && index > 0)
+                {
+                    // REVIEW: [KeyWorks - 04-19-2022] This will only work if we only allow two iamge types (Embed and SVG)
+                    img_props.type = s_type_names[3];
+                }
+                else
+                {
+                    img_props.type = s_type_names[index];
+                }
 
                 // If the type has changed, then the image property is no longer valid
                 img_props.image.clear();

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -11,8 +11,6 @@
 #include <wx/dir.h>                // wxDir is a class for enumerating the files in a directory
 #include <wx/propgrid/propgrid.h>  // wxPropertyGrid
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "ui_images.h"
 
 using namespace wxue_img;

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -386,8 +386,9 @@ static std::vector<std::pair<const char*, const char*>> prefix_pair = {
     { "box", "_box" },
     { "bundle", "_bundle" },  // just in case we want to add help for this
     { "button", "_button" },
-    { "combo", "_combo" },
+    { "colour", "_colour" },
     { "column", "_column" },
+    { "combo", "_combo" },
     { "ctrl", "_ctrl" },
     { "dialog", "_dialog" },  // stddialog becomes std_dialog
     { "double", "_double" },

--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -37,10 +37,13 @@ static bool isBookHasImage(Node* node);
 
 static void AddBookImageList(Node* node_book, wxObject* widget);
 static void BookCtorAddImagelist(ttlib::cstr& code, Node* node);
-static void AddTreebookSubImages(Node* node, wxImageList* img_list);
 static void AddTreebookSubImages(Node* node, wxBookCtrlBase::Images& bundle_list);
 static void AddTreebookImageCode(ttlib::cstr& code, Node* node, size_t& image_index);
 static int GetTreebookImageIndex(Node* node);
+
+#if 0
+static void AddTreebookSubImages(Node* node, wxImageList* img_list);
+#endif
 
 //////////////////////////////////////////  BookPageGenerator  //////////////////////////////////////////
 
@@ -1074,6 +1077,7 @@ static bool isBookHasImage(Node* node)
     return false;
 }
 
+#if 0
 static void AddTreebookSubImages(Node* node, wxImageList* img_list)
 {
     if (!img_list)
@@ -1096,6 +1100,7 @@ static void AddTreebookSubImages(Node* node, wxImageList* img_list)
         }
     }
 }
+#endif
 
 static void AddTreebookSubImages(Node* node, wxBookCtrlBase::Images& bundle_list)
 {

--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -7,8 +7,6 @@
 
 #include <wx/propgrid/propgrid.h>  // wxPropertyGrid
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "gen_base.h"     // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "gen_common.h"   // GeneratorLibrary -- Generator classes
 #include "mainapp.h"      // App -- App class

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -186,11 +186,6 @@ void BaseCodeGenerator::GenerateBaseClass(Node* project, Node* form_node, PANEL_
         hdr_includes.insert("#include <wx/event.h>");
     }
 
-    if (form_node->isGen(gen_Images))
-    {
-        hdr_includes.insert("#include <wx/mstream.h>");
-    }
-
     if (panel_type != CPP_PANEL)
     {
         // BUGBUG: [KeyWorks - 01-25-2021] Need to look for base_class_name property of all children, and add each name
@@ -947,6 +942,11 @@ void BaseCodeGenerator::CollectIncludes(Node* node, std::set<std::string>& set_s
 
 void BaseCodeGenerator::GatherGeneratorIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
+    if (node->isGen(gen_Images))
+    {
+        return;
+    }
+
     bool isAddToSrc = false;
 
     // If the component is set for local access only, then add the header file to the source set. Once all processing is

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1910,9 +1910,27 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
         {
             if ((iter.type() == type_image || iter.type() == type_animation) && iter.HasValue())
             {
-                ttlib::multiview parts(iter.as_string(), BMP_PROP_SEPARATOR, tt::TRIM::both);
+                ttlib::multistr parts(iter.as_string(), BMP_PROP_SEPARATOR, tt::TRIM::both);
                 if (parts.size() < IndexImage + 1)
                     continue;
+
+                // If the is a Images form, then we need to see if the image property refers to an image within the Images
+                // form. If so, a function call will be made to the Image Form's source code to load the image and therefore
+                // we don't need to generate and special header files or generate the general purpose image loading function.
+
+                if (m_ImagesForm && m_form_node != m_ImagesForm)
+                {
+                    if (auto bundle = wxGetApp().GetPropertyImageBundle(parts); bundle && bundle->lst_filenames.size())
+                    {
+                        if (auto embed = wxGetApp().GetEmbeddedImage(bundle->lst_filenames[0]); embed)
+                        {
+                            if (embed->form == m_ImagesForm)
+                            {
+                                continue;
+                            }
+                        }
+                    }
+                }
 
                 if (parts[IndexType] == "Embed")
                 {

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -11,8 +11,6 @@
 
 #include <wx/filename.h>  // wxFileName - encapsulates a file path
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-#include "ttstr.h"       // ttString, ttSaveCwd -- Enhanced version of wxString
 #include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
 
 #include "gen_base.h"

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -47,6 +47,12 @@ namespace result
     };
 }  // namespace result
 
+// This determines the longest line when generating embedded images. Do *not* use constexpr for this -- at some point we may
+// want to allow the user to set maximum line length of all generated code, and if so, this will need to reflect the user's
+// preference.
+
+constexpr int max_image_line_length { 125 };
+
 int WriteCMakeFile(bool test_only = true);  // See gen_cmake.cpp
 
 // If NeedsGenerateCheck is true, this will not write any files, but will return true if at
@@ -92,6 +98,9 @@ protected:
         Protected,
         Public
     };
+
+    // This method is in images_form.cpp, and handles both source and header code generation
+    void GenerateImagesForm();
 
     ttlib::cstr GetDeclaration(Node* node);
 

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -162,8 +162,9 @@ private:
     bool m_is_derived_class { true };
 
     // These are also initialized whenever GenerateBaseClass() is called
-    bool m_NeedArtProviderHeader { false };
-    bool m_NeedHeaderFunction { false };
-    bool m_NeedAnimationFunction { false };
-    bool m_NeedSVGFunction { false };
+    bool m_NeedArtProviderHeader { false };  // Set when Art type is used
+    bool m_NeedHeaderFunction { false };     // Set when Header type is used
+    bool m_NeedAnimationFunction { false };  // Set when an Animation image is used
+    bool m_NeedSVGFunction { false };        // Set when SVG image type is used
+    bool m_NeedImageFunction { false };      // Set when Embed type is used
 };

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -72,7 +72,7 @@ public:
     void SetHdrWriteCode(WriteCode* cw) { m_header = cw; }
     void SetSrcWriteCode(WriteCode* cw) { m_source = cw; }
 
-    void GenerateBaseClass(Node* project, Node* form_node, PANEL_TYPE panel_type = NOT_PANEL);
+    void GenerateBaseClass(Node* form_node, PANEL_TYPE panel_type = NOT_PANEL);
 
     // GenerateDerivedClass() is in gen_derived.cpp
 
@@ -158,6 +158,8 @@ private:
     std::set<wxBitmapType> m_type_generated;
 
     Node* m_form_node;
+    Node* m_ImagesForm;
+    Node* m_project;
 
     PANEL_TYPE m_panel_type { NOT_PANEL };
 

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -150,6 +150,8 @@ private:
     WriteCode* m_source;
 
     ttlib::cstr m_baseFullPath;
+    ttlib::cstr m_header_ext { ".h" };
+
     EventVector m_CtxMenuEvents;
 
     std::vector<const EmbeddedImage*> m_embedded_images;

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Generate Src and Hdr files for Base Class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -101,7 +101,16 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
                 {
                     if (pClassList)
                     {
-                        pClassList->emplace_back(form->prop_as_string(prop_class_name));
+                        if (form->isGen(gen_Images))
+                        {
+                            // While technically this is a "form" it doesn't have the usual properties set
+
+                            pClassList->emplace_back(GenEnum::map_GenNames[gen_Images]);
+                        }
+                        else
+                        {
+                            pClassList->emplace_back(form->prop_as_string(prop_class_name));
+                        }
                         continue;
                     }
                     else
@@ -361,7 +370,16 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
         for (size_t pos = 0; pos < project->GetChildCount(); ++pos)
         {
             auto form = project->GetChild(pos);
-            if (form->prop_as_string(prop_class_name).is_sameas(iter_class))
+
+            // The Images class doesn't have a prop_class_name, so use "Images". Note that this will fail if there is a real
+            // form where the user set the class name to "Images". If this wasn't an Internal function, then we would need to
+            // store nodes rather than class names.
+
+            ttlib::cstr class_name(form->prop_as_string(prop_class_name));
+            if (form->isGen(gen_Images))
+                class_name = "Images";
+
+            if (class_name.is_sameas(iter_class))
             {
                 BaseCodeGenerator codegen;
 

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -86,7 +86,7 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
             auto cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
             codegen.SetSrcWriteCode(cpp_cw.get());
 
-            codegen.GenerateBaseClass(project, form);
+            codegen.GenerateBaseClass(form);
 
             path.replace_extension(header_ext);
             auto retval = h_cw->WriteFile(NeedsGenerateCheck);
@@ -397,7 +397,7 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
                 auto cpp_cw = std::make_unique<FileCodeWriter>(base_file.wx_str());
                 codegen.SetSrcWriteCode(cpp_cw.get());
 
-                codegen.GenerateBaseClass(project, form);
+                codegen.GenerateBaseClass(form);
 
                 base_file.replace_extension(header_ext);
                 bool new_hdr = (h_cw->WriteFile(true) > 0);
@@ -421,7 +421,7 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
                     cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
                     codegen.SetSrcWriteCode(cpp_cw.get());
 
-                    codegen.GenerateBaseClass(project, form);
+                    codegen.GenerateBaseClass(form);
 
                     path.replace_extension(header_ext);
                     h_cw->WriteFile();
@@ -451,7 +451,7 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
                     cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
                     codegen.SetSrcWriteCode(cpp_cw.get());
 
-                    codegen.GenerateBaseClass(project, form);
+                    codegen.GenerateBaseClass(form);
 
                     path.replace_extension(source_ext);
                     cpp_cw->WriteFile();
@@ -460,7 +460,6 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
                     base_file.replace_extension(source_ext);
                     paths.append_child("left").text().set(base_file.c_str());
                     paths.append_child("left-readonly").text().set("0");
-
                     paths.append_child("right").text().set(path.c_str());
                     paths.append_child("right-readonly").text().set("1");
                 }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -837,7 +837,7 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
 
     else if (parts[IndexType].is_sameas("XPM") || parts[IndexImage].extension().is_sameas(".xpm", tt::CASE::either))
     {
-        if (auto bundle = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(description); bundle)
+        if (auto bundle = wxGetApp().GetPropertyImageBundle(description); bundle)
         {
             if (bundle->lst_filenames.size() == 1)
             {
@@ -882,7 +882,14 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
     }
     else if (description.is_sameprefix("SVG"))
     {
-        auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(parts[IndexImage]);
+        if (auto function_name = wxGetApp().GetBundleFuncName(description); function_name.size())
+        {
+            // We get here if there is an Image form that contains the function to retrieve this bundle.
+            code = function_name;
+            return true;
+        }
+
+        auto embed = wxGetApp().GetEmbeddedImage(parts[IndexImage]);
         if (!embed)
         {
             FAIL_MSG(ttlib::cstr() << description << " not embedded!")

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -7,8 +7,6 @@
 
 #include <charconv>  // for std::to_chars
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "gen_common.h"
 
 #include "lambdas.h"      // Functions for formatting and storage of lamda events

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -884,7 +884,7 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
         {
             // We get here if there is an Image form that contains the function to retrieve this bundle.
             code = function_name;
-            return true;
+            return false;
         }
 
         auto embed = wxGetApp().GetEmbeddedImage(parts[IndexImage]);
@@ -907,6 +907,13 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
     }
     else
     {
+        if (auto function_name = wxGetApp().GetBundleFuncName(description); function_name.size())
+        {
+            // We get here if there is an Image form that contains the function to retrieve this bundle.
+            code = function_name;
+            return false;
+        }
+
         if (auto bundle = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(description); bundle)
         {
             if (bundle->lst_filenames.size() == 1)

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -22,8 +22,6 @@
 
 #include <thread>
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "gen_base.h"
 
 #include "mainapp.h"       // App -- App class

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -11,8 +11,6 @@
 
 #include <wx/filename.h>  // wxFileName - encapsulates a file path
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-#include "ttstr.h"       // ttString, ttSaveCwd -- Enhanced version of wxString
 #include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
 
 #include "gen_base.h"

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -393,6 +393,8 @@ void BaseCodeGenerator::GenerateImagesForm()
         }
 
         m_header->writeLine();
+        m_header->writeLine("wxImage wxueImage(const unsigned char* data, size_t size_data);");
+        m_header->writeLine();
         m_header->writeLine("namespace wxue_img\n{");
         m_header->Indent();
         m_header->SetLastLineBlank();

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -384,7 +384,7 @@ void BaseCodeGenerator::GenerateImagesForm()
             ttlib::cstr code("#if wxCHECK_VERSION(3, 1, 6)\n\t");
             code << "#include <wx/bmpbndl.h>";
             code << "\n#else\n\t";
-            code << "#include <wx/bitmap.h>";
+            code << "#include <wx/image.h>";
             code << "\n#endif";
             m_header->writeLine(code, indent::auto_keep_whitespace);
         }

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -10,7 +10,6 @@
 #include <wx/statbmp.h>   // wxStaticBitmap class interface
 #include <wx/stattext.h>  // wxStaticText base header
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
 #include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
 
 #include "images_form.h"

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -11,14 +11,17 @@
 #include <wx/stattext.h>  // wxStaticText base header
 
 #include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
+#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
 
 #include "images_form.h"
 
 #include "bitmaps.h"      // Contains various images handling functions
+#include "gen_base.h"     // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "mainapp.h"      // compiler_standard -- Main application class
 #include "mainframe.h"    // MainFrame -- Main window frame
 #include "node.h"         // Node class
 #include "pjtsettings.h"  // ProjectSettings -- Hold data for currently loaded project
+#include "write_code.h"   // Write code to Scintilla or file
 
 #include "ui_images.h"
 
@@ -94,4 +97,134 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
     sizer->Add(m_bitmap, wxSizerFlags(1).Border(wxALL).Expand());
 
     return sizer;
+}
+
+// clang-format off
+
+// These strings are also in gen_base.cpp
+
+inline constexpr const auto txt_wxueImageFunction = R"===(
+// Convert a data array into a wxImage
+inline wxImage wxueImage(const unsigned char* data, size_t size_data)
+{
+    wxMemoryInputStream strm(data, size_data);
+    wxImage image;
+    image.LoadFile(strm);
+    return image;
+};
+)===";
+
+inline constexpr const auto txt_GetBundleFromSVG = R"===(
+// Convert compressed SVG string into a wxBitmapBundle
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+{
+    auto str = std::make_unique<char[]>(size_svg);
+    wxMemoryInputStream stream_in(data, size_data);
+    wxZlibInputStream zlib_strm(stream_in);
+    zlib_strm.Read(str.get(), size_svg);
+    return wxBitmapBundle::FromSVG(str.get(), def_size);
+};
+)===";
+
+// clang-format on
+
+void BaseCodeGenerator::GenerateImagesForm()
+{
+    if (m_embedded_images.empty())
+    {
+        return;
+    }
+
+    if (m_panel_type != HDR_PANEL)
+    {
+        bool is_namespace_written = false;
+        for (auto iter_array: m_embedded_images)
+        {
+            if (iter_array->form != m_form_node)
+                continue;
+
+            if (!is_namespace_written)
+            {
+                m_source->writeLine();
+                m_source->writeLine("namespace wxue_img\n{");
+                m_source->Indent();
+                is_namespace_written = true;
+            }
+            m_source->writeLine();
+            ttlib::cstr code;
+            code.reserve(max_image_line_length + 16);
+            // SVG images store the original size in the high 32 bits
+            size_t max_pos = (iter_array->array_size & 0xFFFFFFFF);
+            code << "const unsigned char " << iter_array->array_name << '[' << max_pos << "] {";
+
+            m_source->writeLine(code);
+
+            size_t pos = 0;
+            while (pos < max_pos)
+            {
+                code.clear();
+                // -8 to account for 4 indent + max 3 chars for number + comma
+                for (; pos < max_pos && code.size() < static_cast<size_t>(max_image_line_length - 8); ++pos)
+                {
+                    code << static_cast<int>(iter_array->array_data[pos]) << ',';
+                }
+                if (pos >= max_pos && code.back() == ',')
+                    code.pop_back();
+                m_source->writeLine(code);
+            }
+            m_source->writeLine("};");
+        }
+        if (is_namespace_written)
+        {
+            m_source->writeLine();
+            m_source->Unindent();
+            m_source->writeLine("}\n");
+        }
+    }
+
+    if (m_panel_type != CPP_PANEL)
+    {
+        bool is_namespace_written = false;
+        for (auto iter_array: m_embedded_images)
+        {
+            if (iter_array->form != m_form_node)
+                continue;
+
+            if (!is_namespace_written)
+            {
+                m_header->writeLine();
+                m_header->writeLine("namespace wxue_img\n{");
+
+                if (m_form_node->isType(type_images))
+                {
+                    ttlib::textfile function;
+                    function.ReadString(txt_wxueImageFunction);
+                    for (auto& iter: function)
+                    {
+                        m_header->write("\t");
+                        if (iter.size() && iter.at(0) == ' ')
+                            m_header->write("\t");
+                        m_header->writeLine(iter);
+                    }
+                    m_header->writeLine();
+                }
+
+                m_header->Indent();
+                if (!m_form_node->isType(type_images))
+                {
+                    m_header->writeLine("// Images declared in this class module:");
+                    m_header->writeLine();
+                }
+                is_namespace_written = true;
+            }
+            m_header->writeLine(ttlib::cstr("extern const unsigned char ")
+                                << iter_array->array_name << '[' << (iter_array->array_size & 0xFFFFFFFF) << "];");
+        }
+        if (is_namespace_written)
+        {
+            m_header->Unindent();
+            m_header->writeLine("}\n");
+        }
+    }
 }

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -44,7 +44,7 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
     auto node = wxGetFrame().GetSelectedNode();
     if (node->isGen(gen_embedded_image))
     {
-        auto bundle = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(node->prop_as_string(prop_bitmap));
+        auto bundle = wxGetApp().GetPropertyImageBundle(node->prop_as_string(prop_bitmap));
 
         ttlib::multiview mstr(node->prop_as_string(prop_bitmap), ';');
 

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -302,22 +302,26 @@ void BaseCodeGenerator::GenerateImagesForm()
                 }
             }
 
-            m_source->writeLine();
-            for (auto embed: m_embedded_images)
+            if (!m_NeedSVGFunction && is_old_widgets)
             {
-                if (embed->form != m_form_node || embed->type == wxBITMAP_TYPE_INVALID)
-                    continue;
+                m_source->writeLine("#else", indent::none);
                 m_source->writeLine();
-                ttlib::cstr code("wxImage image_");
-                code << embed->array_name << "()";
-                m_source->writeLine(code);
-                m_source->writeLine("{");
-                m_source->Indent();
-                code = "return wxueImage(";
-                code << embed->array_name << ", " << embed->array_size << ");";
-                m_source->writeLine(code);
-                m_source->Unindent();
-                m_source->writeLine("}");
+                for (auto embed: m_embedded_images)
+                {
+                    if (embed->form != m_form_node || embed->type == wxBITMAP_TYPE_INVALID)
+                        continue;
+                    m_source->writeLine();
+                    ttlib::cstr code("wxImage image_");
+                    code << embed->array_name << "()";
+                    m_source->writeLine(code);
+                    m_source->writeLine("{");
+                    m_source->Indent();
+                    code = "return wxueImage(";
+                    code << embed->array_name << ", " << embed->array_size << ");";
+                    m_source->writeLine(code);
+                    m_source->Unindent();
+                    m_source->writeLine("}");
+                }
             }
         }
 
@@ -428,16 +432,20 @@ void BaseCodeGenerator::GenerateImagesForm()
             }
         }
 
-        if (m_NeedImageFunction)
+        if (!m_NeedSVGFunction && is_old_widgets)
         {
-            m_header->writeLine();
-            for (auto embed: m_embedded_images)
+            if (m_NeedImageFunction)
             {
-                if (embed->form != m_form_node || embed->type == wxBITMAP_TYPE_INVALID)
-                    continue;
-                ttlib::cstr code("wxImage image_");
-                code << embed->array_name << "();";
-                m_header->writeLine(code);
+                m_header->writeLine("#else", indent::none);
+                m_header->writeLine();
+                for (auto embed: m_embedded_images)
+                {
+                    if (embed->form != m_form_node || embed->type == wxBITMAP_TYPE_INVALID)
+                        continue;
+                    ttlib::cstr code("wxImage image_");
+                    code << embed->array_name << "();";
+                    m_header->writeLine(code);
+                }
             }
         }
     }

--- a/src/generate/listctrl_widgets.cpp
+++ b/src/generate/listctrl_widgets.cpp
@@ -9,8 +9,6 @@
 #include <wx/event.h>     // Event classes
 #include <wx/listctrl.h>  // wxSearchCtrlBase class
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "gen_common.h"  // GeneratorLibrary -- Generator classes
 #include "node.h"        // Node class
 #include "utils.h"       // Utility functions that work with properties

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -18,8 +18,6 @@
 #include <wx/statline.h>           // wxStaticLine class interface
 #include <wx/statusbr.h>           // wxStatusBar class interface
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "bitmaps.h"      // Contains various images handling functions
 #include "gen_common.h"   // GeneratorLibrary -- Generator classes
 #include "mainapp.h"      // App -- Main application class

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -14,8 +14,6 @@
 #include <wx/textwrapper.h>  // declaration of wxTextWrapper class
 #include <wx/wrapsizer.h>    // provide wrapping sizer for layout (wxWrapSizer)
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "gen_common.h"  // GeneratorLibrary -- Generator classes
 #include "node.h"        // Node class
 

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -13,8 +13,6 @@
 #include <wx/sizer.h>              // provide wxSizer class for layout
 #include <wx/stc/stc.h>            // A wxWidgets implementation of Scintilla.
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "styled_text.h"
 
 #include "gen_common.h"    // GeneratorLibrary -- Generator classes

--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -12,8 +12,6 @@
 #include <wx/filename.h>  // wxFileName - encapsulates a file path
 #include <wx/stc/stc.h>   // Scintilla
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "write_code.h"
 
 #include "mainapp.h"       // App -- Main application class

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -16,8 +16,6 @@
 #include <wx/wfstream.h>  // File stream classes
 #include <wx/zstream.h>   // zlib stream classes
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "pugixml.hpp"  // xml parser
 
 #include "mainapp.h"      // compiler_standard -- Main application class

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -99,9 +99,8 @@ void ProjectSettings::CollectNodeBundles(Node* node, Node* form)
     }
 }
 
-bool ProjectSettings::AddNewEmbeddedBundle(const ttlib::cstr& description, ttlib::cstr path, Node* form)
+bool ProjectSettings::AddNewEmbeddedBundle(const ttlib::multistr& parts, ttlib::cstr path, Node* form)
 {
-    ttlib::multistr parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
     ASSERT(parts.size() > 1)
 
     ttlib::cstr lookup_str;
@@ -376,9 +375,8 @@ bool ProjectSettings::AddEmbeddedBundleImage(ttlib::cstr path, Node* form)
     return false;
 }
 
-ImageBundle* ProjectSettings::ProcessBundleProperty(const ttlib::cstr& description, Node* node)
+ImageBundle* ProjectSettings::ProcessBundleProperty(const ttlib::multistr& parts, Node* node)
 {
-    ttlib::multistr parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
     ASSERT(parts.size() > 1)
 
     ttlib::cstr lookup_str;
@@ -412,7 +410,7 @@ ImageBundle* ProjectSettings::ProcessBundleProperty(const ttlib::cstr& descripti
     }
     else if (parts[IndexType].contains("Embed"))
     {
-        if (AddNewEmbeddedBundle(description, parts[IndexImage], node->get_form()))
+        if (AddNewEmbeddedBundle(parts, parts[IndexImage], node->get_form()))
         {
             return &m_bundles[lookup_str];
         }
@@ -423,7 +421,7 @@ ImageBundle* ProjectSettings::ProcessBundleProperty(const ttlib::cstr& descripti
     }
     else if (parts[IndexType].contains("SVG"))
     {
-        if (AddNewEmbeddedBundle(description, parts[IndexImage], node->get_form()))
+        if (AddNewEmbeddedBundle(parts, parts[IndexImage], node->get_form()))
         {
             return &m_bundles[lookup_str];
         }
@@ -433,7 +431,7 @@ ImageBundle* ProjectSettings::ProcessBundleProperty(const ttlib::cstr& descripti
         }
     }
 
-    auto image_first = wxGetApp().GetProjectSettings()->GetPropertyBitmap(description, false);
+    auto image_first = wxGetApp().GetProjectSettings()->GetPropertyBitmap(parts, false);
     if (!image_first.IsOk())
     {
         return nullptr;

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -11,8 +11,6 @@
 
 #include <wx/mstream.h>  // Memory stream classes
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "import_formblder.h"
 
 #include "base_generator.h"  // BaseGenerator -- Base widget generator class

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -55,8 +55,6 @@ namespace rapidjson
 
 using namespace rapidjson;
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "base_generator.h"  // BaseGenerator -- Base widget generator class
 #include "mainapp.h"         // App -- Main application class
 #include "mainframe.h"       // Main window frame

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -5,8 +5,6 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "import_xml.h"
 
 #include "gen_enums.h"    // Enumerations for generators

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -12,8 +12,6 @@
 #include <wx/sysopt.h>   // wxSystemOptions
 #include <wx/utils.h>    // Miscellaneous utilities
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "mainapp.h"
 
 #include "appoptions.h"          // AppOptions -- Application-wide options

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -327,7 +327,6 @@ ttlib::cstr App::GetBundleFuncName(const ttlib::cstr& description)
                         {
                             name << "wxue_img::bundle_" << embed->array_name << "()";
                         }
-
                     }
                     break;
                 }

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -66,6 +66,7 @@ public:
     wxImage GetImage(const ttlib::cstr& description);
     wxBitmapBundle GetBitmapBundle(const ttlib::cstr& description, Node* node);
 
+    const ImageBundle* GetPropertyImageBundle(const ttlib::multistr& parts, Node* node = nullptr);
     const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description, Node* node = nullptr);
     EmbeddedImage* GetEmbeddedImage(ttlib::sview path);
 

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Main application class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -18,9 +18,11 @@ namespace pugi
     class xml_document;
 }
 
+class ImportXML;
 class MainFrame;
 class ProjectSettings;
-class ImportXML;
+
+struct EmbeddedImage;
 struct ImageBundle;
 
 // Current version of wxUiEditor project files
@@ -63,7 +65,12 @@ public:
 
     wxImage GetImage(const ttlib::cstr& description);
     wxBitmapBundle GetBitmapBundle(const ttlib::cstr& description, Node* node);
+
     const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description, Node* node = nullptr);
+    EmbeddedImage* GetEmbeddedImage(ttlib::sview path);
+
+    // If there is an Image form containing this bundle, return it's name
+    ttlib::cstr GetBundleFuncName(const ttlib::cstr& description);
 
     ProjectSettings* GetProjectSettings() { return m_pjtSettings; };
 

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -12,8 +12,6 @@
 #include <wx/animate.h>                // wxAnimation and wxAnimationCtrl
 #include <wx/propgrid/propgriddefs.h>  // wxPropertyGrid miscellaneous definitions
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "font_prop.h"     // FontProperty -- FontProperty class
 #include "mainapp.h"       // App -- App class
 #include "mainapp.h"       // App -- Main application class

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -304,7 +304,7 @@ wxBitmapBundle NodeProperty::as_bitmap_bundle() const
 
 const ImageBundle* NodeProperty::as_image_bundle() const
 {
-    auto bundle_ptr = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(m_value);
+    auto bundle_ptr = wxGetApp().GetPropertyImageBundle(m_value);
     if (!bundle_ptr || !bundle_ptr->bundle.IsOk())
         return nullptr;
     else

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -182,7 +182,7 @@ void BasePanel::GenerateBaseClass()
     if (m_GenerateDerivedCode == 1)
         codegen.GenerateDerivedClass(project, m_cur_form, panel_type);
     else if (m_GenerateDerivedCode == 0)
-        codegen.GenerateBaseClass(project, m_cur_form, panel_type);
+        codegen.GenerateBaseClass(m_cur_form, panel_type);
     else
         codegen.GenerateXrcClass(project, m_cur_form, panel_type);
 

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -35,6 +35,11 @@ CodeDisplay::CodeDisplay(wxWindow* parent) : CodeDisplayBase(parent)
     ttlib::cstr widget_keywords("\
         wxToolBar \
         wxMenuBar \
+        wxBitmapBundle \
+        wxBitmap \
+        wxImage \
+        wxMemoryInputStream \
+        wxVector \
         wxWindow"
 
         );

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -11,8 +11,6 @@
 #include <wx/toolbar.h>   // wxToolBar interface declaration
 #include <wx/wupdlock.h>  // wxWindowUpdateLocker prevents window redrawing
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "nav_panel.h"
 
 #include "bitmaps.h"          // Contains various images handling functions

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -18,8 +18,6 @@
 #include <wx/propgrid/propgrid.h>  // wxPropertyGrid
 #include <wx/wupdlock.h>           // wxWindowUpdateLocker prevents window redrawing
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "propgrid_panel.h"
 
 #include "appoptions.h"      // AppOptions -- Application-wide options

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1079,7 +1079,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                 ttlib::cstr value;
                 // Do NOT call GetValueAsString() -- we need to return the value the way the custom property formatted it
                 value << m_prop_grid->GetPropertyValue(property).GetString().wx_str();
-                ttlib::multistr parts(value, BMP_PROP_SEPARATOR);
+                ttlib::multistr parts(value, BMP_PROP_SEPARATOR, tt::TRIM::both);
                 // If the image field is empty, then the entire property needs to be cleared
                 if (parts.size() > IndexImage && parts[IndexImage].empty())
                 {
@@ -1088,7 +1088,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                 else
                 {
                     // This ensures that all images from a bitmap bundle get added
-                    wxGetApp().GetProjectSettings()->UpdateBundle(value, prop->GetNode());
+                    wxGetApp().GetProjectSettings()->UpdateBundle(parts, prop->GetNode());
                 }
 
                 modifyProperty(prop, value);

--- a/src/pch.h
+++ b/src/pch.h
@@ -81,14 +81,15 @@
 
 #include "ttlibspace.h"  // This must be included before any other ttLib header files
 
-#include "ttcstr.h"   // ttlib::cstr -- std::string with additional functions
-#include "ttcview.h"  // ttlib::cview -- string_view functionality on a zero-terminated char string.
-#include "ttstr.h"    // ttString -- wxString with ttlib::cstr equivalent functions
-#include "ttsview.h"  // sview -- std::string_view with additional methods
+#include "ttcstr.h"      // ttlib::cstr -- std::string with additional functions
+#include "ttcview.h"     // ttlib::cview -- std::string_view functionality on a zero-terminated char string.
+#include "ttmultistr.h"  // ttlib::multistr -- breaks a single string into multiple strings
+#include "ttstr.h"       // ttString -- wxString with ttlib::cstr equivalent functions
+#include "ttsview.h"     // ttlib::sview -- std::string_view with additional methods
 
 #if !defined(int_t)
 
-// signed integer type with width determined by platform
+// signed integer type, width determined by platform
 typedef ptrdiff_t int_t;
 
 #endif  // not !defined(int_t)

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -16,10 +16,6 @@
 #include <wx/mstream.h>   // Memory stream classes
 #include <wx/wfstream.h>  // File stream classes
 
-#include "ttcview.h"     // cview -- string_view functionality on a zero-terminated char string.
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-#include "ttsview.h"     // sview -- std::string_view with additional methods
-
 #include "pjtsettings.h"  // ProjectSettings
 
 #include "bitmaps.h"    // Map of bitmaps accessed by name

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -488,6 +488,7 @@ void ProjectSettings::InitializeArrayName(EmbeddedImage* embed, ttlib::sview fil
 
 EmbeddedImage* ProjectSettings::GetEmbeddedImage(ttlib::sview path)
 {
+    // REVIEW: [KeyWorks - 05-03-2022] Do we still need this lock?
     std::unique_lock<std::mutex> add_lock(m_mutex_embed_add);
 
     if (auto result = m_map_embedded.find(path.filename()); result != m_map_embedded.end())

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -33,16 +33,6 @@ inline wxAnimation GetAnimFromHdr(const unsigned char* data, size_t size_data)
     return animation;
 };
 
-inline ttlib::cstr ConvertToLookup(const ttlib::cstr& description)
-{
-    ttlib::multistr parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
-    ASSERT(parts.size() > 1)
-
-    ttlib::cstr lookup_str;
-    lookup_str << parts[0] << ';' << parts[1].filename();
-    return lookup_str;
-}
-
 namespace wxue_img
 {
     extern const unsigned char pulsing_unknown_gif[377];
@@ -83,10 +73,8 @@ ttlib::cstr& ProjectSettings::setProjectPath(const ttlib::cstr& file, bool remov
     return m_projectPath;
 }
 
-wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool check_image)
+wxImage ProjectSettings::GetPropertyBitmap(const ttlib::multistr& parts, bool check_image)
 {
-    ttlib::multiview parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
-
     if (parts[IndexImage].empty())
     {
         return GetInternalImage("unknown");
@@ -179,9 +167,8 @@ wxImage ProjectSettings::GetPropertyBitmap(const ttlib::cstr& description, bool 
     return image;
 }
 
-void ProjectSettings::UpdateBundle(const ttlib::cstr& description, Node* node)
+void ProjectSettings::UpdateBundle(const ttlib::multistr& parts, Node* node)
 {
-    ttlib::multiview parts(description, ';', tt::TRIM::both);
     if (parts.size() < 2)
         return;
 
@@ -191,7 +178,7 @@ void ProjectSettings::UpdateBundle(const ttlib::cstr& description, Node* node)
     auto result = m_bundles.find(lookup_str);
     if (result == m_bundles.end())
     {
-        ProcessBundleProperty(description, node);
+        ProcessBundleProperty(parts, node);
         result = m_bundles.find(lookup_str);
     }
 
@@ -219,7 +206,7 @@ void ProjectSettings::UpdateBundle(const ttlib::cstr& description, Node* node)
 
 wxBitmapBundle ProjectSettings::GetPropertyBitmapBundle(const ttlib::cstr& description, Node* node)
 {
-    ttlib::multiview parts(description, ';', tt::TRIM::both);
+    ttlib::multistr parts(description, ';', tt::TRIM::both);
     if (parts.size() < 2)
     {
         return GetInternalImage("unknown");
@@ -228,12 +215,12 @@ wxBitmapBundle ProjectSettings::GetPropertyBitmapBundle(const ttlib::cstr& descr
     ttlib::cstr lookup_str;
     lookup_str << parts[0] << ';' << parts[1].filename();
 
-    if (auto result = m_bundles.find(ConvertToLookup(description)); result != m_bundles.end())
+    if (auto result = m_bundles.find(lookup_str); result != m_bundles.end())
     {
         return result->second.bundle;
     }
 
-    if (auto result = ProcessBundleProperty(description, node); result)
+    if (auto result = ProcessBundleProperty(parts, node); result)
     {
         return result->bundle;
     }
@@ -241,9 +228,8 @@ wxBitmapBundle ProjectSettings::GetPropertyBitmapBundle(const ttlib::cstr& descr
     return GetInternalImage("unknown");
 }
 
-const ImageBundle* ProjectSettings::GetPropertyImageBundle(const ttlib::cstr& description, Node* node)
+const ImageBundle* ProjectSettings::GetPropertyImageBundle(const ttlib::multistr& parts, Node* node)
 {
-    ttlib::multiview parts(description, ';', tt::TRIM::both);
     if (parts.size() < 2)
     {
         return nullptr;
@@ -258,7 +244,7 @@ const ImageBundle* ProjectSettings::GetPropertyImageBundle(const ttlib::cstr& de
     }
     else if (node)
     {
-        return ProcessBundleProperty(description, node);
+        return ProcessBundleProperty(parts, node);
     }
     else
     {

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Hold data for currently loaded project
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -46,7 +46,10 @@ public:
     ttlib::cstr& SetProjectPath(const ttString& path, bool remove_filename = true);
     ttlib::cstr& setProjectPath(const ttlib::cstr& path, bool remove_filename = true);
 
+    // Returns the directory the project file is in as a ttlib::cstr
     ttlib::cstr& getProjectPath() { return m_projectPath; }
+
+    // Returns the directory the project file is in as a ttString
     ttString GetProjectPath() { return ttString() << m_projectPath.wx_str(); }
 
     // This takes the full bitmap property description and uses that to determine the image

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -68,6 +68,8 @@ public:
 
     // ImageBundle contains the filenames of each image in the bundle, needed to generate the
     // code for the bundle.
+    //
+    // Returns nullptr if there is no ImageBundle
     const ImageBundle* GetPropertyImageBundle(const ttlib::multistr& parts, Node* node = nullptr);
     const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description, Node* node = nullptr)
     {

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -56,18 +56,35 @@ public:
     // to load. The image is cached for as long as the project is open.
     //
     // If check_image is true, and !image.IsOK(), GetInternalImage() is returned
-    wxImage GetPropertyBitmap(const ttlib::cstr& description, bool check_image = true);
+    wxImage GetPropertyBitmap(const ttlib::multistr& parts, bool check_image = true);
+
+    inline wxImage GetPropertyBitmap(const ttlib::cstr& description, bool check_image = true)
+    {
+        ttlib::multistr parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
+        return GetPropertyBitmap(parts, check_image);
+    }
 
     wxBitmapBundle GetPropertyBitmapBundle(const ttlib::cstr& description, Node* node);
 
     // ImageBundle contains the filenames of each image in the bundle, needed to generate the
     // code for the bundle.
-    const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description, Node* node = nullptr);
+    const ImageBundle* GetPropertyImageBundle(const ttlib::multistr& parts, Node* node = nullptr);
+    const ImageBundle* GetPropertyImageBundle(const ttlib::cstr& description, Node* node = nullptr)
+    {
+        ttlib::multistr parts(description, ';', tt::TRIM::both);
+        return GetPropertyImageBundle(parts, node);
+    }
 
-    ImageBundle* ProcessBundleProperty(const ttlib::cstr& description, Node* node);
+    ImageBundle* ProcessBundleProperty(const ttlib::multistr& parts, Node* node);
+
+    inline ImageBundle* ProcessBundleProperty(const ttlib::cstr& description, Node* node)
+    {
+        ttlib::multistr parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
+        return ProcessBundleProperty(parts, node);
+    }
 
     // This adds the bundle if new, or updates the embed->form if the node has changed
-    void UpdateBundle(const ttlib::cstr& description, Node* node);
+    void UpdateBundle(const ttlib::multistr& parts, Node* node);
 
     // This takes the full animation property description and uses that to determine the image
     // to load. The image is cached for as long as the project is open.
@@ -88,7 +105,13 @@ protected:
 
     void CollectNodeBundles(Node* node, Node* form);
 
-    bool AddNewEmbeddedBundle(const ttlib::cstr& description, ttlib::cstr path, Node* form);
+    bool AddNewEmbeddedBundle(const ttlib::multistr& parts, ttlib::cstr path, Node* form);
+
+    inline bool AddNewEmbeddedBundle(const ttlib::cstr& description, ttlib::cstr path, Node* form)
+    {
+        ttlib::multistr parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
+        return AddNewEmbeddedBundle(parts, path, form);
+    }
 
     // Reads the image and stores it in m_map_embedded
     bool AddEmbeddedBundleImage(ttlib::cstr path, Node* form);

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd.h"  // cwd -- Class for storing and optionally restoring the current directory
 
 #include <wx/utils.h>  // Miscellaneous utilities
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -6,7 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
 
 #include <wx/utils.h>  // Miscellaneous utilities
 

--- a/src/project/saveproject.cpp
+++ b/src/project/saveproject.cpp
@@ -5,8 +5,6 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "mainapp.h"    // App -- Main application class
 #include "node.h"       // Node class
 #include "prop_decl.h"  // PropChildDeclaration and PropDeclaration classes

--- a/src/utils/font_prop.cpp
+++ b/src/utils/font_prop.cpp
@@ -8,8 +8,6 @@
 #include <charconv>  // for std::to_chars
 #include <cstdlib>   // for std::atof
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "font_prop.h"
 
 #include "node_creator.h"  // NodeCreator -- Class used to create nodes

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -11,8 +11,6 @@
 #include <wx/gdicmn.h>   // Common GDI classes, types and declarations
 #include <wx/mstream.h>  // Memory stream classes
 
-#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
-
 #include "node.h"          // Node class
 #include "node_creator.h"  // NodeCreator class
 #include "utils.h"         // Utility functions that work with properties


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR overhauls the code generation when an Images form is specified. It now generates functions, declared in the generated header file which can be used to load wxBitmapBundles in any generated source file. The functions are quite simple, so can easily be called by the user in any non-generated code as well. It handles both bundles and SVG images.