### PR TITLE
Create skeleton for generating and previewing XRC files.

### DIFF
--- a/docs/XRC.md
+++ b/docs/XRC.md
@@ -1,0 +1,7 @@
+# XRC
+
+**wxUiEditor** can generate XRC either as individual files, or a combined file. Many of the properties that would automatically generate the necessary code for you are not available when using an XRC file. You are _strongly_ encouraged _NOT_ to use XRC for C++ projects!
+
+If you are using a programming language other than C++, then generating XRC is the only way you can use **wxUiEditor** to design your UI. You can use the `Preview XRC...` command under the Tools menu if you want to see what a Dialog will look like. If this looks different than it does in the Mockup panel, it's because you set properties that cannot be passed to XRC files. If you look at the XRC panel to the right of the Mockup panel, you will see comments about every property that you have set which is not available in XRC.
+
+Several other designers import XRC files. Technically you could export your XRC files and import it into another designer. However, not only will you lose any of the properties mentioned above, but the other designers generally don't support all of the options that XRC does. That means you can lose additional functionality simply because they don't support the XRC setting that **wxUiEditor** generated.

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -64,6 +64,20 @@ public:
     // Return true if all construction and settings code was written to src_code
     virtual bool GenConstruction(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
 
+#if defined(XRC_ENABLED)
+    // Generate object and all properties. Restore indendation, but do not add </object>.
+    //
+    // Return true if object was created
+    virtual bool GenXRC(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
+
+    // Generate information about unsupported properties, writing to
+    // code_gen->GetHeaderWriter().
+    //
+    // Return true if information was written
+    virtual bool GenXRCInfo(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
+#endif // XRC_ENABLED
+
+
     // Return true if the Generic version of the control is being used.
     virtual bool IsGeneric(Node*) { return false; }
 

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -47,6 +47,13 @@ using OptionalIncludes = std::optional<std::vector<std::string>>;
 class BaseGenerator
 {
 public:
+    enum
+    {
+        xrc_not_supported = 0,
+        xrc_sizer_item_created,
+        xrc_updated
+    };
+
     BaseGenerator() {}
     virtual ~BaseGenerator() {}
 
@@ -64,16 +71,13 @@ public:
     // Return true if all construction and settings code was written to src_code
     virtual bool GenConstruction(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
 
-    // Generate object and all properties. Restore indendation, but do not add </object>.
+    // Add attributes to object, and all properties
     //
-    // Return true if object was created
-    virtual bool GenXRC(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
+    // Return an xrc_ enum (e.g. xrc_sizer_item_created)
+    virtual int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) { return xrc_not_supported; }
 
-    // Generate information about unsupported properties, writing to
-    // code_gen->GetHeaderWriter().
-    //
-    // Return true if information was written
-    virtual bool GenXRCInfo(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
+    // Return the required wxXmlResourceHandler
+    virtual void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) {}
 
     // Return true if the Generic version of the control is being used.
     virtual bool IsGeneric(Node*) { return false; }

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -64,7 +64,6 @@ public:
     // Return true if all construction and settings code was written to src_code
     virtual bool GenConstruction(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
 
-#if defined(XRC_ENABLED)
     // Generate object and all properties. Restore indendation, but do not add </object>.
     //
     // Return true if object was created
@@ -75,8 +74,6 @@ public:
     //
     // Return true if information was written
     virtual bool GenXRCInfo(Node*, BaseCodeGenerator* /* code_gen */) { return false; }
-#endif // XRC_ENABLED
-
 
     // Return true if the Generic version of the control is being used.
     virtual bool IsGeneric(Node*) { return false; }

--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -236,6 +236,59 @@ std::optional<ttlib::cstr> FrameFormGenerator::GenConstruction(Node* node)
     return code;
 }
 
+bool FrameFormGenerator::GenXRC(Node* node, BaseCodeGenerator* code_gen)
+{
+    auto m_source = code_gen->GetSrcWriter();
+    m_source->writeLine(ttlib::cstr("<object class=\"wxFrame\" name=\"") << node->prop_as_string(prop_class_name) << "\">");
+
+    m_source->Indent();
+    if (node->HasValue(prop_title))
+    {
+        m_source->writeLine(ttlib::cstr("<title>") << node->prop_as_string(prop_title) << "</title>");
+    }
+    if (node->HasValue(prop_center))
+    {
+        m_source->writeLine("<centered>1</centered>");
+    }
+    m_source->Unindent();
+
+    return true;
+}
+
+bool FrameFormGenerator::GenXRCInfo(Node* node, BaseCodeGenerator* code_gen)
+{
+    auto m_header = code_gen->GetHeaderWriter();
+
+    std::set<std::string> unsupported;
+
+    if (node->prop_as_bool(prop_persist))
+    {
+        unsupported.emplace("persist");
+    }
+    if (node->prop_as_string(prop_center).is_sameas("wxVERTICAL") ||
+        node->prop_as_string(prop_center).is_sameas("wxHORIZONTAL"))
+    {
+        unsupported.emplace("window can only be centered in both directions");
+    }
+
+    if (unsupported.size())
+    {
+        m_header->writeLine("wxFrame unsupported properties (unavailable in XRC):");
+
+        m_header->Indent();
+        for (auto& iter: unsupported)
+        {
+            m_header->writeLine(iter);
+        }
+        m_header->Unindent();
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 std::optional<ttlib::cstr> FrameFormGenerator::GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node)
 {
     return GenFormCode(cmd, node);

--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -445,7 +445,7 @@ int FrameFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
         }
         if (node->HasValue(prop_tooltip))
         {
-            object.append_child(pugi::node_comment).set_value(" tooltip colour cannot be be set in the XRC file. ");
+            object.append_child(pugi::node_comment).set_value(" tooltip cannot be be set in the XRC file. ");
         }
         if (node->HasValue(prop_context_help))
         {
@@ -457,7 +457,7 @@ int FrameFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
         }
         if (node->HasValue(prop_hidden))
         {
-            object.append_child(pugi::node_comment).set_value(" hidden colour cannot be be set in the XRC file. ");
+            object.append_child(pugi::node_comment).set_value(" hidden cannot be be set in the XRC file. ");
         }
     }
 

--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -68,6 +68,59 @@ bool DialogFormGenerator::GenConstruction(Node* node, BaseCodeGenerator* code_ge
     return true;
 }
 
+bool DialogFormGenerator::GenXRC(Node* node, BaseCodeGenerator* code_gen)
+{
+    auto m_source = code_gen->GetSrcWriter();
+    m_source->writeLine(ttlib::cstr("<object class=\"wxDialog\" name=\"") << node->prop_as_string(prop_class_name) << "\">");
+
+    m_source->Indent();
+    if (node->HasValue(prop_title))
+    {
+        m_source->writeLine(ttlib::cstr("<title>") << node->prop_as_string(prop_title) << "</title>");
+    }
+    if (node->HasValue(prop_center))
+    {
+        m_source->writeLine(node->prop_as_string(prop_center).is_sameas("no") ? "<centered>0</centered>" : "<centered>1</centered>");
+    }
+    m_source->Unindent();
+
+    return true;
+}
+
+bool DialogFormGenerator::GenXRCInfo(Node* node, BaseCodeGenerator* code_gen)
+{
+    auto m_header = code_gen->GetHeaderWriter();
+
+    std::set<std::string> unsupported;
+
+    if (node->prop_as_bool(prop_persist))
+    {
+        unsupported.emplace("persist");
+    }
+    if (node->prop_as_string(prop_center).is_sameas("wxVERTICAL") ||
+        node->prop_as_string(prop_center).is_sameas("wxHORIZONTAL"))
+    {
+        unsupported.emplace("dialog can only be centered in both directions");
+    }
+
+    if (unsupported.size())
+    {
+        m_header->writeLine("wxFrame unsupported properties (unavailable in XRC):");
+
+        m_header->Indent();
+        for (auto& iter: unsupported)
+        {
+            m_header->writeLine(iter);
+        }
+        m_header->Unindent();
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 std::optional<ttlib::cstr> DialogFormGenerator::GenEvents(NodeEvent* event, const std::string& class_name)
 {
     return GenEventCode(event, class_name);

--- a/src/generate/form_widgets.h
+++ b/src/generate/form_widgets.h
@@ -19,12 +19,12 @@ public:
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
 
-    bool GenXRC(Node* node, BaseCodeGenerator* code_gen) override;
-    bool GenXRCInfo(Node* node, BaseCodeGenerator* code_gen) override;
-
     bool AllowPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
 class PopupWinGenerator : public BaseGenerator
@@ -58,11 +58,12 @@ class DialogFormGenerator : public BaseGenerator
 public:
     // Return true if all construction and settings code was written to src_code
     bool GenConstruction(Node*, BaseCodeGenerator* code_gen) override;
-    bool GenXRC(Node* node, BaseCodeGenerator* code_gen) override;
-    bool GenXRCInfo(Node* node, BaseCodeGenerator* code_gen) override;
 
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/form_widgets.h
+++ b/src/generate/form_widgets.h
@@ -19,6 +19,10 @@ public:
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
 
+#if defined(XRC_ENABLED)
+    bool GenXRC(Node* node, BaseCodeGenerator* code_gen) override;
+    bool GenXRCInfo(Node* node, BaseCodeGenerator* code_gen) override;
+#endif
     bool AllowPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;

--- a/src/generate/form_widgets.h
+++ b/src/generate/form_widgets.h
@@ -19,10 +19,9 @@ public:
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
 
-#if defined(XRC_ENABLED)
     bool GenXRC(Node* node, BaseCodeGenerator* code_gen) override;
     bool GenXRCInfo(Node* node, BaseCodeGenerator* code_gen) override;
-#endif
+
     bool AllowPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
@@ -59,11 +58,8 @@ class DialogFormGenerator : public BaseGenerator
 public:
     // Return true if all construction and settings code was written to src_code
     bool GenConstruction(Node*, BaseCodeGenerator* code_gen) override;
-
-#if defined(XRC_ENABLED)
     bool GenXRC(Node* node, BaseCodeGenerator* code_gen) override;
     bool GenXRCInfo(Node* node, BaseCodeGenerator* code_gen) override;
-#endif
 
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/generate/form_widgets.h
+++ b/src/generate/form_widgets.h
@@ -60,6 +60,11 @@ public:
     // Return true if all construction and settings code was written to src_code
     bool GenConstruction(Node*, BaseCodeGenerator* code_gen) override;
 
+#if defined(XRC_ENABLED)
+    bool GenXRC(Node* node, BaseCodeGenerator* code_gen) override;
+    bool GenXRCInfo(Node* node, BaseCodeGenerator* code_gen) override;
+#endif
+
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -89,6 +89,8 @@ public:
     // Write code to m_source that will load any handlers needed by the form's class
     void GenerateHandlers();
 
+    PANEL_TYPE GetPanelType() { return m_panel_type; }
+
 protected:
     void WritePropSourceCode(Node* node, GenEnum::PropName prop);
     void WritePropHdrCode(Node* node, GenEnum::PropName prop);

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -81,6 +81,7 @@ public:
 
     // code for this is in gen_xrc.cpp
     void GenerateXrcClass(Node* form_node, PANEL_TYPE panel_type = NOT_PANEL);
+    void PreviewXrcClass(Node* form_node);
 
     auto GetHeaderWriter() { return m_header; }
     auto GetSrcWriter() { return m_source; }

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -80,7 +80,7 @@ public:
     int GenerateDerivedClass(Node* project, Node* form_node, PANEL_TYPE panel_type = NOT_PANEL);
 
     // code for this is in gen_xrc.cpp
-    void GenerateXrcClass(Node* project, Node* form_node, PANEL_TYPE panel_type = NOT_PANEL);
+    void GenerateXrcClass(Node* form_node, PANEL_TYPE panel_type = NOT_PANEL);
 
     auto GetHeaderWriter() { return m_header; }
     auto GetSrcWriter() { return m_source; }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -9,11 +9,13 @@
 
 #include "gen_common.h"
 
+#include "gen_base.h"     // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "lambdas.h"      // Functions for formatting and storage of lamda events
 #include "mainapp.h"      // App -- App class
 #include "node.h"         // Node class
 #include "pjtsettings.h"  // ProjectSettings -- Hold data for currently loaded project
 #include "utils.h"        // Utility functions that work with properties
+#include "write_code.h"   // WriteCode -- Write code to Scintilla or file
 
 ttlib::cstr GenerateSizerFlags(Node* node)
 {
@@ -1699,5 +1701,67 @@ void GenerateWindowSettings(Node* node, ttlib::cstr& code)
         if (!node->IsForm())
             code << node->get_node_name() << "->";
         code << "SetHelpText(" << GenerateQuotedString(node->prop_as_string(prop_context_help)) << ");";
+    }
+}
+
+void GenXrcSizerItem(Node* node, BaseCodeGenerator* code_gen)
+{
+    auto m_source = code_gen->GetSrcWriter();
+    m_source->writeLine("<object class=\"sizeritem\">");
+    m_source->Indent();
+    ttlib::cstr flags;
+    flags << node->prop_as_string(prop_borders);
+    if (node->HasValue(prop_flags))
+    {
+        if (flags.size())
+        {
+            flags << '|';
+        }
+        flags << node->prop_as_string(prop_flags);
+    }
+    if (node->HasValue(prop_alignment))
+    {
+        if (flags.size())
+        {
+            flags << '|';
+        }
+        flags << node->prop_as_string(prop_alignment);
+    }
+    if (flags.size())
+    {
+        m_source->writeLine(ttlib::cstr("<flag>") << flags << "</flag>");
+    }
+
+    if (node->HasValue(prop_border_size))
+    {
+        m_source->writeLine(ttlib::cstr("<border>") << node->prop_as_string(prop_border_size) << "</border>");
+    }
+}
+
+void GenXrcSizerItem(Node* node, pugi::xml_node& object)
+{
+    object.append_attribute("class").set_value("sizeritem");
+    ttlib::cstr flags;
+    flags << node->prop_as_string(prop_borders);
+    if (node->HasValue(prop_flags))
+    {
+        if (flags.size())
+        {
+            flags << '|';
+        }
+        flags << node->prop_as_string(prop_flags);
+    }
+    if (node->HasValue(prop_alignment))
+    {
+        if (flags.size())
+        {
+            flags << '|';
+        }
+        flags << node->prop_as_string(prop_alignment);
+    }
+    object.append_child("flag").text().set(flags.c_str());
+    if (node->HasValue(prop_border_size))
+    {
+        object.append_child("border").text().set(node->prop_as_string(prop_border_size).c_str());
     }
 }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1764,4 +1764,5 @@ void GenXrcSizerItem(Node* node, pugi::xml_node& object)
     {
         object.append_child("border").text().set(node->prop_as_string(prop_border_size).c_str());
     }
+    object.append_child("option").text().set(node->prop_as_string(prop_proportion).c_str());
 }

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -131,3 +131,8 @@ ttlib::cstr GenerateNewAssignment(Node* node, bool use_generic = false);
 std::optional<ttlib::cstr> GenGetSetCode(Node* node);
 
 std::optional<ttlib::cstr> GenValidatorSettings(Node* node);
+
+// Write sizeritem XRC code
+void GenXrcSizerItem(Node* node, BaseCodeGenerator* code_gen);
+
+void GenXrcSizerItem(Node*, pugi::xml_node& object);

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -33,8 +33,6 @@ inline constexpr const auto txt_XRC_HEADER = R"===(<?xml version="1.0"?>
 inline constexpr const auto txt_XRC_FOOTER = R"===(</resource>
 )===";
 
-#if defined(XRC_ENABLED)
-
 static bool s_isXmlInitalized { false };
 
 void MainFrame::OnPreviewXrc(wxCommandEvent& /* event */)
@@ -150,12 +148,8 @@ void GenXrcInfo(Node* node, BaseCodeGenerator* code_gen)
     }
 }
 
-#endif
-
 void BaseCodeGenerator::GenerateXrcClass(Node* form_node, PANEL_TYPE panel_type)
 {
-#if defined(XRC_ENABLED)
-
     m_project = wxGetApp().GetProject();
     m_form_node = form_node;
 
@@ -192,6 +186,4 @@ void BaseCodeGenerator::GenerateXrcClass(Node* form_node, PANEL_TYPE panel_type)
     {
         GenXrcInfo(form_node, this);
     }
-
-#endif  // defined(XRC_ENABLED)
 }

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -85,20 +85,24 @@ void MainFrame::OnPreviewXrc(wxCommandEvent& /* event */)
             return;
         }
 
+        auto xrc_resource = wxXmlResource::Get();
+
         if (!s_isXmlInitalized)
         {
-            wxXmlResource::Get()->InitAllHandlers();
+            xrc_resource->InitAllHandlers();
             s_isXmlInitalized = true;
         }
 
-        if (!wxXmlResource::Get()->LoadDocument(xmlDoc.release()))
+        wxString res_name("wxuiPreview");
+
+        if (!xrc_resource->LoadDocument(xmlDoc.release(), res_name))
         {
             wxMessageBox("wxWidgets could not parse the XRC data.", "XRC Dialog Preview");
             return;
         }
 
         wxDialog dlg;
-        if (wxXmlResource::Get()->LoadDialog(&dlg, this, form_node->prop_as_string(prop_class_name)))
+        if (xrc_resource->LoadDialog(&dlg, this, form_node->prop_as_string(prop_class_name)))
         {
             dlg.ShowModal();
         }
@@ -107,6 +111,7 @@ void MainFrame::OnPreviewXrc(wxCommandEvent& /* event */)
             wxMessageBox(ttlib::cstr("Could not load ") << form_node->prop_as_string(prop_class_name) << " resource.",
                          "XRC Dialog Preview");
         }
+        xrc_resource->Unload(res_name);
     }
     catch (const std::exception& TESTING_PARAM(e))
     {

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -48,7 +48,14 @@ void MainFrame::OnPreviewXrc(wxCommandEvent& /* event */)
     auto form_node = m_selected_node.get();
     if (!form_node->IsForm())
     {
-        form_node = form_node->get_form();
+        if (form_node->isGen(gen_Project) && form_node->GetChildCount())
+        {
+            form_node = form_node->GetChild(0);
+        }
+        else
+        {
+            form_node = form_node->get_form();
+        }
     }
 
     if (!form_node->isGen(gen_wxDialog))
@@ -91,7 +98,7 @@ void MainFrame::OnPreviewXrc(wxCommandEvent& /* event */)
         }
 
         wxDialog dlg;
