### PR TITLE
Add Internal testing option for Release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,16 +73,17 @@ include(src/ui/wxui_code.cmake)  # This will set ${wxue_generated_code} with lis
 include(src/file_list.cmake)     # This will set ${file_list} with a list of source files
 
 if (INTERNAL_TESTING)
-
     include(src/internal/wxui_internal.cmake)  # This will set ${wxui_internal} with a list of source files
+
+    # Note that setting the INTERNAL_TESTING doesn't just add these modules, it also
+    # enables the three assertion macros in a Release build, and may change other
+    # functionality as well. It should NEVER be used for a production build!
 
     set (wxui_internal ${wxui_internal}
         ${CMAKE_CURRENT_LIST_DIR}/src/internal/code_compare.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/internal/nodeinfo.cpp
     )
-
 endif()
-
 
 # Note the requirement that --config Debug is used to get the additional debug files
 add_executable(wxUiEditor WIN32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,15 +45,14 @@ if (NOT isMultiConfig)
     endif()
 endif()
 
-option(INTERNAL_WIDGETS_SOURCES "Build with internal forked wxWidgets sources" )
+option(INTERNAL_TESTING "Build with internal testing functionality")
 
-if (INTERNAL_WIDGETS_SOURCES)
-    message(NOTICE "Building internal version")
+if (INTERNAL_TESTING)
+    message(NOTICE "Building internal testing version")
 
-    # Add preprocessor definition that can be used to conditionalize code based on whether the
-    # internal wxWidgets libraries are being used.
-    add_compile_definitions(INTERNAL_WIDGETS)
-
+    # In addition to enabling testing-only functionality, this enables ASSERT(), ASSERT_MSG(),
+    # and FAIL_MSG() in a Release build.
+    add_compile_definitions(INTERNAL_TESTING)
 endif()
 
 set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot)
@@ -73,7 +72,7 @@ add_compile_definitions(BETA)
 include(src/ui/wxui_code.cmake)  # This will set ${wxue_generated_code} with list of generated files
 include(src/file_list.cmake)     # This will set ${file_list} with a list of source files
 
-if (INTERNAL_WIDGETS_SOURCES)
+if (INTERNAL_TESTING)
 
     include(src/internal/wxui_internal.cmake)  # This will set ${wxui_internal} with a list of source files
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,15 @@ if (INTERNAL_TESTING)
     set (wxui_internal ${wxui_internal}
         ${CMAKE_CURRENT_LIST_DIR}/src/internal/code_compare.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/internal/nodeinfo.cpp
-    )
+
+        # These are always included in Debug builds, with INTERNAL_TESTING we also need them
+        # in Release builds.
+        $<$<CONFIG:Release>:${CMAKE_CURRENT_LIST_DIR}/src/debugging/msg_logging.cpp>
+        $<$<CONFIG:Release>:${CMAKE_CURRENT_LIST_DIR}/src/debugging/msgframe.cpp>
+        $<$<CONFIG:Release>:${CMAKE_CURRENT_LIST_DIR}/src/debugging/msgframe_base.cpp>
+        $<$<CONFIG:Release>:${CMAKE_CURRENT_LIST_DIR}/src/debugging/debugsettings.cpp>
+        $<$<CONFIG:Release>:${CMAKE_CURRENT_LIST_DIR}/src/debugging/debugsettingsBase.cpp>
+        )
 endif()
 
 # Note the requirement that --config Debug is used to get the additional debug files

--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -34,6 +34,7 @@ Files:
 
     mainapp.cpp           # Main application class
     mainframe.cpp         # Main window frame
+    assertion_dlg.cpp     # Assertion Dialog
 
     appoptions.cpp        # Application-wide options
     bitmaps.cpp           # Map of bitmaps accessed by name
@@ -202,8 +203,6 @@ DebugFiles:
     debugging/debugsettings.cpp         # Settings while running the Debug version of wxUiEditor
     debugging/debugsettingsBase.cpp     # wxUiEditor generated file
     debugging/msgframe_base.cpp         # wxUiEditor generated file
-
-    ../ttLib/src/winsrc/ttdebug_min.cpp  # ttAssertionMsg
 
 Docs:
     # ttBld will ignore this section -- it's here just for convenience as a shortcut to open some of the documentation

--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -15,7 +15,7 @@ Options:
     Crt_rel:          dll      # [static | dll] type of CRT to link to in release builds
     Crt_dbg:          dll      # [static | dll] type of CRT to link to in debug builds
 
-    CFlags_cmn:       /std:c++17 /Zc:__cplusplus /utf-8 /DUNICODE /DINTERNAL_WIDGETS
+    CFlags_cmn:       /std:c++17 /Zc:__cplusplus /utf-8 /DUNICODE /DINTERNAL_TESTING
     CFlags_rel:       /DNDEBUG # static wxWidgets libraries in release build
 
     TargetDir:        ../build/CMakeFiles/CMakeTmp   # just a temporary location for the library

--- a/src/appoptions.h
+++ b/src/appoptions.h
@@ -23,24 +23,24 @@ public:
     void set_SizersExpand(bool setting) { m_sizers_always_expand = setting; }
     void set_isWakaTimeEnabled(bool setting) { m_enable_wakatime = setting; }
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     bool get_FilterWarningMsgs() { return m_filter_warning_msgs; }
     void set_FilterWarningMsgs(bool setting) { m_filter_warning_msgs = setting; }
 
     wxString& get_ChmFile() { return m_chm_file; }
     void set_ChmFile(const wxString& str) { m_chm_file = str; }
-#endif  // _DEBUG
+#endif
 
 private:
     bool m_sizers_all_borders;
     bool m_sizers_always_expand;
     bool m_enable_wakatime;
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     bool m_filter_warning_msgs { false };  // controls display of warning messages in debug CMsgFrame window
 
     wxString m_chm_file;  // path to wxWidgets chm file
-#endif                    // _DEBUG
+#endif
 };
 
 extern AppOptions g_AppOptions;

