### PR TITLE
Add wxFrame icon property

### DIFF
--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -248,6 +248,12 @@ std::optional<ttlib::cstr> FrameFormGenerator::GenEvents(NodeEvent* event, const
 
 std::optional<ttlib::cstr> FrameFormGenerator::GenSettings(Node* node, size_t& /* auto_indent */)
 {
+    if (auto code = GenerateIconCode(node->prop_as_string(prop_icon)); code.size())
+    {
+        code << GenFormSettings(node);
+        return code;
+    }
+
     return GenFormSettings(node);
 }
 
@@ -538,7 +544,7 @@ ttlib::cstr GenerateIconCode(const ttlib::cstr& description)
 
     ttlib::multiview parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
 
-    if (parts[IndexImage].empty())
+    if (parts.size() < 2 || parts[IndexImage].empty())
     {
         return code;
     }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1351,6 +1351,12 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
             m_source->writeLine(result.value(), indent::none);
             m_source->Indent();
         }
+
+        if (form_node->isGen(gen_wxFrame))
+        {
+            GenerateHandlers();
+        }
+
         size_t auto_indent = indent::auto_no_whitespace;
         if (auto result = generator->GenSettings(form_node, auto_indent); result)
         {
@@ -1366,7 +1372,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
         m_source->Indent();
     }
 
-    if (!form_node->isGen(gen_wxWizard))
+    if (!form_node->isGen(gen_wxWizard) && !form_node->isGen(gen_wxFrame))
     {
         GenerateHandlers();
     }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1202,25 +1202,7 @@ ttlib::cstr GenFormSettings(Node* node)
 
             code << ");";
         }
-
-        if (node->HasValue(prop_icon))
-        {
-            if (code.size())
-                code << '\n';
-            auto image_code = GenerateBitmapCode(node->prop_as_string(prop_icon));
-            if (!image_code.contains(".Scale") && image_code.is_sameprefix("wxImage("))
-            {
-                code << "SetIcon(wxIcon(" << image_code.subview(sizeof("wxImage")) << ");";
-            }
-            else
-            {
-                code << "wxIcon icon;\n";
-                code << "icon.CopyFromBitmap(" << GenerateBitmapCode(node->prop_as_string(prop_icon)) << ");\n";
-                code << "SetIcon(wxIcon(icon));";
-            }
-        }
     }
-
     if (node->prop_as_string(prop_window_extra_style).size())
         code << "\nSetExtraStyle(GetExtraStyle() | " << node->prop_as_string(prop_window_extra_style) << ");";
 

--- a/src/to_casts.h
+++ b/src/to_casts.h
@@ -23,7 +23,7 @@ public:
 
     inline operator int() const noexcept
     {
-        ASSERT_MSG(v <= INT_MAX, "value is too large to convert to int")
+        ASSERT_MSG(static_cast<const int>(v) == -1 || v <= INT_MAX, "value is too large to convert to int")
         return static_cast<const int>(v);
     }
 };

--- a/src/xml/forms_xml.xml
+++ b/src/xml/forms_xml.xml
@@ -59,6 +59,8 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 			<option name="wxBOTH" />
 			wxBOTH
 		</property>
+		<property name="icon" type="image"
+			help="Specifies the image to display in the title bar of the frame." />
 	</gen>
 
 	<gen class="wxPopupTransientWindow" image="wxPopupTransientWindow" type="form">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds an icon property to **wxFrame** windows. Implementation was a bit more complicated then might be expected, because unlike the Dialog form generator, the Frame form generator does not utilize 2-step construction. That meant changing the base generator code to special case a wxFrame generator in order to load any required handlers before the icon gets set.

I also removed support for prop_icon from `GenFormSettings()`. **wxFrame** was the only thing that called this before, and now it calls a different function, so there is no longer any need to support the icon property in the common settings function.