-        if (wxXmlResource::Get()->LoadDialog(&dlg, NULL, form_node->prop_as_string(prop_class_name)))
+        if (wxXmlResource::Get()->LoadDialog(&dlg, this, form_node->prop_as_string(prop_class_name)))
         {
             dlg.ShowModal();
         }

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -59,12 +59,18 @@ int BoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* 
         GenXrcSizerItem(node, object);
         auto sizer = object.append_child("object");
         sizer.append_attribute("class").set_value("wxBoxSizer");
+        sizer.append_attribute("name").set_value(node->prop_as_string(prop_var_name).c_str());
         sizer.append_child("orient").text().set(node->prop_as_string(prop_orientation).c_str());
+        if (node->HasValue(prop_minimum_size))
+        {
+            sizer.append_child("minsize").text().set(node->prop_as_string(prop_minimum_size).c_str());
+        }
         return BaseGenerator::xrc_sizer_item_created;
     }
     else
     {
         object.append_attribute("class").set_value("wxBoxSizer");
+        object.append_attribute("name").set_value(node->prop_as_string(prop_var_name).c_str());
         object.append_child("orient").text().set(node->prop_as_string(prop_orientation).c_str());
         return BaseGenerator::xrc_updated;
     }

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -14,8 +14,10 @@
 #include <wx/textwrapper.h>  // declaration of wxTextWrapper class
 #include <wx/wrapsizer.h>    // provide wrapping sizer for layout (wxWrapSizer)
 