--- a/src/assertion_dlg.cpp
+++ b/src/assertion_dlg.cpp
@@ -1,0 +1,47 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Assertion Dialog
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License ( see ../LICENSE )
+/////////////////////////////////////////////////////////////////////////////
+
+#include <cstdlib>
+#include <mutex>
+
+#include <wx/msgdlg.h>
+
+static std::mutex g_mutexAssert;
+
+bool AssertionDlg(const char* filename, const char* function, int line, const char* cond, const std::string& msg)
+{
+    // This is in case additional message processing results in an assert while this one is already being displayed.
+    std::unique_lock<std::mutex> classLock(g_mutexAssert);
+
+    ttlib::cstr str;
+
+    if (cond)
+        str << "Expression: " << cond << "\n\n";
+    if (!msg.empty())
+        str << "Comment: " << msg << "\n\n";
+
+    str << "File: " << filename << "\n";
+    str << "Function: " << function << "\n";
+    str << "Line: " << line << "\n\n";
+    str << "Press Yes to call wxTrap, No to continue, Cancel to exit program.";
+
+    wxMessageDialog dlg(nullptr, str.wx_str(), "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
+    dlg.SetYesNoCancelLabels("wxTrap", "Continue", "Exit program");
+
+    auto answer = dlg.ShowModal();
+
+    if (answer == wxID_YES)
+    {
+        return true;
+    }
+    else if (answer == wxID_CANCEL)
+    {
+        std::quick_exit(2);
+    }
+
+    return false;
+}

--- a/src/assertion_dlg.h
+++ b/src/assertion_dlg.h
@@ -1,0 +1,35 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Assertion Dialog
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License ( see ../LICENSE )
+/////////////////////////////////////////////////////////////////////////////
+
+// This should *ONLY* be called in the GUI thread!
+//
+// This function is available in Release builds
+bool AssertionDlg(const char* filename, const char* function, int line, const char* cond, const std::string& msg);
+
+#if defined(NDEBUG) && !defined(INTERNAL_TESTING)
+    #define ASSERT(cond)
+    #define ASSERT_MSG(cond, msg)
+    #define FAIL_MSG(msg)
+#else  // not defined(NDEBUG) && !defined(INTERNAL_TESTING)
+    #define ASSERT(cond)                                                      \
+        if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, "")) \
+        {                                                                     \
+            wxTrap();                                                         \
+        }
+
+    #define ASSERT_MSG(cond, msg)                                                \
+        if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, (msg))) \
+        {                                                                        \
+            wxTrap();                                                            \
+        }
+
+    #define FAIL_MSG(msg)                                              \
+        if (AssertionDlg(__FILE__, __func__, __LINE__, "failed", msg)) \
+        {                                                              \
+            wxTrap();                                                  \
+        }
+#endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)

--- a/src/debugging/msg_logging.cpp
+++ b/src/debugging/msg_logging.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Message logging class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -131,6 +131,15 @@ void MsgLogging::AddErrorMsg(ttlib::cview msg)
         frame->SetRightStatusField(str);
 }
 
+void MsgLogging::OnNodeSelected()
+{
+    if (!m_bDestroyed && m_msgFrame)
+    {
+        m_msgFrame->OnNodeSelected();
+    }
+}
+
+#if defined(_DEBUG)
 void MsgLogging::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogRecordInfo& info)
 {
     if (wxGetApp().isMainFrameClosing())
@@ -243,15 +252,6 @@ void MsgLogging::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogR
             // just ignore those: passing them to the base class would result in asserts from DoLogText() because
             // DoLogTextAtLevel() would call it as it doesn't know how to handle these levels otherwise
             break;
-    }
-}
-
-#if defined(_DEBUG)
-void MsgLogging::OnNodeSelected()
-{
-    if (!m_bDestroyed && m_msgFrame)
-    {
-        m_msgFrame->OnNodeSelected();
     }
 }
 #endif

--- a/src/debugging/msg_logging.h
+++ b/src/debugging/msg_logging.h
@@ -1,17 +1,19 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Message logging class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
+// In a Debug build, we use our custom logging class to retrieve wxWidgets messages. In a Release build with INTERNAL_TESTING
+// set, we still have the custom class and window, but there is no log window to derive from, or messages from wxWidgets to
+// intercept.
+
 #if defined(_DEBUG)
-// clang-format off
     #include <wx/log.h>  // Assorted wxLogXXX functions, and wxLog (sink for logs)
     #include <wx/generic/logg.h>  // wxLogGui class
-// clang-format on
 #endif  // _DEBUG
 
 class MsgFrame;
@@ -32,8 +34,9 @@ public:
     void AddWarningMsg(ttlib::cview msg);
     void AddErrorMsg(ttlib::cview msg);
 
-#if defined(_DEBUG)
     void OnNodeSelected();
+
+#if defined(_DEBUG)
     void DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogRecordInfo& info) override;
 #endif
 

--- a/src/debugging/msgframe.cpp
+++ b/src/debugging/msgframe.cpp
@@ -18,7 +18,7 @@
 #include "mainframe.h"       // MainFrame -- Main window frame
 #include "node.h"            // Node class
 
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
     #include "internal/nodeinfo_base.h"  // NodeInfo -- Node memory usage dialog
 #endif
 