+#include "gen_base.h"    // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "gen_common.h"  // GeneratorLibrary -- Generator classes
 #include "node.h"        // Node class
+#include "write_code.h"  // WriteCode -- Write code to Scintilla or file
 
 #include "sizer_widgets.h"
 
@@ -50,6 +52,28 @@ bool BoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
     return true;
 }
 
+int BoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+{
+    if (node->GetParent()->IsSizer())
+    {
+        GenXrcSizerItem(node, object);
+        auto sizer = object.append_child("object");
+        sizer.append_attribute("class").set_value("wxBoxSizer");
+        sizer.append_child("orient").text().set(node->prop_as_string(prop_orientation).c_str());
+        return BaseGenerator::xrc_sizer_item_created;
+    }
+    else
+    {
+        object.append_attribute("class").set_value("wxBoxSizer");
+        object.append_child("orient").text().set(node->prop_as_string(prop_orientation).c_str());
+        return BaseGenerator::xrc_updated;
+    }
+}
+
+void BoxSizerGenerator::RequiredHandlers(Node* /* node */, std::set<std::string>& handlers)
+{
+    handlers.emplace("wxSizerXmlHandler");
+}
 //////////////////////////////////////////  GridSizerGenerator  //////////////////////////////////////////
 
 wxObject* GridSizerGenerator::CreateMockup(Node* node, wxObject* /*parent*/)

--- a/src/generate/sizer_widgets.h
+++ b/src/generate/sizer_widgets.h
@@ -28,6 +28,9 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
 class GridSizerGenerator : public BaseGenerator

--- a/src/generate/write_code.h
+++ b/src/generate/write_code.h
@@ -49,10 +49,10 @@ public:
 
     virtual void Clear() = 0;
 
-protected:
     // Derived class provides this to write text to whatever output device is being used
     virtual void doWrite(ttlib::sview code) = 0;
 
+protected:
     void WriteCodeLine(ttlib::sview code, size_t indentation);
 
 private:
@@ -67,7 +67,7 @@ public:
     FileCodeWriter(const wxString& file) : m_filename(file) { m_buffer.clear(); }
 
     void Clear() override { m_buffer.clear(); };
-    const ttlib::cstr& GetString() const { return m_buffer; };
+    ttlib::cstr& GetString() { return m_buffer; };
 
     // Returns -1 if an error occurred, 0 if no update is needed, 1 on success
     int WriteFile(bool test_only = false);

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -80,6 +80,7 @@ enum
     id_ShowLogger,
     id_NodeMemory,
     id_CodeDiffDlg,
+    id_PreviewXRC,
     id_FindWidget
 };
 
@@ -128,6 +129,12 @@ MainFrame::MainFrame() :
     menuInternal->AppendSeparator();
     menuInternal->Append(id_DebugCurrentTest, "&Current Test", "Current debugging test");
     menuInternal->Append(id_ConvertImage, "&Convert Image...", "Image conversion testing...");