@@ -343,7 +343,7 @@ void MsgFrame::OnParent(wxCommandEvent& WXUNUSED(event))
         }
         else
         {
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
             NodeInfo dlg(this);
             dlg.ShowModal();
 #endif

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -4,6 +4,7 @@ set (file_list
 
     ${CMAKE_CURRENT_LIST_DIR}/mainapp.cpp           # Main application class
     ${CMAKE_CURRENT_LIST_DIR}/mainframe.cpp         # Main window frame
+    ${CMAKE_CURRENT_LIST_DIR}/assertion_dlg.cpp     # Assertion Dialog
 
     ${CMAKE_CURRENT_LIST_DIR}/appoptions.cpp        # Application-wide options
     ${CMAKE_CURRENT_LIST_DIR}/bitmaps.cpp           # Map of bitmaps accessed by name
@@ -162,7 +163,4 @@ set (file_list
 
     $<$<CONFIG:Debug>:${CMAKE_CURRENT_LIST_DIR}/debugging/msgframe_base.cpp>       # wxUiEditor generated file
     $<$<CONFIG:Debug>:${CMAKE_CURRENT_LIST_DIR}/debugging/debugsettingsBase.cpp>   # wxUiEditor generated file
-
-    $<$<CONFIG:Debug>:${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/winsrc/ttdebug_min.cpp>  # ttAssertionMsg
-
 )

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -607,7 +607,6 @@ void BaseCodeGenerator::GenSrcEventBinding(Node* node, const EventVector& events
     if (!propName)
     {
         FAIL_MSG(ttlib::cstr("Missing \"name\" property in ") << node->DeclName() << " class.");
-        BETA_ERROR(ttlib::cstr("\nMissing \"name\" property in ") << node->DeclName() << " class.")
         return;
     }
 
@@ -615,7 +614,6 @@ void BaseCodeGenerator::GenSrcEventBinding(Node* node, const EventVector& events
     if (class_name.empty())
     {
         FAIL_MSG("Property name cannot be null");
-        BETA_ERROR("Property name cannot be null")
         return;
     }
 
@@ -1184,7 +1182,6 @@ ttlib::cstr BaseCodeGenerator::GetDeclaration(Node* node)
         else
         {
             FAIL_MSG("Unrecognized class name so no idea how to declare it in the header file.")
-            BETA_ERROR("Unrecognized class name so no idea how to declare it in the header file.")
         }
     }
     else if (class_name.is_sameas("CustomControl"))
@@ -1213,7 +1210,6 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     if (!form_node->HasValue(prop_class_name))
     {
         FAIL_MSG(ttlib::cstr("Missing \"name\" property in ") << form_node->DeclName());
-        BETA_ERROR(ttlib::cstr("\nMissing \"name\" property in ") << form_node->DeclName());
         return;
     }
 

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -60,7 +60,7 @@ int WriteCMakeFile(bool test_only = true);  // See gen_cmake.cpp
 // class name over every form that needs updating.
 bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck = false, std::vector<ttlib::cstr>* pClassList = nullptr);
 
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
 void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node root);
 #endif
 

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -339,7 +339,7 @@ void MainFrame::OnGenInhertedClass(wxCommandEvent& WXUNUSED(e))
     }
 }
 
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
 
     #include "pugixml.hpp"
 
@@ -468,4 +468,4 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
     }
 }
 
-#endif  // defined(INTERNAL_WIDGETS)
+#endif  // defined(INTERNAL_TESTING)

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -161,7 +161,7 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
                 ++currentFiles;
             }
         }