+
+    #if defined(XRC_ENABLED)
+
+    menuInternal->Append(id_PreviewXRC, "Preview XRC Dialog...", "Show a dialog using XRC");
+
+    #endif
 
     m_submenu_import_recent = new wxMenu();
     m_menuFile->AppendSeparator();
@@ -277,6 +284,11 @@ MainFrame::MainFrame() :
         id_DebugPreferences);
 
     Bind(wxEVT_MENU, &App::DbgCurrentTest, &wxGetApp(), id_DebugCurrentTest);
+
+    #if defined(XRC_ENABLED)
+    Bind(wxEVT_MENU, &MainFrame::OnPreviewXrc, this, id_PreviewXRC);
+    #endif
+
 #endif
 
     AddCustomEventHandler(GetEventHandler());

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -130,7 +130,7 @@ MainFrame::MainFrame() :
     menuInternal->Append(id_DebugCurrentTest, "&Current Test", "Current debugging test");
     menuInternal->Append(id_ConvertImage, "&Convert Image...", "Image conversion testing...");
 
-    menuInternal->Append(id_PreviewXRC, "Preview XRC...", "Show a dialog using XRC");
+    menuInternal->Append(id_PreviewXRC, "Preview XRC...\tCtrl+R", "Show a dialog using XRC");
 
     m_submenu_import_recent = new wxMenu();
     m_menuFile->AppendSeparator();

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1024,6 +1024,12 @@ void MainFrame::OnAuiNotebookPageChanged(wxAuiNotebookEvent&)
         {
             m_derivedPanel->GenerateBaseClass();
         }
+#if defined(XRC_ENABLED)
+        else if (page == m_xrcPanel)
+        {
+            m_xrcPanel->GenerateBaseClass();
+        }
+#endif  // XRC_ENABLED
     }
 }
 
@@ -1068,9 +1074,9 @@ wxWindow* MainFrame::CreateNoteBook(wxWindow* parent)
     m_derivedPanel = new BasePanel(m_notebook, this, 1);
     m_notebook->AddPage(m_derivedPanel, "Derived", false, wxWithImages::NO_IMAGE);
 
-#if defined(_DEBUG) || defined(INTERNAL_TESTING)
-    // m_xrcPanel = new BasePanel(m_notebook, this, -1);
-    // m_notebook->AddPage(m_xrcPanel, "XRC", false, wxWithImages::NO_IMAGE);
+#if defined(XRC_ENABLED)
+    m_xrcPanel = new BasePanel(m_notebook, this, -1);
+    m_notebook->AddPage(m_xrcPanel, "XRC", false, wxWithImages::NO_IMAGE);
 #endif
 
     return m_notebook;

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -130,11 +130,7 @@ MainFrame::MainFrame() :
     menuInternal->Append(id_DebugCurrentTest, "&Current Test", "Current debugging test");
     menuInternal->Append(id_ConvertImage, "&Convert Image...", "Image conversion testing...");
 
-    #if defined(XRC_ENABLED)
-
-    menuInternal->Append(id_PreviewXRC, "Preview XRC Dialog...", "Show a dialog using XRC");
-
-    #endif
+    menuInternal->Append(id_PreviewXRC, "Preview XRC...", "Show a dialog using XRC");
 
     m_submenu_import_recent = new wxMenu();
     m_menuFile->AppendSeparator();
@@ -284,11 +280,7 @@ MainFrame::MainFrame() :
         id_DebugPreferences);
 
     Bind(wxEVT_MENU, &App::DbgCurrentTest, &wxGetApp(), id_DebugCurrentTest);
-
-    #if defined(XRC_ENABLED)
     Bind(wxEVT_MENU, &MainFrame::OnPreviewXrc, this, id_PreviewXRC);
-    #endif
-
 #endif
 
     AddCustomEventHandler(GetEventHandler());
@@ -1036,12 +1028,10 @@ void MainFrame::OnAuiNotebookPageChanged(wxAuiNotebookEvent&)
         {
             m_derivedPanel->GenerateBaseClass();
         }
-#if defined(XRC_ENABLED)
         else if (page == m_xrcPanel)
         {
             m_xrcPanel->GenerateBaseClass();
         }
-#endif  // XRC_ENABLED
     }
 }
 
@@ -1086,10 +1076,8 @@ wxWindow* MainFrame::CreateNoteBook(wxWindow* parent)
     m_derivedPanel = new BasePanel(m_notebook, this, 1);
     m_notebook->AddPage(m_derivedPanel, "Derived", false, wxWithImages::NO_IMAGE);
 
-#if defined(XRC_ENABLED)
     m_xrcPanel = new BasePanel(m_notebook, this, -1);
     m_notebook->AddPage(m_xrcPanel, "XRC", false, wxWithImages::NO_IMAGE);
-#endif
 
     return m_notebook;
 }

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -270,12 +270,7 @@ protected:
 
 #endif
 
-#if defined(XRC_ENABLED)
-
     void OnPreviewXrc(wxCommandEvent& e);
-
-#endif
-
 
     wxWindow* CreateNoteBook(wxWindow* parent);
 
@@ -299,9 +294,7 @@ private:
 
     BasePanel* m_generatedPanel { nullptr };
     BasePanel* m_derivedPanel { nullptr };
-#if defined(XRC_ENABLED)
     BasePanel* m_xrcPanel { nullptr };
-#endif
 
     int m_MainSashPosition { 300 };
     int m_SecondarySashPosition { 300 };

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -292,7 +292,7 @@ private:
 
     BasePanel* m_generatedPanel { nullptr };
     BasePanel* m_derivedPanel { nullptr };
-#if defined(INTERNAL_TESTING)
+#if defined(XRC_ENABLED)
     BasePanel* m_xrcPanel { nullptr };
 #endif
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -270,6 +270,13 @@ protected:
 
 #endif
 
+#if defined(XRC_ENABLED)
+
+    void OnPreviewXrc(wxCommandEvent& e);
+
+#endif
+
+
     wxWindow* CreateNoteBook(wxWindow* parent);
 
     void CreateSplitters();

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -221,7 +221,6 @@ public:
 
 protected:
     void OnAbout(wxCommandEvent& event) override;
-    void OnImportRecent(wxCommandEvent& event);
     void OnAppendCrafter(wxCommandEvent& event) override;
     void OnAppendFormBuilder(wxCommandEvent& event) override;
     void OnAppendGlade(wxCommandEvent& event) override;
@@ -238,6 +237,7 @@ protected:
     void OnGenInhertedClass(wxCommandEvent& event) override;
     void OnGenerateCode(wxCommandEvent& event) override;
     void OnImportProject(wxCommandEvent& event);
+    void OnImportRecent(wxCommandEvent& event);
     void OnImportWindowsResource(wxCommandEvent& event) override;
     void OnInsertWidget(wxCommandEvent&) override;
     void OnNewProject(wxCommandEvent& event);
@@ -245,6 +245,7 @@ protected:
     void OnOpenRecentProject(wxCommandEvent& event);
     void OnOptionsDlg(wxCommandEvent& event) override;
     void OnPaste(wxCommandEvent& event) override;
+    void OnPreviewXrc(wxCommandEvent& event) override;
     void OnSaveAsProject(wxCommandEvent& event) override;
     void OnSaveProject(wxCommandEvent& event) override;
     void OnToggleExpandLayout(wxCommandEvent&) override;
@@ -270,7 +271,6 @@ protected:
 
 #endif
 
-    void OnPreviewXrc(wxCommandEvent& e);
 
     wxWindow* CreateNoteBook(wxWindow* parent);
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -271,7 +271,6 @@ protected:
 
 #endif
 
-
     wxWindow* CreateNoteBook(wxWindow* parent);
 
     void CreateSplitters();

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -52,6 +52,19 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, int GenerateDerivedCode
         m_hPanel = new CodeDisplay(m_notebook);
         m_notebook->AddPage(m_hPanel, "header", false, wxWithImages::NO_IMAGE);
     }
+#if defined(XRC_ENABLED)
+    else if (GenerateDerivedCode == -1)
+    {
+        m_cppPanel = new CodeDisplay(m_notebook, true);
+        m_notebook->AddPage(m_cppPanel, "source", false, wxWithImages::NO_IMAGE);
+
+        // A lot of code expects m_hPanel to exist. This will give us something to add additional information to, such as
+        // which properties are not supported.
+
+        m_hPanel = new CodeDisplay(m_notebook);
+        m_notebook->AddPage(m_hPanel, "info", false, wxWithImages::NO_IMAGE);
+    }
+#endif
     else
     {
         m_cppPanel = new CodeDisplay(m_notebook);
@@ -131,7 +144,7 @@ void BasePanel::OnFind(wxFindDialogEvent& event)
     {
         m_cppPanel->GetEventHandler()->ProcessEvent(event);
     }
-    else if (text == "header")
+    else if (text == "header" || text == "info")
     {
         m_hPanel->GetEventHandler()->ProcessEvent(event);
     }

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -197,7 +197,7 @@ void BasePanel::GenerateBaseClass()
     else if (m_GenerateDerivedCode == 0)
         codegen.GenerateBaseClass(m_cur_form, panel_type);
     else
-        codegen.GenerateXrcClass(project, m_cur_form, panel_type);
+        codegen.GenerateXrcClass(m_cur_form, panel_type);
 
     if (panel_type == CPP_PANEL)
     {

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -157,7 +157,7 @@ void BasePanel::GenerateBaseClass()
 
     // If no form is selected, display the first child form of the project
     m_cur_form = wxGetFrame().GetSelectedForm();
-    if (!m_cur_form)
+    if (!m_cur_form && m_GenerateDerivedCode != -1)
     {
         if (project->GetChildCount() > 0)
         {

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -52,7 +52,6 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, int GenerateDerivedCode
         m_hPanel = new CodeDisplay(m_notebook);
         m_notebook->AddPage(m_hPanel, "header", false, wxWithImages::NO_IMAGE);
     }
-#if defined(XRC_ENABLED)
     else if (GenerateDerivedCode == -1)
     {
         m_cppPanel = new CodeDisplay(m_notebook, true);
@@ -64,7 +63,6 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, int GenerateDerivedCode
         m_hPanel = new CodeDisplay(m_notebook);
         m_notebook->AddPage(m_hPanel, "info", false, wxWithImages::NO_IMAGE);
     }
-#endif
     else
     {
         m_cppPanel = new CodeDisplay(m_notebook);

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -24,7 +24,9 @@ extern const char* g_u8_cpp_keywords;
 const int node_marker = 1;
 
 #if defined(XRC_ENABLED)
-const char* g_xrc_keywords = "resource";
+
+const char* g_xrc_keywords = "centered class name object resource title";
+
 #endif
 
 CodeDisplay::CodeDisplay(wxWindow* parent, bool is_XML) : CodeDisplayBase(parent), m_isXML(is_XML)
@@ -40,6 +42,7 @@ CodeDisplay::CodeDisplay(wxWindow* parent, bool is_XML) : CodeDisplayBase(parent
         m_scintilla->StyleSetForeground(wxSTC_H_TAG, *wxBLUE);
         m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour(0, 128, 0));
         m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, *wxRED);
+        m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, *wxRED);
         m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
         m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
     }

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -23,7 +23,7 @@ extern const char* g_u8_cpp_keywords;
 
 const int node_marker = 1;
 
-const char* g_xrc_keywords = "centered class icon name object pos resource size stock_client stock_id style title";
+const char* g_xrc_keywords = "centered class icon name object orient pos resource size stock_client stock_id style title";
 
 CodeDisplay::CodeDisplay(wxWindow* parent, bool is_XML) : CodeDisplayBase(parent), m_isXML(is_XML)
 {

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -23,12 +23,32 @@ extern const char* g_u8_cpp_keywords;
 
 const int node_marker = 1;
 
-CodeDisplay::CodeDisplay(wxWindow* parent) : CodeDisplayBase(parent)
-{
-    // On Windows, this saves converting the UTF16 characters to ANSI.
-    m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_u8_cpp_keywords);
+#if defined(XRC_ENABLED)
+const char* g_xrc_keywords = "resource";
+#endif
 
-    // clang-format off
+CodeDisplay::CodeDisplay(wxWindow* parent, bool is_XML) : CodeDisplayBase(parent), m_isXML(is_XML)
+{
+    if (m_isXML)
+    {
+        m_scintilla->SetLexer(wxSTC_LEX_XML);
+        // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
+        m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_xrc_keywords);
+
+        m_scintilla->StyleSetBold(wxSTC_H_TAG, true);
+        m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#E91AFF"));
+        m_scintilla->StyleSetForeground(wxSTC_H_TAG, *wxBLUE);
+        m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, *wxRED);
+        m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
+    }
+    else
+    {
+        // On Windows, this saves converting the UTF16 characters to ANSI.
+        m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_u8_cpp_keywords);
+
+        // clang-format off
 
     // Add regular classes that have different generator class names
 
@@ -44,40 +64,40 @@ CodeDisplay::CodeDisplay(wxWindow* parent) : CodeDisplayBase(parent)
 
         );
 