-        catch (const std::exception& DBG_PARAM(e))
+        catch (const std::exception& TESTING_PARAM(e))
         {
             MSG_ERROR(e.what());
             wxMessageBox(ttlib::cstr("An internal error occurred generating code files for ")

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -90,7 +90,6 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
                 if (!subwindow)
                 {
                     FAIL_MSG("Child of splitter is not derived from wxWindow class.");
-                    BETA_ERROR("Child of splitter is not derived from wxWindow class.");
                     return;
                 }
 
@@ -115,7 +114,6 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
                 if (!subwindow0 || !subwindow1)
                 {
                     FAIL_MSG("Child of splitter is not derived from wxWindow class.");
-                    BETA_ERROR("Child of splitter is not derived from wxWindow class.");
                     return;
                 }
 

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -345,12 +345,12 @@ bool ProjectSettings::AddEmbeddedBundleImage(ttlib::cstr path, Node* form)
                     }
                     else
                     {
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
                         auto org_size = static_cast<size_t>(stream.GetLength());
                         auto png_size = read_stream->GetBufferSize();
                         ttlib::cstr size_comparison;
                         size_comparison.Format("Original: %ku, new: %ku", org_size, png_size);
-#endif  // _DEBUG
+#endif
 
                         embed->type = handler->GetType();
                         embed->array_size = stream.GetSize();
@@ -612,7 +612,7 @@ bool ProjectSettings::AddSvgBundleImage(ttlib::cstr path, Node* form)
     embed->array_data = std::make_unique<unsigned char[]>(compressed_size);
     memcpy(embed->array_data.get(), read_stream->GetBufferStart(), compressed_size);
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     wxFile file_original(path.wx_str(), wxFile::read);
     if (file_original.IsOpened())
     {

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -151,7 +151,7 @@ bool FormBuilder::Import(const ttString& filename, bool write_doc)
             m_project->CreateDoc(m_docOut);
     }
 
-    catch (const std::exception& DBG_PARAM(e))
+    catch (const std::exception& TESTING_PARAM(e))
     {
         MSG_ERROR(e.what());
         wxMessageBox(wxString("This wxFormBuilder project file is invalid and cannot be loaded: ") << filename,

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -1177,14 +1177,14 @@ void WxCrafter::KnownProperty(Node* node, const Value& value, GenEnum::PropName 
                     prop_name = prop_help;
                 else
                 {
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
                     if ((prop_value.IsString() && prop_value.GetStringLength()) ||
                         (prop_value.IsBool() && prop_value.GetBool()))
                     {
                         MSG_INFO(ttlib::cstr() << node->DeclName() << " doesn't have a property called "
                                                << GenEnum::map_PropNames[prop_name]);
                     }
-#endif  // _DEBUG
+#endif
                 }
             }
             if (prop_value.IsBool())

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -52,7 +52,7 @@ bool WxGlade::Import(const ttString& filename, bool write_doc)
             m_project->CreateDoc(m_docOut);
     }
 
-    catch (const std::exception& DBG_PARAM(e))
+    catch (const std::exception& TESTING_PARAM(e))
     {
         MSG_ERROR(e.what());
         wxMessageBox(wxString("This project file is invalid and cannot be loaded: ") << filename, "Import Project");

--- a/src/import/import_wxsmith.cpp
+++ b/src/import/import_wxsmith.cpp
@@ -53,7 +53,7 @@ bool WxSmith::Import(const ttString& filename, bool write_doc)
             m_project->CreateDoc(m_docOut);
     }
 
-    catch (const std::exception& DBG_PARAM(e))
+    catch (const std::exception& TESTING_PARAM(e))
     {
         MSG_ERROR(e.what());
         wxMessageBox(wxString("This project file is invalid and cannot be loaded: ") << filename, "Import Project");

--- a/src/internal/code_compare.cpp
+++ b/src/internal/code_compare.cpp
@@ -6,7 +6,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
 
 #include <wx/dir.h>  // wxDir is a class for enumerating the files in a directory
 
@@ -91,7 +91,7 @@ HINSTANCE winShellRun(std::string_view filename, std::string_view args, std::str
 
 void CodeCompare::OnWinMerge(wxCommandEvent& /* event */)
 {
-    #if defined(INTERNAL_WIDGETS)
+    #if defined(INTERNAL_TESTING)
     pugi::xml_document doc;
     auto root = doc.append_child("project");
 
@@ -110,4 +110,4 @@ void CodeCompare::OnWinMerge(wxCommandEvent& /* event */)
     #endif
 }
 
-#endif  // defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#endif  // defined(_DEBUG) || defined(INTERNAL_TESTING)

--- a/src/internal/nodeinfo.cpp
+++ b/src/internal/nodeinfo.cpp
@@ -6,7 +6,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-#if defined(INTERNAL_WIDGETS) || defined(_DEBUG)
+#if defined(INTERNAL_TESTING) || defined(_DEBUG)
 
 #include "nodeinfo_base.h"  // auto-generated: nodeinfo_base.h and nodeinfo_base.cpp
 
@@ -78,4 +78,4 @@ void NodeInfo::OnInit(wxInitDialogEvent& /* event */)
     Fit();
 }
 
-#endif  // defined(INTERNAL_WIDGETS) || defined(_DEBUG)
+#endif  // defined(INTERNAL_TESTING) || defined(_DEBUG)

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -454,6 +454,7 @@ void App::ShowMsgWindow()
 
 void App::DbgCurrentTest(wxCommandEvent&)
 {
+    FAIL_MSG("test")
     wxMessageBox("Add code you want to test to (mainapp.cpp) App::DbgCurrentTest()", txtVersion);
 }
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -100,10 +100,14 @@ bool App::OnInit()
     // If we're just providing text-popups for help, then this is all we need.
     wxHelpProvider::Set(new wxSimpleHelpProvider);
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     g_pMsgLogging = new MsgLogging();
-    wxLog::SetActiveTarget(g_pMsgLogging);
 #endif
+
+#if defined(_DEBUG)
+    // wxLog only exists in _DEBUG builds
+    wxLog::SetActiveTarget(g_pMsgLogging);
+#endif  // _DEBUG
 
     SetVendorName("KeyWorks");
 
@@ -441,20 +445,17 @@ void App::OnFatalException()
 
 #endif  // defined(_MSC_VER) && defined(wxUSE_ON_FATAL_EXCEPTION)
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
 
 void App::ShowMsgWindow()
 {
     g_pMsgLogging->ShowLogger();
 }
 
-#endif  // defined(_DEBUG)
-
-#if defined(_DEBUG) || defined(INTERNAL_TESTING)
-
 void App::DbgCurrentTest(wxCommandEvent&)
 {
-    FAIL_MSG("test")
+    FAIL_MSG("test FAIL_MSG() macro")
+
     wxMessageBox("Add code you want to test to (mainapp.cpp) App::DbgCurrentTest()", txtVersion);
 }
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -450,7 +450,7 @@ void App::ShowMsgWindow()
 
 #endif  // defined(_DEBUG)
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
 
 void App::DbgCurrentTest(wxCommandEvent&)
 {

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -112,14 +112,11 @@ public:
     void SetLanguage(wxLanguage language) { m_lang = language; }
     wxLanguage GetLanguage() { return m_lang; }
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
 
     void ShowMsgWindow();
     bool AutoMsgWindow() { return (m_prefs.flags & PREFS_MSG_WINDOW); }
 
-#endif
-
-#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     void DbgCurrentTest(wxCommandEvent& event);
 #endif
 

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -119,7 +119,7 @@ public:
 
 #endif
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     void DbgCurrentTest(wxCommandEvent& event);
 #endif
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -524,7 +524,6 @@ void MainFrame::OnInsertWidget(wxCommandEvent&)
             return CreateToolNode(result->second);
         }
         FAIL_MSG(ttlib::cstr() << "No property enum type exists for dlg.GetWidget()! This should be impossible...")
-        BETA_ERROR("\nNo property enum type exists for dlg.GetWidget().")
     }
 }
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -53,7 +53,7 @@
 #include "ui/importwinres_base.h"  // ImportWinResDlg -- Dialog for Importing a Windows resource file
 #include "ui/insertwidget_base.h"  // InsertWidget -- Dialog to lookup and insert a widget
 
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
     #include "internal/code_compare_base.h"
     #include "internal/nodeinfo_base.h"
 #endif
@@ -112,7 +112,7 @@ MainFrame::MainFrame() :
     m_FileHistory.AddFilesToMenu();
     config->SetPath("/");
 
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
     auto menuInternal = new wxMenu;
 
     menuInternal->Append(id_CodeDiffDlg, "Compare Code &Generation...",
@@ -261,7 +261,7 @@ MainFrame::MainFrame() :
         },
         id_Magnify);
 
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
     Bind(
         wxEVT_MENU,
         [this](wxCommandEvent&)
@@ -281,7 +281,7 @@ MainFrame::MainFrame() :
         id_NodeMemory);
 #endif
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     Bind(wxEVT_MENU, &MainFrame::OnFindWidget, this, id_FindWidget);
 #endif
 
@@ -304,7 +304,7 @@ MainFrame::MainFrame() :
         id_ShowLogger);
 #endif
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     Bind(wxEVT_MENU, &App::DbgCurrentTest, &wxGetApp(), id_DebugCurrentTest);
 #endif
 
@@ -549,7 +549,7 @@ void MainFrame::OnOpenRecentProject(wxCommandEvent& event)
     }
 }
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
 void MainFrame::OnImportRecent(wxCommandEvent& event)
 {
     ttString file = m_ImportHistory.GetHistoryFile(event.GetId() - (wxID_FILE1 + 1000));
@@ -567,7 +567,7 @@ void MainFrame::OnImportRecent(wxCommandEvent& event)
     else if (extension == ".xrc")
         wxGetApp().AppendXRC(files);
 }