-    // clang-format on
+        // clang-format on
 
-    for (auto iter: g_NodeCreator.GetNodeDeclarationArray())
-    {
-        if (!iter)
+        for (auto iter: g_NodeCreator.GetNodeDeclarationArray())
         {
-            // This will happen if there is an enumerated value but no generator for it
-            continue;
+            if (!iter)
+            {
+                // This will happen if there is an enumerated value but no generator for it
+                continue;
+            }
+
+            if (!iter->DeclName().is_sameprefix("wx") || iter->DeclName().is_sameas("wxContextMenuEvent"))
+                continue;
+            widget_keywords << ' ' << iter->DeclName();
         }
 
-        if (!iter->DeclName().is_sameprefix("wx") || iter->DeclName().is_sameas("wxContextMenuEvent"))
-            continue;
-        widget_keywords << ' ' << iter->DeclName();
+        // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
+        m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) widget_keywords.c_str());
+        m_scintilla->StyleSetBold(wxSTC_C_WORD, true);
+        m_scintilla->StyleSetForeground(wxSTC_C_WORD, *wxBLUE);
+        m_scintilla->StyleSetForeground(wxSTC_C_WORD2, wxColour("#E91AFF"));
+        m_scintilla->StyleSetForeground(wxSTC_C_STRING, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, *wxRED);
     }
-
-    // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
-    m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) widget_keywords.c_str());
 
     // TODO: [KeyWorks - 01-02-2022] We do this because currently font selection uses a facename which is not cross-platform.
     // See issue #597.
     wxFont font(10, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
     m_scintilla->StyleSetFont(wxSTC_STYLE_DEFAULT, font);
-
-    m_scintilla->StyleSetBold(wxSTC_C_WORD, true);
-    m_scintilla->StyleSetForeground(wxSTC_C_WORD, *wxBLUE);
-    m_scintilla->StyleSetForeground(wxSTC_C_WORD2, wxColour("#E91AFF"));
-    m_scintilla->StyleSetForeground(wxSTC_C_STRING, wxColour(0, 128, 0));
-    m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, wxColour(0, 128, 0));
-    m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
-    m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour(0, 128, 0));
-    m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, wxColour(0, 128, 0));
-    m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, wxColour(0, 128, 0));
-    m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, wxColour(0, 128, 0));
-    m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, *wxRED);
 
     m_scintilla->MarkerDefine(node_marker, wxSTC_MARK_BOOKMARK, wxNullColour, *wxGREEN);
 

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -167,8 +167,10 @@ void CodeDisplay::CodeGenerationComplete()
 
 void CodeDisplay::OnNodeSelected(Node* node)
 {
-    if (!node->HasProp(prop_var_name))
+    if (!node->HasProp(prop_var_name) && !m_isXML)
+    {
         return;  // probably a form, spacer, or image
+    }
 
     auto is_event = wxGetFrame().GetPropPanel()->IsEventPageShowing();
 
@@ -186,6 +188,19 @@ void CodeDisplay::OnNodeSelected(Node* node)
             name.Replace("->Bind", " = ");
             line = (to_int) m_view.FindLineContaining(name);
         }