-#endif  // defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#endif  // defined(_DEBUG) || defined(INTERNAL_TESTING)
 
 void MainFrame::OnNewProject(wxCommandEvent&)
 {
@@ -1091,7 +1091,7 @@ wxWindow* MainFrame::CreateNoteBook(wxWindow* parent)
     m_derivedPanel = new BasePanel(m_notebook, this, 1);
     m_notebook->AddPage(m_derivedPanel, "Derived", false, wxWithImages::NO_IMAGE);
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     // m_xrcPanel = new BasePanel(m_notebook, this, -1);
     // m_notebook->AddPage(m_xrcPanel, "XRC", false, wxWithImages::NO_IMAGE);
 #endif
@@ -1722,7 +1722,7 @@ void MainFrame::PushUndoAction(UndoActionPtr cmd, bool add_to_stack)
         m_undo_stack.Push(cmd);
 }
 
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
 
 void MainFrame::OnCodeCompare(wxCommandEvent& WXUNUSED(event))
 {
@@ -1751,7 +1751,7 @@ Node* FindChildNode(Node* node, GenEnum::GenName name)
     return nullptr;
 }
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
 
 void MainFrame::OnFindWidget(wxCommandEvent& WXUNUSED(event))
 {
@@ -1782,4 +1782,4 @@ void MainFrame::OnFindWidget(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-#endif  // defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#endif  // defined(_DEBUG) || defined(INTERNAL_TESTING)

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -210,7 +210,7 @@ public:
 
     wxInfoBar* GetPropInfoBar() { return m_info_bar; }
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     wxFileHistory* GetAppendImportHistory() { return &m_ImportHistory; }
 #endif  // _DEBUG
 
@@ -259,11 +259,11 @@ protected:
 
     void OnNodeSelected(CustomEvent& event);
 
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
     void OnCodeCompare(wxCommandEvent& event);
 #endif
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     void OnFindWidget(wxCommandEvent& event);
 #endif
 
@@ -295,7 +295,7 @@ private:
 
     BasePanel* m_generatedPanel { nullptr };
     BasePanel* m_derivedPanel { nullptr };
-#if defined(INTERNAL_WIDGETS)
+#if defined(INTERNAL_TESTING)
     BasePanel* m_xrcPanel { nullptr };
 #endif
 
@@ -312,7 +312,7 @@ private:
     wxFindReplaceDialog* m_findDialog { nullptr };
 
     wxFileHistory m_FileHistory;
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     wxFileHistory m_ImportHistory;
     wxMenu* m_submenu_import_recent;
 

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -222,7 +222,6 @@ NodeSharedPtr NodeCreator::CreateNode(ttlib::cview name, Node* parent)
     if (result == rmap_GenNames.end())
     {
         FAIL_MSG(ttlib::cstr() << "No component definition for " << name);
-        BETA_ERROR(ttlib::cstr() << "\nNo component definition for " << name);
         return {};
     }
 

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -430,7 +430,7 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview xml_data)
     while (generator)
     {
         auto class_name = generator.attribute("class").as_string();
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
         if (rmap_GenNames.find(class_name) == rmap_GenNames.end())
         {
             MSG_WARNING(ttlib::cstr("Unrecognized class name -- ") << class_name);
@@ -448,7 +448,7 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview xml_data)
             }
         }
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
         if (type == gen_type_unknown)
         {
             MSG_WARNING(ttlib::cstr("Unrecognized class type -- ") << type_name);

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -540,8 +540,6 @@ void NavigationPanel::OnNodeSelected(CustomEvent& event)
     {
         FAIL_MSG(ttlib::cstr("There is no tree item associated with this object.\n\tClass: ")
                  << node->DeclName() << "\n\tName: " << node->prop_as_string(prop_var_name).wx_str());
-        BETA_ERROR(ttlib::cstr("\nThere is no tree item associated with this object.\n\tClass: ")
-                   << node->DeclName() << "\n\tName: " << node->prop_as_string(prop_var_name).wx_str());
     }
 }
 

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -723,12 +723,7 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
     {
         // If this actually happens, then we silently do nothing leaving the user no idea of why it didn't work
         FAIL_MSG("If this occurs, we need to figure out why and then add a message to let the user know why.")
-#if !defined(_DEBUG)
-        INTERNAL_ERROR(ttlib::cstr() << "\nThe following node is missing a parent: " << node->get_node_name())
-        throw;
-#else
         return;
-#endif  // _DEBUG
     }
 
     auto childPos = parent->GetChildPosition(node);
@@ -742,12 +737,7 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
     {
         // If this actually happens, then we silently do nothing leaving the user no idea of why it didn't work
         FAIL_MSG("If this occurs, we need to figure out why and then add a message to let the user know why.")
-#if !defined(_DEBUG)
-        INTERNAL_ERROR(ttlib::cstr() << "\nThe following node is missing a sizer parent: " << node->get_node_name())
-        throw;
-#else
         return;
-#endif  // _DEBUG
     }
 
     // Avoid the temptation to set new_sizer to the raw pointer so that .get() doesn't have to be called below. Doing so will

--- a/src/pch.h
+++ b/src/pch.h
@@ -169,66 +169,31 @@ constexpr const char BMP_PROP_SEPARATOR = ';';
 
 #endif  // defined(NDEBUG)
 
-#if defined(NDEBUG)
+#include "assertion_dlg.h"  // Assertion Dialog
 
-    #define ASSERT(cond)
-    #define ASSERT_MSG(cond, msg)
-    #define FAIL_MSG(msg)
+#if defined(NDEBUG) && !defined(INTERNAL_TESTING)
+    #define CHECK2_MSG(cond, op, msg) wxASSERT_MSG(cond, msg)
+    #define CHECK_MSG(cond, rc, msg)  wxCHECK2_MSG(cond, return rc, msg)
+    #define CHECK(cond, rc)           wxCHECK2_MSG(cond, return rc, (const char*) nullptr)
+    #define CHECK2(cond, op)          wxCHECK2_MSG(cond, op, (const char*) nullptr)
+    #define CHECK_RET(cond, msg)      wxCHECK2_MSG(cond, return, msg)
+#else
 