+    }
+    else if (m_isXML)
+    {
+        ttlib::cstr search("name=\"");
+        if (node->HasValue(prop_var_name))
+        {
+            search << node->prop_as_string(prop_var_name);
+        }
+        else
+        {
+            search << node->prop_as_string(prop_class_name);
+        }
+        line = (to_int) m_view.FindLineContaining(search);
     }
     else
     {

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -23,11 +23,7 @@ extern const char* g_u8_cpp_keywords;
 
 const int node_marker = 1;
 
-#if defined(XRC_ENABLED)
-
-const char* g_xrc_keywords = "centered class name object resource title";
-
-#endif
+const char* g_xrc_keywords = "centered class icon name object pos resource size stock_client stock_id style title";
 
 CodeDisplay::CodeDisplay(wxWindow* parent, bool is_XML) : CodeDisplayBase(parent), m_isXML(is_XML)
 {

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -26,7 +26,7 @@ class Node;
 class CodeDisplay : public CodeDisplayBase, public WriteCode
 {
 public:
-    CodeDisplay(wxWindow* parent);
+    CodeDisplay(wxWindow* parent, bool is_XML = false);
 
     // Clears scintilla and internal buffer, removes read-only flag in scintilla
     void Clear() override;
@@ -48,4 +48,5 @@ protected:
 
 private:
     ttlib::viewfile m_view;
+    bool m_isXML;
 };

--- a/src/pch.h
+++ b/src/pch.h
@@ -118,14 +118,6 @@ extern ttlib::cstr tt_empty_cstr;
 // Character used to separate the fields in a bitmap property
 constexpr const char BMP_PROP_SEPARATOR = ';';
 
-#if defined(INTERNAL_TESTING)
-    // REVIEW: [randalph - 05-13-2022] I don't know yet whether exporting XRC would be useful given how few of our properties
-    // are supported by the current wxWidgets XRC support. However, I distinguish between internal testing and xrc code, so
-    // it gets it's own definition here to use throughout our code.
-
-    #define XRC_ENABLED
-#endif
-
 //////////////////////////////////////// macros ////////////////////////////////////////
 
 #if defined(NDEBUG) && !defined(INTERNAL_TESTING)

--- a/src/pch.h
+++ b/src/pch.h
@@ -118,6 +118,14 @@ extern ttlib::cstr tt_empty_cstr;
 // Character used to separate the fields in a bitmap property
 constexpr const char BMP_PROP_SEPARATOR = ';';
 
+#if defined(INTERNAL_TESTING)
+    // REVIEW: [randalph - 05-13-2022] I don't know yet whether exporting XRC would be useful given how few of our properties
+    // are supported by the current wxWidgets XRC support. However, I distinguish between internal testing and xrc code, so
+    // it gets it's own definition here to use throughout our code.
+
+    #define XRC_ENABLED
+#endif
+
 //////////////////////////////////////// macros ////////////////////////////////////////
 
 #if defined(NDEBUG) && !defined(INTERNAL_TESTING)

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -263,6 +263,11 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     auto menu_item20 = new wxMenuItem(m_menuTools, id_GenerateDerived, "Create &Derived Code",
         "Creates the files and classes that derive from the generated base classes", wxITEM_NORMAL);
     m_menuTools->Append(menu_item20);
+
+    m_menuTools->AppendSeparator();
+
+    auto menu_item_8 = new wxMenuItem(m_menuTools, wxID_ANY, "Preview XRC...");
+    m_menuTools->Append(menu_item_8);
     m_menubar->Append(m_menuTools, "&Tools");
 
     m_menuHelp = new wxMenu();
@@ -489,6 +494,7 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     Bind(wxEVT_MENU, &MainFrameBase::OnToggleExpandLayout, this, id_Expand);
     Bind(wxEVT_MENU, &MainFrameBase::OnGenerateCode, this, id_GenerateCode);
     Bind(wxEVT_MENU, &MainFrameBase::OnGenInhertedClass, this, id_GenerateDerived);
+    Bind(wxEVT_MENU, &MainFrameBase::OnPreviewXrc, this, menu_item_8->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnAbout, this, wxID_ABOUT);
     Bind(wxEVT_MENU, &MainFrameBase::OnBrowseDocs, this, menu_item_6->GetId());
     Bind(wxEVT_UPDATE_UI, &MainFrameBase::OnUpdateBrowseDocs, this, menu_item_6->GetId());

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -80,6 +80,7 @@ protected:
     virtual void OnOpenProject(wxCommandEvent& event) { event.Skip(); }
     virtual void OnOptionsDlg(wxCommandEvent& event) { event.Skip(); }
     virtual void OnPaste(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnPreviewXrc(wxCommandEvent& event) { event.Skip(); }
     virtual void OnSaveAsProject(wxCommandEvent& event) { event.Skip(); }
     virtual void OnSaveProject(wxCommandEvent& event) { event.Skip(); }
     virtual void OnToggleExpandLayout(wxCommandEvent& event) { event.Skip(); }

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -1169,6 +1169,14 @@
             label="Create &amp;Derived Code"
             var_name="menu_item20"
             wxEVT_MENU="OnGenInhertedClass" />
+          <node
+            class="separator"
+            var_name="separator_2" />
+          <node
+            class="wxMenuItem"
+            label="Preview XRC..."
+            var_name="menu_item_8"
+            wxEVT_MENU="OnPreviewXrc" />
         </node>
         <node
           class="wxMenu"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR implements the initial code that will enable creating XRC files. It creates an XRC panel to the right of the Derived panel. The `source` sub-panel contains a commented version of the XRC that would be generated. The `info` panel lists all of the handlers required to implemnt the current form. There is also a `Preview XRC...` command added to the Tools menu. Currently, this will only display a dialog.

In the source panel, a comment will be added for every property the user sets which is not supported in the XRC. This will let the user know what additional changes they will need to make in their own code after the XRC resource is loaded. The current plan is not to include the comments when writing the XRC to an actual file.

Currently, we don't write an XRC file. The plan will be to either write a single mondo XRC file, or write individual files.

For now, the only widgets that are enabled are wxDialog, wxFrame, and wxBoxSizer. The next step will be to start enabling all the rest of the widgets.