-#else  // Debug build only
-
-    #if defined(_WIN32) && !defined(NONWIN_TEST)
-
-bool ttAssertionMsg(const char* filename, const char* function, int line, const char* cond, const std::string& msg);
-
-    // Unlike the wxASSERT macros, these will provide an Abort button allowing you to immediately terminate the
-    // application. The assertion information is easier to read, but does not provide a call stack or the ability to
-    // ignore the assertion.
-
-        #define ASSERT(cond)                                                            \
-            {                                                                           \
-                if (!(cond) && ttAssertionMsg(__FILE__, __func__, __LINE__, #cond, "")) \
-                {                                                                       \
-                    wxTrap();                                                           \
-                }                                                                       \
-            }
-
-        #define ASSERT_MSG(cond, msg)                                                  \
-            if (!(cond) && ttAssertionMsg(__FILE__, __func__, __LINE__, #cond, (msg))) \
-            {                                                                          \
-                wxTrap();                                                              \
-            }
-
-        #define FAIL_MSG(msg)                                               \
-            if (ttAssertionMsg(__FILE__, __func__, __LINE__, nullptr, msg)) \
-            {                                                               \
-                wxTrap();                                                   \
-            }
-
-    #else  // not defined(_WIN32)
-        #define ASSERT(cond)          wxASSERT(cond)
-        #define ASSERT_MSG(cond, msg) wxASSERT_MSG(cond, msg)
-        #define FAIL_MSG(msg)         wxFAIL_MSG(msg)
-    #endif  // _WIN32
-
-#endif  // defined(NDEBUG)
-
-#if defined(_WIN32) && !defined(NONWIN_TEST)
-// These are essentially the same as the wxWidgets macros except that it calls ttAssertionMsg instead of
+// These are essentially the same as the wxWidgets macros except that it calls AssertionDlg instead of
 // wxFAIL_COND_MSG
 
-    #define CHECK2_MSG(cond, op, msg)                                       \
-        if (cond)                                                           \
-        {                                                                   \
-        }                                                                   \
-        else                                                                \
-        {                                                                   \
-            if (ttAssertionMsg(__FILE__, __func__, __LINE__, #cond, (msg))) \
-            {                                                               \
-                wxTrap();                                                   \
-            }                                                               \
-            op;                                                             \
-        }                                                                   \
+    #define CHECK2_MSG(cond, op, msg)                                     \
+        if (cond)                                                         \
+        {                                                                 \
+        }                                                                 \
+        else                                                              \
+        {                                                                 \
+            if (AssertionDlg(__FILE__, __func__, __LINE__, #cond, (msg))) \
+            {                                                             \
+                wxTrap();                                                 \
+            }                                                             \
+            op;                                                           \
+        }                                                                 \
         struct wxDummyCheckStruct /* just to force a semicolon */
 
     #define CHECK_MSG(cond, rc, msg) CHECK2_MSG(cond, return rc, msg)
@@ -236,10 +201,4 @@ bool ttAssertionMsg(const char* filename, const char* function, int line, const 
     #define CHECK2(cond, op)         CHECK2_MSG(cond, op, (const char*) nullptr)
     #define CHECK_RET(cond, msg)     CHECK2_MSG(cond, return, msg)
 
-#else
-    #define CHECK2_MSG(cond, op, msg) wxASSERT_MSG(cond, msg)
-    #define CHECK_MSG(cond, rc, msg)  wxCHECK2_MSG(cond, return rc, msg)
-    #define CHECK(cond, rc)           wxCHECK2_MSG(cond, return rc, (const char*) nullptr)
-    #define CHECK2(cond, op)          wxCHECK2_MSG(cond, op, (const char*) nullptr)
-    #define CHECK_RET(cond, msg)      wxCHECK2_MSG(cond, return, msg)
-#endif
+#endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)

--- a/src/pch.h
+++ b/src/pch.h
@@ -1,13 +1,22 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Precompiled header file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
 // This header file is used to create a pre-compiled header for use in the entire project
 
 #pragma once
+
+// Ensure that _DEBUG is defined in non-release builds
+#if !defined(NDEBUG) && !defined(_DEBUG)
+    #define _DEBUG
+#endif
+
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
+    #define INTERNAL_TESTING
+#endif
 
 #define wxUSE_GUI         1
 #define wxUSE_NO_MANIFEST 1
@@ -31,12 +40,9 @@
     #endif
 #endif
 
-// Ensure that _DEBUG is defined in non-release builds
-#if !defined(NDEBUG) && !defined(_DEBUG)
-    #define _DEBUG
+#if defined(_DEBUG)
+    #include <wx/debug.h>  // Misc debug functions and macros
 #endif
-
-#include <wx/debug.h>  // Misc debug functions and macros
 
 // These warnings are still generated in 3.1.16
 
@@ -114,14 +120,17 @@ constexpr const char BMP_PROP_SEPARATOR = ';';
 
 //////////////////////////////////////// macros ////////////////////////////////////////
 
-#if defined(NDEBUG)
+#if defined(NDEBUG) && !defined(INTERNAL_TESTING)
 
     #define MSG_INFO(msg)
     #define MSG_EVENT(msg)
     #define MSG_WARNING(msg)
     #define MSG_ERROR(msg)
 
-#else  // not defined(NDEBUG)
+    // Use this macro to comment out parameters that are not used in Release builds
+    #define TESTING_PARAM(param) /* param */
+
+#else
 
 // These messages can be individually enabled/disabled in the Preferences dialog (Debug tab).
 // Note that none of these are displayed in a Release build.
@@ -145,7 +154,10 @@ constexpr const char BMP_PROP_SEPARATOR = ';';
             g_pMsgLogging->AddErrorMsg(msg); \
         }
 
-#endif  // defined(NDEBUG)
+    // Use this macro to comment out parameters that are not used in Release builds
+    #define TESTING_PARAM(param) param
+
+#endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)
 
 #include "assertion_dlg.h"  // Assertion Dialog
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -14,7 +14,7 @@
     #define _DEBUG
 #endif
 
-#if defined(_DEBUG) || defined(INTERNAL_TESTING)
+#if defined(_DEBUG) && !defined(INTERNAL_TESTING)
     #define INTERNAL_TESTING
 #endif
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -114,28 +114,6 @@ constexpr const char BMP_PROP_SEPARATOR = ';';
 
 //////////////////////////////////////// macros ////////////////////////////////////////
 
-// Use INTERNAL_ERROR(msg) if you always want to report a problem in any Debug or Release build. Use BETA_ERROR(msg) if this
-// is just something you want reported on during a Debug or Release beta build (which presumably will be fixed and not occur
-// before a non-beta Release). You do not need to call these if you are instead calling throw std::...()
-
-#if defined(BETA)
-    #define BETA_ERROR(msg)                                                                                              \
-        {                                                                                                                \
-            wxMessageBox(wxString("An internal error occured in ") << __func__ << " at line " << __LINE__ << '.' << msg, \
-                         txtVersion);                                                                                    \
-        }
-#else
-    #define BETA_ERROR(msg) \
-        {                   \
-        }
-#endif
-
-#define INTERNAL_ERROR(msg)                                                                                          \
-    {                                                                                                                \
-        wxMessageBox(wxString("An internal error occured in ") << __func__ << " at line " << __LINE__ << '.' << msg, \
-                     txtVersion);                                                                                    \
-    }
-
 #if defined(NDEBUG)
 
     #define MSG_INFO(msg)

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -441,7 +441,7 @@ bool ProjectSettings::AddNewEmbeddedImage(ttlib::cstr path, Node* form, std::uni
                     }
                     else
                     {
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
                         auto org_size = static_cast<size_t>(stream.GetLength());
                         auto png_size = read_stream->GetBufferSize();
                         ttlib::cstr size_comparison;

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -453,7 +453,7 @@ bool App::Import(ImportXML& import, ttString& file, bool append)
     m_ProjectVersion = ImportProjectVersion;
     if (import.Import(file))
     {
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
         ttString full_path(file);
         full_path.make_absolute();
         wxGetFrame().GetAppendImportHistory()->AddFileToHistory(full_path);

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -154,7 +154,7 @@ NodeSharedPtr App::LoadProject(pugi::xml_document& doc)
         }
         project = g_NodeCreator.CreateNode(node);
     }
-    catch (const std::exception& DBG_PARAM(e))
+    catch (const std::exception& TESTING_PARAM(e))
     {
         MSG_ERROR(e.what());
         wxMessageBox("This wxUiEditor project file is invalid and cannot be loaded.", "Load Project");

--- a/src/startup_dlg.cpp
+++ b/src/startup_dlg.cpp
@@ -53,7 +53,7 @@ void StartupDlg::OnInit(wxInitDialogEvent& event)
         }
     }
 
-#if defined(_DEBUG) || defined(INTERNAL_WIDGETS)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     auto append_history_ptr = wxGetFrame().GetAppendImportHistory();
     for (size_t idx = 0; idx < append_history_ptr->GetCount(); ++idx)
     {

--- a/src/ui/import_dlg.cpp
+++ b/src/ui/import_dlg.cpp
@@ -33,7 +33,7 @@ enum
 
 void ImportDlg::OnInitDialog(wxInitDialogEvent& WXUNUSED(event))
 {
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     m_combo_recent_dirs->Show();
     m_btnRemove->Show();
 #endif  // _DEBUG
@@ -49,7 +49,7 @@ void ImportDlg::OnInitDialog(wxInitDialogEvent& WXUNUSED(event))
     config->SetPath("/preferences");
     auto import_type = config->Read("import_type", IMPORT_FB);
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     m_FileHistory.Load(*config);
     for (size_t idx = 0; idx < m_FileHistory.GetCount(); ++idx)
     {
@@ -119,7 +119,7 @@ void ImportDlg::OnInitDialog(wxInitDialogEvent& WXUNUSED(event))
     if (files.size())
         m_checkListProjects->InsertItems(files, 0);
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     // Because m_combo_recent_dirs was created hidden and is shown in Debug builds.
     Fit();
 #endif
@@ -164,7 +164,7 @@ void ImportDlg::OnOK(wxCommandEvent& event)
     else
         config->Write("import_type", static_cast<long>(IMPORT_FB));
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     m_FileHistory.Save(*config);
 #endif
     config->SetPath("/");
@@ -179,7 +179,7 @@ void ImportDlg::OnDirectory(wxCommandEvent& WXUNUSED(event))
     if (dlg.ShowModal() != wxID_OK)
         return;
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     m_FileHistory.AddFileToHistory(dlg.GetPath());
     m_combo_recent_dirs->AppendString(dlg.GetPath());
 #endif
@@ -218,7 +218,7 @@ void ImportDlg::OnDirectory(wxCommandEvent& WXUNUSED(event))
         m_checkListProjects->InsertItems(files, 0);
 }
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
 void ImportDlg::OnRecentDir(wxCommandEvent& WXUNUSED(event))
 {
     auto result = m_combo_recent_dirs->GetValue();

--- a/src/ui/import_dlg.h
+++ b/src/ui/import_dlg.h
@@ -45,14 +45,14 @@ protected:
 
     void OnOK(wxCommandEvent& event) override;
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     void OnRecentDir(wxCommandEvent& event) override;
     void OnRemove(wxCommandEvent& event) override;
 #endif
 
 private:
     std::vector<ttString> m_lstProjects;
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     wxFileHistory m_FileHistory;
 #endif
 };

--- a/src/wakatime.cpp
+++ b/src/wakatime.cpp
@@ -116,11 +116,7 @@ void WakaTime::SetWakaExePath()
 
 // Number of seconds before sending WakaTime a heartbeat. WakaTime docs recommend a two minute interval (120 seconds).
 
-#if defined(_DEBUG)
-constexpr const intmax_t waka_interval = 1;
-#else
 constexpr const intmax_t waka_interval = 120;
-#endif  // _DEBUG
 
 void WakaTime::SendHeartbeat(bool FileSavedEvent)
 {
@@ -151,10 +147,6 @@ void WakaTime::SendHeartbeat(bool FileSavedEvent)
             {
                 cmd << " --write";
             }
-
-#if defined(_DEBUG)
-            cmd << " --verbose";
-#endif  // _DEBUG
 
             wxExecute(cmd, wxEXEC_HIDE_CONSOLE);
         }

--- a/src/winres/winres_ctrl.cpp
+++ b/src/winres/winres_ctrl.cpp
@@ -95,7 +95,7 @@ static const ClassGenPair lst_name_gen[] = {
 
 void resCtrl::ParseDirective(WinResource* pWinResource, ttlib::cview line)
 {
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     // Create a copy of the original line without the extra spaces that can be used to send to our log window if there are
     // problems processing it.
 
@@ -220,7 +220,7 @@ void resCtrl::ParseDirective(WinResource* pWinResource, ttlib::cview line)
 
         else
         {
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
             ttlib::cstr msg("Unrecognized CONTROL: ");
             auto pos = line.find_space();
             msg << line.subview(0, pos);
@@ -305,7 +305,7 @@ void resCtrl::ParseDirective(WinResource* pWinResource, ttlib::cview line)
             // TODO: [KeyWorks - 06-01-2021] We handle all controls that MS documented on 05/31/2018, which as of 6/01/2021
             // is still the current documentation. So, if we get here the control is unrecognizable.
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
             ttlib::cstr msg("Unrecognized resource directive: ");
             auto pos = line.find_space();
             msg << line.subview(0, pos);

--- a/src/winres/winres_ctrl.h
+++ b/src/winres/winres_ctrl.h
@@ -64,9 +64,9 @@ public:
     }
 
     bool ParseDimensions(ttlib::cview line, wxRect& duRect, wxRect& pixelRect);
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     auto& GetOrginalLine() { return m_original_line; }
-#endif  // _DEBUG
+#endif
 
     NodeSharedPtr SetNodePtr(NodeSharedPtr node)
     {
@@ -116,9 +116,9 @@ private:
     // Some styles like UDS_AUTOBUDDY have to be post-processed during actual layout.
     ttlib::cstr m_non_processed_style;
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     ttlib::cstr m_original_line;
-#endif  // _DEBUG
+#endif
 
     // Caution -- wxRect is *NOT* the same as a Windows RECT structure. wxRect stores width and height, RECT stores right and
     // bottom positions.

--- a/src/winres/winres_dlg.cpp
+++ b/src/winres/winres_dlg.cpp
@@ -39,7 +39,7 @@ void resForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, s
     m_form_type = isDialog ? form_dialog : form_panel;
     m_form_node = g_NodeCreator.NewNode(isDialog ? gen_wxDialog : gen_PanelForm);
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     ttlib::cstr fullpath;
     fullpath.assignCwd();
     fullpath.append_filename(txtfile.filename().filename());
@@ -48,15 +48,15 @@ void resForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, s
     fullpath.forwardslashestoback();
     #endif  // _WIN32
     m_form_node->prop_set_value(prop_base_src_includes, ttlib::cstr() << "// " << fullpath);
-#endif  // _DEBUG
+#endif
 
     ttlib::cstr value;  // General purpose string we can use throughout this function
     value = line.substr(0, end);
     m_form_node->prop_set_value(prop_class_name, ConvertFormID(value));
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     m_form_id = m_form_node->prop_as_string(prop_class_name);
-#endif  // _DEBUG
+#endif
 
     line.remove_prefix(end);
     line.moveto_digit();

--- a/src/winres/winres_form.h
+++ b/src/winres/winres_form.h
@@ -189,7 +189,7 @@ private:
 
     bool m_is_popup_menu { false };
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     // Makes it easier to know exactly which form we're looking at in the debugger
     ttlib::cstr m_form_id;
 #endif  // _DEBUG

--- a/src/winres/winres_layout.cpp
+++ b/src/winres/winres_layout.cpp
@@ -736,7 +736,7 @@ void resForm::Adopt(Node* node, resCtrl* child)
 
 void resForm::Adopt(const NodeSharedPtr& node, resCtrl& child)
 {
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     ASSERT_MSG(!child.isAdded(), "Logic problem, child has already been added.");
     if (child.isAdded())
     {

--- a/src/winres/winres_menu.cpp
+++ b/src/winres/winres_menu.cpp
@@ -65,7 +65,7 @@ void resForm::ParseMenu(WinResource* pWinResource, ttlib::textfile& txtfile, siz
     m_form_type = form_menu;
     m_form_node = g_NodeCreator.NewNode(m_is_popup_menu ? gen_PopupMenu : gen_MenuBar);
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     m_form_node->prop_set_value(prop_base_src_includes, ttlib::cstr() << "// " << txtfile.filename());
 #endif  // _DEBUG
 
@@ -74,7 +74,7 @@ void resForm::ParseMenu(WinResource* pWinResource, ttlib::textfile& txtfile, siz
     value = line.substr(0, end);
     m_form_node->prop_set_value(prop_class_name, ConvertFormID(value));
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     m_form_id = m_form_node->prop_as_string(prop_class_name);
 #endif  // _DEBUG
 

--- a/src/xpm.cpp
+++ b/src/xpm.cpp
@@ -151,7 +151,7 @@ static const ImageMap png_headers[] = {
 
 // A different Icon is used for debug builds so that it is easier to identify that a debug build is being run.
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
     { "logo16", debug_16_png, sizeof(debug_16_png) },
     { "logo32", debug_32_png, sizeof(debug_32_png) }
 #else


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR replaces the INTERNAL_WIDGETS_SOURCES option in CMakeLists.txt with a new INTERNAL_TESTING option. The new option sets a compiler definition of the same name (/DINTERNAL_TESTING). This does not need to be set for Debug builds as INTERNAL_TESTING will always be set in a Debug build.

The Debug menu that appeared to the right of the Help menu has been replaced with an Internal menu that appears in Debug builds, and Release builds with INTERNAL_TESTING set.

Most of the testing functionality that was previously only available under Debug builds is now available in Release builds if INTERRNAL_TESTING is set. This includes all of the assertion macros, all of the MSG_...() macros, and the custom log window.

A Release build with INTERNAL_TESTING does not have debug symbols, so it's not really suitable to run under a debugger, but the assert and msg_ macros should catch the same error conditions that the debug version would in spite of the compiler optimization.

Closes #714
