### PR TITLE
Major refactor overhaul

### DIFF
--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -25,7 +25,7 @@ There are two submodules: `ttLib` and `wxSnapshot`.
 
 If you are planning on contributing code, the following sections contain information about the code that might not be immediately obvious. Reading these sections may make the code easier to understand, as well as ensuring that PR's are written in a way that matches the rest of the code base.
 
-Note that the code requires a C++17 compliant compiler -- which means you should be using C++17 coding conventions. That includes using `std::string_view` (or `ttlib::cview`) for strings when practical. See the **Strings** section below for information about working with `wxString`.
+Note that the code requires a C++20 compliant compiler -- which means you should be using C++20 coding conventions. That includes using `std::string_view` (or `ttlib::sview`) for strings when practical. See the **Strings** section below for information about working with `wxString`.
 
 ## Debug builds
 
@@ -33,11 +33,11 @@ When you create a debug build, there will be an additional **Internal** menu to 
 
 ## Strings
 
-The only time **wxString** should be used in **wxUiEditor** is when a string will be used for UI or for filenames. The **ttLib** class **ttString** derives from **wxString** and is often used in the code for working with filenames instead of passing the string to a **wxFileName**.
+The only time **wxString** should be used in **wxUiEditor** is when a string will be used for UI or for filenames. The **ttLib** class `ttString` derives from `wxString` and is often used instead of `wxString` since it has more automatic conversion of the UTF8 strings that are used throughout the code.
 
-Both `ttString` and `ttlib::cstr` have a `wx_str()` method that will perform UTF8<->UTF16 conversion when compiled for Windows, and no conversion when compiled for other platforms. `ttlib::cstr` is essentially std::string with additional methods including `wx_str()`.
+Both `ttString` and `ttlib::cstr` have a `wx_str()` method that will perform UTF8<->UTF16 conversion when compiled for Windows, and no conversion when compiled for other platforms. `ttlib::cstr` is essentially `std::string` with additional methods including `wx_str()`. Note that when constructing a `wxString` from a `std::string` or `std::string_view` on Windows, you will get an ANSI to UTF16 conversion. If you construct a `ttString` from `std::string` or `std::string_view` on Windows, it will perform a UTF8 to UTF16 conversion (no conversion at all if not on Windows). Since wxUiEditor works exclusively with UTF8 strings, `ttString` is preferable to `wxString` in most cases.
 
-In most cases, **ttlib::cview** is used instead of **std::string_view**. **ttlib::cview** inherits from **std::string_view** but points to a zero-terminated string.
+You will generally see `ttlib::sview` used instead of `std::string_view`. Like `ttlib::cstr`, this class provides dozens of additional methods beside the standard base class.
 
 ## size_t and int_t
 

--- a/pugixml/pugixml.cpp
+++ b/pugixml/pugixml.cpp
@@ -132,8 +132,10 @@ using std::memset;
 #endif
 
 // In some environments MSVC is a compiler but the CRT lacks certain MSVC-specific features
-#if defined(_MSC_VER) && !defined(__S3E__)
+#if defined(_MSC_VER) && !defined(__S3E__) && !defined(_WIN32_WCE)
 #	define PUGI__MSVC_CRT_VERSION _MSC_VER
+#elif defined(_WIN32_WCE)
+#	define PUGI__MSVC_CRT_VERSION 1310 // MSVC7.1
 #endif
 
 // Not all platforms have snprintf; we define a wrapper that uses snprintf if possible. This only works with buffers with a known size.
@@ -242,6 +244,9 @@ PUGI__NS_BEGIN
 		return lhs[count] == 0;
 	}
 
+#if 0
+// REVIEW: [KeyWorks - 05-16-2022] This function is not declared in pugixml.hpp, and therefore never used
+
 	// Get length of wide string, even if CRT lacks wide character support
 	PUGI__FN size_t strlength_wide(const wchar_t* s)
 	{
@@ -255,6 +260,7 @@ PUGI__NS_BEGIN
 		return static_cast<size_t>(end - s);
 	#endif
 	}
+#endif
 PUGI__NS_END
 
 // auto_ptr-like object for exception recovery
@@ -432,12 +438,14 @@ PUGI__NS_BEGIN
 #endif
 
 	// extra metadata bits
+	static const uintptr_t xml_memory_page_contents_const_mask = 128;
 	static const uintptr_t xml_memory_page_contents_shared_mask = 64;
 	static const uintptr_t xml_memory_page_name_allocated_mask = 32;
 	static const uintptr_t xml_memory_page_value_allocated_mask = 16;
 	static const uintptr_t xml_memory_page_type_mask = 15;
 
 	// combined masks for string uniqueness
+	static const uintptr_t xml_memory_page_contents_const_or_shared_mask = xml_memory_page_contents_const_mask | xml_memory_page_contents_shared_mask;
 	static const uintptr_t xml_memory_page_name_allocated_or_shared_mask = xml_memory_page_name_allocated_mask | xml_memory_page_contents_shared_mask;
 	static const uintptr_t xml_memory_page_value_allocated_or_shared_mask = xml_memory_page_value_allocated_mask | xml_memory_page_contents_shared_mask;
 
@@ -526,7 +534,8 @@ PUGI__NS_BEGIN
 			xml_memory_page* page = xml_memory_page::construct(memory);
 			assert(page);
 
-			page->allocator = _root->allocator;
+			assert(this == _root->allocator);
+			page->allocator = this;
 
 			return page;
 		}
@@ -1050,7 +1059,27 @@ namespace pugi
 	{
 		xml_attribute_struct(impl::xml_memory_page* page): header(page, 0), namevalue_base(0)
 		{
-			PUGI__STATIC_ASSERT(sizeof(xml_attribute_struct) == 8);
+			PUGI__STATIC_ASSERT(sizeof(xml_attribute_struct) == 8 + 8);
+		}
+
+		inline string_view_t unsafe_name_sv() const {
+			return string_view_t(name, name_len);
+		}
+
+		inline string_view_t unsafe_value_sv() const {
+			return string_view_t(value, value_len);
+		}
+
+		inline string_view_t value_sv() const {
+			return value ? unsafe_value_sv() : PUGIXML_EMPTY_SV;
+		}
+
+		inline bool equals_name(string_view_t rhs) const {
+			return name && unsafe_name_sv() == rhs;
+		}
+
+		inline bool equals_value(string_view_t rhs) const {
+			return value_sv() == rhs;
 		}
 
 		impl::compact_header header;
@@ -1062,13 +1091,32 @@ namespace pugi
 
 		impl::compact_pointer<xml_attribute_struct, 6> prev_attribute_c;
 		impl::compact_pointer<xml_attribute_struct, 7, 0> next_attribute;
+
+		int name_len;
+		int value_len;
 	};
 
 	struct xml_node_struct
 	{
 		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): header(page, type), namevalue_base(0)
 		{
-			PUGI__STATIC_ASSERT(sizeof(xml_node_struct) == 12);
+			PUGI__STATIC_ASSERT(sizeof(xml_node_struct) == 12 + 8);
+		}
+
+		inline string_view_t unsafe_name_sv() const {
+			return string_view_t(name, name_len);
+		}
+
+		inline string_view_t unsafe_value_sv() const {
+			return string_view_t(value, value_len);
+		}
+
+		inline string_view_t value_sv() const {
+			return value ? unsafe_value_sv() : PUGIXML_EMPTY_SV;
+		}
+
+		inline bool equals_name(string_view_t rhs) const {
+			return name && unsafe_name_sv() == rhs;
 		}
 
 		impl::compact_header header;
@@ -1086,6 +1134,9 @@ namespace pugi
 		impl::compact_pointer<xml_node_struct, 10, 0> next_sibling;
 
 		impl::compact_pointer<xml_attribute_struct, 11, 0> first_attribute;
+
+		int name_len;
+		int value_len;
 	};
 }
 #else
@@ -1098,10 +1149,33 @@ namespace pugi
 			header = PUGI__GETHEADER_IMPL(this, page, 0);
 		}
 
+		inline string_view_t unsafe_name_sv() const {
+			return string_view_t(name, name_len);
+		}
+
+		inline string_view_t unsafe_value_sv() const {
+			return string_view_t(value, value_len);
+		}
+
+		inline string_view_t value_sv() const {
+			return value ? unsafe_value_sv() : PUGIXML_EMPTY_SV;
+		}
+
+		inline bool equals_name(string_view_t rhs) const {
+			return name && unsafe_name_sv() == rhs;
+		}
+
+		inline bool equals_value(string_view_t rhs) const {
+			return value_sv() == rhs;
+		}
+
 		uintptr_t header;
 
 		char_t*	name;
 		char_t*	value;
+
+		int name_len;
+		int value_len;
 
 		xml_attribute_struct* prev_attribute_c;
 		xml_attribute_struct* next_attribute;
@@ -1114,10 +1188,28 @@ namespace pugi
 			header = PUGI__GETHEADER_IMPL(this, page, type);
 		}
 
+		inline string_view_t unsafe_name_sv() const {
+			return string_view_t(name, name_len);
+		}
+
+		inline string_view_t unsafe_value_sv() const {
+			return string_view_t(value, value_len);
+		}
+
+		inline string_view_t value_sv() const {
+			return value ? unsafe_value_sv() : PUGIXML_EMPTY_SV;
+		}
+
+		inline bool equals_name(string_view_t rhs) const {
+			return name && unsafe_name_sv() == rhs;
+		}
+
 		uintptr_t header;
 
 		char_t* name;
 		char_t* value;
+		int name_len;
+		int value_len;
 
 		xml_node_struct* parent;
 
@@ -2339,7 +2431,7 @@ PUGI__NS_BEGIN
 	inline bool strcpy_insitu_allow(size_t length, const Header& header, uintptr_t header_mask, char_t* target)
 	{
 		// never reuse shared memory
-		if (header & xml_memory_page_contents_shared_mask) return false;
+		if (header & xml_memory_page_contents_const_or_shared_mask) return false;
 
 		size_t target_length = strlength(target);
 
@@ -2353,9 +2445,11 @@ PUGI__NS_BEGIN
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN bool strcpy_insitu(String& dest, Header& header, uintptr_t header_mask, const char_t* source, size_t source_length)
+	PUGI__FN bool strcpy_insitu(String& dest, int& dest_len, Header& header, uintptr_t header_mask, const char_t* source, size_t source_length, bool shallow_copy = false)
 	{
-		if (source_length == 0)
+		dest_len = static_cast<int>(source_length);
+
+		if (source_length == 0 || shallow_copy)
 		{
 			// empty string and null pointer are equivalent, so just deallocate old memory
 			xml_allocator* alloc = PUGI__GETPAGE_IMPL(header)->allocator;
@@ -2363,8 +2457,11 @@ PUGI__NS_BEGIN
 			if (header & header_mask) alloc->deallocate_string(dest);
 
 			// mark the string as not allocated
-			dest = 0;
+			dest = source_length == 0 ? NULL : const_cast<char_t*>(source);
 			header &= ~header_mask;
+
+			// mark dest as shared to avoid reuse document buffer memory
+			header |= xml_memory_page_contents_const_mask;
 
 			return true;
 		}
@@ -2372,7 +2469,7 @@ PUGI__NS_BEGIN
 		{
 			// we can reuse old buffer, so just copy the new data (including zero terminator)
 			memcpy(dest, source, source_length * sizeof(char_t));
-			dest[source_length] = 0;
+			dest[source_length] = '\0';
 
 			return true;
 		}
@@ -2388,7 +2485,7 @@ PUGI__NS_BEGIN
 
 			// copy the string (including zero terminator)
 			memcpy(buf, source, source_length * sizeof(char_t));
-			buf[source_length] = 0;
+			buf[source_length] = '\0';
 
 			// deallocate old buffer (*after* the above to protect against overlapping memory and/or allocation failures)
 			if (header & header_mask) alloc->deallocate_string(dest);
@@ -2396,6 +2493,9 @@ PUGI__NS_BEGIN
 			// the string is now allocated, so set the flag
 			dest = buf;
 			header |= header_mask;
+
+			// remove dest shared mask for continue reuse document buffer memory
+			header &= ~xml_memory_page_contents_const_mask;
 
 			return true;
 		}
@@ -2592,13 +2692,15 @@ PUGI__NS_BEGIN
 	#define PUGI__SCANFOR(X)            { while (*s != 0 && !(X)) ++s; }
 	#define PUGI__SCANWHILE(X)          { while (X) ++s; }
 	#define PUGI__SCANWHILE_UNROLL(X)   { for (;;) { char_t ss = s[0]; if (PUGI__UNLIKELY(!(X))) { break; } ss = s[1]; if (PUGI__UNLIKELY(!(X))) { s += 1; break; } ss = s[2]; if (PUGI__UNLIKELY(!(X))) { s += 2; break; } ss = s[3]; if (PUGI__UNLIKELY(!(X))) { s += 3; break; } s += 4; } }
-	#define PUGI__ENDSEG()              { ch = *s; *s = 0; ++s; }
+    #define PUGI__ENDSEG(p,v)          { ch = *s; p->v##_len = static_cast<int>(s - p->v); *s = '\0'; ++s; }
 	#define PUGI__THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(0)
 	#define PUGI__CHECK_ERROR(err, m)   { if (*s == 0) PUGI__THROW_ERROR(err, m); }
 
-	PUGI__FN char_t* strconv_comment(char_t* s, char_t endch)
+	PUGI__FN char_t* strconv_comment(char_t* s, char_t endch, int& len)
 	{
 		gap g;
+
+		char_t* begin = s;
 
 		while (true)
 		{
@@ -2612,7 +2714,9 @@ PUGI__NS_BEGIN
 			}
 			else if (s[0] == '-' && s[1] == '-' && PUGI__ENDSWITH(s[2], '>')) // comment ends here
 			{
-				*g.flush(s) = 0;
+				char_t* end = g.flush(s);
+				*end = '\0';
+				len = static_cast<int>(end - begin);
 
 				return s + (s[2] == '>' ? 3 : 2);
 			}
@@ -2624,9 +2728,11 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN char_t* strconv_cdata(char_t* s, char_t endch)
+	PUGI__FN char_t* strconv_cdata(char_t* s, char_t endch, int& len)
 	{
 		gap g;
+
+		char_t* begin = s;
 
 		while (true)
 		{
@@ -2640,7 +2746,9 @@ PUGI__NS_BEGIN
 			}
 			else if (s[0] == ']' && s[1] == ']' && PUGI__ENDSWITH(s[2], '>')) // CDATA ends here
 			{
-				*g.flush(s) = 0;
+				char_t* end = g.flush(s);
+				*end = '\0';
+				len = static_cast<int>(end - begin);
 
 				return s + 1;
 			}
@@ -2652,11 +2760,11 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	typedef char_t* (*strconv_pcdata_t)(char_t*);
+	typedef char_t* (*strconv_pcdata_t)(char_t*, int& len);
 
 	template <typename opt_trim, typename opt_eol, typename opt_escape> struct strconv_pcdata_impl
 	{
-		static char_t* parse(char_t* s)
+		static char_t* parse(char_t* s, int& len)
 		{
 			gap g;
 
@@ -2674,7 +2782,8 @@ PUGI__NS_BEGIN
 						while (end > begin && PUGI__IS_CHARTYPE(end[-1], ct_space))
 							--end;
 
-					*end = 0;
+					*end = '\0';
+					len = static_cast<int>(end - begin);
 
 					return s + 1;
 				}
@@ -2696,7 +2805,8 @@ PUGI__NS_BEGIN
 						while (end > begin && PUGI__IS_CHARTYPE(end[-1], ct_space))
 							--end;
 
-					*end = 0;
+					*end = '\0';
+					len = static_cast<int>(end - begin);
 
 					return s;
 				}
@@ -2723,13 +2833,15 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	typedef char_t* (*strconv_attribute_t)(char_t*, char_t);
+	typedef char_t* (*strconv_attribute_t)(char_t*, char_t, int& len);
 
 	template <typename opt_escape> struct strconv_attribute_impl
 	{
-		static char_t* parse_wnorm(char_t* s, char_t end_quote)
+		static char_t* parse_wnorm(char_t* s, char_t end_quote, int& len)
 		{
 			gap g;
+
+			char_t* begin = s;
 
 			// trim leading whitespaces
 			if (PUGI__IS_CHARTYPE(*s, ct_space))
@@ -2750,8 +2862,10 @@ PUGI__NS_BEGIN
 				{
 					char_t* str = g.flush(s);
 
-					do *str-- = 0;
+					do *str-- = '\0';
 					while (PUGI__IS_CHARTYPE(*str, ct_space));
+
+					len = static_cast<int>(str + 1 - begin);
 
 					return s + 1;
 				}
@@ -2779,9 +2893,11 @@ PUGI__NS_BEGIN
 			}
 		}
 
-		static char_t* parse_wconv(char_t* s, char_t end_quote)
+		static char_t* parse_wconv(char_t* s, char_t end_quote, int& len)
 		{
 			gap g;
+
+			char_t* begin = s;
 
 			while (true)
 			{
@@ -2789,7 +2905,9 @@ PUGI__NS_BEGIN
 
 				if (*s == end_quote)
 				{
-					*g.flush(s) = 0;
+					char_t* end = g.flush(s);
+					*end = '\0';
+					len = static_cast<int>(end - begin);
 
 					return s + 1;
 				}
@@ -2815,9 +2933,11 @@ PUGI__NS_BEGIN
 			}
 		}
 
-		static char_t* parse_eol(char_t* s, char_t end_quote)
+		static char_t* parse_eol(char_t* s, char_t end_quote, int& len)
 		{
 			gap g;
+
+			char_t* begin = s;
 
 			while (true)
 			{
@@ -2825,7 +2945,9 @@ PUGI__NS_BEGIN
 
 				if (*s == end_quote)
 				{
-					*g.flush(s) = 0;
+					char_t* end = g.flush(s);
+					*end = '\0';
+					len = static_cast<int>(end - begin);
 
 					return s + 1;
 				}
@@ -2847,9 +2969,11 @@ PUGI__NS_BEGIN
 			}
 		}
 
-		static char_t* parse_simple(char_t* s, char_t end_quote)
+		static char_t* parse_simple(char_t* s, char_t end_quote, int& len)
 		{
 			gap g;
+
+			char_t* begin = s;
 
 			while (true)
 			{
@@ -2857,7 +2981,9 @@ PUGI__NS_BEGIN
 
 				if (*s == end_quote)
 				{
-					*g.flush(s) = 0;
+					char_t* end = g.flush(s);
+					*end = '\0';
+					len = static_cast<int>(end - begin);
 
 					return s + 1;
 				}
@@ -3057,7 +3183,7 @@ PUGI__NS_BEGIN
 
 					if (PUGI__OPTSET(parse_eol) && PUGI__OPTSET(parse_comments))
 					{
-						s = strconv_comment(s, endch);
+						s = strconv_comment(s, endch, cursor->value_len);
 
 						if (!s) PUGI__THROW_ERROR(status_bad_comment, cursor->value);
 					}
@@ -3067,9 +3193,10 @@ PUGI__NS_BEGIN
 						PUGI__SCANFOR(s[0] == '-' && s[1] == '-' && PUGI__ENDSWITH(s[2], '>'));
 						PUGI__CHECK_ERROR(status_bad_comment, s);
 
-						if (PUGI__OPTSET(parse_comments))
-							*s = 0; // Zero-terminate this segment at the first terminating '-'.
-
+						if (PUGI__OPTSET(parse_comments)) {
+							*s = '\0'; // Zero-terminate this segment at the first terminating '-'.
+							cursor->value_len = static_cast<int>(s - cursor->value);
+						}
 						s += (s[2] == '>' ? 3 : 2); // Step over the '\0->'.
 					}
 				}
@@ -3089,7 +3216,7 @@ PUGI__NS_BEGIN
 
 						if (PUGI__OPTSET(parse_eol))
 						{
-							s = strconv_cdata(s, endch);
+							s = strconv_cdata(s, endch, cursor->value_len);
 
 							if (!s) PUGI__THROW_ERROR(status_bad_cdata, cursor->value);
 						}
@@ -3099,7 +3226,8 @@ PUGI__NS_BEGIN
 							PUGI__SCANFOR(s[0] == ']' && s[1] == ']' && PUGI__ENDSWITH(s[2], '>'));
 							PUGI__CHECK_ERROR(status_bad_cdata, s);
 
-							*s++ = 0; // Zero-terminate this segment.
+							cursor->value_len = static_cast<int>(s - cursor->value);
+							*s++ = '\0'; // Zero-terminate this segment.
 						}
 					}
 					else // Flagged for discard, but we still have to scan for the terminator.
@@ -3127,7 +3255,7 @@ PUGI__NS_BEGIN
 				if (!s) return s;
 
 				assert((*s == 0 && endch == '>') || *s == '>');
-				if (*s) *s++ = 0;
+				if (*s) *s++ = '\0';
 
 				if (PUGI__OPTSET(parse_doctype))
 				{
@@ -3136,6 +3264,7 @@ PUGI__NS_BEGIN
 					PUGI__PUSHNODE(node_doctype);
 
 					cursor->value = mark;
+					cursor->value_len = static_cast<int>(s - mark - 1);
 				}
 			}
 			else if (*s == 0 && endch == '-') PUGI__THROW_ERROR(status_bad_comment, s);
@@ -3181,7 +3310,7 @@ PUGI__NS_BEGIN
 
 				cursor->name = target;
 
-				PUGI__ENDSEG();
+				PUGI__ENDSEG(cursor, name);
 
 				// parse value/attributes
 				if (ch == '?')
@@ -3214,10 +3343,8 @@ PUGI__NS_BEGIN
 					{
 						// store value and step over >
 						cursor->value = value;
-
+						PUGI__ENDSEG(cursor, value);
 						PUGI__POPNODE();
-
-						PUGI__ENDSEG();
 
 						s += (*s == '>');
 					}
@@ -3262,7 +3389,7 @@ PUGI__NS_BEGIN
 						cursor->name = s;
 
 						PUGI__SCANWHILE_UNROLL(PUGI__IS_CHARTYPE(ss, ct_symbol)); // Scan for a terminator.
-						PUGI__ENDSEG(); // Save char in 'ch', terminate & step over.
+						PUGI__ENDSEG(cursor, name); // Save char in 'ch', terminate & step over.
 
 						if (ch == '>')
 						{
@@ -3283,7 +3410,7 @@ PUGI__NS_BEGIN
 									a->name = s; // Save the offset.
 
 									PUGI__SCANWHILE_UNROLL(PUGI__IS_CHARTYPE(ss, ct_symbol)); // Scan for a terminator.
-									PUGI__ENDSEG(); // Save char in 'ch', terminate & step over.
+									PUGI__ENDSEG(a, name); // Save char in 'ch', terminate & step over.
 
 									if (PUGI__IS_CHARTYPE(ch, ct_space))
 									{
@@ -3303,7 +3430,7 @@ PUGI__NS_BEGIN
 											++s; // Step over the quote.
 											a->value = s; // Save the offset.
 
-											s = strconv_attribute(s, ch);
+											s = strconv_attribute(s, ch, a->value_len);
 
 											if (!s) PUGI__THROW_ERROR(status_bad_attribute, a->value);
 
@@ -3441,20 +3568,22 @@ PUGI__NS_BEGIN
 
 					if (cursor->parent || PUGI__OPTSET(parse_fragment))
 					{
+						pugi::xml_node_struct* target;
 						if (PUGI__OPTSET(parse_embed_pcdata) && cursor->parent && !cursor->first_child && !cursor->value)
 						{
-							cursor->value = s; // Save the offset.
+							target = cursor; // cursor->value = s; // Save the offset.
 						}
 						else
 						{
 							PUGI__PUSHNODE(node_pcdata); // Append a new node on the tree.
 
-							cursor->value = s; // Save the offset.
+							target = cursor; // cursor->value = s; // Save the offset.
 
 							PUGI__POPNODE(); // Pop since this is a standalone.
 						}
 
-						s = strconv_pcdata(s);
+						target->value = s;
+						s = strconv_pcdata(s, target->value_len);
 
 						if (!*s) break;
 					}
@@ -4387,7 +4516,7 @@ PUGI__NS_BEGIN
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN void node_copy_string(String& dest, Header& header, uintptr_t header_mask, char_t* source, Header& source_header, xml_allocator* alloc)
+	PUGI__FN void node_copy_string(String& dest, int& dest_len, Header& header, uintptr_t header_mask, char_t* source, int source_len, Header& source_header, xml_allocator* alloc)
 	{
 		assert(!dest && (header & header_mask) == 0);
 
@@ -4396,20 +4525,21 @@ PUGI__NS_BEGIN
 			if (alloc && (source_header & header_mask) == 0)
 			{
 				dest = source;
+				dest_len = source_len;
 
 				// since strcpy_insitu can reuse document buffer memory we need to mark both source and dest as shared
 				header |= xml_memory_page_contents_shared_mask;
 				source_header |= xml_memory_page_contents_shared_mask;
 			}
 			else
-				strcpy_insitu(dest, header, header_mask, source, strlength(source));
+				strcpy_insitu(dest, dest_len, header, header_mask, source, source_len);
 		}
 	}
 
 	PUGI__FN void node_copy_contents(xml_node_struct* dn, xml_node_struct* sn, xml_allocator* shared_alloc)
 	{
-		node_copy_string(dn->name, dn->header, xml_memory_page_name_allocated_mask, sn->name, sn->header, shared_alloc);
-		node_copy_string(dn->value, dn->header, xml_memory_page_value_allocated_mask, sn->value, sn->header, shared_alloc);
+		node_copy_string(dn->name, dn->name_len, dn->header, xml_memory_page_name_allocated_mask, sn->name, sn->name_len, sn->header, shared_alloc);
+		node_copy_string(dn->value, dn->value_len, dn->header, xml_memory_page_value_allocated_mask, sn->value, sn->value_len, sn->header, shared_alloc);
 
 		for (xml_attribute_struct* sa = sn->first_attribute; sa; sa = sa->next_attribute)
 		{
@@ -4417,8 +4547,8 @@ PUGI__NS_BEGIN
 
 			if (da)
 			{
-				node_copy_string(da->name, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->header, shared_alloc);
-				node_copy_string(da->value, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->header, shared_alloc);
+				node_copy_string(da->name, da->name_len, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->name_len, sa->header, shared_alloc);
+				node_copy_string(da->value, da->value_len, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->value_len, sa->header, shared_alloc);
 			}
 		}
 	}
@@ -4435,6 +4565,9 @@ PUGI__NS_BEGIN
 
 		while (sit && sit != sn)
 		{
+			// loop invariant: dit is inside the subtree rooted at dn
+			assert(dit);
+
 			// when a tree is copied into one of the descendants, we need to skip that subtree to avoid an infinite loop
 			if (sit != dn)
 			{
@@ -4464,9 +4597,14 @@ PUGI__NS_BEGIN
 
 				sit = sit->parent;
 				dit = dit->parent;
+
+				// loop invariant: dit is inside the subtree rooted at dn while sit is inside sn
+				assert(sit == sn || dit);
 			}
 			while (sit != sn);
 		}
+
+		assert(!sit || dit == dn->parent);
 	}
 
 	PUGI__FN void node_copy_attribute(xml_attribute_struct* da, xml_attribute_struct* sa)
@@ -4474,8 +4612,8 @@ PUGI__NS_BEGIN
 		xml_allocator& alloc = get_allocator(da);
 		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : 0;
 
-		node_copy_string(da->name, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->header, shared_alloc);
-		node_copy_string(da->value, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->header, shared_alloc);
+		node_copy_string(da->name, da->name_len, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->name_len, sa->header, shared_alloc);
+		node_copy_string(da->value, da->value_len, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->value_len, sa->header, shared_alloc);
 	}
 
 	inline bool is_text_node(xml_node_struct* node)
@@ -4639,53 +4777,54 @@ PUGI__NS_BEGIN
 
 	// set value with conversion functions
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_ascii(String& dest, Header& header, uintptr_t header_mask, char* buf)
+	PUGI__FN bool set_value_ascii(String& dest, int& dest_len, Header& header, uintptr_t header_mask, char* buf, size_t len)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
+		(void)len;
 		char_t wbuf[128];
-		assert(strlen(buf) < sizeof(wbuf) / sizeof(wbuf[0]));
+		assert(len < sizeof(wbuf) / sizeof(wbuf[0]));
 
 		size_t offset = 0;
 		for (; buf[offset]; ++offset) wbuf[offset] = buf[offset];
 
-		return strcpy_insitu(dest, header, header_mask, wbuf, offset);
+		return strcpy_insitu(dest, dest_len, header, header_mask, wbuf, offset);
 	#else
-		return strcpy_insitu(dest, header, header_mask, buf, strlen(buf));
+		return strcpy_insitu(dest, dest_len, header, header_mask, buf, len);
 	#endif
 	}
 
 	template <typename U, typename String, typename Header>
-	PUGI__FN bool set_value_integer(String& dest, Header& header, uintptr_t header_mask, U value, bool negative)
+	PUGI__FN bool set_value_integer(String& dest, int& dest_len, Header& header, uintptr_t header_mask, U value, bool negative)
 	{
 		char_t buf[64];
 		char_t* end = buf + sizeof(buf) / sizeof(buf[0]);
 		char_t* begin = integer_to_string(buf, end, value, negative);
 
-		return strcpy_insitu(dest, header, header_mask, begin, end - begin);
+		return strcpy_insitu(dest, dest_len, header, header_mask, begin, end - begin);
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, float value, int precision)
+	PUGI__FN bool set_value_convert(String& dest, int& dest_len, Header& header, uintptr_t header_mask, float value, int precision)
 	{
 		char buf[128];
-		PUGI__SNPRINTF(buf, "%.*g", precision, double(value));
+		int n = PUGI__SNPRINTF(buf, "%.*g", precision, double(value));
 
-		return set_value_ascii(dest, header, header_mask, buf);
+		return set_value_ascii(dest, dest_len, header, header_mask, buf, n);
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, double value, int precision)
+	PUGI__FN bool set_value_convert(String& dest, int& dest_len, Header& header, uintptr_t header_mask, double value, int precision)
 	{
 		char buf[128];
-		PUGI__SNPRINTF(buf, "%.*g", precision, value);
+		int n = PUGI__SNPRINTF(buf, "%.*g", precision, value);
 
-		return set_value_ascii(dest, header, header_mask, buf);
+		return set_value_ascii(dest, dest_len, header, header_mask, buf, n);
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_bool(String& dest, Header& header, uintptr_t header_mask, bool value)
+	PUGI__FN bool set_value_bool(String& dest, int& dest_len, Header& header, uintptr_t header_mask, bool value)
 	{
-		return strcpy_insitu(dest, header, header_mask, value ? PUGIXML_TEXT("true") : PUGIXML_TEXT("false"), value ? 4 : 5);
+		return strcpy_insitu(dest, dest_len, header, header_mask, value ? PUGIXML_TEXT("true") : PUGIXML_TEXT("false"), value ? 4 : 5, true);
 	}
 
 	PUGI__FN xml_parse_result load_buffer_impl(xml_document_struct* doc, xml_node_struct* root, void* contents, size_t size, unsigned int options, xml_encoding encoding, bool is_mutable, bool own, char_t** out_buffer)
@@ -4724,7 +4863,7 @@ PUGI__NS_BEGIN
 	// we need to get length of entire file to load it in memory; the only (relatively) sane way to do it is via seek/tell trick
 	PUGI__FN xml_parse_status get_file_size(FILE* file, size_t& out_result)
 	{
-	#if defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400 && !defined(_WIN32_WCE)
+	#if defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
 		// there are 64-bit versions of fseek/ftell, let's use them
 		typedef __int64 length_type;
 
@@ -5182,9 +5321,9 @@ namespace pugi
 		return _attr && _attr->prev_attribute_c->next_attribute ? xml_attribute(_attr->prev_attribute_c) : xml_attribute();
 	}
 
-	PUGI__FN const char_t* xml_attribute::as_string(const char_t* def) const
+	PUGI__FN string_view_t xml_attribute::as_string(string_view_t def) const
 	{
-		return (_attr && _attr->value) ? _attr->value + 0 : def;
+		return (_attr && _attr->value) ? _attr->unsafe_value_sv() : def;
 	}
 
 	PUGI__FN int xml_attribute::as_int(int def) const
@@ -5229,14 +5368,14 @@ namespace pugi
 		return !_attr;
 	}
 
-	PUGI__FN const char_t* xml_attribute::name() const
+	PUGI__FN string_view_t xml_attribute::name() const
 	{
-		return (_attr && _attr->name) ? _attr->name + 0 : PUGIXML_TEXT("");
+		return (_attr && _attr->name) ? _attr->unsafe_name_sv() : PUGIXML_EMPTY_SV;
 	}
 
-	PUGI__FN const char_t* xml_attribute::value() const
+	PUGI__FN string_view_t xml_attribute::value() const
 	{
-		return (_attr && _attr->value) ? _attr->value + 0 : PUGIXML_TEXT("");
+		return (_attr && _attr->value) ? _attr->unsafe_value_sv() : PUGIXML_EMPTY_SV;
 	}
 
 	PUGI__FN size_t xml_attribute::hash_value() const
@@ -5249,7 +5388,7 @@ namespace pugi
 		return _attr;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(const char_t* rhs)
+	PUGI__FN xml_attribute& xml_attribute::operator=(string_view_t rhs)
 	{
 		set_value(rhs);
 		return *this;
@@ -5291,7 +5430,7 @@ namespace pugi
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(bool rhs)
+	PUGI__FN xml_attribute& xml_attribute::operator=(boolean rhs)
 	{
 		set_value(rhs);
 		return *this;
@@ -5311,81 +5450,81 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_attribute::set_name(const char_t* rhs)
+	PUGI__FN bool xml_attribute::set_name(string_view_t rhs, bool shallow_copy)
 	{
 		if (!_attr) return false;
 
-		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs, impl::strlength(rhs));
+		return impl::strcpy_insitu(_attr->name, _attr->name_len, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs.data(), rhs.length(), shallow_copy);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(const char_t* rhs)
+	PUGI__FN bool xml_attribute::set_value(string_view_t rhs, bool shallow_copy)
 	{
 		if (!_attr) return false;
 
-		return impl::strcpy_insitu(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs));
+		return impl::strcpy_insitu(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.length(), shallow_copy);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(int rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_integer<unsigned int>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
+		return impl::set_value_integer<unsigned int>(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(unsigned int rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_integer<unsigned int>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, false);
+		return impl::set_value_integer<unsigned int>(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, false);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(long rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_integer<unsigned long>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
+		return impl::set_value_integer<unsigned long>(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(unsigned long rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_integer<unsigned long>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, false);
+		return impl::set_value_integer<unsigned long>(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, false);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(double rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, default_double_precision);
+		return impl::set_value_convert(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, default_double_precision);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(double rhs, int precision)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, precision);
+		return impl::set_value_convert(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, precision);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(float rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, default_float_precision);
+		return impl::set_value_convert(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, default_float_precision);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(float rhs, int precision)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, precision);
+		return impl::set_value_convert(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, precision);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(bool rhs)
+	PUGI__FN bool xml_attribute::set_value(boolean rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_bool(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs);
+		return impl::set_value_bool(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs);
 	}
 
 #ifdef PUGIXML_HAS_LONG_LONG
@@ -5393,14 +5532,14 @@ namespace pugi
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_integer<unsigned long long>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
+		return impl::set_value_integer<unsigned long long>(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
 	}
 
 	PUGI__FN bool xml_attribute::set_value(unsigned long long rhs)
 	{
 		if (!_attr) return false;
 
-		return impl::set_value_integer<unsigned long long>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, false);
+		return impl::set_value_integer<unsigned long long>(_attr->value, _attr->value_len, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, false);
 	}
 #endif
 
@@ -5463,7 +5602,7 @@ namespace pugi
 		return xml_object_range<xml_node_iterator>(begin(), end());
 	}
 
-	PUGI__FN xml_object_range<xml_named_node_iterator> xml_node::children(const char_t* name_) const
+	PUGI__FN xml_object_range<xml_named_node_iterator> xml_node::children(string_view_t name_) const
 	{
 		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(0, _root, name_));
 	}
@@ -5508,9 +5647,9 @@ namespace pugi
 		return !_root;
 	}
 
-	PUGI__FN const char_t* xml_node::name() const
+	PUGI__FN string_view_t xml_node::name() const
 	{
-		return (_root && _root->name) ? _root->name + 0 : PUGIXML_TEXT("");
+		return (_root && _root->name) ? _root->unsafe_name_sv() : PUGIXML_EMPTY_SV;
 	}
 
 	PUGI__FN xml_node_type xml_node::type() const
@@ -5518,38 +5657,38 @@ namespace pugi
 		return _root ? PUGI__NODETYPE(_root) : node_null;
 	}
 
-	PUGI__FN const char_t* xml_node::value() const
+	PUGI__FN string_view_t xml_node::value() const
 	{
-		return (_root && _root->value) ? _root->value + 0 : PUGIXML_TEXT("");
+		return (_root && _root->value) ? _root->unsafe_value_sv() : PUGIXML_EMPTY_SV;
 	}
 
-	PUGI__FN xml_node xml_node::child(const char_t* name_) const
+	PUGI__FN xml_node xml_node::child(const string_view_t name_) const
 	{
 		if (!_root) return xml_node();
 
 		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
-			if (i->name && impl::strequal(name_, i->name)) return xml_node(i);
+			if (i->equals_name(name_)) return xml_node(i);
 
 		return xml_node();
 	}
 
-	PUGI__FN xml_attribute xml_node::attribute(const char_t* name_) const
+	PUGI__FN xml_attribute xml_node::attribute(string_view_t name_) const
 	{
 		if (!_root) return xml_attribute();
 
 		for (xml_attribute_struct* i = _root->first_attribute; i; i = i->next_attribute)
-			if (i->name && impl::strequal(name_, i->name))
+			if (i->equals_name(name_))
 				return xml_attribute(i);
 
 		return xml_attribute();
 	}
 
-	PUGI__FN xml_node xml_node::next_sibling(const char_t* name_) const
+	PUGI__FN xml_node xml_node::next_sibling(string_view_t name_) const
 	{
 		if (!_root) return xml_node();
 
 		for (xml_node_struct* i = _root->next_sibling; i; i = i->next_sibling)
-			if (i->name && impl::strequal(name_, i->name)) return xml_node(i);
+			if (i->equals_name(name_)) return xml_node(i);
 
 		return xml_node();
 	}
@@ -5559,17 +5698,17 @@ namespace pugi
 		return _root ? xml_node(_root->next_sibling) : xml_node();
 	}
 
-	PUGI__FN xml_node xml_node::previous_sibling(const char_t* name_) const
+	PUGI__FN xml_node xml_node::previous_sibling(string_view_t name_) const
 	{
 		if (!_root) return xml_node();
 
 		for (xml_node_struct* i = _root->prev_sibling_c; i->next_sibling; i = i->prev_sibling_c)
-			if (i->name && impl::strequal(name_, i->name)) return xml_node(i);
+			if (i->equals_name(name_)) return xml_node(i);
 
 		return xml_node();
 	}
 
-	PUGI__FN xml_attribute xml_node::attribute(const char_t* name_, xml_attribute& hint_) const
+	PUGI__FN xml_attribute xml_node::attribute(string_view_t name_, xml_attribute& hint_) const
 	{
 		xml_attribute_struct* hint = hint_._attr;
 
@@ -5580,7 +5719,7 @@ namespace pugi
 
 		// optimistically search from hint up until the end
 		for (xml_attribute_struct* i = hint; i; i = i->next_attribute)
-			if (i->name && impl::strequal(name_, i->name))
+			if (i->equals_name(name_))
 			{
 				// update hint to maximize efficiency of searching for consecutive attributes
 				hint_._attr = i->next_attribute;
@@ -5591,7 +5730,7 @@ namespace pugi
 		// wrap around and search from the first attribute until the hint
 		// 'j' null pointer check is technically redundant, but it prevents a crash in case the assertion above fails
 		for (xml_attribute_struct* j = _root->first_attribute; j && j != hint; j = j->next_attribute)
-			if (j->name && impl::strequal(name_, j->name))
+			if (j->equals_name(name_))
 			{
 				// update hint to maximize efficiency of searching for consecutive attributes
 				hint_._attr = j->next_attribute;
@@ -5625,22 +5764,22 @@ namespace pugi
 		return xml_text(_root);
 	}
 
-	PUGI__FN const char_t* xml_node::child_value() const
+	PUGI__FN string_view_t xml_node::child_value() const
 	{
-		if (!_root) return PUGIXML_TEXT("");
+		if (!_root) return PUGIXML_EMPTY_SV;
 
 		// element nodes can have value if parse_embed_pcdata was used
 		if (PUGI__NODETYPE(_root) == node_element && _root->value)
-			return _root->value;
+			return _root->value_sv();
 
 		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
 			if (impl::is_text_node(i) && i->value)
-				return i->value;
+				return i->value_sv();
 
-		return PUGIXML_TEXT("");
+		return PUGIXML_EMPTY_SV;
 	}
 
-	PUGI__FN const char_t* xml_node::child_value(const char_t* name_) const
+	PUGI__FN string_view_t xml_node::child_value(string_view_t name_) const
 	{
 		return child(name_).child_value();
 	}
@@ -5665,27 +5804,27 @@ namespace pugi
 		return _root && _root->first_child ? xml_node(_root->first_child->prev_sibling_c) : xml_node();
 	}
 
-	PUGI__FN bool xml_node::set_name(const char_t* rhs)
+	PUGI__FN bool xml_node::set_name(string_view_t rhs, bool shallow_copy)
 	{
 		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
 
 		if (type_ != node_element && type_ != node_pi && type_ != node_declaration)
 			return false;
 
-		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs, impl::strlength(rhs));
+		return impl::strcpy_insitu(_root->name, _root->name_len, _root->header, impl::xml_memory_page_name_allocated_mask, rhs.data(), rhs.length(), shallow_copy);
 	}
 
-	PUGI__FN bool xml_node::set_value(const char_t* rhs)
+	PUGI__FN bool xml_node::set_value(string_view_t rhs, bool shallow_copy)
 	{
 		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
 
 		if (type_ != node_pcdata && type_ != node_cdata && type_ != node_comment && type_ != node_pi && type_ != node_doctype)
 			return false;
 
-		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs));
+		return impl::strcpy_insitu(_root->value, _root->value_len, _root->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.length(), shallow_copy);
 	}
 
-	PUGI__FN xml_attribute xml_node::append_attribute(const char_t* name_)
+	PUGI__FN xml_attribute xml_node::append_attribute(string_view_t name_, bool shallow_copy)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 
@@ -5697,12 +5836,12 @@ namespace pugi
 
 		impl::append_attribute(a._attr, _root);
 
-		a.set_name(name_);
+		a.set_name(name_, shallow_copy);
 
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::prepend_attribute(const char_t* name_)
+	PUGI__FN xml_attribute xml_node::prepend_attribute(string_view_t name_, bool shallow_copy)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 
@@ -5714,12 +5853,12 @@ namespace pugi
 
 		impl::prepend_attribute(a._attr, _root);
 
-		a.set_name(name_);
+		a.set_name(name_, shallow_copy);
 
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_attribute_after(const char_t* name_, const xml_attribute& attr)
+	PUGI__FN xml_attribute xml_node::insert_attribute_after(string_view_t name_, const xml_attribute& attr, bool shallow_copy)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
@@ -5732,12 +5871,12 @@ namespace pugi
 
 		impl::insert_attribute_after(a._attr, attr._attr, _root);
 
-		a.set_name(name_);
+		a.set_name(name_, shallow_copy);
 
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_attribute_before(const char_t* name_, const xml_attribute& attr)
+	PUGI__FN xml_attribute xml_node::insert_attribute_before(string_view_t name_, const xml_attribute& attr, bool shallow_copy)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
@@ -5750,7 +5889,7 @@ namespace pugi
 
 		impl::insert_attribute_before(a._attr, attr._attr, _root);
 
-		a.set_name(name_);
+		a.set_name(name_, shallow_copy);
 
 		return a;
 	}
@@ -5837,7 +5976,7 @@ namespace pugi
 
 		impl::append_node(n._root, _root);
 
-		if (type_ == node_declaration) n.set_name(PUGIXML_TEXT("xml"));
+		if (type_ == node_declaration) n.set_name(PUGIXML_TEXT("xml"), true);
 
 		return n;
 	}
@@ -5854,7 +5993,7 @@ namespace pugi
 
 		impl::prepend_node(n._root, _root);
 
-		if (type_ == node_declaration) n.set_name(PUGIXML_TEXT("xml"));
+		if (type_ == node_declaration) n.set_name(PUGIXML_TEXT("xml"), true);
 
 		return n;
 	}
@@ -5872,7 +6011,7 @@ namespace pugi
 
 		impl::insert_node_before(n._root, node._root);
 
-		if (type_ == node_declaration) n.set_name(PUGIXML_TEXT("xml"));
+		if (type_ == node_declaration) n.set_name(PUGIXML_TEXT("xml"), true);
 
 		return n;
 	}
@@ -5890,43 +6029,43 @@ namespace pugi
 
 		impl::insert_node_after(n._root, node._root);
 
-		if (type_ == node_declaration) n.set_name(PUGIXML_TEXT("xml"));
+		if (type_ == node_declaration) n.set_name(PUGIXML_TEXT("xml"), true);
 
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::append_child(const char_t* name_)
+	PUGI__FN xml_node xml_node::append_child(string_view_t name_, bool shallow_copy)
 	{
 		xml_node result = append_child(node_element);
 
-		result.set_name(name_);
+		result.set_name(name_, shallow_copy);
 
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::prepend_child(const char_t* name_)
+	PUGI__FN xml_node xml_node::prepend_child(string_view_t name_, bool shallow_copy)
 	{
 		xml_node result = prepend_child(node_element);
 
-		result.set_name(name_);
+		result.set_name(name_, shallow_copy);
 
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_after(const char_t* name_, const xml_node& node)
+	PUGI__FN xml_node xml_node::insert_child_after(string_view_t name_, const xml_node& node, bool shallow_copy)
 	{
 		xml_node result = insert_child_after(node_element, node);
 
-		result.set_name(name_);
+		result.set_name(name_, shallow_copy);
 
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_before(const char_t* name_, const xml_node& node)
+	PUGI__FN xml_node xml_node::insert_child_before(string_view_t name_, const xml_node& node, bool shallow_copy)
 	{
 		xml_node result = insert_child_before(node_element, node);
 
-		result.set_name(name_);
+		result.set_name(name_, shallow_copy);
 
 		return result;
 	}
@@ -6069,7 +6208,7 @@ namespace pugi
 		return moved;
 	}
 
-	PUGI__FN bool xml_node::remove_attribute(const char_t* name_)
+	PUGI__FN bool xml_node::remove_attribute(string_view_t name_)
 	{
 		return remove_attribute(attribute(name_));
 	}
@@ -6109,7 +6248,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN bool xml_node::remove_child(const char_t* name_)
+	PUGI__FN bool xml_node::remove_child(string_view_t name_)
 	{
 		return remove_child(child(name_));
 	}
@@ -6183,28 +6322,28 @@ namespace pugi
 		return impl::load_buffer_impl(doc, _root, const_cast<void*>(contents), size, options, encoding, false, false, &extra->buffer);
 	}
 
-	PUGI__FN xml_node xml_node::find_child_by_attribute(const char_t* name_, const char_t* attr_name, const char_t* attr_value) const
+	PUGI__FN xml_node xml_node::find_child_by_attribute(string_view_t name_, string_view_t attr_name, string_view_t attr_value) const
 	{
 		if (!_root) return xml_node();
 
 		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
-			if (i->name && impl::strequal(name_, i->name))
+			if (i->name && i->equals_name(name_))
 			{
 				for (xml_attribute_struct* a = i->first_attribute; a; a = a->next_attribute)
-					if (a->name && impl::strequal(attr_name, a->name) && impl::strequal(attr_value, a->value ? a->value + 0 : PUGIXML_TEXT("")))
+					if (a->equals_name(attr_name) && a->equals_value(attr_value))
 						return xml_node(i);
 			}
 
 		return xml_node();
 	}
 
-	PUGI__FN xml_node xml_node::find_child_by_attribute(const char_t* attr_name, const char_t* attr_value) const
+	PUGI__FN xml_node xml_node::find_child_by_attribute(const string_view_t attr_name, const string_view_t attr_value) const
 	{
 		if (!_root) return xml_node();
 
 		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
 			for (xml_attribute_struct* a = i->first_attribute; a; a = a->next_attribute)
-				if (a->name && impl::strequal(attr_name, a->name) && impl::strequal(attr_value, a->value ? a->value + 0 : PUGIXML_TEXT("")))
+				if (a->equals_name(attr_name) && a->equals_value(attr_value))
 					return xml_node(i);
 
 		return xml_node();
@@ -6463,18 +6602,18 @@ namespace pugi
 		return _data() == 0;
 	}
 
-	PUGI__FN const char_t* xml_text::get() const
+	PUGI__FN string_view_t xml_text::get() const
 	{
 		xml_node_struct* d = _data();
 
-		return (d && d->value) ? d->value + 0 : PUGIXML_TEXT("");
+		return (d && d->value) ? d->unsafe_value_sv() : PUGIXML_EMPTY_SV;
 	}
 
-	PUGI__FN const char_t* xml_text::as_string(const char_t* def) const
+	PUGI__FN string_view_t xml_text::as_string(string_view_t def) const
 	{
 		xml_node_struct* d = _data();
 
-		return (d && d->value) ? d->value + 0 : def;
+		return (d && d->value) ? d->unsafe_value_sv() : def;
 	}
 
 	PUGI__FN int xml_text::as_int(int def) const
@@ -6528,74 +6667,74 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_text::set(const char_t* rhs)
+	PUGI__FN bool xml_text::set(string_view_t rhs, bool shallow_copy)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::strcpy_insitu(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs)) : false;
+		return dn ? impl::strcpy_insitu(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.length(), shallow_copy) : false;
 	}
 
 	PUGI__FN bool xml_text::set(int rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_integer<unsigned int>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
+		return dn ? impl::set_value_integer<unsigned int>(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
 	}
 
 	PUGI__FN bool xml_text::set(unsigned int rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_integer<unsigned int>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, false) : false;
+		return dn ? impl::set_value_integer<unsigned int>(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, false) : false;
 	}
 
 	PUGI__FN bool xml_text::set(long rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_integer<unsigned long>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
+		return dn ? impl::set_value_integer<unsigned long>(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
 	}
 
 	PUGI__FN bool xml_text::set(unsigned long rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_integer<unsigned long>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, false) : false;
+		return dn ? impl::set_value_integer<unsigned long>(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, false) : false;
 	}
 
 	PUGI__FN bool xml_text::set(float rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, default_float_precision) : false;
+		return dn ? impl::set_value_convert(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, default_float_precision) : false;
 	}
 
 	PUGI__FN bool xml_text::set(float rhs, int precision)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, precision) : false;
+		return dn ? impl::set_value_convert(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, precision) : false;
 	}
 
 	PUGI__FN bool xml_text::set(double rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, default_double_precision) : false;
+		return dn ? impl::set_value_convert(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, default_double_precision) : false;
 	}
 
 	PUGI__FN bool xml_text::set(double rhs, int precision)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, precision) : false;
+		return dn ? impl::set_value_convert(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, precision) : false;
 	}
 
-	PUGI__FN bool xml_text::set(bool rhs)
+	PUGI__FN bool xml_text::set(boolean rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_bool(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs) : false;
+		return dn ? impl::set_value_bool(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs) : false;
 	}
 
 #ifdef PUGIXML_HAS_LONG_LONG
@@ -6603,18 +6742,18 @@ namespace pugi
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_integer<unsigned long long>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
+		return dn ? impl::set_value_integer<unsigned long long>(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
 	}
 
 	PUGI__FN bool xml_text::set(unsigned long long rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
-		return dn ? impl::set_value_integer<unsigned long long>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, false) : false;
+		return dn ? impl::set_value_integer<unsigned long long>(dn->value, dn->value_len, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, false) : false;
 	}
 #endif
 
-	PUGI__FN xml_text& xml_text::operator=(const char_t* rhs)
+	PUGI__FN xml_text& xml_text::operator=(string_view_t rhs)
 	{
 		set(rhs);
 		return *this;
@@ -6656,7 +6795,7 @@ namespace pugi
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(bool rhs)
+	PUGI__FN xml_text& xml_text::operator=(boolean rhs)
 	{
 		set(rhs);
 		return *this;
@@ -6815,15 +6954,15 @@ namespace pugi
 		return temp;
 	}
 
-	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(): _name(0)
+	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(): _name(0), _name_len(0)
 	{
 	}
 
-	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(const xml_node& node, const char_t* name): _wrap(node), _parent(node.parent()), _name(name)
+	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(const xml_node& node, string_view_t name): _wrap(node), _parent(node.parent()), _name(name.data()), _name_len(static_cast<int>(name.length()))
 	{
 	}
 
-	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(xml_node_struct* ref, xml_node_struct* parent, const char_t* name): _wrap(ref), _parent(parent), _name(name)
+	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(xml_node_struct* ref, xml_node_struct* parent, string_view_t name): _wrap(ref), _parent(parent), _name(name.data()), _name_len(static_cast<int>(name.length()))
 	{
 	}
 
@@ -6852,7 +6991,7 @@ namespace pugi
 	PUGI__FN xml_named_node_iterator& xml_named_node_iterator::operator++()
 	{
 		assert(_wrap._root);
-		_wrap = _wrap.next_sibling(_name);
+		_wrap = _wrap.next_sibling(string_view_t(_name, _name_len));
 		return *this;
 	}
 
@@ -6865,14 +7004,15 @@ namespace pugi
 
 	PUGI__FN xml_named_node_iterator& xml_named_node_iterator::operator--()
 	{
+		string_view_t name = string_view_t(_name, _name_len);
 		if (_wrap._root)
-			_wrap = _wrap.previous_sibling(_name);
+			_wrap = _wrap.previous_sibling(name);
 		else
 		{
 			_wrap = _parent.last_child();
 
-			if (!impl::strequal(_wrap.name(), _name))
-				_wrap = _wrap.previous_sibling(_name);
+			if (_wrap.name() != name)
+				_wrap = _wrap.previous_sibling(name);
 		}
 
 		return *this;
@@ -7306,28 +7446,16 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN std::string PUGIXML_FUNCTION as_utf8(const wchar_t* str)
+	PUGI__FN std::string PUGIXML_FUNCTION as_utf8(const pugi::wstring_view& str)
 	{
-		assert(str);
-
-		return impl::as_utf8_impl(str, impl::strlength_wide(str));
+		return impl::as_utf8_impl(str.data(), str.length());
 	}
 
-	PUGI__FN std::string PUGIXML_FUNCTION as_utf8(const std::basic_string<wchar_t>& str)
+	PUGI__FN std::wstring PUGIXML_FUNCTION as_wide(const pugi::string_view& str)
 	{
-		return impl::as_utf8_impl(str.c_str(), str.size());
-	}
+		assert(str.data());
 
-	PUGI__FN std::basic_string<wchar_t> PUGIXML_FUNCTION as_wide(const char* str)
-	{
-		assert(str);
-
-		return impl::as_wide_impl(str, strlen(str));
-	}
-
-	PUGI__FN std::basic_string<wchar_t> PUGIXML_FUNCTION as_wide(const std::string& str)
-	{
-		return impl::as_wide_impl(str.c_str(), str.size());
+		return impl::as_wide_impl(str.data(), str.length());
 	}
 #endif
 
@@ -7824,9 +7952,9 @@ PUGI__NS_BEGIN
 		}
 
 	public:
-		static xpath_string from_const(const char_t* str)
+		static xpath_string from_const(string_view_t str)
 		{
-			return xpath_string(str, false, 0);
+			return xpath_string(str.data(), false, 0);
 		}
 
 		static xpath_string from_heap_preallocated(const char_t* begin, const char_t* end)
@@ -7997,7 +8125,7 @@ PUGI__NS_BEGIN
 				xpath_string result;
 
 				// element nodes can have value if parse_embed_pcdata was used
-				if (n.value()[0])
+				if (!n.value().empty())
 					result.append(xpath_string::from_const(n.value()), alloc);
 
 				xml_node cur = n.first_child();
@@ -8261,7 +8389,7 @@ PUGI__NS_BEGIN
 	}
 
 	// gets mantissa digits in the form of 0.xxxxx with 0. implied and the exponent
-#if defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400 && !defined(_WIN32_WCE)
+#if defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
 	PUGI__FN void convert_number_to_mantissa_exponent(double value, char (&buffer)[32], char** out_mantissa, int* out_exponent)
 	{
 		// get base values
@@ -8367,7 +8495,7 @@ PUGI__NS_BEGIN
 
 		// zero-terminate
 		assert(s < result + result_size);
-		*s = 0;
+		*s = '\0';
 
 		return xpath_string::from_heap_preallocated(result, s);
 	}
@@ -8453,7 +8581,7 @@ PUGI__NS_BEGIN
 
 	PUGI__FN const char_t* qualified_name(const xpath_node& node)
 	{
-		return node.attribute() ? node.attribute().name() : node.node().name();
+		return node.attribute() ? node.attribute().name().data() : node.node().name().data();
 	}
 
 	PUGI__FN const char_t* local_name(const xpath_node& node)
@@ -8479,7 +8607,7 @@ PUGI__NS_BEGIN
 
 		bool operator()(xml_attribute a) const
 		{
-			const char_t* name = a.name();
+			const char_t* name = a.name().data();
 
 			if (!starts_with(name, PUGIXML_TEXT("xmlns"))) return false;
 
@@ -8489,7 +8617,7 @@ PUGI__NS_BEGIN
 
 	PUGI__FN const char_t* namespace_uri(xml_node node)
 	{
-		namespace_uri_predicate pred = node.name();
+		namespace_uri_predicate pred = node.name().data();
 
 		xml_node p = node;
 
@@ -8497,7 +8625,7 @@ PUGI__NS_BEGIN
 		{
 			xml_attribute a = p.find_attribute(pred);
 
-			if (a) return a.value();
+			if (a) return a.value().data();
 
 			p = p.parent();
 		}
@@ -8507,7 +8635,7 @@ PUGI__NS_BEGIN
 
 	PUGI__FN const char_t* namespace_uri(xml_attribute attr, xml_node parent)
 	{
-		namespace_uri_predicate pred = attr.name();
+		namespace_uri_predicate pred = attr.name().data();
 
 		// Default namespace does not apply to attributes
 		if (!pred.prefix) return PUGIXML_TEXT("");
@@ -8518,7 +8646,7 @@ PUGI__NS_BEGIN
 		{
 			xml_attribute a = p.find_attribute(pred);
 
-			if (a) return a.value();
+			if (a) return a.value().data();
 
 			p = p.parent();
 		}
@@ -10401,7 +10529,7 @@ PUGI__NS_BEGIN
 
 					if (a)
 					{
-						const char_t* value = a.value();
+						const char_t* value = a.value().data();
 
 						// strnicmp / strncasecmp is not portable
 						for (const char_t* lit = lang.c_str(); *lit; ++lit)
@@ -10423,7 +10551,7 @@ PUGI__NS_BEGIN
 
 				xml_attribute attr = c.n.node().attribute(_left->_data.nodetest);
 
-				return attr && strequal(attr.value(), value) && is_xpath_attribute(attr.name());
+				return attr && strequal(attr.value().data(), value) && is_xpath_attribute(attr.name().data());
 			}
 
 			case ast_variable:

--- a/pugixml/pugixml.hpp
+++ b/pugixml/pugixml.hpp
@@ -6,6 +6,8 @@
  *
  * Github location: https://github.com/zeux/pugixml
  *
+ * Forked version with std::string_view: https://github.com/zeux/pugixml
+ *
  * This library is distributed under the MIT License. See notice at the end
  * of this file.
  *
@@ -13,8 +15,16 @@
  * Copyright (C) 2003, by Kristen Wegner (kristen@tima.net)
  */
 
-// [KeyWorks - 03-291-2020] Added cvalue(), cname(), as_cstr(), child_cvalue and child_as_cstr() when compiled with
-// _TTLIB_CVIEW_AVAILABLE_ defined. These functions return a ttlib::cview (string_view to a zero-terminated string)
+// [KeyWorks - 05-16-2022] Additions:
+//
+// as_std_str() -- returns std::string
+// child_as_std_str() -- returns child value as std::string
+// child_as_std_str(string_view_t name)  -- returns child value as std::string
+
+// if TTLIB_ADDITIONS is defined:
+//
+// Same as above, but adding as_sview and add_cstr variations which return ttlib::sview and ttlib::cstr repectively
+// The only difference is that these classes add additional methods to std::string_view and std::string
 
 #pragma once
 
@@ -44,6 +54,16 @@
 #	include <iosfwd>
 #	include <string>
 #endif
+
+#if (defined(__cplusplus) && __cplusplus == 201703L) || (defined(_MSC_VER) && _MSC_VER > 1900 && ((defined(_HAS_CXX17) && _HAS_CXX17 == 1) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201402L))))
+#ifndef PUGI_CXX17_FEATURES
+#define PUGI_CXX17_FEATURES 1
+#endif // C++17 features macro
+#endif // C++17 features check
+
+#if defined(PUGI_CXX17_FEATURES) && PUGI_CXX17_FEATURES
+#include <string_view>
+#endif // C++17 features
 
 // Macro for deprecated features
 #ifndef PUGIXML_DEPRECATED
@@ -136,6 +156,126 @@
 #	define PUGIXML_CHAR char
 #endif
 
+
+// The string_view
+namespace pugi {
+#if defined(PUGI_CXX17_FEATURES) && PUGI_CXX17_FEATURES
+	template <typename C, typename T = std::char_traits<C> >
+	using basic_string_view = std::basic_string_view<C, T>;
+	typedef std::string_view string_view;
+	typedef std::wstring_view wstring_view;
+#else
+	template <typename Char, typename Traits = std::char_traits<Char> >
+	struct basic_string_view {
+		const Char* p;
+		std::size_t s;
+
+		basic_string_view(const std::basic_string<Char, Traits>& r)
+			: p(r.c_str()), s(r.size()) {
+		}
+		basic_string_view(const Char* ptr)
+			: p(ptr), s(Traits::length(ptr)) {
+		}
+		basic_string_view(const Char* ptr, std::size_t sz)
+			: p(ptr), s(sz) {
+		}
+
+		static int compare(const Char* lhs_p, std::size_t lhs_sz, const Char* rhs_p, std::size_t rhs_sz) {
+			int result = Traits::compare(lhs_p, rhs_p, lhs_sz < rhs_sz ? lhs_sz : rhs_sz);
+			if (result != 0)
+				return result;
+			if (lhs_sz < rhs_sz)
+				return -1;
+			if (lhs_sz > rhs_sz)
+				return 1;
+			return 0;
+		}
+
+		const Char* begin() const {
+			return p;
+		}
+
+		const Char* end() const {
+			return p + s;
+		}
+
+		const Char* cbegin() const {
+			return p;
+		}
+
+		const Char* cend() const {
+			return p + s;
+		}
+
+		const Char* data() const {
+			return p;
+		}
+
+		std::size_t size() const {
+			return s;
+		}
+
+		std::size_t length() const {
+			return size();
+		}
+
+		bool empty() const {
+			return 0 == s;
+		}
+
+		const Char& operator[](size_t index) const {
+			return p[index];
+		}
+
+		operator std::basic_string<Char, Traits>() const {
+			return std::basic_string<Char, Traits>(data(), size());
+		}
+
+		bool operator==(const basic_string_view& r) const {
+			return compare(p, s, r.data(), r.size()) == 0;
+		}
+
+		bool operator==(const Char* r) const {
+			return compare(r, Traits::length(r), p, s) == 0;
+		}
+
+		bool operator==(const std::basic_string<Char, Traits>& r) const {
+			return compare(r.data(), r.size(), p, s) == 0;
+		}
+
+		bool operator!=(const basic_string_view& r) const {
+			return !(*this == r);
+		}
+
+		bool operator!=(const char* r) const {
+			return !(*this == r);
+		}
+
+		bool operator!=(const std::basic_string<Char, Traits>& r) const {
+			return !(*this == r);
+		}
+	};
+} // namespace pugi
+
+namespace pugi {
+	typedef basic_string_view<char> string_view;
+	typedef basic_string_view<wchar_t> wstring_view;
+#endif
+} // namespace pugi
+
+// The explicit boolean type to avoid compiler ambiguous match const char_t* as scalar type 'bool',
+// because we preferred compiler match const char_t* as string_view_t
+namespace pugi {
+	struct boolean {
+		boolean() : value(false) {}
+		explicit boolean(bool bval) : value(bval) {}
+		bool value;
+		operator bool() const { return value; }
+	};
+	static const boolean (true_value)(true);
+	static const boolean (false_value)(false);
+} // namespace pugi
+
 namespace pugi
 {
 	// Character type used for all internal storage and operations; depends on PUGIXML_WCHAR_MODE
@@ -145,7 +285,12 @@ namespace pugi
 	// String type used for operations that work with STL string; depends on PUGIXML_WCHAR_MODE
 	typedef std::basic_string<PUGIXML_CHAR, std::char_traits<PUGIXML_CHAR>, std::allocator<PUGIXML_CHAR> > string_t;
 #endif
+
+	// string_view type used for operations that work with pugi::string_view, depends on PUGIXML_WCHAR_MODE
+	typedef pugi::basic_string_view<char_t, std::char_traits<char_t> > string_view_t;
 }
+
+#define PUGIXML_EMPTY_SV pugi::string_view_t(PUGIXML_TEXT(""), 0)
 
 // The PugiXML namespace
 namespace pugi
@@ -401,23 +546,19 @@ namespace pugi
 		bool empty() const;
 
 		// Get attribute name/value, or "" if attribute is empty
-		const char_t* name() const;
-		const char_t* value() const;
+		string_view_t name() const;
+
+		string_view_t value() const;
 
 		// Get attribute value, or the default value if attribute is empty
-		const char_t* as_string(const char_t* def = PUGIXML_TEXT("")) const;
+		string_view_t as_string(string_view_t def = PUGIXML_EMPTY_SV) const;
 
-#if defined(_TTLIB_CVIEW_AVAILABLE_)
-        ttlib::cview cname() const { return { name() }; }
-        ttlib::cview cvalue() const { return { value() }; }
+        std::string as_std_str(string_view_t def = PUGIXML_EMPTY_SV) const { return std::string(as_string(def)); }
 
-        ttlib::cview as_cview(const char_t* defvalue = "") const { return { as_string(defvalue) }; }
-        ttlib::cstr as_cstr(const char_t* defvalue = "") const
-        {
-            ttlib::cstr str(as_string(defvalue));
-            return str;
-        }
-#endif
+	#if defined(TTLIB_ADDITIONS)
+        ttlib::sview as_sview(string_view_t def = PUGIXML_EMPTY_SV) const { return as_string(def); }
+        ttlib::cstr as_cstr(string_view_t def = PUGIXML_EMPTY_SV) const { return as_std_str(def); }
+	#endif
 
 		// Get attribute value as a number, or the default value if conversion did not succeed or attribute is empty
 		int as_int(int def = 0) const;
@@ -434,8 +575,8 @@ namespace pugi
 		bool as_bool(bool def = false) const;
 
 		// Set attribute name/value (returns false if attribute is empty or there is not enough memory)
-		bool set_name(const char_t* rhs);
-		bool set_value(const char_t* rhs);
+		bool set_name(string_view_t rhs, bool shallow_copy = false);
+		bool set_value(string_view_t rhs, bool shallow_copy = false);
 
 		// Set attribute value with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set_value(int rhs);
@@ -446,7 +587,7 @@ namespace pugi
 		bool set_value(double rhs, int precision);
 		bool set_value(float rhs);
 		bool set_value(float rhs, int precision);
-		bool set_value(bool rhs);
+		bool set_value(boolean rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		bool set_value(long long rhs);
@@ -454,14 +595,14 @@ namespace pugi
 	#endif
 
 		// Set attribute value (equivalent to set_value without error checking)
-		xml_attribute& operator=(const char_t* rhs);
+		xml_attribute& operator=(string_view_t rhs);
 		xml_attribute& operator=(int rhs);
 		xml_attribute& operator=(unsigned int rhs);
 		xml_attribute& operator=(long rhs);
 		xml_attribute& operator=(unsigned long rhs);
 		xml_attribute& operator=(double rhs);
 		xml_attribute& operator=(float rhs);
-		xml_attribute& operator=(bool rhs);
+		xml_attribute& operator=(boolean rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_attribute& operator=(long long rhs);
@@ -525,25 +666,27 @@ namespace pugi
 		xml_node_type type() const;
 
 		// Get node name, or "" if node is empty or it has no name
-		const char_t* name() const;
+		string_view_t name() const;
 
 		// Get node value, or "" if node is empty or it has no value
 		// Note: For <node>text</node> node.value() does not return "text"! Use child_value() or text() methods to access text inside nodes.
-		const char_t* value() const;
+		string_view_t value() const;
 
-#if defined(_TTLIB_CVIEW_AVAILABLE_)
-        ttlib::cview cname() const { return { name() }; }
-        ttlib::cview cvalue() const { return { value() }; }
-        ttlib::cstr  as_cstr() const { ttlib::cstr str(value()); return str; }
+        std::string as_std_str() const { return std::string(value()); }
+        std::string child_as_std_str() const { return std::string(child_value()); }
+        std::string child_as_std_str(string_view_t name) const { return std::string(child_value(name)); }
 
-		ttlib::cview child_cvalue() const { return { child_value() }; }
-        ttlib::cstr  child_as_cstr() const { ttlib::cstr str(child_value()); return str; }
+	#if defined(TTLIB_ADDITIONS)
+		ttlib::sview as_sview() const { return value(); }
+        ttlib::cstr  as_cstr() const { return as_std_str(); }
 
-        // Get child value of child with specified name. Equivalent to child(name).child_cvalue().
-		ttlib::cview child_cvalue(const char_t* name) const { return { child_value(name) }; }
+        ttlib::sview child_as_sview() const { return child_value(); }
+        ttlib::cstr  child_as_cstr() const { return child_as_std_str(); }
+
         // Get child value of child with specified name. Equivalent to child(name).child_as_cstr().
-        ttlib::cstr  child_as_cstr(const char_t* name) const { ttlib::cstr str(child_value(name)); return str; }
-#endif
+        ttlib::sview child_as_sview(string_view_t name) const { return child_value(name); }
+        ttlib::cstr  child_as_cstr(string_view_t name) const { return child_as_std_str(name); }
+	#endif
 
 		// Get attribute list
 		xml_attribute first_attribute() const;
@@ -567,29 +710,29 @@ namespace pugi
 		xml_text text() const;
 
 		// Get child, attribute or next/previous sibling with the specified name
-		xml_node child(const char_t* name) const;
-		xml_attribute attribute(const char_t* name) const;
-		xml_node next_sibling(const char_t* name) const;
-		xml_node previous_sibling(const char_t* name) const;
+		xml_node child(string_view_t name) const;
+		xml_attribute attribute(string_view_t name) const;
+		xml_node next_sibling(string_view_t name) const;
+		xml_node previous_sibling(string_view_t name) const;
 
 		// Get attribute, starting the search from a hint (and updating hint so that searching for a sequence of attributes is fast)
-		xml_attribute attribute(const char_t* name, xml_attribute& hint) const;
+		xml_attribute attribute(string_view_t name, xml_attribute& hint) const;
 
 		// Get child value of current node; that is, value of the first child node of type PCDATA/CDATA
-		const char_t* child_value() const;
+		string_view_t child_value() const;
 
 		// Get child value of child with specified name. Equivalent to child(name).child_value().
-		const char_t* child_value(const char_t* name) const;
+		string_view_t child_value(string_view_t name) const;
 
 		// Set node name/value (returns false if node is empty, there is not enough memory, or node can not have name/value)
-		bool set_name(const char_t* rhs);
-		bool set_value(const char_t* rhs);
+		bool set_name(string_view_t rhs, bool shallow_copy = false);
+		bool set_value(string_view_t rhs, bool shallow_copy = false);
 
 		// Add attribute with specified name. Returns added attribute, or empty attribute on errors.
-		xml_attribute append_attribute(const char_t* name);
-		xml_attribute prepend_attribute(const char_t* name);
-		xml_attribute insert_attribute_after(const char_t* name, const xml_attribute& attr);
-		xml_attribute insert_attribute_before(const char_t* name, const xml_attribute& attr);
+		xml_attribute append_attribute(string_view_t name, bool shallow_copy = false);
+		xml_attribute prepend_attribute(string_view_t name, bool shallow_copy = false);
+		xml_attribute insert_attribute_after(string_view_t name, const xml_attribute& attr, bool shallow_copy = false);
+		xml_attribute insert_attribute_before(string_view_t name, const xml_attribute& attr, bool shallow_copy = false);
 
 		// Add a copy of the specified attribute. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_copy(const xml_attribute& proto);
@@ -604,10 +747,10 @@ namespace pugi
 		xml_node insert_child_before(xml_node_type type, const xml_node& node);
 
 		// Add child element with specified name. Returns added node, or empty node on errors.
-		xml_node append_child(const char_t* name);
-		xml_node prepend_child(const char_t* name);
-		xml_node insert_child_after(const char_t* name, const xml_node& node);
-		xml_node insert_child_before(const char_t* name, const xml_node& node);
+		xml_node append_child(string_view_t name, bool shallow_copy = false);
+		xml_node prepend_child(string_view_t name, bool shallow_copy = false);
+		xml_node insert_child_after(string_view_t name, const xml_node& node, bool shallow_copy = false);
+		xml_node insert_child_before(string_view_t name, const xml_node& node, bool shallow_copy = false);
 
 		// Add a copy of the specified node as a child. Returns added node, or empty node on errors.
 		xml_node append_copy(const xml_node& proto);
@@ -623,14 +766,14 @@ namespace pugi
 
 		// Remove specified attribute
 		bool remove_attribute(const xml_attribute& a);
-		bool remove_attribute(const char_t* name);
+		bool remove_attribute(string_view_t name);
 
 		// Remove all attributes
 		bool remove_attributes();
 
 		// Remove specified child
 		bool remove_child(const xml_node& n);
-		bool remove_child(const char_t* name);
+		bool remove_child(string_view_t name);
 
 		// Remove all children
 		bool remove_children();
@@ -689,8 +832,8 @@ namespace pugi
 		}
 
 		// Find child node by attribute name/value
-		xml_node find_child_by_attribute(const char_t* name, const char_t* attr_name, const char_t* attr_value) const;
-		xml_node find_child_by_attribute(const char_t* attr_name, const char_t* attr_value) const;
+		xml_node find_child_by_attribute(string_view_t name, string_view_t attr_name, string_view_t attr_value) const;
+		xml_node find_child_by_attribute(string_view_t attr_name, string_view_t attr_value) const;
 
 	#ifndef PUGIXML_NO_STL
 		// Get the absolute node path from root as a text string.
@@ -741,7 +884,7 @@ namespace pugi
 
 		// Range-based for support
 		xml_object_range<xml_node_iterator> children() const;
-		xml_object_range<xml_named_node_iterator> children(const char_t* name) const;
+		xml_object_range<xml_named_node_iterator> children(string_view_t name) const;
 		xml_object_range<xml_attribute_iterator> attributes() const;
 
 		// Get node offset in parsed file/string (in char_t units) for debugging purposes
@@ -788,24 +931,17 @@ namespace pugi
 		bool empty() const;
 
 		// Get text, or "" if object is empty
-		const char_t* get() const;
+		string_view_t get() const;
 
 		// Get text, or the default value if object is empty
-		const char_t* as_string(const char_t* def = PUGIXML_TEXT("")) const;
+		string_view_t as_string(string_view_t def = PUGIXML_EMPTY_SV) const;
 
-#if defined(_TTLIB_CVIEW_AVAILABLE_)
-        ttlib::cview cget() const { return { get() }; }
-        ttlib::cstr as_cstr(const char_t* defvalue = "") const
-        {
-            ttlib::cstr str(as_string(defvalue));
-            return str;
-        }
-        ttlib::cview as_cview(const char_t* defvalue = "") const
-        {
-            ttlib::cview str(as_string(defvalue));
-            return str;
-        }
-#endif
+		std::string as_std_str(string_view_t def = PUGIXML_EMPTY_SV) const { return std::string(as_string(def)); }
+
+	#if defined(TTLIB_ADDITIONS)
+        ttlib::sview as_sview(string_view_t def = PUGIXML_EMPTY_SV) const { return as_string(def); }
+        ttlib::cstr as_cstr(string_view_t def = PUGIXML_EMPTY_SV) const { return ttlib::cstr(as_string(def)); }
+	#endif
 		// Get text as a number, or the default value if conversion did not succeed or object is empty
 		int as_int(int def = 0) const;
 		unsigned int as_uint(unsigned int def = 0) const;
@@ -821,7 +957,7 @@ namespace pugi
 		bool as_bool(bool def = false) const;
 
 		// Set text (returns false if object is empty or there is not enough memory)
-		bool set(const char_t* rhs);
+		bool set(string_view_t rhs, bool shallow_copy = false);
 
 		// Set text with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set(int rhs);
@@ -832,7 +968,7 @@ namespace pugi
 		bool set(double rhs, int precision);
 		bool set(float rhs);
 		bool set(float rhs, int precision);
-		bool set(bool rhs);
+		bool set(boolean rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		bool set(long long rhs);
@@ -840,14 +976,14 @@ namespace pugi
 	#endif
 
 		// Set text (equivalent to set without error checking)
-		xml_text& operator=(const char_t* rhs);
+		xml_text& operator=(string_view_t rhs);
 		xml_text& operator=(int rhs);
 		xml_text& operator=(unsigned int rhs);
 		xml_text& operator=(long rhs);
 		xml_text& operator=(unsigned long rhs);
 		xml_text& operator=(double rhs);
 		xml_text& operator=(float rhs);
-		xml_text& operator=(bool rhs);
+		xml_text& operator=(boolean rhs);
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_text& operator=(long long rhs);
@@ -968,7 +1104,7 @@ namespace pugi
 		xml_named_node_iterator();
 
 		// Construct an iterator which points to the specified node
-		xml_named_node_iterator(const xml_node& node, const char_t* name);
+		xml_named_node_iterator(const xml_node& node, string_view_t name);
 
 		// Iterator operators
 		bool operator==(const xml_named_node_iterator& rhs) const;
@@ -987,8 +1123,9 @@ namespace pugi
 		mutable xml_node _wrap;
 		xml_node _parent;
 		const char_t* _name;
+		int _name_len;
 
-		xml_named_node_iterator(xml_node_struct* ref, xml_node_struct* parent, const char_t* name);
+		xml_named_node_iterator(xml_node_struct* ref, xml_node_struct* parent, string_view_t name);
 	};
 
 	// Abstract tree walker class (see xml_node::traverse)
@@ -1470,12 +1607,10 @@ namespace pugi
 
 #ifndef PUGIXML_NO_STL
 	// Convert wide string to UTF8
-	std::basic_string<char, std::char_traits<char>, std::allocator<char> > PUGIXML_FUNCTION as_utf8(const wchar_t* str);
-	std::basic_string<char, std::char_traits<char>, std::allocator<char> > PUGIXML_FUNCTION as_utf8(const std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >& str);
+    std::string PUGIXML_FUNCTION as_utf8(const pugi::wstring_view& str);
 
 	// Convert UTF8 to wide string
-	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > PUGIXML_FUNCTION as_wide(const char* str);
-	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > PUGIXML_FUNCTION as_wide(const std::basic_string<char, std::char_traits<char>, std::allocator<char> >& str);
+	std::wstring PUGIXML_FUNCTION as_wide(const pugi::string_view& str);
 #endif
 
 	// Memory allocation function interface; returns pointer to allocated memory or NULL on failure

--- a/src/assertion_dlg.cpp
+++ b/src/assertion_dlg.cpp
@@ -12,7 +12,7 @@
 
 static std::mutex g_mutexAssert;
 
-bool AssertionDlg(const char* filename, const char* function, int line, const char* cond, const std::string& msg)
+bool AssertionDlg(const std::source_location& location, const char* cond, std::string_view msg)
 {
     // This is in case additional message processing results in an assert while this one is already being displayed.
     std::unique_lock<std::mutex> classLock(g_mutexAssert);
@@ -24,9 +24,9 @@ bool AssertionDlg(const char* filename, const char* function, int line, const ch
     if (!msg.empty())
         str << "Comment: " << msg << "\n\n";
 
-    str << "File: " << filename << "\n";
-    str << "Function: " << function << "\n";
-    str << "Line: " << line << "\n\n";
+    str << "File: " << location.file_name() << "\n";
+    str << "Function: " << location.function_name() << "\n";
+    str << "Line: " << (size_t) location.line() << "\n\n";
     str << "Press Yes to call wxTrap, No to continue, Cancel to exit program.";
 
     wxMessageDialog dlg(nullptr, str.wx_str(), "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);

--- a/src/assertion_dlg.h
+++ b/src/assertion_dlg.h
@@ -9,39 +9,71 @@
 
 #include <source_location>
 
+#if defined(__cpp_consteval)
+
 // This should *ONLY* be called in the GUI thread!
 //
 // This function is available in Release builds
 bool AssertionDlg(const std::source_location& location, const char* cond, std::string_view msg);
 
-#if defined(NDEBUG) && !defined(INTERNAL_TESTING)
-    #define ASSERT(cond)
-    #define ASSERT_MSG(cond, msg)
-    #define FAIL_MSG(msg)
-#else  // not defined(NDEBUG) && !defined(INTERNAL_TESTING)
-    #define ASSERT(cond)                                                  \
-        if (!(cond))                                                      \
-        {                                                                 \
-            if (AssertionDlg(std::source_location::current(), #cond, "")) \
-            {                                                             \
-                wxTrap();                                                 \
-            }                                                             \
-        }
+    #if defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define ASSERT(cond)
+        #define ASSERT_MSG(cond, msg)
+        #define FAIL_MSG(msg)
+    #else  // not defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define ASSERT(cond)                                                  \
+            if (!(cond))                                                      \
+            {                                                                 \
+                if (AssertionDlg(std::source_location::current(), #cond, "")) \
+                {                                                             \
+                    wxTrap();                                                 \
+                }                                                             \
+            }
 
-    #define ASSERT_MSG(cond, msg)                                            \
-        if (!(cond))                                                         \
-        {                                                                    \
-            if (AssertionDlg(std::source_location::current(), #cond, (msg))) \
-            {                                                                \
-                wxTrap();                                                    \
-            }                                                                \
-        }
+        #define ASSERT_MSG(cond, msg)                                            \
+            if (!(cond))                                                         \
+            {                                                                    \
+                if (AssertionDlg(std::source_location::current(), #cond, (msg))) \
+                {                                                                \
+                    wxTrap();                                                    \
+                }                                                                \
+            }
 
-    #define FAIL_MSG(msg)                                                       \
-        {                                                                       \
-            if (AssertionDlg(std::source_location::current(), "failed", (msg))) \
-            {                                                                   \
-                wxTrap();                                                       \
-            }                                                                   \
-        }
-#endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define FAIL_MSG(msg)                                                       \
+            {                                                                       \
+                if (AssertionDlg(std::source_location::current(), "failed", (msg))) \
+                {                                                                   \
+                    wxTrap();                                                       \
+                }                                                                   \
+            }
+    #endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)
+
+#else
+
+bool AssertionDlg(const char* filename, const char* function, int line, const char* cond, const std::string& msg);
+
+    #if defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define ASSERT(cond)
+        #define ASSERT_MSG(cond, msg)
+        #define FAIL_MSG(msg)
+    #else  // not defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define ASSERT(cond)                                                      \
+            if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, "")) \
+            {                                                                     \
+                wxTrap();                                                         \
+            }
+
+        #define ASSERT_MSG(cond, msg)                                                \
+            if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, (msg))) \
+            {                                                                        \
+                wxTrap();                                                            \
+            }
+
+        #define FAIL_MSG(msg)                                              \
+            if (AssertionDlg(__FILE__, __func__, __LINE__, "failed", msg)) \
+            {                                                              \
+                wxTrap();                                                  \
+            }
+    #endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)
+
+#endif

--- a/src/assertion_dlg.h
+++ b/src/assertion_dlg.h
@@ -5,31 +5,43 @@
 // License:   Apache License ( see ../LICENSE )
 /////////////////////////////////////////////////////////////////////////////
 
+#pragma once
+
+#include <source_location>
+
 // This should *ONLY* be called in the GUI thread!
 //
 // This function is available in Release builds
-bool AssertionDlg(const char* filename, const char* function, int line, const char* cond, const std::string& msg);
+bool AssertionDlg(const std::source_location& location, const char* cond, std::string_view msg);
 
 #if defined(NDEBUG) && !defined(INTERNAL_TESTING)
     #define ASSERT(cond)
     #define ASSERT_MSG(cond, msg)
     #define FAIL_MSG(msg)
 #else  // not defined(NDEBUG) && !defined(INTERNAL_TESTING)
-    #define ASSERT(cond)                                                      \
-        if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, "")) \
-        {                                                                     \
-            wxTrap();                                                         \
+    #define ASSERT(cond)                                                  \
+        if (!(cond))                                                      \
+        {                                                                 \
+            if (AssertionDlg(std::source_location::current(), #cond, "")) \
+            {                                                             \
+                wxTrap();                                                 \
+            }                                                             \
         }
 
-    #define ASSERT_MSG(cond, msg)                                                \
-        if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, (msg))) \
-        {                                                                        \
-            wxTrap();                                                            \
+    #define ASSERT_MSG(cond, msg)                                            \
+        if (!(cond))                                                         \
+        {                                                                    \
+            if (AssertionDlg(std::source_location::current(), #cond, (msg))) \
+            {                                                                \
+                wxTrap();                                                    \
+            }                                                                \
         }
 
-    #define FAIL_MSG(msg)                                              \
-        if (AssertionDlg(__FILE__, __func__, __LINE__, "failed", msg)) \
-        {                                                              \
-            wxTrap();                                                  \
+    #define FAIL_MSG(msg)                                                       \
+        {                                                                       \
+            if (AssertionDlg(std::source_location::current(), "failed", (msg))) \
+            {                                                                   \
+                wxTrap();                                                       \
+            }                                                                   \
         }
 #endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)

--- a/src/bitmaps.cpp
+++ b/src/bitmaps.cpp
@@ -194,17 +194,17 @@ wxIcon GetIconImage(ttlib::sview name)
 // [KeyWorks - 05-04-2021] Note that we don't display warnings or errors to the user since this will be called during project
 // loading, and there could be dozens of calls to the same problem file(s).
 
-wxImage GetHeaderImage(ttlib::cview filename, size_t* p_original_size, ttString* p_mime_type)
+wxImage GetHeaderImage(ttlib::sview filename, size_t* p_original_size, ttString* p_mime_type)
 {
     wxImage image;
 
-    if (!ttlib::file_exists(filename))
+    if (!filename.file_exists())
     {
         MSG_ERROR(ttlib::cstr() << filename << " passed to GetHeaderImage doesn't exist");
         return image;
     }
 
-    std::ifstream fileOriginal(filename, std::ios::binary | std::ios::in);
+    std::ifstream fileOriginal(filename.as_str(), std::ios::binary | std::ios::in);
     if (!fileOriginal.is_open())
     {
         MSG_ERROR(ttlib::cstr() << filename << " passed to GetHeaderImage could not be read");
@@ -403,15 +403,15 @@ wxImage LoadHeaderImage(const unsigned char* data, size_t size_data)
     return image;
 };
 
-bool GetAnimationImage(wxAnimation& animation, ttlib::cview filename)
+bool GetAnimationImage(wxAnimation& animation, ttlib::sview filename)
 {
-    if (!ttlib::file_exists(filename))
+    if (!filename.file_exists())
     {
         MSG_ERROR(ttlib::cstr() << filename << " passed to GetAnimationanimation doesn't exist");
         return animation.IsOk();
     }
 
-    std::ifstream fileOriginal(filename, std::ios::binary | std::ios::in);
+    std::ifstream fileOriginal(filename.as_str(), std::ios::binary | std::ios::in);
     if (!fileOriginal.is_open())
     {
         MSG_ERROR(ttlib::cstr() << filename << " passed to GetAnimationImage could not be read");

--- a/src/bitmaps.cpp
+++ b/src/bitmaps.cpp
@@ -157,11 +157,11 @@ static const ImageMap png_headers[] = {
 
 };
 
-wxImage GetInternalImage(ttlib::cview name)
+wxImage GetInternalImage(ttlib::sview name)
 {
     for (auto& iter: png_headers)
     {
-        if (name.is_sameas(iter.name))
+        if (name == iter.name)
         {
             return LoadHeaderImage(iter.data, iter.size_data);
         }
@@ -171,7 +171,7 @@ wxImage GetInternalImage(ttlib::cview name)
     return LoadHeaderImage(default_png, sizeof(default_png));
 }
 
-wxIcon GetIconImage(ttlib::cview name)
+wxIcon GetIconImage(ttlib::sview name)
 {
     for (auto& iter: png_headers)
     {

--- a/src/bitmaps.cpp
+++ b/src/bitmaps.cpp
@@ -286,7 +286,7 @@ wxImage GetHeaderImage(ttlib::sview filename, size_t* p_original_size, ttString*
     }
 
     auto image_buffer = std::make_unique<unsigned char[]>(image_buffer_size);
-    unsigned char* ptr_out_buf = image_buffer.get();
+    auto out_buffer = image_buffer.get();
 
     if (isUiditorFile)
     {
@@ -300,7 +300,7 @@ wxImage GetHeaderImage(ttlib::sview filename, size_t* p_original_size, ttString*
                 {
                     value = (value * 10) + (to_uchar) (*buf_ptr - '0');
                 }
-                ptr_out_buf[actual_size] = value;
+                out_buffer[actual_size] = value;
 
                 if (++actual_size > image_buffer_size)
                 {
@@ -348,7 +348,7 @@ wxImage GetHeaderImage(ttlib::sview filename, size_t* p_original_size, ttString*
                 else if (*buf_ptr >= 'a' && *buf_ptr <= 'f')
                     value += (to_uchar) ((*buf_ptr - 'a') + 10);
 
-                ptr_out_buf[actual_size] = value;
+                out_buffer[actual_size] = value;
 
                 if (++actual_size > image_buffer_size)
                 {
@@ -493,7 +493,7 @@ bool GetAnimationImage(wxAnimation& animation, ttlib::sview filename)
     }
 
     auto image_buffer = std::make_unique<unsigned char[]>(image_buffer_size);
-    unsigned char* ptr_out_buf = image_buffer.get();
+    auto out_buffer = image_buffer.get();
 
     if (isUiditorFile)
     {
@@ -507,7 +507,7 @@ bool GetAnimationImage(wxAnimation& animation, ttlib::sview filename)
                 {
                     value = (value * 10) + (to_uchar) (*buf_ptr - '0');
                 }
-                ptr_out_buf[actual_size] = value;
+                out_buffer[actual_size] = value;
 
                 if (++actual_size > image_buffer_size)
                 {
@@ -555,7 +555,7 @@ bool GetAnimationImage(wxAnimation& animation, ttlib::sview filename)
                 else if (*buf_ptr >= 'a' && *buf_ptr <= 'f')
                     value += (to_uchar) ((*buf_ptr - 'a') + 10);
 
-                ptr_out_buf[actual_size] = value;
+                out_buffer[actual_size] = value;
 
                 if (++actual_size > image_buffer_size)
                 {

--- a/src/bitmaps.cpp
+++ b/src/bitmaps.cpp
@@ -32,7 +32,7 @@ struct ImageMap
 
 static const ImageMap png_headers[] = {
 
-    { "unknown", unknown_png, sizeof(unknown_png) },
+    { .name = "unknown", .data = unknown_png, .size_data = sizeof(unknown_png) },
     { "default", default_png, sizeof(default_png) },
 
     { "flex_grid_sizer", flex_grid_sizer_png, sizeof(flex_grid_sizer_png) },

--- a/src/bitmaps.h
+++ b/src/bitmaps.h
@@ -18,10 +18,10 @@ constexpr const int GenImageSize = 22;
 
 // This will first look for an associated PNG Header array, and if unavailable an XPM file.
 // If neither can be found, a 16x16 question mark image is returned.
-wxImage GetInternalImage(ttlib::cview name);
+wxImage GetInternalImage(ttlib::sview name);
 
 // If this is a PNG Header file, the alpha channel will be converted to a mask
-wxIcon GetIconImage(ttlib::cview name);
+wxIcon GetIconImage(ttlib::sview name);
 
 // Converts the ASCII header file into binary data and loads it as an image. It's designed to
 // read header files created by wxUiEditor or wxFormBuilder -- any other generated header

--- a/src/bitmaps.h
+++ b/src/bitmaps.h
@@ -26,12 +26,12 @@ wxIcon GetIconImage(ttlib::sview name);
 // Converts the ASCII header file into binary data and loads it as an image. It's designed to
 // read header files created by wxUiEditor or wxFormBuilder -- any other generated header
 // file might or might not work.
-wxImage GetHeaderImage(ttlib::cview filename, size_t* p_original_size = nullptr, ttString* p_mime_type = nullptr);
+wxImage GetHeaderImage(ttlib::sview filename, size_t* p_original_size = nullptr, ttString* p_mime_type = nullptr);
 
 // Converts the ASCII header file into binary data and loads it as an animation. It's designed to
 // read header files created by wxUiEditor or wxFormBuilder -- any other generated header
 // file might or might not work.
-bool GetAnimationImage(wxAnimation& animation, ttlib::cview filename);
+bool GetAnimationImage(wxAnimation& animation, ttlib::sview filename);
 
 wxAnimation LoadAnimationImage(wxAnimation& animation, const unsigned char* data, size_t size_data);
 

--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -31,7 +31,7 @@ void MainFrame::FireProjectLoadedEvent()
 {
     ProjectLoaded();
 
-    CustomEvent event(EVT_ProjectUpdated, wxGetApp().GetProjectPtr().get());
+    CustomEvent event(EVT_ProjectUpdated, wxGetApp().GetProject());
     for (auto handler: m_custom_event_handlers)
     {
         handler->ProcessEvent(event);
@@ -85,7 +85,7 @@ void MainFrame::FireMultiPropEvent(ModifyProperties* undo_cmd)
 
 void MainFrame::FireProjectUpdatedEvent()
 {
-    CustomEvent event(EVT_ProjectUpdated, wxGetApp().GetProjectPtr().get());
+    CustomEvent event(EVT_ProjectUpdated, wxGetApp().GetProject());
     for (auto handler: m_custom_event_handlers)
     {
         handler->ProcessEvent(event);

--- a/src/customprops/custom_colour_prop.cpp
+++ b/src/customprops/custom_colour_prop.cpp
@@ -208,7 +208,7 @@ EditColourDialog::EditColourDialog(wxWindow* parent, NodeProperty* prop) : Colou
         m_colour_rect->SetColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
         m_combo_system->Select(m_combo_system->FindString("WindowText", true));
     }
-    else if (prop->as_string().is_sameprefix("wx"))
+    else if (prop->as_string().starts_with("wx"))
     {
         m_radio_default->SetValue(false);
         m_radio_custom->SetValue(false);

--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -277,10 +277,9 @@ void EventHandlerDlg::CollectMemberVariables(Node* node, std::set<std::string>& 
         variables.insert(node->prop_as_string(prop_radiobtn_var_name));
     }
 
-    for (size_t i = 0; i < node->GetChildCount(); i++)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto child = node->GetChild(i);
-        CollectMemberVariables(child, variables);
+        CollectMemberVariables(child.get(), variables);
     }
 }
 

--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -14,7 +14,7 @@
 #include "lambdas.h"              // Functions for formatting and storage of lamda events
 
 // List of events and suggested function names
-extern const std::unordered_map<std::string, const char*> s_EventNames;
+extern const std::unordered_map<std::string_view, const char*> s_EventNames;
 
 // Defined in base_panel.cpp
 extern const char* g_u8_cpp_keywords;
@@ -284,7 +284,7 @@ void EventHandlerDlg::CollectMemberVariables(Node* node, std::set<std::string>& 
     }
 }
 
-const std::unordered_map<std::string, const char*> s_EventNames = {
+const std::unordered_map<std::string_view, const char*> s_EventNames = {
 
     { "wxEVT_ACTIVATE", "OnActivate" },
     { "wxEVT_AUITOOLBAR_BEGIN_DRAG", "OnAuiToolBarBeginDrag" },

--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -99,7 +99,7 @@ wxVariant CustomPointProperty::ChildChanged(wxVariant& /* thisValue */, int chil
     return value;
 }
 
-void CustomPointProperty::InitValues(ttlib::cview value)
+void CustomPointProperty::InitValues(ttlib::sview value)
 {
     if (value.empty())
     {

--- a/src/customprops/pg_point.h
+++ b/src/customprops/pg_point.h
@@ -30,7 +30,7 @@ public:
 
     const wxPGEditor* DoGetEditorClass() const override { return wxPGEditor_TextCtrl; }
 
-    void InitValues(ttlib::cview value);
+    void InitValues(ttlib::sview value);
     ttlib::cstr CombineValues();
 
 private:

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -12,37 +12,35 @@
 
 using namespace GenEnum;
 
-std::map<PropType, const char*> GenEnum::map_PropTypes = {
+std::unordered_map<std::string_view, PropType, str_view_hash, std::equal_to<>> GenEnum::umap_PropTypes = {
 
-    // These types need to be listed in xml/gen.dtd
-
-    { type_animation, "animation" },
-    { type_bitlist, "bitlist" },
-    { type_bitmap, "bitmap" },
-    { type_bool, "bool" },
-    { type_code_edit, "code_edit" },
-    { type_editoption, "editoption" },
-    { type_file, "file" },
-    { type_float, "float" },
-    { type_html_edit, "html_edit" },
-    { type_id, "id" },
-    { type_image, "image" },
-    { type_int, "int" },
-    { type_option, "option" },
-    { type_path, "path" },
-    { type_string, "string" },
-    { type_string_code_single, "string_code_single" },
-    { type_string_edit, "string_edit" },
-    { type_string_edit_escapes, "string_edit_escapes" },
-    { type_string_edit_single, "string_edit_single" },
-    { type_string_escapes, "string_escapes" },
-    { type_stringlist, "stringlist" },
-    { type_uint, "uint" },
-    { type_uintpairlist, "uintpairlist" },
-    { type_wxColour, "wxColour" },
-    { type_wxFont, "wxFont" },
-    { type_wxPoint, "wxPoint" },
-    { type_wxSize, "wxSize" },
+    { "animation", type_animation },
+    { "bitlist", type_bitlist },
+    { "bitmap", type_bitmap },
+    { "bool", type_bool },
+    { "code_edit", type_code_edit },
+    { "editoption", type_editoption },
+    { "file", type_file },
+    { "float", type_float },
+    { "html_edit", type_html_edit },
+    { "id", type_id },
+    { "image", type_image },
+    { "int", type_int },
+    { "option", type_option },
+    { "path", type_path },
+    { "string", type_string },
+    { "string_code_single", type_string_code_single },
+    { "string_edit", type_string_edit },
+    { "string_edit_escapes", type_string_edit_escapes },
+    { "string_edit_single", type_string_edit_single },
+    { "string_escapes", type_string_escapes },
+    { "stringlist", type_stringlist },
+    { "uint", type_uint },
+    { "uintpairlist", type_uintpairlist },
+    { "wxColour", type_wxColour },
+    { "wxFont", type_wxFont },
+    { "wxPoint", type_wxPoint },
+    { "wxSize", type_wxSize },
 
 };
 
@@ -387,7 +385,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
 };
 std::map<std::string_view, GenEnum::PropName, std::less<>> GenEnum::rmap_PropNames;
 
-std::map<GenType, const char*> GenEnum::map_GenTypes = {
+std::map<GenType, std::string_view> GenEnum::map_GenTypes = {
 
     { type_aui_tool, "aui_tool" },
     { type_aui_toolbar, "aui_toolbar" },
@@ -606,4 +604,4 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_wxWrapSizer, "wxWrapSizer" },
 
 };
-std::map<std::string_view, GenEnum::GenName, std::less<>> GenEnum::rmap_GenNames;
+std::unordered_map<std::string_view, GenEnum::GenName, str_view_hash, std::equal_to<>> GenEnum::rmap_GenNames;

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -10,6 +10,8 @@
 #include <map>
 #include <unordered_map>
 
+#include "hash_map.h"  // Find std::string_view key in std::unordered_map
+
 namespace GenEnum
 {
     enum PropType : size_t
@@ -46,7 +48,7 @@ namespace GenEnum
         type_unknown,
 
     };
-    extern std::map<PropType, const char*> map_PropTypes;
+    extern std::unordered_map<std::string_view, PropType, str_view_hash, std::equal_to<>> umap_PropTypes;
 
     enum PropName : size_t
     {
@@ -467,7 +469,7 @@ namespace GenEnum
         gen_type_array_size,
         gen_type_unknown = gen_type_array_size
     };
-    extern std::map<GenType, const char*> map_GenTypes;
+    extern std::map<GenType, std::string_view> map_GenTypes;
 
     enum GenName : size_t
     {
@@ -634,6 +636,6 @@ namespace GenEnum
 
     };
     extern std::map<GenEnum::GenName, const char*> map_GenNames;
-    extern std::map<std::string_view, GenEnum::GenName, std::less<>> rmap_GenNames;
+    extern std::unordered_map<std::string_view, GenEnum::GenName, str_view_hash, std::equal_to<>> rmap_GenNames;
 
 }  // namespace GenEnum

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -193,7 +193,7 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
         if (newValue.empty())
             return true;
 
-        for (auto& iter: wxGetApp().GetProject()->GetChildNodePtrs())
+        for (const auto& iter: wxGetApp().GetProject()->GetChildNodePtrs())
         {
             if (iter.get() == prop->GetNode())
             {

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -215,7 +215,7 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
 ttlib::cstr BaseGenerator::GetHelpText(Node* node)
 {
     ttlib::cstr class_name(map_GenNames[node->gen_name()]);
-    if (!class_name.is_sameprefix("wx"))
+    if (!class_name.starts_with("wx"))
     {
         if (class_name == "BookPage")
             class_name = "wxBookCtrl";
@@ -415,7 +415,7 @@ static std::vector<std::pair<const char*, const char*>> prefix_pair = {
 ttlib::cstr BaseGenerator::GetHelpURL(Node* node)
 {
     ttlib::cstr class_name(map_GenNames[node->gen_name()]);
-    if (class_name.is_sameprefix("wx"))
+    if (class_name.starts_with("wx"))
     {
         class_name.erase(0, 2);
         class_name.MakeLower();
@@ -432,7 +432,7 @@ ttlib::cstr BaseGenerator::GetHelpURL(Node* node)
         {
             for (const auto& [key, value]: prefix_pair)
             {
-                if (!class_name.is_sameprefix(key))
+                if (!class_name.starts_with(key))
                     class_name.Replace(key, value);
             }
         }

--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -86,11 +86,11 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
         {
             int idx_image = 0;
             bool is_image_found { false };
-            for (auto& child: grandparent->GetChildNodePtrs())
+            for (const auto& child: grandparent->GetChildNodePtrs())
             {
                 if (child->HasValue(prop_bitmap))
                     ++idx_image;
-                for (auto& grand_child: child->GetChildNodePtrs())
+                for (const auto& grand_child: child->GetChildNodePtrs())
                 {
                     if (grand_child.get() == node)
                     {
@@ -119,7 +119,7 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
         {
             int idx_image = -1;
             bool is_image_found { false };
-            for (auto& child: node_parent->GetChildNodePtrs())
+            for (const auto& child: node_parent->GetChildNodePtrs())
             {
                 if (child.get() == node)
                 {
@@ -135,7 +135,7 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
                 }
                 if (child->GetParent()->isGen(gen_wxTreebook))
                 {
-                    for (auto& grand_child: child->GetChildNodePtrs())
+                    for (const auto& grand_child: child->GetChildNodePtrs())
                     {
                         if (grand_child.get() == node)
                         {
@@ -179,15 +179,15 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
             if (node->HasValue(prop_bitmap) && node_parent->prop_as_bool(prop_display_images))
             {
                 int idx_image = -1;
-                for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child)
+                for (const auto& child: node_parent->GetChildNodePtrs())
                 {
-                    if (node_parent->GetChild(idx_child) == node)
+                    if (child.get() == node)
                     {
                         if (idx_image < 0)
                             idx_image = 0;
                         break;
                     }
-                    if (node_parent->GetChild(idx_child)->HasValue(prop_bitmap))
+                    if (child->HasValue(prop_bitmap))
                     {
                         if (idx_image < 0)
                             idx_image = 0;
@@ -285,15 +285,15 @@ std::optional<ttlib::cstr> BookPageGenerator::GenConstruction(Node* node)
                 idx_image = GetTreebookImageIndex(node);
             else
             {
-                for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child)
+                for (const auto& child: node_parent->GetChildNodePtrs())
                 {
-                    if (node_parent->GetChild(idx_child) == node)
+                    if (child.get() == node)
                     {
                         if (idx_image < 0)
                             idx_image = 0;
                         break;
                     }
-                    if (node_parent->GetChild(idx_child)->HasValue(prop_bitmap))
+                    if (child->HasValue(prop_bitmap))
                     {
                         if (idx_image < 0)
                             idx_image = 0;
@@ -331,13 +331,17 @@ wxObject* PageCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
         if (node_parent->isGen(gen_wxToolbook))
         {
             int idx_image = -1;
-            for (size_t idx_child = 0; idx_child < node_parent->GetChildCount(); ++idx_child, ++idx_image)
+            for (const auto& child: node_parent->GetChildNodePtrs())
             {
-                if (node_parent->GetChild(idx_child) == node)
+                if (child.get() == node)
                 {
                     if (idx_image < 0)
                         idx_image = 0;
                     break;
+                }
+                else
+                {
+                    ++idx_image;
                 }
             }
             book->AddPage(wxStaticCast(widget, wxWindow), node->prop_as_wxString(prop_label), false, idx_image);
@@ -914,7 +918,7 @@ static void AddBookImageList(Node* node_book, wxObject* widget)
     {
 #if 1
         wxBookCtrlBase::Images bundle_list;
-        for (auto& child_node: node_book->GetChildNodePtrs())
+        for (const auto& child_node: node_book->GetChildNodePtrs())
         {
             if (child_node->HasValue(prop_bitmap))
             {
@@ -933,7 +937,7 @@ static void AddBookImageList(Node* node_book, wxObject* widget)
 
         wxImageList* img_list = nullptr;
 
-        for (auto& child_node: node_book->GetChildNodePtrs())
+        for (const auto& child_node: node_book->GetChildNodePtrs())
         {
             if (child_node->HasValue(prop_bitmap))
             {
@@ -980,7 +984,7 @@ static void BookCtorAddImagelist(ttlib::cstr& code, Node* node)
         }
 
         code << "\n\t\twxBookCtrlBase::Images bundle_list;";
-        for (auto& child_node: node->GetChildNodePtrs())
+        for (const auto& child_node: node->GetChildNodePtrs())
         {
             if (child_node->HasValue(prop_bitmap))
             {
@@ -1008,7 +1012,7 @@ static void BookCtorAddImagelist(ttlib::cstr& code, Node* node)
             code << "\n\t\tauto img_list = new wxImageList;";
 
             size_t image_index = 0;
-            for (auto& child_node: node->GetChildNodePtrs())
+            for (const auto& child_node: node->GetChildNodePtrs())
             {
                 // Note: when we generate the code, we could look at the actual image and determine whether it's already
                 // the correct size and only scale it if needed. However, that requires the user to know to regenerate
@@ -1054,7 +1058,7 @@ static bool isBookHasImage(Node* node)
 {
     bool is_book = !node->isGen(gen_BookPage);
 
-    for (auto& child_node: node->GetChildNodePtrs())
+    for (const auto& child_node: node->GetChildNodePtrs())
     {
         if (child_node->isGen(gen_BookPage))
         {
@@ -1063,7 +1067,7 @@ static bool isBookHasImage(Node* node)
             if (is_book && !node->isGen(gen_wxTreebook))
                 continue;
 
-            for (auto& grand_child: child_node->GetChildNodePtrs())
+            for (const auto& grand_child: child_node->GetChildNodePtrs())
             {
                 if (grand_child->isGen(gen_BookPage))
                 {
@@ -1083,7 +1087,7 @@ static void AddTreebookSubImages(Node* node, wxImageList* img_list)
     if (!img_list)
         return;
 
-    for (auto& child_node: node->GetChildNodePtrs())
+    for (const auto& child_node: node->GetChildNodePtrs())
     {
         if (child_node->isGen(gen_BookPage))
         {
@@ -1104,7 +1108,7 @@ static void AddTreebookSubImages(Node* node, wxImageList* img_list)
 
 static void AddTreebookSubImages(Node* node, wxBookCtrlBase::Images& bundle_list)
 {
-    for (auto& child_node: node->GetChildNodePtrs())
+    for (const auto& child_node: node->GetChildNodePtrs())
     {
         if (child_node->isGen(gen_BookPage))
         {
@@ -1119,7 +1123,7 @@ static void AddTreebookSubImages(Node* node, wxBookCtrlBase::Images& bundle_list
 
 static void AddTreebookImageCode(ttlib::cstr& code, Node* child_node, size_t& image_index)
 {
-    for (auto& grand_child: child_node->GetChildNodePtrs())
+    for (const auto& grand_child: child_node->GetChildNodePtrs())
     {
         if (grand_child->isGen(gen_BookPage) && grand_child->HasValue(prop_bitmap))
         {
@@ -1145,13 +1149,13 @@ static int GetTreebookImageIndex(Node* node)
         treebook = treebook->GetParent();
     }
 
-    for (auto& child_node: treebook->GetChildNodePtrs())
+    for (const auto& child_node: treebook->GetChildNodePtrs())
     {
         if (child_node.get() == node)
             return idx_image;
         if (child_node->HasValue(prop_bitmap))
             ++idx_image;
-        for (auto& grand_child: child_node->GetChildNodePtrs())
+        for (const auto& grand_child: child_node->GetChildNodePtrs())
         {
             if (grand_child->isGen(gen_BookPage))
             {

--- a/src/generate/book_widgets.cpp
+++ b/src/generate/book_widgets.cpp
@@ -1023,7 +1023,7 @@ static void BookCtorAddImagelist(ttlib::cstr& code, Node* node)
                     code << "\n\t\tauto img_" << image_index << " = ";
                     code << GenerateBitmapCode(child_node->prop_as_string(prop_bitmap)) << ";";
                     code << "\n\t\timg_list->Add(img_" << image_index;
-                    if (child_node->prop_as_string(prop_bitmap).is_sameprefix("Art;"))
+                    if (child_node->prop_as_string(prop_bitmap).starts_with("Art;"))
                         code << ".ConvertToImage()";
                     code << ");";
                     ++image_index;
@@ -1130,7 +1130,7 @@ static void AddTreebookImageCode(ttlib::cstr& code, Node* child_node, size_t& im
             code << "\n\t\tauto img_" << image_index << " = ";
             code << GenerateBitmapCode(grand_child->prop_as_string(prop_bitmap)) << ";";
             code << "\n\t\timg_list->Add(img_" << image_index;
-            if (grand_child->prop_as_string(prop_bitmap).is_sameprefix("Art;"))
+            if (grand_child->prop_as_string(prop_bitmap).starts_with("Art;"))
                 code << ".ConvertToImage()";
             code << ");";
             ++image_index;

--- a/src/generate/form_widgets.cpp
+++ b/src/generate/form_widgets.cpp
@@ -817,7 +817,7 @@ ttlib::cstr GenerateIconCode(const ttlib::cstr& description)
             code << art_client;
         code << ").GetIconFor(this));\n";
     }
-    else if (description.is_sameprefix("SVG"))
+    else if (description.starts_with("SVG"))
     {
         auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(parts[IndexImage]);
         if (!embed)
@@ -845,7 +845,7 @@ ttlib::cstr GenerateIconCode(const ttlib::cstr& description)
                 name.remove_extension();
                 name.Replace(".", "_", true);  // fix wxFormBuilder header files
 
-                if (parts[IndexType].is_sameprefix("Embed"))
+                if (parts[IndexType].starts_with("Embed"))
                 {
                     auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(bundle->lst_filenames[0]);
                     if (embed)
@@ -865,7 +865,7 @@ ttlib::cstr GenerateIconCode(const ttlib::cstr& description)
                     ttlib::cstr name(iter.filename());
                     name.remove_extension();
                     name.Replace(".", "_", true);  // fix wxFormBuilder header files
-                    if (parts[IndexType].is_sameprefix("Embed"))
+                    if (parts[IndexType].starts_with("Embed"))
                     {
                         auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(iter);
                         if (embed)
@@ -890,7 +890,7 @@ ttlib::cstr GenerateIconCode(const ttlib::cstr& description)
     {
         code << "#else\n";
         auto image_code = GenerateBitmapCode(description);
-        if (!image_code.contains(".Scale") && image_code.is_sameprefix("wxImage("))
+        if (!image_code.contains(".Scale") && image_code.starts_with("wxImage("))
         {
             code << "SetIcon(wxIcon(" << image_code.subview(sizeof("wxImage")) << ");\n";
         }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1074,7 +1074,7 @@ ttlib::cstr BaseCodeGenerator::GetDeclaration(Node* node)
 
     ttlib::cstr class_name(node->DeclName());
 
-    if (class_name.is_sameprefix("wx"))
+    if (class_name.starts_with("wx"))
     {
         if (node->HasValue(prop_derived_class))
         {
@@ -1483,7 +1483,7 @@ void BaseCodeGenerator::GenConstruction(Node* node)
                                                  ttlib::is_found(result.value().find("\n\t\t"))) ?
                                                     indent::none :
                                                     indent::auto_no_whitespace);
-            if (result.value().is_sameprefix("\t{"))
+            if (result.value().starts_with("\t{"))
             {
                 need_closing_brace = true;
             }
@@ -1699,7 +1699,7 @@ void BaseCodeGenerator::CollectIDs(Node* node, std::set<std::string>& set_ids)
         if (iter.type() == type_id)
         {
             auto& prop_id = iter.as_string();
-            if (!prop_id.is_sameprefix("wxID_"))
+            if (!prop_id.starts_with("wxID_"))
                 set_ids.insert(prop_id);
         }
     }
@@ -1778,7 +1778,7 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
         {
             if (auto bundle = wxGetApp().GetProjectSettings()->GetPropertyImageBundle(iter.as_string()); bundle)
             {
-                if (value.is_sameprefix("Embed") || value.is_sameprefix("SVG"))
+                if (value.starts_with("Embed") || value.starts_with("SVG"))
                 {
                     for (auto& idx_image: bundle->lst_filenames)
                     {
@@ -1800,7 +1800,7 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
                         }
                     }
                 }
-                else if (value.is_sameprefix("Header") || value.is_sameprefix("XPM"))
+                else if (value.starts_with("Header") || value.starts_with("XPM"))
                 {
                     for (auto& idx_image: bundle->lst_filenames)
                     {
@@ -1819,7 +1819,7 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
 
         else if (iter.type() == type_animation)
         {
-            if (value.is_sameprefix("Embed"))
+            if (value.starts_with("Embed"))
             {
                 ttlib::multiview parts(value, BMP_PROP_SEPARATOR, tt::TRIM::both);
 
@@ -1852,7 +1852,7 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
                     m_embedded_images.emplace_back(embed);
                 }
             }
-            else if (value.is_sameprefix("Header") || value.is_sameprefix("XPM"))
+            else if (value.starts_with("Header") || value.starts_with("XPM"))
             {
                 ttlib::multiview parts(value);
                 if (ttlib::is_whitespace(parts[IndexImage].front()))

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -120,7 +120,7 @@ void BaseCodeGenerator::GenerateBaseClass(Node* form_node, PANEL_TYPE panel_type
     m_form_node = form_node;
     m_ImagesForm = nullptr;
 
-    for (auto& form: m_project->GetChildNodePtrs())
+    for (const auto& form: m_project->GetChildNodePtrs())
     {
         if (form->isGen(gen_Images))
         {
@@ -1024,7 +1024,7 @@ void BaseCodeGenerator::GatherGeneratorIncludes(Node* node, std::set<std::string
                 {
                     if (auto function_name = wxGetApp().GetBundleFuncName(iter.as_string()); function_name.size())
                     {
-                        for (auto& form: wxGetApp().GetProject()->GetChildNodePtrs())
+                        for (const auto& form: wxGetApp().GetProject()->GetChildNodePtrs())
                         {
                             if (form->isGen(gen_Images))
                             {
@@ -1704,7 +1704,7 @@ void BaseCodeGenerator::CollectIDs(Node* node, std::set<std::string>& set_ids)
         }
     }
 
-    for (auto& iter: node->GetChildNodePtrs())
+    for (const auto& iter: node->GetChildNodePtrs())
     {
         CollectIDs(iter.get(), set_ids);
     }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -666,10 +666,8 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
     {
         std::set<ttlib::cstr> code_lines;
 
-        for (size_t idx_events = 0; idx_events < events.size(); ++idx_events)
+        for (auto& event: events)
         {
-            auto& event = events[idx_events];
-
             // Ignore lambda's and functions in another class
             if (event->get_value().contains("[") || event->get_value().contains("::"))
                 continue;
@@ -682,9 +680,10 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
             if (event->GetNode()->IsForm() && event->get_name() == "wxEVT_CONTEXT_MENU")
             {
                 bool has_handler = false;
-                for (size_t pos_child = 0; pos_child < event->GetNode()->GetChildCount(); pos_child++)
+
+                for (const auto& child: event->GetNode()->GetChildNodePtrs())
                 {
-                    if (event->GetNode()->GetChild(pos_child)->isGen(gen_wxContextMenuEvent))
+                    if (child->isGen(gen_wxContextMenuEvent))
                     {
                         has_handler = true;
                         break;
@@ -732,10 +731,8 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
         // Unlike the above code, there shouldn't be any wxEVT_CONTEXT_MENU events since m_CtxMenuEvents should only contain
         // menu items events.
 
-        for (size_t idx_events = 0; idx_events < m_CtxMenuEvents.size(); ++idx_events)
+        for (const auto& event: m_CtxMenuEvents)
         {
-            auto& event = m_CtxMenuEvents[idx_events];
-
             // Ignore lambda's and functions in another class
             if (event->get_value().contains("[") || event->get_value().contains("::"))
                 continue;
@@ -802,19 +799,17 @@ void BaseCodeGenerator::CollectMemberVariables(Node* node, Permission perm, std:
             }
         }
 
-        for (size_t i = 0; i < node->GetChildCount(); i++)
+        for (const auto& child: node->GetChildNodePtrs())
         {
-            auto child = node->GetChild(i);
-            CollectMemberVariables(child, perm, code_lines);
+            CollectMemberVariables(child.get(), perm, code_lines);
         }
 
         return;
     }
 
-    for (size_t i = 0; i < node->GetChildCount(); i++)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto child = node->GetChild(i);
-        CollectMemberVariables(child, perm, code_lines);
+        CollectMemberVariables(child.get(), perm, code_lines);
     }
 }
 
@@ -822,10 +817,9 @@ void BaseCodeGenerator::CollectValidatorVariables(Node* node, std::set<std::stri
 {
     GenValVarsBase(node->GetNodeDeclaration(), node, code_lines);
 
-    for (size_t i = 0; i < node->GetChildCount(); i++)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto child = node->GetChild(i);
-        CollectValidatorVariables(child, code_lines);
+        CollectValidatorVariables(child.get(), code_lines);
     }
 }
 
@@ -840,10 +834,9 @@ void BaseCodeGenerator::GenValidatorFunctions(Node* node)
         }
     }
 
-    for (size_t i = 0; i < node->GetChildCount(); i++)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto child = node->GetChild(i);
-        GenValidatorFunctions(child);
+        GenValidatorFunctions(child.get());
     }
 }
 
@@ -1061,10 +1054,9 @@ void BaseCodeGenerator::GatherGeneratorIncludes(Node* node, std::set<std::string
     }
 
     // Now parse all the children
-    for (size_t i = 0; i < node->GetChildCount(); i++)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto child = node->GetChild(i);
-        GatherGeneratorIncludes(child, set_src, set_hdr);
+        GatherGeneratorIncludes(child.get(), set_src, set_hdr);
     }
 }
 
@@ -1389,11 +1381,11 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
     }
 
     m_source->SetLastLineBlank();
-    for (size_t i = 0; i < form_node->GetChildCount(); i++)
+    for (const auto& child: form_node->GetChildNodePtrs())
     {
-        if (form_node->GetChild(i)->isGen(gen_wxContextMenuEvent))
+        if (child->isGen(gen_wxContextMenuEvent))
             continue;
-        GenConstruction(form_node->GetChild(i));
+        GenConstruction(child.get());
     }
 
     if (auto result = generator->GenAdditionalCode(code_after_children, form_node); result)
@@ -1431,11 +1423,11 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
     m_source->writeLine("}");
 
     Node* node_ctx_menu = nullptr;
-    for (size_t pos_child = 0; pos_child < form_node->GetChildCount(); pos_child++)
+    for (const auto& child: form_node->GetChildNodePtrs())
     {
-        if (form_node->GetChild(pos_child)->isGen(gen_wxContextMenuEvent))
+        if (child->isGen(gen_wxContextMenuEvent))
         {
-            node_ctx_menu = form_node->GetChild(pos_child);
+            node_ctx_menu = child.get();
             break;
         }
     }
@@ -1720,18 +1712,17 @@ void BaseCodeGenerator::CollectEventHandlers(Node* node, EventVector& events)
         }
     }
 
-    for (size_t i = 0; i < node->GetChildCount(); ++i)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto child = node->GetChild(i);
         if (child->isGen(gen_wxContextMenuEvent))
         {
-            for (size_t ctx_child_pos = 0; ctx_child_pos < child->GetChildCount(); ++ctx_child_pos)
+            for (const auto& ctx_child: child->GetChildNodePtrs())
             {
-                CollectEventHandlers(child->GetChild(ctx_child_pos), m_CtxMenuEvents);
+                CollectEventHandlers(ctx_child.get(), m_CtxMenuEvents);
             }
             continue;
         }
-        CollectEventHandlers(child, events);
+        CollectEventHandlers(child.get(), events);
     }
 }
 
@@ -1785,9 +1776,9 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
                         if (auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(idx_image); embed)
                         {
                             bool is_found = false;
-                            for (size_t idx = 0; idx < m_embedded_images.size(); ++idx)
+                            for (auto pimage: m_embedded_images)
                             {
-                                if (m_embedded_images[idx] == embed)
+                                if (pimage == embed)
                                 {
                                     is_found = true;
                                     break;
@@ -1837,9 +1828,9 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
                     else
                     {
                         bool is_found = false;
-                        for (size_t idx = 0; idx < m_embedded_images.size(); ++idx)
+                        for (auto& pimage: m_embedded_images)
                         {
-                            if (m_embedded_images[idx] == embed)
+                            if (pimage == embed)
                             {
                                 is_found = true;
                                 break;
@@ -1905,9 +1896,8 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
         }
     }
 
-    for (size_t i = 0; i < node->GetChildCount(); i++)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto child = node->GetChild(i);
         for (auto& iter: child->get_props_vector())
         {
             if ((iter.type() == type_image || iter.type() == type_animation) && iter.HasValue())
@@ -1960,7 +1950,7 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
         }
         if (child->GetChildCount())
         {
-            ParseImageProperties(child);
+            ParseImageProperties(child.get());
         }
     }
 }
@@ -1974,9 +1964,9 @@ void BaseCodeGenerator::AddPersistCode(Node* node)
         m_source->writeLine(code);
     }
 
-    for (size_t i = 0; i < node->GetChildCount(); ++i)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        AddPersistCode(node->GetChild(i));
+        AddPersistCode(child.get());
     }
 }
 
@@ -2006,9 +1996,9 @@ void BaseCodeGenerator::GenContextMenuHandler(Node* form_node, Node* node_ctx_me
     auto node_menu = g_NodeCreator.NewNode(g_NodeCreator.GetNodeDeclaration("wxMenu"));
     node_menu->prop_set_value(prop_var_name, "pmenu");
 
-    for (size_t pos_child = 0; pos_child < node_ctx_menu->GetChildCount(); ++pos_child)
+    for (const auto& child: node_ctx_menu->GetChildNodePtrs())
     {
-        auto child_node = g_NodeCreator.MakeCopy(node_ctx_menu->GetChildPtr(pos_child));
+        auto child_node = g_NodeCreator.MakeCopy(child);
         node_menu->Adopt(child_node);
         GenCtxConstruction(child_node.get());
     }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1712,11 +1712,12 @@ void BaseCodeGenerator::CollectIDs(Node* node, std::set<std::string>& set_ids)
 
 void BaseCodeGenerator::CollectEventHandlers(Node* node, EventVector& events)
 {
-    for (size_t i = 0; i < node->GetEventCount(); ++i)
+    for (auto& iter: node->GetMapEvents())
     {
-        auto event = node->GetEvent(i);
-        if (!event->get_value().empty())
-            events.push_back(event);
+        if (iter.second.get_value().size())
+        {
+            events.push_back(&iter.second);
+        }
     }
 
     for (size_t i = 0; i < node->GetChildCount(); ++i)

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -29,7 +29,7 @@ int WriteCMakeFile(bool test_only)
     // need to tread that directory as the root of the file.
 
     ttlib::cstr cmake_file = project->prop_as_string(prop_cmake_file);
-    if (cmake_file.is_sameprefix(".."))
+    if (cmake_file.starts_with(".."))
     {
         ttlib::cstr new_dir(cmake_file);
         new_dir.remove_filename();

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -63,7 +63,7 @@ int WriteCMakeFile(bool test_only)
 
     std::set<ttlib::cstr> base_files;
 
-    for (auto& iter: project->GetChildNodePtrs())
+    for (const auto& iter: project->GetChildNodePtrs())
     {
         if (!iter->HasValue(prop_base_file))
             continue;

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -55,9 +55,8 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
     }
 
     bool generate_result = true;
-    for (size_t pos = 0; pos < project->GetChildCount(); ++pos)
+    for (const auto& form: project->GetChildNodePtrs())
     {
-        auto form = project->GetChild(pos);
         if (auto& base_file = form->prop_as_string(prop_base_file); base_file.size())
         {
             path = base_file;
@@ -86,7 +85,7 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
             auto cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
             codegen.SetSrcWriteCode(cpp_cw.get());
 
-            codegen.GenerateBaseClass(form);
+            codegen.GenerateBaseClass(form.get());
 
             path.replace_extension(header_ext);
             auto retval = h_cw->WriteFile(NeedsGenerateCheck);
@@ -226,9 +225,8 @@ void MainFrame::OnGenInhertedClass(wxCommandEvent& WXUNUSED(e))
 
     size_t currentFiles = 0;
 
-    for (size_t pos = 0; pos < project->GetChildCount(); ++pos)
+    for (const auto& form: project->GetChildNodePtrs())
     {
-        auto form = project->GetChildPtr(pos);
         if (auto& file = form->prop_as_string(prop_derived_file); file.size())
         {
             path = file;
@@ -367,10 +365,8 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
 
     for (auto& iter_class: ClassList)
     {
-        for (size_t pos = 0; pos < project->GetChildCount(); ++pos)
+        for (const auto& form: project->GetChildNodePtrs())
         {
-            auto form = project->GetChild(pos);
-
             // The Images class doesn't have a prop_class_name, so use "Images". Note that this will fail if there is a real
             // form where the user set the class name to "Images". If this wasn't an Internal function, then we would need to
             // store nodes rather than class names.
@@ -397,7 +393,7 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
                 auto cpp_cw = std::make_unique<FileCodeWriter>(base_file.wx_str());
                 codegen.SetSrcWriteCode(cpp_cw.get());
 
-                codegen.GenerateBaseClass(form);
+                codegen.GenerateBaseClass(form.get());
 
                 base_file.replace_extension(header_ext);
                 bool new_hdr = (h_cw->WriteFile(true) > 0);
@@ -421,7 +417,7 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
                     cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
                     codegen.SetSrcWriteCode(cpp_cw.get());
 
-                    codegen.GenerateBaseClass(form);
+                    codegen.GenerateBaseClass(form.get());
 
                     path.replace_extension(header_ext);
                     h_cw->WriteFile();
@@ -451,7 +447,7 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
                     cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
                     codegen.SetSrcWriteCode(cpp_cw.get());
 
-                    codegen.GenerateBaseClass(form);
+                    codegen.GenerateBaseClass(form.get());
 
                     path.replace_extension(source_ext);
                     cpp_cw->WriteFile();

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -390,7 +390,7 @@ void GenStyle(Node* node, ttlib::cstr& code, const char* prefix)
     }
 }
 
-void GeneratePosSizeFlags(Node* node, ttlib::cstr& code, bool uses_def_validator, ttlib::cview def_style)
+void GeneratePosSizeFlags(Node* node, ttlib::cstr& code, bool uses_def_validator, ttlib::sview def_style)
 {
     if (node->HasValue(prop_window_name))
     {
@@ -1518,7 +1518,7 @@ std::optional<ttlib::cstr> GenValidatorSettings(Node* node)
     return {};
 }
 
-static void AddPropIfUsed(PropName prop_name, ttlib::cview func_name, Node* node, ttlib::cstr& code)
+static void AddPropIfUsed(PropName prop_name, ttlib::sview func_name, Node* node, ttlib::cstr& code)
 {
     if (prop_name == prop_background_colour)
     {

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -476,7 +476,7 @@ void GeneratePosSizeFlags(Node* node, ttlib::cstr& code, bool uses_def_validator
         else
         {
             code << ",\n\t\t";
-            if (code.is_sameprefix("    "))
+            if (code.starts_with("    "))
             {
                 code.insert(0, 4, ' ');
             }
@@ -741,7 +741,7 @@ ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description)
 
     ttlib::multiview parts(description, BMP_PROP_SEPARATOR, tt::TRIM::both);
 
-    if (parts[IndexType].is_sameprefix("SVG"))
+    if (parts[IndexType].starts_with("SVG"))
     {
         code << "wxNullBitmap /* SVG images require wxWidgets 3.1.6 */";
         return code;
@@ -787,7 +787,7 @@ ttlib::cstr GenerateBitmapCode(const ttlib::cstr& description)
         name.remove_extension();
         name.Replace(".", "_", true);  // wxFormBuilder writes files with the extra dots that have to be converted to '_'
 
-        if (parts[IndexType].is_sameprefix("Embed"))
+        if (parts[IndexType].starts_with("Embed"))
         {
             auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(parts[IndexImage]);
             if (embed)
@@ -888,7 +888,7 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
             code << name << "_xpm)";
         }
     }
-    else if (description.is_sameprefix("SVG"))
+    else if (description.starts_with("SVG"))
     {
         if (auto function_name = wxGetApp().GetBundleFuncName(description); function_name.size())
         {
@@ -933,7 +933,7 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
                 name.remove_extension();
                 name.Replace(".", "_", true);  // fix wxFormBuilder header files
 
-                if (parts[IndexType].is_sameprefix("Embed"))
+                if (parts[IndexType].starts_with("Embed"))
                 {
                     auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(bundle->lst_filenames[0]);
                     if (embed)
@@ -951,7 +951,7 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
                 name.remove_extension();
                 name.Replace(".", "_", true);  // fix wxFormBuilder header files
 
-                if (parts[IndexType].is_sameprefix("Embed"))
+                if (parts[IndexType].starts_with("Embed"))
                 {
                     auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(bundle->lst_filenames[0]);
                     if (embed)
@@ -965,7 +965,7 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
                 name.remove_extension();
                 name.Replace(".", "_", true);
 
-                if (parts[IndexType].is_sameprefix("Embed"))
+                if (parts[IndexType].starts_with("Embed"))
                 {
                     auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(bundle->lst_filenames[1]);
                     if (embed)
@@ -983,7 +983,7 @@ bool GenerateBundleCode(const ttlib::cstr& description, ttlib::cstr& code)
                     ttlib::cstr name(iter.filename());
                     name.remove_extension();
                     name.Replace(".", "_", true);  // fix wxFormBuilder header files
-                    if (parts[IndexType].is_sameprefix("Embed"))
+                    if (parts[IndexType].starts_with("Embed"))
                     {
                         auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(iter);
                         if (embed)
@@ -1053,7 +1053,7 @@ bool GenerateVectorCode(const ttlib::cstr& description, ttlib::cstr& code)
         else
         {
             name.Replace(".", "_", true);  // fix wxFormBuilder header files
-            if (parts[IndexType].is_sameprefix("Embed"))
+            if (parts[IndexType].starts_with("Embed"))
             {
                 auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(iter);
                 if (embed)

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -23,7 +23,7 @@ class wxPropertyGridEvent;
 // Common component functions
 
 // Flags are added with no space around '|' character.
-inline void AddBitFlag(ttlib::cstr& strFlags, ttlib::cview flag)
+inline void AddBitFlag(ttlib::cstr& strFlags, ttlib::sview flag)
 {
     if (strFlags.size())
         strFlags << '|';
@@ -65,7 +65,7 @@ ttlib::cstr GetParentName(Node* node);
 //
 // If the only style specified is def_style, then it will not be added.
 void GeneratePosSizeFlags(Node* node, ttlib::cstr& code, bool uses_def_validator = false,
-                          ttlib::cview def_style = tt_empty_cstr);
+                          ttlib::sview def_style = tt_empty_cstr);
 
 // Generate any non-default wxWindow settings
 void GenerateWindowSettings(Node* node, ttlib::cstr& code);

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -380,7 +380,7 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_TYP
                     if (event->GetNode()->IsForm() && event->get_name() == "wxEVT_CONTEXT_MENU")
                     {
                         bool is_handled = false;
-                        for (auto& iter: event->GetNode()->GetChildNodePtrs())
+                        for (const auto& iter: event->GetNode()->GetChildNodePtrs())
                         {
                             if (iter->isGen(gen_wxContextMenuEvent))
                             {

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -337,10 +337,8 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_TYP
         m_header->writeLine(ttlib::cstr() << "// Handlers for " << m_form_node->get_node_name() << " events");
 
         std::set<std::string> generatedHandlers;
-        for (size_t i = 0; i < events.size(); i++)
+        for (auto event: events)
         {
-            auto event = events[i];
-
             // Ignore lambda's and functions in another class
             if (event->get_value().contains("[") || event->get_value().contains("::"))
                 continue;

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -133,7 +133,7 @@ int GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
     if (result == BaseGenerator::xrc_sizer_item_created)
     {
         auto actual_object = object.child("object");
-        for (auto& child: node->GetChildNodePtrs())
+        for (const auto& child: node->GetChildNodePtrs())
         {
             auto child_object = actual_object.append_child("object");
             auto child_result = GenXrcObject(child.get(), child_object, add_comments);
@@ -147,7 +147,7 @@ int GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
     }
     else if (result == BaseGenerator::xrc_updated)
     {
-        for (auto& child: node->GetChildNodePtrs())
+        for (const auto& child: node->GetChildNodePtrs())
         {
             auto child_object = object.append_child("object");
             auto child_result = GenXrcObject(child.get(), child_object, add_comments);
@@ -169,7 +169,7 @@ void CollectHandlers(Node* node, std::set<std::string>& handlers)
 {
     auto generator = node->GetNodeDeclaration()->GetGenerator();
     generator->RequiredHandlers(node, handlers);
-    for (auto& child: node->GetChildNodePtrs())
+    for (const auto& child: node->GetChildNodePtrs())
     {
         generator = child->GetNodeDeclaration()->GetGenerator();
         generator->RequiredHandlers(child.get(), handlers);

--- a/src/generate/grid_widgets.cpp
+++ b/src/generate/grid_widgets.cpp
@@ -367,30 +367,28 @@ void PropertyGridGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
 {
     auto pg = wxStaticCast(wxobject, wxPropertyGrid);
     auto node = GetMockup()->GetNode(wxobject);
-    size_t count = node->GetChildCount();
-    for (size_t i = 0; i < count; ++i)
+
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto childObj = node->GetChild(i);
-        if (childObj->isGen(gen_propGridItem))
+        if (child->isGen(gen_propGridItem))
         {
-            if (childObj->prop_as_string(prop_type) == "Category")
+            if (child->prop_as_string(prop_type) == "Category")
             {
-                pg->Append(
-                    new wxPropertyCategory(childObj->prop_as_wxString(prop_label), childObj->prop_as_wxString(prop_label)));
+                pg->Append(new wxPropertyCategory(child->prop_as_wxString(prop_label), child->prop_as_wxString(prop_label)));
             }
             else
             {
                 wxPGProperty* prop = wxDynamicCast(
-                    wxCreateDynamicObject("wx" + (childObj->prop_as_string(prop_type)) + "Property"), wxPGProperty);
+                    wxCreateDynamicObject("wx" + (child->prop_as_string(prop_type)) + "Property"), wxPGProperty);
                 if (prop)
                 {
-                    prop->SetLabel(childObj->prop_as_wxString(prop_label));
-                    prop->SetName(childObj->prop_as_wxString(prop_label));
+                    prop->SetLabel(child->prop_as_wxString(prop_label));
+                    prop->SetName(child->prop_as_wxString(prop_label));
                     pg->Append(prop);
 
-                    if (childObj->HasValue(prop_help))
+                    if (child->HasValue(prop_help))
                     {
-                        pg->SetPropertyHelpString(prop, childObj->prop_as_wxString(prop_help));
+                        pg->SetPropertyHelpString(prop, child->prop_as_wxString(prop_help));
                     }
                 }
             }
@@ -454,39 +452,36 @@ void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /
     auto pgm = wxStaticCast(wxobject, wxPropertyGridManager);
 
     auto node = GetMockup()->GetNode(wxobject);
-    size_t count = node->GetChildCount();
-    for (size_t i = 0; i < count; ++i)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto childObj = node->GetChild(i);
-        if (childObj->isGen(gen_propGridPage))
+        if (child->isGen(gen_propGridPage))
         {
             wxPropertyGridPage* page =
-                pgm->AddPage(childObj->prop_as_wxString(prop_label), childObj->prop_as_wxBitmapBundle(prop_bitmap));
+                pgm->AddPage(child->prop_as_wxString(prop_label), child->prop_as_wxBitmapBundle(prop_bitmap));
 
-            for (size_t j = 0; j < childObj->GetChildCount(); ++j)
+            for (const auto& inner_child: child->GetChildNodePtrs())
             {
-                auto innerChildObj = childObj->GetChild(j);
-                if (innerChildObj->isGen(gen_propGridItem))
+                if (inner_child->isGen(gen_propGridItem))
                 {
-                    if (innerChildObj->prop_as_string(prop_type) == "Category")
+                    if (inner_child->prop_as_string(prop_type) == "Category")
                     {
-                        page->Append(new wxPropertyCategory(innerChildObj->prop_as_wxString(prop_label),
-                                                            innerChildObj->prop_as_wxString(prop_label)));
+                        page->Append(new wxPropertyCategory(inner_child->prop_as_wxString(prop_label),
+                                                            inner_child->prop_as_wxString(prop_label)));
                     }
                     else
                     {
                         wxPGProperty* prop = wxDynamicCast(
-                            wxCreateDynamicObject("wx" + (innerChildObj->prop_as_string(prop_type)) + "Property"),
+                            wxCreateDynamicObject("wx" + (inner_child->prop_as_string(prop_type)) + "Property"),
                             wxPGProperty);
                         if (prop)
                         {
-                            prop->SetLabel(innerChildObj->prop_as_wxString(prop_label));
-                            prop->SetName(innerChildObj->prop_as_wxString(prop_label));
+                            prop->SetLabel(inner_child->prop_as_wxString(prop_label));
+                            prop->SetName(inner_child->prop_as_wxString(prop_label));
                             page->Append(prop);
 
-                            if (innerChildObj->HasValue(prop_help))
+                            if (inner_child->HasValue(prop_help))
                             {
-                                page->SetPropertyHelpString(prop, innerChildObj->prop_as_wxString(prop_help));
+                                page->SetPropertyHelpString(prop, inner_child->prop_as_wxString(prop_help));
                             }
                         }
                     }
@@ -495,7 +490,7 @@ void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /
         }
     }
 
-    if (count)
+    if (node->GetChildCount())
     {
         pgm->SelectPage(0);
     }

--- a/src/generate/grid_widgets.cpp
+++ b/src/generate/grid_widgets.cpp
@@ -574,17 +574,17 @@ ttlib::cstr PropertyGridItemGenerator::GetHelpURL(Node* node)
 
     else
     {
-        if (!type.is_sameprefix("string"))
+        if (!type.starts_with("string"))
             type.Replace("string", "_string");
-        if (!type.is_sameprefix("choice"))
+        if (!type.starts_with("choice"))
             type.Replace("choice", "_choice");
-        if (!type.is_sameprefix("colour"))
+        if (!type.starts_with("colour"))
             type.Replace("colour", "_colour");
-        if (!type.is_sameprefix("enum"))
+        if (!type.starts_with("enum"))
             type.Replace("enum", "_enum");
-        if (!type.is_sameprefix("int"))
+        if (!type.starts_with("int"))
             type.Replace("int", "_int");
-        if (!type.is_sameprefix("file"))
+        if (!type.starts_with("file"))
             type.Replace("file", "_file");
 
         url << type << "_property.html";

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -248,7 +248,7 @@ void BaseCodeGenerator::GenerateImagesForm()
                 m_source->SetLastLineBlank();
             }
 
-            for (auto& child: m_form_node->GetChildNodePtrs())
+            for (const auto& child: m_form_node->GetChildNodePtrs())
             {
                 if (auto bundle = pjsettings->GetPropertyImageBundle(child->prop_as_string(prop_bitmap));
                     bundle && bundle->lst_filenames.size())
@@ -417,7 +417,7 @@ void BaseCodeGenerator::GenerateImagesForm()
             m_header->writeLine("#if wxCHECK_VERSION(3, 1, 6)", indent::none);
         }
 
-        for (auto& child: m_form_node->GetChildNodePtrs())
+        for (const auto& child: m_form_node->GetChildNodePtrs())
         {
             if (auto bundle = pjsettings->GetPropertyImageBundle(child->prop_as_string(prop_bitmap));
                 bundle && bundle->lst_filenames.size())

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -67,11 +67,11 @@ void MenuBarBase::OnLeftMenuClick(wxMouseEvent& event)
     }
     else
     {
-        for (size_t pos_menu = 0; pos_menu < m_node_menubar->GetChildCount(); ++pos_menu)
+        for (const auto& child: m_node_menubar->GetChildNodePtrs())
         {
-            if (m_node_menubar->GetChild(pos_menu)->prop_as_string(prop_label) == text)
+            if (child->prop_as_string(prop_label) == text)
             {
-                menu_node = m_node_menubar->GetChild(pos_menu);
+                menu_node = child.get();
                 break;
             }
         }
@@ -116,8 +116,7 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
             // label and bitmap.
 
             int id = wxID_ANY;
-            if (menu_item->prop_as_string(prop_id) != "wxID_ANY" &&
-                menu_item->prop_as_string(prop_id).starts_with("wxID_"))
+            if (menu_item->prop_as_string(prop_id) != "wxID_ANY" && menu_item->prop_as_string(prop_id).starts_with("wxID_"))
                 id = g_NodeCreator.GetConstantAsInt(menu_item->prop_as_string(prop_id), wxID_ANY);
 
             auto item = new wxMenuItem(sub_menu, id, menu_label, menu_item->prop_as_wxString(prop_help),

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -37,7 +37,7 @@ wxObject* MenuBarBase::CreateMockup(Node* node, wxObject* parent)
     }
     else
     {
-        for (auto& iter: node->GetChildNodePtrs())
+        for (const auto& iter: node->GetChildNodePtrs())
         {
             auto label = new wxStaticText(panel, wxID_ANY, iter->prop_as_wxString(prop_label));
             sizer->Add(label, wxSizerFlags().Border(wxALL));
@@ -90,7 +90,7 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
 {
     auto sub_menu = new wxMenu;
 
-    for (auto& menu_item: menu_node->GetChildNodePtrs())
+    for (const auto& menu_item: menu_node->GetChildNodePtrs())
     {
         if (menu_item->isType(type_submenu))
         {

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -117,7 +117,7 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
 
             int id = wxID_ANY;
             if (menu_item->prop_as_string(prop_id) != "wxID_ANY" &&
-                menu_item->prop_as_string(prop_id).is_sameprefix("wxID_"))
+                menu_item->prop_as_string(prop_id).starts_with("wxID_"))
                 id = g_NodeCreator.GetConstantAsInt(menu_item->prop_as_string(prop_id), wxID_ANY);
 
             auto item = new wxMenuItem(sub_menu, id, menu_label, menu_item->prop_as_wxString(prop_help),

--- a/src/generate/misc_widgets.cpp
+++ b/src/generate/misc_widgets.cpp
@@ -89,7 +89,7 @@ std::optional<ttlib::cstr> AnimationGenerator::GenConstruction(Node* node)
         ttlib::cstr name(parts[IndexImage].filename());
         name.remove_extension();
         name.LeftTrim();
-        if (parts[IndexType].is_sameprefix("Embed"))
+        if (parts[IndexType].starts_with("Embed"))
         {
             auto embed = wxGetApp().GetProjectSettings()->GetEmbeddedImage(parts[IndexImage]);
             if (embed)

--- a/src/generate/radio_widgets.cpp
+++ b/src/generate/radio_widgets.cpp
@@ -237,7 +237,7 @@ std::optional<ttlib::cstr> RadioBoxGenerator::GenConstruction(Node* node)
     ttlib::cstr code;
 
     ttlib::cstr choice_name(node->get_node_name());
-    if (choice_name.is_sameprefix("m_"))
+    if (choice_name.starts_with("m_"))
         choice_name.erase(0, 2);
     choice_name << "_choices";
     code << "\twxString " << choice_name << "[] = {";

--- a/src/generate/ribbon_widgets.cpp
+++ b/src/generate/ribbon_widgets.cpp
@@ -328,18 +328,15 @@ void RibbonButtonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxp
     auto btn_bar = wxStaticCast(wxobject, wxRibbonButtonBar);
 
     auto node = GetMockup()->GetNode(wxobject);
-    size_t count = node->GetChildCount();
-    for (size_t i = 0; i < count; ++i)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto childObj = node->GetChild(i);
-
-        auto bmp = childObj->prop_as_wxBitmap(prop_bitmap);
+        auto bmp = child->prop_as_wxBitmap(prop_bitmap);
         if (!bmp.IsOk())
             bmp = GetInternalImage("default");
 
         // REVIEW: This is still a bitmap rather then a bundle as of the 3.1.6 release
-        btn_bar->AddButton(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, childObj->prop_as_wxString(prop_help),
-                           (wxRibbonButtonKind) childObj->prop_as_int(prop_kind));
+        btn_bar->AddButton(wxID_ANY, child->prop_as_wxString(prop_label), bmp, child->prop_as_wxString(prop_help),
+                           (wxRibbonButtonKind) child->prop_as_int(prop_kind));
     }
 }
 
@@ -427,23 +424,20 @@ void RibbonToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpar
     auto btn_bar = wxDynamicCast(wxobject, wxRibbonToolBar);
 
     auto node = GetMockup()->GetNode(wxobject);
-    size_t count = node->GetChildCount();
-    for (size_t idx = 0; idx < count; ++idx)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto childObj = node->GetChild(idx);
-
-        if (childObj->isGen(gen_ribbonSeparator))
+        if (child->isGen(gen_ribbonSeparator))
         {
             btn_bar->AddSeparator();
         }
         else
         {
-            auto bmp = childObj->prop_as_wxBitmap(prop_bitmap);
+            auto bmp = child->prop_as_wxBitmap(prop_bitmap);
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
             // REVIEW: This is still a bitmap rather then a bundle as of the 3.1.6 release
-            btn_bar->AddTool(wxID_ANY, bmp, childObj->prop_as_wxString(prop_help),
-                             (wxRibbonButtonKind) childObj->prop_as_int(prop_kind));
+            btn_bar->AddTool(wxID_ANY, bmp, child->prop_as_wxString(prop_help),
+                             (wxRibbonButtonKind) child->prop_as_int(prop_kind));
         }
     }
     btn_bar->Realize();
@@ -551,13 +545,11 @@ void RibbonGalleryGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpar
     auto gallery = wxStaticCast(wxobject, wxRibbonGallery);
 
     auto node = GetMockup()->GetNode(wxobject);
-    size_t count = node->GetChildCount();
-    for (size_t i = 0; i < count; ++i)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        auto childObj = node->GetChild(i);
-        if (childObj->isGen(gen_ribbonGalleryItem))
+        if (child->isGen(gen_ribbonGalleryItem))
         {
-            auto bmp = childObj->prop_as_wxBitmap(prop_bitmap);
+            auto bmp = child->prop_as_wxBitmap(prop_bitmap);
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
 

--- a/src/generate/sizer_widgets.cpp
+++ b/src/generate/sizer_widgets.cpp
@@ -1217,23 +1217,23 @@ std::optional<ttlib::cstr> StdDialogButtonSizerGenerator::GenEvents(NodeEvent* e
         (event->GetEventInfo()->get_event_class() == "wxCommandEvent" ? "wxEVT_BUTTON" : "wxEVT_UPDATE_UI");
     code << "Bind(" << evt_str << comma << handler << comma;
 
-    if (event->get_name().is_sameprefix("OKButton"))
+    if (event->get_name().starts_with("OKButton"))
         code << "wxID_OK);";
-    else if (event->get_name().is_sameprefix("YesButton"))
+    else if (event->get_name().starts_with("YesButton"))
         code << "wxID_YES);";
-    else if (event->get_name().is_sameprefix("SaveButton"))
+    else if (event->get_name().starts_with("SaveButton"))
         code << "wxID_SAVE);";
-    else if (event->get_name().is_sameprefix("ApplyButton"))
+    else if (event->get_name().starts_with("ApplyButton"))
         code << "wxID_APPLY);";
-    else if (event->get_name().is_sameprefix("NoButton"))
+    else if (event->get_name().starts_with("NoButton"))
         code << "wxID_NO);";
-    else if (event->get_name().is_sameprefix("CancelButton"))
+    else if (event->get_name().starts_with("CancelButton"))
         code << "wxID_CANCEL);";
-    else if (event->get_name().is_sameprefix("CloseButton"))
+    else if (event->get_name().starts_with("CloseButton"))
         code << "wxID_CLOSE);";
-    else if (event->get_name().is_sameprefix("HelpButton"))
+    else if (event->get_name().starts_with("HelpButton"))
         code << "wxID_HELP);";
-    else if (event->get_name().is_sameprefix("ContextHelpButton"))
+    else if (event->get_name().starts_with("ContextHelpButton"))
         code << "wxID_CONTEXT_HELP);";
 
     return code;

--- a/src/generate/tree_widgets.cpp
+++ b/src/generate/tree_widgets.cpp
@@ -70,7 +70,7 @@ void TreeListCtrlGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
     auto widget = wxStaticCast(wxobject, wxTreeListCtrl);
     auto node = GetMockup()->GetNode(wxobject);
 
-    for (auto& iter: node->GetChildNodePtrs())
+    for (const auto& iter: node->GetChildNodePtrs())
     {
         widget->AppendColumn(iter->prop_as_wxString(prop_label), iter->prop_as_int(prop_width),
                              static_cast<wxAlignment>(iter->prop_as_int(prop_alignment)), iter->prop_as_int(prop_flags));

--- a/src/generate/wizard_form.cpp
+++ b/src/generate/wizard_form.cpp
@@ -227,12 +227,11 @@ std::vector<Node*> WizardFormGenerator::GetChildPanes(Node* parent)
 {
     std::vector<Node*> panes;
 
-    for (size_t pos = 0; pos < parent->GetChildCount(); ++pos)
+    for (const auto& child: parent->GetChildNodePtrs())
     {
-        auto child = parent->GetChild(pos);
         if (child->isGen(gen_wxWizardPageSimple))
         {
-            panes.emplace_back(child);
+            panes.emplace_back(child.get());
         }
     }
 

--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -36,7 +36,7 @@ void WriteCode::WriteCodeLine(ttlib::sview code, size_t indentation)
         {
             // Don't indent #if, #else or #endif
             if (code[0] != '#' ||
-                !(code.is_sameprefix("#if") || code.is_sameprefix("#else") || code.is_sameprefix("#endif")))
+                !(code.starts_with("#if") || code.starts_with("#else") || code.starts_with("#endif")))
             {
                 for (int i = 0; i < m_indent; ++i)
                 {

--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -35,8 +35,7 @@ void WriteCode::WriteCodeLine(ttlib::sview code, size_t indentation)
         if (indentation != indent::none)
         {
             // Don't indent #if, #else or #endif
-            if (code[0] != '#' ||
-                !(code.starts_with("#if") || code.starts_with("#else") || code.starts_with("#endif")))
+            if (code[0] != '#' || !(code.starts_with("#if") || code.starts_with("#else") || code.starts_with("#endif")))
             {
                 for (int i = 0; i < m_indent; ++i)
                 {

--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -1,0 +1,35 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Find std::string_view key in std::unordered_map
+// Author:    https://en.cppreference.com/w/cpp/container/unordered_map/find
+/////////////////////////////////////////////////////////////////////////////
+
+// Example (only works with C++20 or later):
+//
+// std::unordered_map<std::string, std::string, str_view_hash, std::equal_to<>> my_map = {
+//     { "foo", "bar" }
+// };
+//
+// std::string_view name("foo");
+//
+// if (auto result = my_map.find(name); result != my_map.end())
+// {
+//     return result->second;
+
+#if !(__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L))
+    #error "This method can only be used with a C++20 or later compiler"
+#endif
+
+#pragma once
+
+#include <functional>  // for std::hash
+#include <unordered_map>
+
+struct str_view_hash
+{
+    using hash_type = std::hash<std::string_view>;
+    using is_transparent = void;
+
+    size_t operator()(const char* str) const { return hash_type {}(str); }
+    size_t operator()(std::string_view str) const { return hash_type {}(str); }
+    size_t operator()(std::string const& str) const { return hash_type {}(str); }
+};

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -78,7 +78,7 @@ void ProjectSettings::CollectNodeBundles(const NodeSharedPtr& node, const NodeSh
         else if (iter.type() == type_animation)
         {
             auto& value = iter.as_string();
-            if (value.is_sameprefix("Embed"))
+            if (value.starts_with("Embed"))
             {
                 ttlib::multiview parts(value, BMP_PROP_SEPARATOR, tt::TRIM::both);
                 if (parts[IndexImage].size())
@@ -126,7 +126,7 @@ bool ProjectSettings::AddNewEmbeddedBundle(const ttlib::multistr& parts, ttlib::
         }
     }
 
-    if (parts[IndexType].is_sameprefix("SVG"))
+    if (parts[IndexType].starts_with("SVG"))
     {
         if (AddSvgBundleImage(path, form))
         {

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -47,21 +47,21 @@ inline ttlib::cstr ConvertToLookup(const ttlib::cstr& description)
 
 void ProjectSettings::CollectBundles()
 {
-    for (auto& iter: wxGetApp().GetProject()->GetChildNodePtrs())
+    for (const auto& form: wxGetApp().GetProject()->GetChildNodePtrs())
     {
-        CollectNodeBundles(iter.get(), iter.get());
+        CollectNodeBundles(form, form);
 
-        if (iter->HasProp(prop_icon) && iter->HasValue(prop_icon))
+        if (form->HasProp(prop_icon) && form->HasValue(prop_icon))
         {
-            if (!m_bundles.contains(ConvertToLookup(iter->prop_as_string(prop_icon))))
+            if (!m_bundles.contains(ConvertToLookup(form->prop_as_string(prop_icon))))
             {
-                ProcessBundleProperty(iter->prop_as_string(prop_icon), iter.get());
+                ProcessBundleProperty(form->prop_as_string(prop_icon), form.get());
             }
         }
     }
 }
 
-void ProjectSettings::CollectNodeBundles(Node* node, Node* form)
+void ProjectSettings::CollectNodeBundles(const NodeSharedPtr& node, const NodeSharedPtr& form)
 {
     for (auto& iter: node->get_props_vector())
     {
@@ -72,7 +72,7 @@ void ProjectSettings::CollectNodeBundles(Node* node, Node* form)
         {
             if (!m_bundles.contains(ConvertToLookup(iter.as_string())))
             {
-                ProcessBundleProperty(iter.as_string(), form);
+                ProcessBundleProperty(iter.as_string(), form.get());
             }
         }
         else if (iter.type() == type_animation)
@@ -85,15 +85,15 @@ void ProjectSettings::CollectNodeBundles(Node* node, Node* form)
                 {
                     if (!m_map_embedded.contains(parts[IndexImage].filename()))
                     {
-                        AddEmbeddedImage(parts[IndexImage], form);
+                        AddEmbeddedImage(parts[IndexImage], form.get());
                     }
                 }
             }
         }
     }
-    for (auto& child: node->GetChildNodePtrs())
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        CollectNodeBundles(child.get(), form);
+        CollectNodeBundles(child, form);
     }
 }
 

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -53,7 +53,7 @@ void ProjectSettings::CollectBundles()
 
         if (iter->HasProp(prop_icon) && iter->HasValue(prop_icon))
         {
-            if (m_bundles.find(ConvertToLookup(iter->prop_as_string(prop_icon))) == m_bundles.end())
+            if (!m_bundles.contains(ConvertToLookup(iter->prop_as_string(prop_icon))))
             {
                 ProcessBundleProperty(iter->prop_as_string(prop_icon), iter.get());
             }
@@ -70,7 +70,7 @@ void ProjectSettings::CollectNodeBundles(Node* node, Node* form)
 
         if (iter.type() == type_image)
         {
-            if (m_bundles.find(ConvertToLookup(iter.as_string())) == m_bundles.end())
+            if (!m_bundles.contains(ConvertToLookup(iter.as_string())))
             {
                 ProcessBundleProperty(iter.as_string(), form);
             }
@@ -83,7 +83,7 @@ void ProjectSettings::CollectNodeBundles(Node* node, Node* form)
                 ttlib::multiview parts(value, BMP_PROP_SEPARATOR, tt::TRIM::both);
                 if (parts[IndexImage].size())
                 {
-                    if (auto result = m_map_embedded.find(parts[IndexImage].filename()); result == m_map_embedded.end())
+                    if (!m_map_embedded.contains(parts[IndexImage].filename()))
                     {
                         AddEmbeddedImage(parts[IndexImage], form);
                     }
@@ -380,8 +380,7 @@ ImageBundle* ProjectSettings::ProcessBundleProperty(const ttlib::multistr& parts
     ttlib::cstr lookup_str;
     lookup_str << parts[0] << ';' << parts[1].filename();
 
-    ASSERT_MSG(m_bundles.find(lookup_str) == m_bundles.end(),
-               "ProcessBundleProperty should not be called if bundle already exists!")
+    ASSERT_MSG(!m_bundles.contains(lookup_str), "ProcessBundleProperty should not be called if bundle already exists!")
 
     if (parts[IndexImage].empty())
     {

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -225,7 +225,7 @@ void FormBuilder::CreateProjectNode(pugi::xml_node& xml_obj, Node* new_node)
                 {
                     m_class_decoration = xml_prop.text().as_string();
                     // Current formbuild uses "; " as the default property value
-                    if (m_class_decoration.is_sameprefix((";")))
+                    if (m_class_decoration.starts_with((";")))
                     {
                         m_class_decoration.clear();
                     }

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -186,41 +186,42 @@ void FormBuilder::CreateProjectNode(pugi::xml_node& xml_obj, Node* new_node)
                 // In wxUE, a lot of properties are specific to the form. For example, it's perfectly fine to
                 // connect to events using Bind for a Dialog and a table macro for a Frame.
 
-                if (prop_name.as_cview().is_sameas("internationalize"))
+                if (prop_name.as_string() == "internationalize")
                 {
                     new_node->get_prop_ptr(prop_internationalize)->set_value(xml_prop.text().as_bool() ? "1" : "0");
                 }
-                else if (prop_name.as_cview().is_sameas("help_provider"))
+                else if (prop_name.as_string() == "help_provider")
                 {
                     new_node->get_prop_ptr(prop_help_provider)->set_value(xml_prop.text().as_string());
                 }
-                else if (prop_name.as_cview().is_sameas("precompiled_header"))
+                else if (prop_name.as_string() == "precompiled_header")
                 {
                     // wxFormBuilder calls it a precompiled header, but uses it as a preamble.
                     new_node->get_prop_ptr(prop_src_preamble)->set_value(xml_prop.text().as_string());
                 }
 
-                else if (prop_name.as_cview().is_sameas("embedded_files_path"))
+                else if (prop_name.as_string() == "embedded_files_path")
                 {
-                    ttString path(xml_prop.text().as_cstr().wx_str());
+                    // Unlike wxString, this ctor will call FromUTF8() on Windows
+                    ttString path(xml_prop.text().as_string());
                     ttString root(m_importProjectFile);
                     root.remove_filename();
                     path.make_relative_wx(root);
                     m_project->prop_set_value(prop_art_directory, path);
                 }
-                else if (prop_name.as_cview().is_sameas("path"))
+                else if (prop_name.as_string() == "path")
                 {
-                    ttString path(xml_prop.text().as_cstr().wx_str());
+                    ttString path(xml_prop.text().as_string());
                     ttString root(m_importProjectFile);
                     root.remove_filename();
                     path.make_relative_wx(root);
                     m_project->prop_set_value(prop_base_directory, path);
                 }
-                else if (prop_name.as_cview().is_sameas("file"))
+                else if (prop_name.as_string() == "file")
                 {
                     m_baseFile = xml_prop.text().as_string();
                 }
-                else if (prop_name.as_cview().is_sameas("class_decoration"))
+                else if (prop_name.as_string() == "class_decoration")
                 {
                     m_class_decoration = xml_prop.text().as_string();
                     // Current formbuild uses "; " as the default property value
@@ -229,9 +230,9 @@ void FormBuilder::CreateProjectNode(pugi::xml_node& xml_obj, Node* new_node)
                         m_class_decoration.clear();
                     }
                 }
-                else if (prop_name.as_cview().is_sameas("namespace") && xml_prop.text().as_cview().size())
+                else if (prop_name.as_string() == "namespace" && xml_prop.text().as_string().size())
                 {
-                    ConvertNameSpaceProp(new_node->get_prop_ptr(prop_name_space), xml_prop.text().as_cview());
+                    ConvertNameSpaceProp(new_node->get_prop_ptr(prop_name_space), xml_prop.text().as_string());
                 }
             }
         }
@@ -247,7 +248,7 @@ void FormBuilder::CreateProjectNode(pugi::xml_node& xml_obj, Node* new_node)
 
 NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, Node* sizeritem)
 {
-    auto class_name = xml_obj.attribute("class").as_cview();
+    auto class_name = xml_obj.attribute("class").as_sview();
     if (class_name.empty())
         return NodeSharedPtr();
 
@@ -258,7 +259,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
         {
             gen_name = gen_oldbookpage;
         }
-        else if (class_name.is_sameprefix("ribbon"))
+        else if (class_name.starts_with("ribbon"))
         {
             if (class_name.contains("Tool"))
             {
@@ -299,9 +300,9 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
     {
         for (auto& iter: xml_obj.children())
         {
-            if (iter.attribute("name").as_cview().is_sameas("style"))
+            if (iter.attribute("name").as_string() == "style")
             {
-                if (iter.text().as_cview().contains("wxCHK_3STATE"))
+                if (iter.text().as_sview().contains("wxCHK_3STATE"))
                     gen_name = gen_Check3State;
                 break;
             }
@@ -362,7 +363,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
 
     for (auto xml_prop = xml_obj.child("property"); xml_prop; xml_prop = xml_prop.next_sibling("property"))
     {
-        if (auto prop_name = xml_prop.attribute("name").as_cview(); prop_name.size())
+        if (auto prop_name = xml_prop.attribute("name").as_string(); prop_name.size())
         {
             auto wxue_prop = MapPropName(xml_prop.attribute("name").value());
             auto prop_ptr = newobject->get_prop_ptr(wxue_prop);
@@ -394,7 +395,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
                     {
                         if (prop_ptr = newobject->get_prop_ptr(prop_image_size); prop_ptr)
                         {
-                            prop_ptr->set_value(xml_prop.text().as_cview());
+                            prop_ptr->set_value(xml_prop.text().as_string());
                             auto size = prop_ptr->as_size();
                             if (size != wxDefaultSize)
                             {
@@ -412,7 +413,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
                     if (!xml_prop.text().empty())
                     {
                         ttlib::cstr animation("Embed;");
-                        animation << xml_prop.text().as_cview() << ";[-1,-1]";
+                        animation << xml_prop.text().as_string() << ";[-1,-1]";
                         prop_ptr->set_value(animation);
                     }
                 }
@@ -456,7 +457,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
 
             // If we get here, wxue_prop will be prop_unknown and prop_ptr will be null.
 
-            if (prop_name.is_sameas("name"))
+            if (prop_name == "name")
             {
                 if (newobject->IsForm())
                 {
@@ -478,16 +479,16 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
 
                 if (prop_ptr)
                 {
-                    prop_ptr->set_value(xml_prop.text().as_cview());
+                    prop_ptr->set_value(xml_prop.text().as_string());
                 }
                 continue;
             }
-            else if (prop_name.is_sameas("declaration"))
+            else if (prop_name == "declaration")
             {
                 // This property is for a custom control, and we don't use this specific property
                 continue;
             }
-            else if (prop_name.is_sameas("construction"))
+            else if (prop_name == "construction")
             {
                 ttlib::cstr copy = xml_prop.text().as_string();
                 if (auto pos = copy.find('('); ttlib::is_found(pos))
@@ -502,14 +503,14 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
                 newobject->prop_set_value(prop_parameters, copy);
                 continue;
             }
-            else if (prop_name.is_sameas("settings"))
+            else if (prop_name == "settings")
             {
                 newobject->prop_set_value(prop_settings_code, xml_prop.text().as_string());
             }
-            else if (prop_name.is_sameas("include"))
+            else if (prop_name == "include")
             {
                 ttlib::cstr header;
-                header.ExtractSubString(xml_prop.text().as_cview().view_stepover());
+                header.ExtractSubString(xml_prop.text().as_sview().view_stepover());
                 if (header.size())
                 {
                     newobject->prop_set_value(prop_header, header);
@@ -519,7 +520,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
 
             // If the property actually has a value, then we need to see if we can convert it. We ignore unknown
             // properties that don't have a value.
-            if (auto value = xml_prop.text().as_cview(); value.size())
+            if (auto value = xml_prop.text().as_string(); value.size())
             {
                 ProcessPropValue(xml_prop, prop_name, class_name, newobject.get());
             }
@@ -573,13 +574,13 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
     auto xml_event = xml_obj.child("event");
     while (xml_event)
     {
-        if (auto event_name = xml_event.attribute("name").as_cview();
-            event_name.size() && xml_event.text().as_cview().size())
+        if (auto event_name = xml_event.attribute("name").as_std_str();
+            event_name.size() && xml_event.text().as_string().size())
         {
-            if (auto result = m_mapEventNames.find(event_name.c_str()); result != m_mapEventNames.end())
+            if (auto result = m_mapEventNames.find(event_name); result != m_mapEventNames.end())
             {
                 event_name = result->second;
-                if (event_name.is_sameas("wxEVT_MENU") && newobject->isGen(gen_tool))
+                if (event_name == "wxEVT_MENU" && newobject->isGen(gen_tool))
                     event_name = "wxEVT_TOOL";
             }
             else
@@ -587,14 +588,14 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
                 // There is nothing in the wxWidgets source code that actually generates wxEVT_HIBERNATE that I can find as
                 // of wxWidgets 3.1.3. It was removed in wxFormBuilder (but I couldn't find a reason as to why).
                 // Documentation states it's part of WinCE which we don't support.
-                if (event_name.is_sameas("OnHibernate"))
+                if (event_name == "OnHibernate")
                 {
                     xml_event = xml_event.next_sibling("event");
                     continue;
                 }
 
                 // REVIEW: [KeyWorks - 10-28-2020] We don't support this, but we could convert it if it's actually used.
-                else if (event_name.is_sameas("OnMouseEvents"))
+                else if (event_name == "OnMouseEvents")
                 {
                     xml_event = xml_event.next_sibling("event");
                     continue;
@@ -607,7 +608,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
 
             if (auto event = newobject->GetEvent(event_name); event)
             {
-                event->set_value(xml_event.text().as_cview());
+                event->set_value(xml_event.text().as_string());
             }
         }
 
@@ -680,76 +681,76 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
     return newobject;
 }
 
-void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_name, ttlib::cview class_name,
+void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::sview prop_name, ttlib::sview class_name,
                                    Node* newobject)
 {
-    if (g_setIgnoreProps.find(prop_name.c_str()) != g_setIgnoreProps.end())
+    if (g_setIgnoreProps.contains(std::string(prop_name)))
     {
         return;
     }
 
     // validator_style sets the wxFILTER flags and is only valid in a wxTextValidator, so it's
     // removed from widgets that can't use it.
-    else if (prop_name.is_sameas("validator_style"))
+    else if (prop_name == "validator_style")
     {
         return;
     }
 
     // validator_type is only valid in wxTextValidator, where it let's the user choose between wxTextValidator and
     // wxGenericValidator
-    else if (prop_name.is_sameas("validator_type"))
+    else if (prop_name == "validator_type")
     {
         // BUGBUG: [KeyWorks - 11-07-2020] This IS valid for text controls, so we need to process it
         return;
     }
 
     // This will be caused by a spacer item which isn't actually a widget, so has no access property
-    else if (prop_name.is_sameas(map_PropNames[prop_class_access]))
+    else if (prop_name == map_PropNames[prop_class_access])
     {
         return;
     }
 
     // The label property in a wxMenuBar is not supported (since it can't actually be used)
-    else if (prop_name.is_sameas(map_PropNames[prop_label]))
+    else if (prop_name == map_PropNames[prop_label])
     {
         return;
     }
 
     // This is most likely a Dialog class -- we don't support wxAUI in that class. We silently ignore it...
-    else if (prop_name.is_sameas("aui_managed") || prop_name.is_sameas("aui_manager_style"))
+    else if (prop_name == "aui_managed" || prop_name == "aui_manager_style")
     {
         return;
     }
 
-    else if (prop_name.is_sameas("flag") && (class_name.is_sameas("sizeritem") || class_name.is_sameas("gbsizeritem")))
+    else if (prop_name == "flag" && (class_name == "sizeritem" || class_name == "gbsizeritem"))
     {
         HandleSizerItemProperty(xml_prop, newobject);
     }
 
-    else if (prop_name.is_sameas("name"))
+    else if (prop_name == "name")
     {
-        if (class_name.is_sameas("Project"))
+        if (class_name == "Project")
             return;  // we don't use this (and neither does wxFormBuilder for that matter)
-        else if (class_name.is_sameas("wxDialog"))
-            newobject->prop_set_value(prop_class_name, xml_prop.text().as_cview());
+        else if (class_name == "wxDialog")
+            newobject->prop_set_value(prop_class_name, xml_prop.text().as_string());
     }
-    else if (prop_name.is_sameas("permission"))
+    else if (prop_name == "permission")
     {
-        auto value = xml_prop.text().as_cview();
-        if (value.is_sameas("protected") || value.is_sameas("private"))
+        auto value = xml_prop.text().as_string();
+        if (value == "protected" || value == "private")
             newobject->prop_set_value(prop_class_access, "protected:");
-        else if (value.is_sameas("public"))
+        else if (value == "public")
             newobject->prop_set_value(prop_class_access, "public:");
         else
             newobject->prop_set_value(prop_class_access, "none");
     }
 
-    else if (prop_name.is_sameas("border"))
+    else if (prop_name == "border")
     {
-        newobject->prop_set_value(prop_border_size, xml_prop.text().as_cview());
+        newobject->prop_set_value(prop_border_size, xml_prop.text().as_string());
     }
 
-    else if (prop_name.is_sameas("enabled"))
+    else if (prop_name == "enabled")
     {
         // Form builder will apply enabled to things like a ribbon tool which cannot be enabled/disabled
         auto disabled = newobject->get_prop_ptr(prop_disabled);
@@ -757,72 +758,72 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
             disabled->set_value(xml_prop.text().as_bool() ? 0 : 1);
     }
 
-    else if (prop_name.is_sameas("disabled"))
+    else if (prop_name == "disabled")
     {
-        if (class_name.is_sameas("wxToggleButton") || class_name.is_sameas("wxButton"))
+        if (class_name == "wxToggleButton" || class_name == "wxButton")
         {
-            newobject->get_prop_ptr(prop_disabled_bmp)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_disabled_bmp)->set_value(xml_prop.text().as_string());
         }
     }
-    else if (prop_name.is_sameas("pressed"))
+    else if (prop_name == "pressed")
     {
-        if (class_name.is_sameas("wxToggleButton") || class_name.is_sameas("wxButton"))
+        if (class_name == "wxToggleButton" || class_name == "wxButton")
         {
-            newobject->get_prop_ptr(prop_pressed_bmp)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_pressed_bmp)->set_value(xml_prop.text().as_string());
         }
     }
 
-    else if (prop_name.is_sameas("value"))
+    else if (prop_name == "value")
     {
-        if (class_name.is_sameas("wxRadioButton"))
+        if (class_name == "wxRadioButton")
         {
-            newobject->get_prop_ptr(prop_checked)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_checked)->set_value(xml_prop.text().as_string());
         }
-        else if (class_name.is_sameas("wxSpinCtrl"))
+        else if (class_name == "wxSpinCtrl")
         {
-            newobject->get_prop_ptr(prop_initial)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_initial)->set_value(xml_prop.text().as_string());
         }
-        else if (class_name.is_sameas("wxToggleButton"))
+        else if (class_name == "wxToggleButton")
         {
-            newobject->get_prop_ptr(prop_pressed)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_pressed)->set_value(xml_prop.text().as_string());
         }
-        else if (class_name.is_sameas("wxSlider") || class_name.is_sameas("wxGauge") || class_name.is_sameas("wxScrollBar"))
+        else if (class_name == "wxSlider" || class_name == "wxGauge" || class_name == "wxScrollBar")
         {
-            newobject->get_prop_ptr(prop_position)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_position)->set_value(xml_prop.text().as_string());
         }
-        else if (class_name.is_sameas("wxComboBox") || class_name.is_sameas("wxBitmapComboBox"))
+        else if (class_name == "wxComboBox" || class_name == "wxBitmapComboBox")
         {
-            newobject->get_prop_ptr(prop_selection_string)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_selection_string)->set_value(xml_prop.text().as_string());
         }
-        else if (class_name.is_sameas("wxFilePickerCtrl") || class_name.is_sameas("wxDirPickerCtrl"))
+        else if (class_name == "wxFilePickerCtrl" || class_name == "wxDirPickerCtrl")
         {
-            newobject->get_prop_ptr(prop_initial_path)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_initial_path)->set_value(xml_prop.text().as_string());
         }
-        else if (class_name.is_sameas("wxFontPickerCtrl"))
+        else if (class_name == "wxFontPickerCtrl")
         {
-            newobject->get_prop_ptr(prop_initial_font)->set_value(xml_prop.text().as_cview());
+            newobject->get_prop_ptr(prop_initial_font)->set_value(xml_prop.text().as_string());
         }
         else
         {
             auto prop = newobject->get_prop_ptr(prop_value);
             if (prop)
-                prop->set_value(xml_prop.text().as_cview());
+                prop->set_value(xml_prop.text().as_string());
         }
     }
-    else if (prop_name.is_sameas("flags") && class_name.is_sameas("wxWrapSizer"))
+    else if (prop_name == "flags" && class_name == "wxWrapSizer")
     {
         auto prop = newobject->get_prop_ptr(prop_wrap_flags);
-        auto prop_value = xml_prop.text().as_cstr();
+        auto prop_value = xml_prop.text().as_sview();
         if (prop_value.contains("wxWRAPSIZER_DEFAULT_FLAGS"))
             prop_value = "wxEXTEND_LAST_ON_EACH_LINE|wxREMOVE_LEADING_SPACES";
         prop->set_value(prop_value);
     }
-    else if (prop_name.is_sameas("selection") && (class_name.is_sameas("wxComboBox") || class_name.is_sameas("wxChoice") ||
-                                                  class_name.is_sameas("wxBitmapComboBox")))
+    else if (prop_name == "selection" &&
+             (class_name == "wxComboBox" || class_name == "wxChoice" || class_name == "wxBitmapComboBox"))
     {
-        newobject->get_prop_ptr(prop_selection_int)->set_value(xml_prop.text().as_cview());
+        newobject->get_prop_ptr(prop_selection_int)->set_value(xml_prop.text().as_string());
     }
-    else if (prop_name.is_sameas("style") && class_name.is_sameas("wxCheckBox"))
+    else if (prop_name == "style" && class_name == "wxCheckBox")
     {
         // wxCHK_2STATE and wxCHK_3STATE are part of the type property instead of style
         ttlib::multiview styles(xml_prop.text().as_string());
@@ -849,25 +850,25 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
             prop->set_value("new_style");
         }
     }
-    else if (prop_name.is_sameas("style") && class_name.is_sameas("wxToolBar"))
+    else if (prop_name == "style" && class_name == "wxToolBar")
     {
         auto prop = newobject->get_prop_ptr(prop_style);
         auto prop_value = xml_prop.text().as_cstr();
         prop_value.Replace("wxTB_DEFAULT_STYLE", "wxTB_HORIZONTAL");
         prop->set_value(prop_value);
     }
-    else if (prop_name.is_sameas("orient"))
+    else if (prop_name == "orient")
     {
         if (auto prop = newobject->get_prop_ptr(prop_orientation); prop)
         {
             prop->set_value(xml_prop.text().as_string());
         }
     }
-    else if (prop_name.is_sameas("hidden") && newobject->isGen(gen_wxDialog))
+    else if (prop_name == "hidden" && newobject->isGen(gen_wxDialog))
     {
         return;
     }
-    else if (prop_name.is_sameas("subclass"))
+    else if (prop_name == "subclass")
     {
         ttlib::multistr parts(xml_prop.text().as_string(), ';', tt::TRIM::both);
         if (parts[0].empty())
@@ -885,7 +886,7 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
             }
         }
     }
-    else if (prop_name.is_sameas("folding"))
+    else if (prop_name == "folding")
     {
         if (xml_prop.text().as_bool())
         {
@@ -893,7 +894,7 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
             newobject->prop_set_value(prop_fold_width, "16");
         }
     }
-    else if (prop_name.is_sameas("line_numbers"))
+    else if (prop_name == "line_numbers")
     {
         if (xml_prop.text().as_bool())
         {
@@ -903,11 +904,11 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_n
 
     else
     {
-        if (xml_prop.text().as_cview().size())
+        if (xml_prop.text().as_string().size())
         {
-            if (prop_name.is_sameas("hidden") && newobject->isGen(gen_ribbonTool))
+            if (prop_name == "hidden" && newobject->isGen(gen_ribbonTool))
                 return;
-            else if (xml_prop.text().as_cview().is_sameas("wxWS_EX_VALIDATE_RECURSIVELY"))
+            else if (xml_prop.text().as_string() == "wxWS_EX_VALIDATE_RECURSIVELY")
                 return;
             MSG_INFO(ttlib::cstr() << prop_name << "(" << xml_prop.text().as_string() << ") property in " << class_name
                                    << " class not supported");
@@ -954,9 +955,9 @@ void FormBuilder::BitmapProperty(pugi::xml_node& xml_prop, NodeProperty* prop)
             prop->set_value(bitmap);
         }
     }
-    else if (org_value.contains("Load From Art") && !xml_prop.text().as_cview().is_sameprefix("Load From Art Provider; ;"))
+    else if (org_value.contains("Load From Art") && xml_prop.text().as_string() != "Load From Art Provider; ;")
     {
-        ttlib::cstr value(xml_prop.text().as_cview());
+        ttlib::cstr value = xml_prop.text().as_std_str();
         value.Replace("Load From Art Provider; ", "Art;", false, tt::CASE::either);
         value.Replace("; ", "|", false, tt::CASE::either);
         if (value.back() == '|')
@@ -972,7 +973,7 @@ inline bool is_printable(unsigned char ch) { return (ch > 31 && ch < 128); }
 
 inline bool is_numeric(unsigned char ch) { return (ch >= '0' && ch <= '9'); }
 
-void FormBuilder::ConvertNameSpaceProp(NodeProperty* prop, ttlib::cview org_names)
+void FormBuilder::ConvertNameSpaceProp(NodeProperty* prop, std::string_view org_names)
 {
     if (org_names.empty())
         return;

--- a/src/import/import_formblder.h
+++ b/src/import/import_formblder.h
@@ -29,11 +29,10 @@ public:
     NodeSharedPtr CreateFbpNode(pugi::xml_node& xml_prop, Node* parent, Node* sizeritem = nullptr);
 
 protected:
-    void ConvertNameSpaceProp(NodeProperty* prop, ttlib::cview org_names);
+    void ConvertNameSpaceProp(NodeProperty* prop, std::string_view org_names);
 
     // Called when a property is unknown and has a value set.
-    void ProcessPropValue(pugi::xml_node& xml_prop, ttlib::cview prop_name, ttlib::cview class_name, Node* newobject);
-    void ProcessStyleProperty(pugi::xml_node& xml_prop, ttlib::cview class_name, Node* newobject);
+    void ProcessPropValue(pugi::xml_node& xml_prop, ttlib::sview prop_name, ttlib::sview class_name, Node* newobject);
 
     void BitmapProperty(pugi::xml_node& xml_obj, NodeProperty* prop);
     void CreateProjectNode(pugi::xml_node& xml_obj, Node* new_node);

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -687,7 +687,7 @@ void WxCrafter::ProcessSizerFlags(Node* node, const Value& array)
     // If the node has porp_alignment, then it will also have prop_borders and prop_flags
     if (node->HasProp(prop_alignment))
     {
-        if (all_items.find("wxEXPAND") != all_items.end())
+        if (all_items.contains("wxEXPAND"))
         {
             node->prop_set_value(prop_flags, "wxEXPAND");
         }
@@ -695,26 +695,26 @@ void WxCrafter::ProcessSizerFlags(Node* node, const Value& array)
         {
             auto alignment = node->prop_as_raw_ptr(prop_alignment);
 
-            if (all_items.find("wxALIGN_CENTER") != all_items.end())
+            if (all_items.contains("wxALIGN_CENTER"))
             {
                 if (alignment->size())
                     *alignment << '|';
                 *alignment << "wxALIGN_CENTER";
             }
-            else if (all_items.find("wxALIGN_CENTER_HORIZONTAL") != all_items.end())
+            else if (all_items.contains("wxALIGN_CENTER_HORIZONTAL"))
             {
                 if (alignment->size())
                     *alignment << '|';
                 *alignment << "wxALIGN_CENTER_HORIZONTAL";
             }
-            else if (all_items.find("wxALIGN_CENTER_VERTICAL") != all_items.end())
+            else if (all_items.contains("wxALIGN_CENTER_VERTICAL"))
             {
                 if (alignment->size())
                     *alignment << '|';
                 *alignment << "wxALIGN_CENTER_VERTICAL";
             }
 
-            if (all_items.find("wxALIGN_RIGHT") != all_items.end())
+            if (all_items.contains("wxALIGN_RIGHT"))
             {
                 if (!alignment->contains("wxALIGN_CENTER"))
                 {
@@ -723,7 +723,7 @@ void WxCrafter::ProcessSizerFlags(Node* node, const Value& array)
                     *alignment << "wxALIGN_RIGHT";
                 }
             }
-            else if (all_items.find("wxALIGN_LEFT") != all_items.end())
+            else if (all_items.contains("wxALIGN_LEFT"))
             {
                 if (!alignment->contains("wxALIGN_CENTER"))
                 {
@@ -732,7 +732,7 @@ void WxCrafter::ProcessSizerFlags(Node* node, const Value& array)
                     *alignment << "wxALIGN_LEFT";
                 }
             }
-            else if (all_items.find("wxALIGN_TOP") != all_items.end())
+            else if (all_items.contains("wxALIGN_TOP"))
             {
                 if (!alignment->contains("wxALIGN_CENTER"))
                 {
@@ -741,7 +741,7 @@ void WxCrafter::ProcessSizerFlags(Node* node, const Value& array)
                     *alignment << "wxALIGN_TOP";
                 }
             }
-            else if (all_items.find("wxALIGN_BOTTOM") != all_items.end())
+            else if (all_items.contains("wxALIGN_BOTTOM"))
             {
                 if (!alignment->contains("wxALIGN_CENTER"))
                 {
@@ -755,7 +755,7 @@ void WxCrafter::ProcessSizerFlags(Node* node, const Value& array)
 
     if (node->HasProp(prop_border))
     {
-        if (all_items.find("wxALL") != all_items.end())
+        if (all_items.contains("wxALL"))
         {
             node->prop_set_value(prop_border, "wxALL");
         }
@@ -764,25 +764,25 @@ void WxCrafter::ProcessSizerFlags(Node* node, const Value& array)
             auto border_ptr = node->prop_as_raw_ptr(prop_border);
             border_ptr->clear();
 
-            if (all_items.find("wxLEFT") != all_items.end())
+            if (all_items.contains("wxLEFT"))
             {
                 if (border_ptr->size())
                     *border_ptr << ',';
                 *border_ptr << "wxLEFT";
             }
-            if (all_items.find("wxRIGHT") != all_items.end())
+            if (all_items.contains("wxRIGHT"))
             {
                 if (border_ptr->size())
                     *border_ptr << ',';
                 *border_ptr << "wxRIGHT";
             }
-            if (all_items.find("wxTOP") != all_items.end())
+            if (all_items.contains("wxTOP"))
             {
                 if (border_ptr->size())
                     *border_ptr << ',';
                 *border_ptr << "wxTOP";
             }
-            if (all_items.find("wxBOTTOM") != all_items.end())
+            if (all_items.contains("wxBOTTOM"))
             {
                 if (border_ptr->size())
                     *border_ptr << ',';

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -948,11 +948,11 @@ GenEnum::PropName WxCrafter::UnknownProperty(Node* node, const Value& value, ttl
             return prop_processed;
         }
 
-        else if (name.is_sameprefix("bitmap file ("))
+        else if (name.starts_with("bitmap file ("))
         {
             return prop_processed;  // These are different icon sizes
         }
-        else if (name.is_sameprefix("bitmap file ("))
+        else if (name.starts_with("bitmap file ("))
         {
             return prop_processed;  // These are different icon sizes
         }
@@ -1280,7 +1280,7 @@ void WxCrafter::ProcessBitmapPropety(Node* node, const Value& object)
     if (ttlib::sview path = object["m_path"].GetString(); path.size())
     {
         ttlib::cstr bitmap;
-        if (path.is_sameprefix("wxART"))
+        if (path.starts_with("wxART"))
         {
             ttlib::multiview parts(path, ',');
             if (parts.size() > 1)
@@ -1334,7 +1334,7 @@ bool WxCrafter::ProcessFont(Node* node, const Value& object)
         if (crafter_str.contains("underlined"))
             font_info.Underlined();
 
-        if (!crafter_str.is_sameprefix("wxSYS_DEFAULT_GUI_FONT"))
+        if (!crafter_str.starts_with("wxSYS_DEFAULT_GUI_FONT"))
         {
             font_info.setDefGuiFont(false);
             font_info.FaceName("");
@@ -1568,7 +1568,7 @@ ttlib::cstr rapidjson::ConvertColour(const rapidjson::Value& colour)
     if (colour.IsString())
     {
         ttlib::sview clr_string = colour.GetString();
-        if (!clr_string.is_sameprefix("Default"))
+        if (!clr_string.starts_with("Default"))
         {
             if (clr_string[0] == '(')
             {
@@ -1580,7 +1580,7 @@ ttlib::cstr rapidjson::ConvertColour(const rapidjson::Value& colour)
                 wxColour clr(clr_string.wx_str());
                 return ConvertColourToString(clr);
             }
-            else if (clr_string.is_sameprefix("wx"))
+            else if (clr_string.starts_with("wx"))
             {
                 result = clr_string;
                 return result;

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -352,7 +352,7 @@ void WxCrafter::ProcessChild(Node* parent, const Value& object)
 
     if (auto& gbSpan = FindValue(object, "gbSpan"); gbSpan.IsString() && !IsSame(gbSpan, "1,1"))
     {
-        ttlib::cview positions = gbSpan.GetString();
+        ttlib::sview positions = gbSpan.GetString();
         new_node->prop_set_value(prop_rowspan, positions.atoi());
         positions.moveto_nondigit();
         positions.moveto_digit();
@@ -360,7 +360,7 @@ void WxCrafter::ProcessChild(Node* parent, const Value& object)
     }
     if (auto& gbPosition = FindValue(object, "gbPosition"); gbPosition.IsString() && !IsSame(gbPosition, "0,0"))
     {
-        ttlib::cview positions = gbPosition.GetString();
+        ttlib::sview positions = gbPosition.GetString();
         new_node->prop_set_value(prop_row, positions.atoi());
         positions.moveto_nondigit();
         positions.moveto_digit();
@@ -1191,7 +1191,7 @@ void WxCrafter::KnownProperty(Node* node, const Value& value, GenEnum::PropName 
                 node->prop_set_value(prop_name, prop_value.GetInt());
             else
             {
-                ttlib::cview val = prop_value.GetString();
+                ttlib::sview val = prop_value.GetString();
                 if (val.is_sameas("-1,-1") &&
                     (prop_name == prop_size || prop_name == prop_min_size || prop_name == prop_pos))
                 {
@@ -1277,7 +1277,7 @@ void WxCrafter::ValueProperty(Node* node, const Value& value)
 
 void WxCrafter::ProcessBitmapPropety(Node* node, const Value& object)
 {
-    if (ttlib::cview path = object["m_path"].GetString(); path.size())
+    if (ttlib::sview path = object["m_path"].GetString(); path.size())
     {
         ttlib::cstr bitmap;
         if (path.is_sameprefix("wxART"))
@@ -1533,7 +1533,7 @@ const Value& rapidjson::FindValue(const rapidjson::Value& object, const char* ke
 
 // wxCrafter doesn't put a space between the words
 
-std::map<std::string, const char*> s_sys_colour_pair = {
+std::map<std::string, const char*, std::less<>> s_sys_colour_pair = {
 
     { "AppWorkspace", "wxSYS_COLOUR_APPWORKSPACE" },
     { "ActiveBorder", "wxSYS_COLOUR_ACTIVEBORDER" },
@@ -1567,7 +1567,7 @@ ttlib::cstr rapidjson::ConvertColour(const rapidjson::Value& colour)
     ttlib::cstr result;
     if (colour.IsString())
     {
-        ttlib::cview clr_string = colour.GetString();
+        ttlib::sview clr_string = colour.GetString();
         if (!clr_string.is_sameprefix("Default"))
         {
             if (clr_string[0] == '(')
@@ -1577,7 +1577,7 @@ ttlib::cstr rapidjson::ConvertColour(const rapidjson::Value& colour)
             }
             else if (colour.GetString()[0] == '#')
             {
-                wxColour clr(clr_string.c_str());
+                wxColour clr(clr_string.wx_str());
                 return ConvertColourToString(clr);
             }
             else if (clr_string.is_sameprefix("wx"))
@@ -1587,7 +1587,7 @@ ttlib::cstr rapidjson::ConvertColour(const rapidjson::Value& colour)
             }
             else
             {
-                if (auto colour_pair = s_sys_colour_pair.find(clr_string.c_str()); colour_pair != s_sys_colour_pair.end())
+                if (auto colour_pair = s_sys_colour_pair.find(clr_string); colour_pair != s_sys_colour_pair.end())
                     result = colour_pair->second;
             }
         }
@@ -1605,7 +1605,7 @@ std::string_view rapidjson::GetSelectedString(const rapidjson::Value& object)
             return array[sel].GetString();
         }
     }
-    return nullptr;
+    return {};
 }
 
 std::vector<std::string> rapidjson::GetStringVector(const rapidjson::Value& array)

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -73,16 +73,16 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
     if (gen_name == gen_unknown)
     {
         // If we don't recognize the class, then try the base= attribute
-        auto base = xml_obj.attribute("base").as_cview();
-        if (base.is_sameas("EditFrame"))
+        auto base = xml_obj.attribute("base").as_string();
+        if (base == "EditFrame")
         {
             gen_name = ConvertToGenName("wxFrame", parent);
         }
-        else if (base.is_sameas("EditDialog"))
+        else if (base == "EditDialog")
         {
             gen_name = ConvertToGenName("wxDialog", parent);
         }
-        else if (base.is_sameas("EditTopLevelPanel"))
+        else if (base == "EditTopLevelPanel")
         {
             gen_name = ConvertToGenName("Panel", parent);
         }
@@ -104,9 +104,9 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
     {
         for (auto& iter: xml_obj.children())
         {
-            if (iter.cname().is_sameas("style"))
+            if (iter.value() == "style")
             {
-                if (iter.text().as_cview().contains("wxCHK_3STATE"))
+                if (iter.text().as_sview().contains("wxCHK_3STATE"))
                     gen_name = gen_Check3State;
                 break;
             }
@@ -193,24 +193,24 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
         {
             for (auto& btn_id: button.children())
             {
-                auto id = btn_id.attribute("name").as_cview();
-                if (id.is_sameas("wxID_OK"))
+                auto id = btn_id.attribute("name").as_string();
+                if (id == "wxID_OK")
                     new_node->get_prop_ptr(prop_OK)->set_value("1");
-                else if (id.is_sameas("wxID_YES"))
+                else if (id == "wxID_YES")
                     new_node->get_prop_ptr(prop_Yes)->set_value("1");
-                else if (id.is_sameas("wxID_SAVE"))
+                else if (id == "wxID_SAVE")
                     new_node->get_prop_ptr(prop_Save)->set_value("1");
-                else if (id.is_sameas("wxID_APPLY"))
+                else if (id == "wxID_APPLY")
                     new_node->get_prop_ptr(prop_Apply)->set_value("1");
-                else if (id.is_sameas("wxID_NO"))
+                else if (id == "wxID_NO")
                     new_node->get_prop_ptr(prop_No)->set_value("1");
-                else if (id.is_sameas("wxID_CANCEL"))
+                else if (id == "wxID_CANCEL")
                     new_node->get_prop_ptr(prop_Cancel)->set_value("1");
-                else if (id.is_sameas("wxID_CLOSE"))
+                else if (id == "wxID_CLOSE")
                     new_node->get_prop_ptr(prop_Close)->set_value("1");
-                else if (id.is_sameas("wxID_HELP"))
+                else if (id == "wxID_HELP")
                     new_node->get_prop_ptr(prop_Help)->set_value("1");
-                else if (id.is_sameas("wxID_CONTEXT_HELP"))
+                else if (id == "wxID_CONTEXT_HELP")
                     new_node->get_prop_ptr(prop_ContextHelp)->set_value("1");
             }
         }

--- a/src/import/import_wxsmith.cpp
+++ b/src/import/import_wxsmith.cpp
@@ -94,9 +94,9 @@ NodeSharedPtr WxSmith::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, Node
     {
         for (auto& iter: xml_obj.children())
         {
-            if (iter.cname().is_sameas("style"))
+            if (iter.value() == "style")
             {
-                if (iter.text().as_cview().contains("wxCHK_3STATE"))
+                if (iter.text().as_sview().contains("wxCHK_3STATE"))
                     gen_name = gen_Check3State;
                 break;
             }
@@ -187,24 +187,24 @@ NodeSharedPtr WxSmith::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, Node
         {
             for (auto& btn_id: button.children())
             {
-                auto id = btn_id.attribute("name").as_cview();
-                if (id.is_sameas("wxID_OK"))
+                auto id = btn_id.attribute("name").as_string();
+                if (id == "wxID_OK")
                     new_node->get_prop_ptr(prop_OK)->set_value("1");
-                else if (id.is_sameas("wxID_YES"))
+                else if (id == "wxID_YES")
                     new_node->get_prop_ptr(prop_Yes)->set_value("1");
-                else if (id.is_sameas("wxID_SAVE"))
+                else if (id == "wxID_SAVE")
                     new_node->get_prop_ptr(prop_Save)->set_value("1");
-                else if (id.is_sameas("wxID_APPLY"))
+                else if (id == "wxID_APPLY")
                     new_node->get_prop_ptr(prop_Apply)->set_value("1");
-                else if (id.is_sameas("wxID_NO"))
+                else if (id == "wxID_NO")
                     new_node->get_prop_ptr(prop_No)->set_value("1");
-                else if (id.is_sameas("wxID_CANCEL"))
+                else if (id == "wxID_CANCEL")
                     new_node->get_prop_ptr(prop_Cancel)->set_value("1");
-                else if (id.is_sameas("wxID_CLOSE"))
+                else if (id == "wxID_CLOSE")
                     new_node->get_prop_ptr(prop_Close)->set_value("1");
-                else if (id.is_sameas("wxID_HELP"))
+                else if (id == "wxID_HELP")
                     new_node->get_prop_ptr(prop_Help)->set_value("1");
-                else if (id.is_sameas("wxID_CONTEXT_HELP"))
+                else if (id == "wxID_CONTEXT_HELP")
                     new_node->get_prop_ptr(prop_ContextHelp)->set_value("1");
             }
         }

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -33,7 +33,7 @@ std::optional<pugi::xml_document> ImportXML::LoadDocFile(const ttString& file)
 
 void ImportXML::HandleSizerItemProperty(const pugi::xml_node& xml_prop, Node* node, Node* parent)
 {
-    auto flag_value = xml_prop.text().as_cview();
+    auto flag_value = xml_prop.text().as_sview();
 
     ttlib::cstr border_value;
     if (flag_value.contains("wxALL"))
@@ -332,7 +332,7 @@ void ImportXML::ProcessStyle(pugi::xml_node& xml_prop, Node* node, NodeProperty*
     }
     else
     {
-        auto view_value = xml_prop.text().as_cview();
+        auto view_value = xml_prop.text().as_sview();
         if (view_value.contains("wxST_SIZEGRIP"))
         {
             auto value = xml_prop.text().as_cstr();
@@ -443,7 +443,7 @@ void ImportXML::ProcessAttributes(const pugi::xml_node& xml_obj, Node* new_node)
 {
     for (auto& iter: xml_obj.attributes())
     {
-        if (iter.cname().is_sameas("name"))
+        if (iter.value() == "name")
         {
             if (new_node->IsForm())
             {
@@ -452,7 +452,7 @@ void ImportXML::ProcessAttributes(const pugi::xml_node& xml_obj, Node* new_node)
                     prop->set_value(iter.value());
                 }
             }
-            else if (iter.as_cview().is_sameprefix("wxID_"))
+            else if (iter.as_string().starts_with("wxID_"))
             {
                 auto prop = new_node->get_prop_ptr(prop_id);
                 if (prop)
@@ -485,7 +485,7 @@ void ImportXML::ProcessAttributes(const pugi::xml_node& xml_obj, Node* new_node)
                 }
             }
         }
-        else if (iter.cname().is_sameas("variable"))
+        else if (iter.value() == "variable")
         {
             if (auto prop = new_node->get_prop_ptr(prop_var_name); prop)
             {
@@ -494,7 +494,7 @@ void ImportXML::ProcessAttributes(const pugi::xml_node& xml_obj, Node* new_node)
                 prop->set_value(new_name);
             }
         }
-        else if (iter.cname().is_sameas("subclass"))
+        else if (iter.value() == "subclass")
         {
             new_node->prop_set_value(prop_derived_class, iter.value());
         }
@@ -507,7 +507,7 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
     {
         auto wxue_prop = MapPropName(iter.name());
 
-        if (iter.cname().is_sameas("object"))
+        if (iter.value() == "object")
         {
             continue;
         }
@@ -554,12 +554,12 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
             }
             continue;
         }
-        else if (iter.cname().is_sameas("tabs"))
+        else if (iter.value() == "tabs")
         {
             ProcessNotebookTabs(iter, node);
             continue;
         }
-        else if (iter.cname().is_sameas("option"))
+        else if (iter.value() == "option")
         {
             if (auto prop = node->get_prop_ptr(prop_proportion); prop)
             {
@@ -585,7 +585,7 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
 
         // Finally, process names that are unique to XRC/ImportXML
 
-        if (iter.cname().is_sameas("orient"))
+        if (iter.value() == "orient")
         {
             prop = node->get_prop_ptr(prop_orientation);
             if (prop)
@@ -593,15 +593,15 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
                 prop->set_value(iter.text().as_string());
             }
         }
-        else if (iter.cname().is_sameas("border"))
+        else if (iter.value() == "border")
         {
             node->prop_set_value(prop_border_size, iter.text().as_string());
         }
-        else if (iter.cname().is_sameas("selection") && node->isGen(gen_wxChoice))
+        else if (iter.value() == "selection" && node->isGen(gen_wxChoice))
         {
             node->prop_set_value(prop_selection_int, iter.text().as_int());
         }
-        else if (iter.cname().is_sameas("selected"))
+        else if (iter.value() == "selected")
         {
             if (node->isGen(gen_oldbookpage))
                 node->prop_set_value(prop_select, iter.text().as_bool());
@@ -610,15 +610,15 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
                 node->prop_set_value(prop_checked, iter.text().as_bool());
             }
         }
-        else if (iter.cname().is_sameas("enabled"))
+        else if (iter.value() == "enabled")
         {
             if (!iter.text().as_bool())
                 node->prop_set_value(prop_disabled, true);
         }
-        else if (iter.cname().is_sameas("subclass"))
+        else if (iter.value() == "subclass")
         {
             // wxFormBuilder and XRC use the same name, but but it has different meanings.
-            auto value = iter.text().as_cview();
+            auto value = iter.text().as_sview();
             if (value.empty())
                 continue;
             if (value.contains(";"))
@@ -645,29 +645,29 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
                 node->prop_set_value(prop_derived_class, value);
             }
         }
-        else if (iter.cname().is_sameas("creating_code"))
+        else if (iter.value() == "creating_code")
         {
             // TODO: [KeyWorks - 12-09-2021] This consists of macros that allow the user to override one or more macros with
             // their own parameter.
         }
-        else if (iter.cname().is_sameas("flag"))
+        else if (iter.value() == "flag")
         {
             if (node->isGen(gen_sizeritem) || node->isGen(gen_gbsizeritem))
                 HandleSizerItemProperty(iter, node, parent);
             else if (!node->isGen(gen_spacer))
             {  // spacer's don't use alignment or border styles
-                MSG_INFO(ttlib::cstr() << iter.cname() << " not supported for " << node->DeclName());
+                MSG_INFO(ttlib::cstr() << iter.name() << " not supported for " << node->DeclName());
             }
         }
-        else if (iter.cname().is_sameas("handler"))
+        else if (iter.name() == "handler")
         {
             ProcessHandler(iter, node);
         }
-        else if (iter.cname().is_sameas("exstyle") && node->isGen(gen_wxDialog))
+        else if (iter.name() == "exstyle" && node->isGen(gen_wxDialog))
         {
             node->prop_set_value(prop_extra_style, iter.text().as_string());
         }
-        else if (iter.cname().is_sameas("cellpos"))
+        else if (iter.name() == "cellpos")
         {
             ttlib::multistr mstr(iter.text().as_string(), ',');
             if (mstr.size())
@@ -678,7 +678,7 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
                     node->prop_set_value(prop_row, mstr[1]);
             }
         }
-        else if (iter.cname().is_sameas("cellspan"))
+        else if (iter.name() == "cellspan")
         {
             ttlib::multistr mstr(iter.text().as_string(), ',');
             if (mstr.size())
@@ -689,7 +689,7 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
                     node->prop_set_value(prop_colspan, mstr[1]);
             }
         }
-        else if (iter.cname().is_sameas("size") && node->isGen(gen_spacer))
+        else if (iter.name() == "size" && node->isGen(gen_spacer))
         {
             ttlib::multistr mstr(iter.text().as_string(), ',');
             if (mstr.size())
@@ -700,17 +700,17 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
                     node->prop_set_value(prop_height, mstr[1]);
             }
         }
-        else if (iter.cname().is_sameas("centered") && node->isGen(gen_wxDialog))
+        else if (iter.name() == "centered" && node->isGen(gen_wxDialog))
         {
             return;  // we always center dialogs
         }
-        else if (iter.cname().is_sameas("focused") && node->isGen(gen_wxTreeCtrl))
+        else if (iter.name() == "focused" && node->isGen(gen_wxTreeCtrl))
         {
             return;  // since we don't add anything to a wxTreeCtrl, we can't set something as the focus
         }
         else
         {
-            MSG_INFO(ttlib::cstr() << "Unrecognized property: " << iter.cname() << " for " << node->DeclName());
+            MSG_INFO(ttlib::cstr() << "Unrecognized property: " << iter.name() << " for " << node->DeclName());
         }
     }
 }
@@ -720,7 +720,7 @@ void ImportXML::ProcessContent(const pugi::xml_node& xml_obj, Node* node)
     ttlib::cstr choices;
     for (auto& iter: xml_obj.children())
     {
-        if (iter.cname().is_sameas("item"))
+        if (iter.name() == "item")
         {
             auto child = iter.child_as_cstr();
             child.Replace("\"", "\\\"", true);
@@ -739,11 +739,11 @@ void ImportXML::ProcessNotebookTabs(const pugi::xml_node& xml_obj, Node* /* node
     m_notebook_tabs.clear();
     for (auto& iter: xml_obj.children())
     {
-        if (iter.cname().is_sameas("tab"))
+        if (iter.name() == "tab")
         {
             if (!iter.attribute("window").empty())
             {
-                m_notebook_tabs[iter.attribute("window").as_string()] = iter.child_as_cstr();
+                m_notebook_tabs[iter.attribute("window").as_std_str()] = iter.child_as_cstr();
             }
         }
     }

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -301,8 +301,8 @@ void ImportXML::ProcessStyle(pugi::xml_node& xml_prop, Node* node, NodeProperty*
         style.clear();
         for (auto& iter: mstr)
         {
-            if (iter.starts_with("wxLC_ICON") || iter.starts_with("wxLC_SMALL_ICON") ||
-                iter.starts_with("wxLC_LIST") || iter.starts_with("wxLC_REPORT"))
+            if (iter.starts_with("wxLC_ICON") || iter.starts_with("wxLC_SMALL_ICON") || iter.starts_with("wxLC_LIST") ||
+                iter.starts_with("wxLC_REPORT"))
             {
                 node->prop_set_value(prop_mode, iter);
             }

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -894,7 +894,7 @@ GenEnum::GenName ImportXML::MapClassName(std::string_view name) const
 }
 
 // clang-format off
-std::unordered_map<std::string, std::string> s_map_old_events = {
+std::map<std::string_view, std::string_view, std::less<>> s_map_old_events = {
 
 
     { "wxEVT_COMMAND_BUTTON_CLICKED",          "wxEVT_BUTTON" },
@@ -928,9 +928,9 @@ std::unordered_map<std::string, std::string> s_map_old_events = {
 };
 // clang-format on
 
-ttlib::cview ImportXML::GetCorrectEventName(ttlib::cview name)
+ttlib::sview ImportXML::GetCorrectEventName(ttlib::sview name)
 {
-    if (auto result = s_map_old_events.find(name.c_str()); result != s_map_old_events.end())
+    if (auto result = s_map_old_events.find(name); result != s_map_old_events.end())
     {
         return result->second;
     }

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -301,8 +301,8 @@ void ImportXML::ProcessStyle(pugi::xml_node& xml_prop, Node* node, NodeProperty*
         style.clear();
         for (auto& iter: mstr)
         {
-            if (iter.is_sameprefix("wxLC_ICON") || iter.is_sameprefix("wxLC_SMALL_ICON") ||
-                iter.is_sameprefix("wxLC_LIST") || iter.is_sameprefix("wxLC_REPORT"))
+            if (iter.starts_with("wxLC_ICON") || iter.starts_with("wxLC_SMALL_ICON") ||
+                iter.starts_with("wxLC_LIST") || iter.starts_with("wxLC_REPORT"))
             {
                 node->prop_set_value(prop_mode, iter);
             }

--- a/src/import/import_xml.h
+++ b/src/import/import_xml.h
@@ -27,7 +27,7 @@ public:
 
     // This will check for an obsolete event name, and if found, it will return the 3.x
     // version of the name. Otherwise, it returns name unmodified.
-    static ttlib::cview GetCorrectEventName(ttlib::cview name);
+    static ttlib::sview GetCorrectEventName(ttlib::sview name);
 
 protected:
     std::optional<pugi::xml_document> LoadDocFile(const ttString& file);

--- a/src/import/import_xml.h
+++ b/src/import/import_xml.h
@@ -51,7 +51,7 @@ protected:
     pugi::xml_document m_docOut;
     ttString m_importProjectFile;
     NodeSharedPtr m_project;
-    std::map<std::string, std::string> m_notebook_tabs;
+    std::map<std::string, std::string, std::less<>> m_notebook_tabs;
 
     std::set<ttlib::cstr> m_errors;
 };

--- a/src/internal/msg_logging.cpp
+++ b/src/internal/msg_logging.cpp
@@ -30,7 +30,7 @@ void MsgLogging::CloseLogger()
         m_msgFrame->Close(true);
 }
 
-void MsgLogging::AddInfoMsg(ttlib::cview msg)
+void MsgLogging::AddInfoMsg(ttlib::sview msg)
 {
     if (wxGetApp().isMainFrameClosing())
         return;
@@ -55,7 +55,7 @@ void MsgLogging::AddInfoMsg(ttlib::cview msg)
         frame->SetRightStatusField(msg);
 }
 
-void MsgLogging::AddEventMsg(ttlib::cview msg)
+void MsgLogging::AddEventMsg(ttlib::sview msg)
 {
     if (wxGetApp().isMainFrameClosing())
         return;
@@ -80,7 +80,7 @@ void MsgLogging::AddEventMsg(ttlib::cview msg)
         frame->SetRightStatusField(ttlib::cstr("Event: ") << msg);
 }
 
-void MsgLogging::AddWarningMsg(ttlib::cview msg)
+void MsgLogging::AddWarningMsg(ttlib::sview msg)
 {
     if (wxGetApp().isMainFrameClosing())
         return;
@@ -109,7 +109,7 @@ void MsgLogging::AddWarningMsg(ttlib::cview msg)
         frame->SetRightStatusField(ttlib::cstr("Warning: ") << msg);
 }
 
-void MsgLogging::AddErrorMsg(ttlib::cview msg)
+void MsgLogging::AddErrorMsg(ttlib::sview msg)
 {
     if (wxGetApp().isMainFrameClosing())
         return;

--- a/src/internal/msg_logging.h
+++ b/src/internal/msg_logging.h
@@ -32,10 +32,10 @@ public:
     void ShowLogger();
     void CloseLogger();
 
-    void AddInfoMsg(ttlib::cview msg);
-    void AddEventMsg(ttlib::cview msg);
-    void AddWarningMsg(ttlib::cview msg);
-    void AddErrorMsg(ttlib::cview msg);
+    void AddInfoMsg(ttlib::sview msg);
+    void AddEventMsg(ttlib::sview msg);
+    void AddWarningMsg(ttlib::sview msg);
+    void AddErrorMsg(ttlib::sview msg);
 
     void OnNodeSelected();
 

--- a/src/internal/msgframe.cpp
+++ b/src/internal/msgframe.cpp
@@ -97,7 +97,7 @@ MsgFrame::MsgFrame(std::vector<ttlib::cstr>* pMsgs, bool* pDestroyed, wxWindow* 
     wxPersistentRegisterAndRestore(this, "MsgWindow");
 }
 
-void MsgFrame::AddWarningMsg(ttlib::cview msg)
+void MsgFrame::AddWarningMsg(ttlib::sview msg)
 {
     if (wxGetApp().GetPrefs().flags & App::PREFS_MSG_WARNING)
     {
@@ -108,7 +108,7 @@ void MsgFrame::AddWarningMsg(ttlib::cview msg)
     }
 }
 
-void MsgFrame::Add_wxWarningMsg(ttlib::cview msg)
+void MsgFrame::Add_wxWarningMsg(ttlib::sview msg)
 {
     if (wxGetApp().GetPrefs().flags & App::PREFS_MSG_WARNING)
     {
@@ -119,7 +119,7 @@ void MsgFrame::Add_wxWarningMsg(ttlib::cview msg)
     }
 }
 
-void MsgFrame::Add_wxInfoMsg(ttlib::cview msg)
+void MsgFrame::Add_wxInfoMsg(ttlib::sview msg)
 {
     if (wxGetApp().GetPrefs().flags & App::PREFS_MSG_INFO)
     {
@@ -130,7 +130,7 @@ void MsgFrame::Add_wxInfoMsg(ttlib::cview msg)
     }
 }
 
-void MsgFrame::AddErrorMsg(ttlib::cview msg)
+void MsgFrame::AddErrorMsg(ttlib::sview msg)
 {
     // Note that we always display error messages
 
@@ -140,7 +140,7 @@ void MsgFrame::AddErrorMsg(ttlib::cview msg)
     m_textCtrl->AppendText(msg.wx_str());
 }
 
-void MsgFrame::Add_wxErrorMsg(ttlib::cview msg)
+void MsgFrame::Add_wxErrorMsg(ttlib::sview msg)
 {
     // Note that we always display error messages
 

--- a/src/internal/msgframe.cpp
+++ b/src/internal/msgframe.cpp
@@ -44,35 +44,35 @@ MsgFrame::MsgFrame(std::vector<ttlib::cstr>* pMsgs, bool* pDestroyed, wxWindow* 
 {
     for (auto& iter: *m_pMsgs)
     {
-        if (iter.is_sameprefix("Error:"))
+        if (iter.starts_with("Error:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxRED));
             m_textCtrl->AppendText("Error: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
             m_textCtrl->AppendText(iter.view_stepover().wx_str());
         }
-        if (iter.is_sameprefix("wxError:"))
+        if (iter.starts_with("wxError:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxRED));
             m_textCtrl->AppendText("wxError: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
             m_textCtrl->AppendText(iter.view_stepover().wx_str());
         }
-        else if (iter.is_sameprefix("Warning:"))
+        else if (iter.starts_with("Warning:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLUE));
             m_textCtrl->AppendText("Warning: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
             m_textCtrl->AppendText(iter.view_stepover().wx_str());
         }
-        else if (iter.is_sameprefix("wxWarning:"))
+        else if (iter.starts_with("wxWarning:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLUE));
             m_textCtrl->AppendText("wxWarning: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
             m_textCtrl->AppendText(iter.view_stepover().wx_str());
         }
-        else if (iter.is_sameprefix("wxInfo:"))
+        else if (iter.starts_with("wxInfo:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxCYAN));
             m_textCtrl->AppendText("wxInfo: ");

--- a/src/internal/msgframe.h
+++ b/src/internal/msgframe.h
@@ -18,16 +18,16 @@ public:
 
     void OnNodeSelected();
 
-    void AddErrorMsg(ttlib::cview msg);
-    void Add_wxErrorMsg(ttlib::cview msg);
+    void AddErrorMsg(ttlib::sview msg);
+    void Add_wxErrorMsg(ttlib::sview msg);
 
-    void AddWarningMsg(ttlib::cview msg);
-    void Add_wxWarningMsg(ttlib::cview msg);
+    void AddWarningMsg(ttlib::sview msg);
+    void Add_wxWarningMsg(ttlib::sview msg);
 
-    void AddInfoMsg(ttlib::cview msg) { m_textCtrl->AppendText(msg.wx_str()); };
-    void AddEventMsg(ttlib::cview msg) { m_textCtrl->AppendText(msg.wx_str()); };
+    void AddInfoMsg(ttlib::sview msg) { m_textCtrl->AppendText(msg.wx_str()); };
+    void AddEventMsg(ttlib::sview msg) { m_textCtrl->AppendText(msg.wx_str()); };
 
-    void Add_wxInfoMsg(ttlib::cview msg);
+    void Add_wxInfoMsg(ttlib::sview msg);
 
 protected:
     void UpdateNodeInfo();

--- a/src/lambdas.cpp
+++ b/src/lambdas.cpp
@@ -17,7 +17,7 @@
 void ExpandLambda(ttlib::cstr& lambda)
 {
     lambda.LeftTrim();
-    if (lambda.is_sameprefix("@@"))
+    if (lambda.starts_with("@@"))
     {
         lambda.erase(0, 2);
     }

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -286,7 +286,7 @@ ttlib::cstr App::GetBundleFuncName(const ttlib::cstr& description)
 {
     ttlib::cstr name;
 
-    for (auto& form: m_project->GetChildNodePtrs())
+    for (const auto& form: m_project->GetChildNodePtrs())
     {
         if (form->isGen(gen_Images))
         {
@@ -297,9 +297,9 @@ ttlib::cstr App::GetBundleFuncName(const ttlib::cstr& description)
                 return name;
             }
 
-            for (auto& iter: form->GetChildNodePtrs())
+            for (const auto& child: form->GetChildNodePtrs())
             {
-                ttlib::multiview form_image_parts(iter->prop_as_string(prop_bitmap), BMP_PROP_SEPARATOR, tt::TRIM::both);
+                ttlib::multiview form_image_parts(child->prop_as_string(prop_bitmap), BMP_PROP_SEPARATOR, tt::TRIM::both);
                 if (form_image_parts.size() < 2)
                 {
                     continue;

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -250,8 +250,8 @@ int App::OnExit()
 
 wxImage App::GetImage(const ttlib::cstr& description)
 {
-    if (description.is_sameprefix("Embed;") || description.is_sameprefix("XPM;") || description.is_sameprefix("Header;") ||
-        description.is_sameprefix("Art;"))
+    if (description.starts_with("Embed;") || description.starts_with("XPM;") || description.starts_with("Header;") ||
+        description.starts_with("Art;"))
     {
         return m_pjtSettings->GetPropertyBitmap(description);
     }
@@ -261,8 +261,8 @@ wxImage App::GetImage(const ttlib::cstr& description)
 
 wxBitmapBundle App::GetBitmapBundle(const ttlib::cstr& description, Node* node)
 {
-    if (description.is_sameprefix("Embed;") || description.is_sameprefix("XPM;") || description.is_sameprefix("Header;") ||
-        description.is_sameprefix("Art;") || description.is_sameprefix("SVG;"))
+    if (description.starts_with("Embed;") || description.starts_with("XPM;") || description.starts_with("Header;") ||
+        description.starts_with("Art;") || description.starts_with("SVG;"))
     {
         return m_pjtSettings->GetPropertyBitmapBundle(description, node);
     }

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1653,11 +1653,12 @@ Node* MainFrame::FindChildSizerItem(Node* node, bool include_splitter)
         return node;
     else
     {
-        for (size_t i = 0; i < node->GetChildCount(); ++i)
+        for (const auto& child: node->GetChildNodePtrs())
         {
-            auto result = FindChildSizerItem(node->GetChild(i), include_splitter);
-            if (result)
+            if (auto result = FindChildSizerItem(child, include_splitter); result)
+            {
                 return result;
+            }
         }
     }
 
@@ -1708,15 +1709,15 @@ void MainFrame::OnCodeCompare(wxCommandEvent& WXUNUSED(event))
 
 Node* FindChildNode(Node* node, GenEnum::GenName name)
 {
-    for (size_t idx_child = 0; idx_child < node->GetChildCount(); ++idx_child)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        if (node->GetChild(idx_child)->isGen(name))
+        if (child->isGen(name))
         {
-            return node->GetChild(idx_child);
+            return child.get();
         }
-        else if (node->GetChild(idx_child)->GetChildCount() > 0)
+        else if (child->GetChildCount() > 0)
         {
-            if (auto child_node = FindChildNode(node->GetChild(idx_child), name); child_node)
+            if (auto child_node = FindChildNode(child.get(), name); child_node)
             {
                 return child_node;
             }

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1393,7 +1393,7 @@ void MainFrame::OnToggleExpandLayout(wxCommandEvent&)
     if (!wasExpanded)
     {
         auto alignment = m_selected_node->get_prop_ptr(prop_alignment);
-        if (alignment && alignment->as_cview().size())
+        if (alignment && alignment->as_string().size())
         {
             // All alignment flags are invalid if wxEXPAND is set
             ModifyProperty(alignment, "");
@@ -1441,9 +1441,9 @@ void MainFrame::ToggleBorderFlag(Node* node, int border)
     ModifyProperty(propFlag, value);
 }
 
-void MainFrame::ModifyProperty(NodeProperty* prop, ttlib::cview value)
+void MainFrame::ModifyProperty(NodeProperty* prop, ttlib::sview value)
 {
-    if (prop && value != prop->as_cview())
+    if (prop && value != prop->as_string())
     {
         PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
     }

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -168,6 +168,10 @@ public:
     // Search for a sizer to move the node into.
     // Set include_splitter to treat a splitter window like a sizer.
     Node* FindChildSizerItem(Node* node, bool include_splitter = false);
+    Node* FindChildSizerItem(const NodeSharedPtr& node, bool include_splitter = false)
+    {
+        return FindChildSizerItem(node.get(), include_splitter);
+    }
 
     // This is the only variable length field, and therefore can hold the most text
     void SetRightStatusField(const ttlib::cstr text) { SetStatusField(text, m_posRightStatusField); }

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -145,7 +145,7 @@ public:
     void RemoveNode(Node* node, bool isCutMode);
 
     // Call this MainFrame version if you don't have access to a node.
-    void ModifyProperty(NodeProperty* prop, ttlib::cview value);
+    void ModifyProperty(NodeProperty* prop, ttlib::sview value);
 
     void ChangeAlignment(Node* node, int align, bool vertical);
 

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -61,10 +61,9 @@ void MockupContent::CreateAllGenerators()
     if (form->isGen(gen_wxWizard))
     {
         m_wizard = new MockupWizard(this, form);
-        for (size_t i = 0; i < form->GetChildCount(); i++)
+        for (const auto& child: form->GetChildNodePtrs())
         {
-            auto child = form->GetChild(i);
-            CreateChildren(child, m_wizard, m_wizard);
+            CreateChildren(child.get(), m_wizard, m_wizard);
         }
 
         m_wizard->AllChildrenAdded();
@@ -128,10 +127,9 @@ void MockupContent::CreateAllGenerators()
 
         else
         {
-            for (size_t i = 0; i < form->GetChildCount(); i++)
+            for (const auto& child: form->GetChildNodePtrs())
             {
-                auto child = form->GetChild(i);
-                CreateChildren(child, this, this, m_parent_sizer);
+                CreateChildren(child.get(), this, this, m_parent_sizer);
             }
         }
     }

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -542,7 +542,7 @@ void MockupContent::OnNodeSelected(Node* node)
                 if (child->isGen(gen_BookPage))
                 {
                     bool is_node_found { false };
-                    for (auto& grand_child: child->GetChildNodePtrs())
+                    for (const auto& grand_child: child->GetChildNodePtrs())
                     {
                         if (grand_child.get() == node)
                         {

--- a/src/newdialogs/new_common.cpp
+++ b/src/newdialogs/new_common.cpp
@@ -59,7 +59,7 @@ void UpdateFormClass(Node* form_node)
 bool IsClassNameUnique(wxString classname)
 {
     auto new_classname = classname.utf8_string();
-    for (auto& iter: wxGetApp().GetProject()->GetChildNodePtrs())
+    for (const auto& iter: wxGetApp().GetProject()->GetChildNodePtrs())
     {
         if (iter.get()->prop_as_string(prop_class_name).is_sameas(new_classname))
         {

--- a/src/nodes/category.h
+++ b/src/nodes/category.h
@@ -17,7 +17,7 @@ using namespace GenEnum;
 class NodeCategory
 {
 public:
-    NodeCategory(ttlib::cview name) { m_name = name; }
+    NodeCategory(std::string_view name) { m_name.assign(name.data(), name.size()); }
 
     const wxString& GetName() { return m_name; }
     ttlib::cstr getName() { return ttlib::cstr(m_name.wx_str()); }
@@ -38,7 +38,7 @@ public:
         return m_events.at(index);
     }
 
-    NodeCategory& AddCategory(ttlib::cview name) { return m_categories.emplace_back(name); }
+    NodeCategory& AddCategory(std::string_view name) { return m_categories.emplace_back(name); }
     std::vector<NodeCategory>& GetCategories() { return m_categories; }
 
     size_t GetPropNameCount() const { return m_prop_names.size(); }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -980,23 +980,12 @@ size_t Node::GetNodeSize() const
         size += iter.GetPropSize();
     }
 
-    // BUGBUG: [KeyWorks - 05-17-2022] This is a very inaccurate way to get node size...
-
-#if 0
-    for (auto& iter: m_events)
+    for (auto& iter: m_map_events)
     {
-        size += iter.GetEventSize();
+        size += iter.second.GetEventSize();
     }
-#endif
-
-    // Add the size of our maps
 
     size += (m_prop_indices.size() * (sizeof(size_t) * 2));
-    // size += (m_event_map.size() * (sizeof(std::string) + sizeof(size_t)));
-
-    // BUGBUG: [KeyWorks - 05-17-2022] This isn't accurate -- need to iterate through the map and add the length of all the
-    // strings in use
-    size += (m_map_events.size() * (sizeof(NodeEvent)));
 
     return size;
 }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -65,9 +65,9 @@ NodeProperty* Node::get_prop_ptr(PropName name)
         return nullptr;
 }
 
-NodeEvent* Node::GetEvent(ttlib::cview name)
+NodeEvent* Node::GetEvent(ttlib::sview name)
 {
-    if (auto it = m_event_map.find(name.c_str()); it != m_event_map.end())
+    if (auto it = m_event_map.find(std::string(name)); it != m_event_map.end())
         return &m_events[it->second];
     else
         return nullptr;

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -30,6 +30,7 @@ struct ImageBundle;
 
 class Node;
 using NodeSharedPtr = std::shared_ptr<Node>;
+using NodeMapEvents = std::unordered_map<std::string, NodeEvent, str_view_hash, std::equal_to<>>;
 
 using namespace GenEnum;
 
@@ -53,10 +54,9 @@ public:
     NodeProperty* get_prop_ptr(PropName name);
 
     NodeEvent* GetEvent(ttlib::sview name);
-    NodeEvent* GetEvent(size_t index);
+    NodeMapEvents& GetMapEvents() { return m_map_events; }
 
     auto GetPropertyCount() const { return m_properties.size(); }
-    auto GetEventCount() const { return m_events.size(); }
     size_t GetInUseEventCount() const;
 
     // Equivalent to AddChild(child); child->SetParent(this);
@@ -208,7 +208,7 @@ public:
     std::vector<NodeProperty>& get_props_vector() { return m_properties; }
 
     NodeProperty* AddNodeProperty(PropDeclaration* info);
-    NodeEvent* AddNodeEvent(const NodeEventInfo* info);
+    void AddNodeEvent(const NodeEventInfo* info);
     void CreateDoc(pugi::xml_document& doc);
 
     // This creates an orphaned node -- it is the caller's responsibility to hook it up with
@@ -225,16 +225,16 @@ public:
 
     // This will modify the property and fire a EVT_NodePropChange event if the property
     // actually changed
-    void ModifyProperty(PropName name, ttlib::cview value);
+    void ModifyProperty(PropName name, ttlib::sview value);
 
     // This will modify the property and fire a EVT_NodePropChange event
-    void ModifyProperty(ttlib::cview name, ttlib::cview value);
+    void ModifyProperty(ttlib::sview name, ttlib::sview value);
 
     // This will modify the property and fire a EVT_NodePropChange event
-    void ModifyProperty(ttlib::cview name, int value);
+    void ModifyProperty(ttlib::sview name, int value);
 
     // This will modify the property and fire a EVT_NodePropChange event
-    void ModifyProperty(NodeProperty* prop, ttlib::cview value);
+    void ModifyProperty(NodeProperty* prop, ttlib::sview value);
 
     // This will modify the property and fire a EVT_NodePropChange event
     void ModifyProperty(NodeProperty* prop, int value);
@@ -267,6 +267,8 @@ public:
     // non-empty value.
     std::vector<NodeProperty*> FindAllChildProperties(PropName name);
 
+    void CopyEventsFrom(Node*);
+
 protected:
     void PostProcessBook(Node* book_node);
     void PostProcessPage(Node* page_node);
@@ -287,12 +289,14 @@ private:
     std::vector<NodeProperty> m_properties;
     std::map<PropName, size_t> m_prop_indices;
 
-    std::vector<NodeEvent> m_events;
-    std::unordered_map<std::string, size_t> m_event_map;
+    // using NodeMapEvents = std::unordered_map<std::string, NodeEvent, str_view_hash, std::equal_to<>>;
+    std::unordered_map<std::string, NodeEvent, str_view_hash, std::equal_to<>> m_map_events;
 
     std::vector<NodeSharedPtr> m_children;
     NodeDeclaration* m_declaration;
 };
+
+using NodeMapEvents = std::unordered_map<std::string, NodeEvent, str_view_hash, std::equal_to<>>;
 
 // Same as wxGetApp() only this returns a reference to the project node
 Node& wxGetProject();

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -70,10 +70,11 @@ public:
 
     // Returns the child's position or GetChildCount() in case of not finding it
     size_t GetChildPosition(Node* node);
+    size_t GetChildPosition(const NodeSharedPtr& node) { return GetChildPosition(node.get()); }
     bool ChangeChildPosition(NodeSharedPtr node, size_t pos);
 
-    void RemoveChild(NodeSharedPtr node);
     void RemoveChild(Node* node);
+    void RemoveChild(const NodeSharedPtr& node) { RemoveChild(node.get()); }
     void RemoveChild(size_t index);
     void RemoveAllChildren() { m_children.clear(); }
 
@@ -85,7 +86,7 @@ public:
 
     bool IsChildAllowed(Node* child);
     bool IsChildAllowed(NodeDeclaration* child);
-    bool IsChildAllowed(NodeSharedPtr child) { return IsChildAllowed(child.get()); }
+    bool IsChildAllowed(const NodeSharedPtr& child) { return IsChildAllowed(child->GetNodeDeclaration()); }
 
     auto gen_type() const { return m_declaration->gen_type(); }
 
@@ -135,7 +136,7 @@ public:
     // Finds the parent form and returns the value of the it's property "class_name"
     const ttlib::cstr& get_form_name();
 
-    auto GetNodeDeclaration() { return m_declaration; }
+    NodeDeclaration* GetNodeDeclaration() { return m_declaration; }
 
     // Returns true if the property exists, has a value (!= wxDefaultSize, !=
     // wxDefaultPosition, or non-sepcified bitmap)
@@ -251,7 +252,7 @@ public:
     void CollectUniqueNames(std::unordered_set<std::string>& name_set, Node* cur_node);
 
     int_t FindInsertionPos(Node* child) const;
-    int_t FindInsertionPos(NodeSharedPtr child) const { return FindInsertionPos(child.get()); }
+    int_t FindInsertionPos(const NodeSharedPtr& child) const { return FindInsertionPos(child.get()); }
 
     // Currently only called in debug builds, but available for release builds should we need it
     size_t GetNodeSize() const;
@@ -268,15 +269,10 @@ public:
     std::vector<NodeProperty*> FindAllChildProperties(PropName name);
 
     void CopyEventsFrom(Node*);
+    void CopyEventsFrom(const NodeSharedPtr& node) { return CopyEventsFrom(node.get()); }
 
 protected:
-    void PostProcessBook(Node* book_node);
-    void PostProcessPage(Node* page_node);
-
     void FindAllChildProperties(std::vector<NodeProperty*>& list, PropName name);
-
-    // wxPanel only, not FormPanel
-    void PostProcessPanel(Node* panel_node);
 
 private:
     NodeSharedPtr m_parent;

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -52,7 +52,7 @@ public:
 
     NodeProperty* get_prop_ptr(PropName name);
 
-    NodeEvent* GetEvent(ttlib::cview name);
+    NodeEvent* GetEvent(ttlib::sview name);
     NodeEvent* GetEvent(size_t index);
 
     auto GetPropertyCount() const { return m_properties.size(); }

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -26,7 +26,7 @@ NodeCreator::~NodeCreator()
     }
 }
 
-NodeDeclaration* NodeCreator::GetNodeDeclaration(ttlib::cview className)
+NodeDeclaration* NodeCreator::GetNodeDeclaration(ttlib::sview className)
 {
     auto result = rmap_GenNames.find(className);
     ASSERT_MSG(result != rmap_GenNames.end(), ttlib::cstr()

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -79,18 +79,17 @@ NodeSharedPtr NodeCreator::NewNode(NodeDeclaration* node_decl)
 size_t NodeCreator::CountChildrenWithSameType(Node* parent, GenType type)
 {
     size_t count = 0;
-    size_t numChildren = parent->GetChildCount();
-    for (size_t i = 0; i < numChildren; ++i)
+    for (const auto& child: parent->GetChildNodePtrs())
     {
-        if (type == parent->GetChild(i)->gen_type())
+        if (type == child->gen_type())
             ++count;
 
         // treat type-sizer and type_gbsizer as the same since forms and contains can only have one of them as the top level
         // sizer.
 
-        else if (type == type_sizer && parent->GetChild(i)->gen_type() == type_gbsizer)
+        else if (type == type_sizer && child->gen_type() == type_gbsizer)
             ++count;
-        else if (type == type_gbsizer && parent->GetChild(i)->gen_type() == type_sizer)
+        else if (type == type_gbsizer && child->gen_type() == type_sizer)
             ++count;
     }
 

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -28,12 +28,13 @@ NodeCreator::~NodeCreator()
 
 NodeDeclaration* NodeCreator::GetNodeDeclaration(ttlib::sview className)
 {
-    auto result = rmap_GenNames.find(className);
-    ASSERT_MSG(result != rmap_GenNames.end(), ttlib::cstr()
-                                                  << "Attempt to get non-existant node declaration for " << className);
-    if (result == rmap_GenNames.end())
-        return nullptr;
-    return m_a_declarations[result->second];
+    if (auto result = rmap_GenNames.find(className); result != rmap_GenNames.end())
+    {
+        return m_a_declarations[result->second];
+    }
+
+    FAIL_MSG(ttlib::cstr() << "Attempt to get non-existant node declaration for " << className);
+    return nullptr;
 }
 
 NodeSharedPtr NodeCreator::NewNode(NodeDeclaration* node_decl)
@@ -216,16 +217,15 @@ NodeSharedPtr NodeCreator::CreateNode(GenName name, Node* parent)
 }
 
 // Called when the GenName isn't availalble
-NodeSharedPtr NodeCreator::CreateNode(ttlib::cview name, Node* parent)
+NodeSharedPtr NodeCreator::CreateNode(ttlib::sview name, Node* parent)
 {
-    auto result = rmap_GenNames.find(name);
-    if (result == rmap_GenNames.end())
+    if (auto result = rmap_GenNames.find(name); result != rmap_GenNames.end())
     {
-        FAIL_MSG(ttlib::cstr() << "No component definition for " << name);
-        return {};
+        return CreateNode(result->second, parent);
     }
 
-    return CreateNode(result->second, parent);
+    FAIL_MSG(ttlib::cstr() << "No component definition for " << name);
+    return {};
 }
 
 NodeSharedPtr NodeCreator::MakeCopy(Node* node)
@@ -246,6 +246,9 @@ NodeSharedPtr NodeCreator::MakeCopy(Node* node)
             copyProp->set_value(iter.as_string());
     }
 
+    copyObj->CopyEventsFrom(node);
+
+#if 0
     auto count = node->GetEventCount();
     for (size_t i = 0; i < count; i++)
     {
@@ -255,14 +258,14 @@ NodeSharedPtr NodeCreator::MakeCopy(Node* node)
         if (copyEvent)
             copyEvent->set_value(event->get_value());
     }
+#endif
 
-    count = node->GetChildCount();
-    for (size_t i = 0; i < count; i++)
+    for (auto& child: node->GetChildNodePtrs())
     {
-        auto childCopy = MakeCopy(node->GetChild(i));
-        ASSERT(childCopy);
-        if (childCopy)
+        if (auto childCopy = MakeCopy(child.get()); childCopy)
+        {
             copyObj->Adopt(childCopy);
+        }
     }
 
     return copyObj;

--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -12,6 +12,8 @@
 #include <set>
 #include <unordered_set>
 
+#include "hash_map.h"  // Find std::string_view key in std::unordered_map
+
 #include "node_decl.h"   // NodeDeclaration class
 #include "node_types.h"  // NodeType -- Class for storing component types and allowable child count
 #include "prop_decl.h"   // PropChildDeclaration and PropDeclaration classes
@@ -40,7 +42,7 @@ public:
     NodeSharedPtr CreateNode(GenName name, Node* parent);
 
     // Only creates the node if the parent allows it as a child
-    NodeSharedPtr CreateNode(ttlib::cview name, Node* parent);
+    NodeSharedPtr CreateNode(ttlib::sview name, Node* parent);
 
     // Creates an orphaned node.
     NodeSharedPtr NewNode(GenEnum::GenName gen_name) { return NewNode(m_a_declarations[gen_name]); }
@@ -66,17 +68,15 @@ public:
 
     void InitGenerators();
 
-    bool IsOldHostType(ttlib::cview old_type) const
-    {
-        return (m_setOldHostTypes.find(old_type.c_str()) != m_setOldHostTypes.end());
-    }
+    bool IsOldHostType(ttlib::sview old_type) const { return m_setOldHostTypes.contains(old_type); }
 
     const NodeDeclarationArray& GetNodeDeclarationArray() const { return m_a_declarations; }
 
     size_t CountChildrenWithSameType(Node* parent, GenType type);
 
 protected:
-    void ParseGeneratorFile(ttlib::cview file);
+    // This must
+    void ParseGeneratorFile(const char* file);
     void ParseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj_info, NodeCategory& category);
 
     NodeType* GetNodeType(GenEnum::GenType type_name) { return &m_a_node_types[static_cast<size_t>(type_name)]; }
@@ -87,7 +87,7 @@ private:
     std::array<NodeDeclaration*, gen_name_array_size> m_a_declarations;
     std::array<NodeType, gen_type_array_size> m_a_node_types;
 
-    std::unordered_set<std::string> m_setOldHostTypes;
+    std::unordered_set<std::string, str_view_hash, std::equal_to<>> m_setOldHostTypes;
 
     std::unordered_map<std::string, int> m_map_constants;
 

--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -52,7 +52,7 @@ public:
     // pointer.
     NodeDeclaration* get_declaration(GenEnum::GenName gen_name) { return m_a_declarations[gen_name]; }
 
-    NodeDeclaration* GetNodeDeclaration(ttlib::cview class_name);
+    NodeDeclaration* GetNodeDeclaration(ttlib::sview class_name);
 
     // This returns the integer value of most wx constants used in various components
     int GetConstantAsInt(const std::string& name, int defValue = 0) const;
@@ -95,7 +95,7 @@ private:
     pugi::xml_document* m_pdoc_interface { nullptr };
 
     // Contains a map to every interface class -- valid only during Initialize()
-    std::map<std::string, pugi::xml_node> m_interfaces;
+    std::map<std::string, pugi::xml_node, std::less<>> m_interfaces;
 };
 
 extern NodeCreator g_NodeCreator;

--- a/src/nodes/node_decl.cpp
+++ b/src/nodes/node_decl.cpp
@@ -11,7 +11,7 @@
 #include "node.h"            // Contains the user-modifiable node
 #include "prop_decl.h"       // PropChildDeclaration and PropDeclaration classes
 
-NodeDeclaration::NodeDeclaration(ttlib::cview class_name, NodeType* type) : m_type(type), m_category(class_name)
+NodeDeclaration::NodeDeclaration(ttlib::sview class_name, NodeType* type) : m_type(type), m_category(class_name)
 {
     m_gen_name = rmap_GenNames[class_name];
     m_gen_type = type->gen_type();
@@ -38,9 +38,9 @@ PropDeclaration* NodeDeclaration::GetPropDeclaration(size_t idx) const
     return nullptr;
 }
 
-NodeEventInfo* NodeDeclaration::GetEventInfo(ttlib::cview name)
+NodeEventInfo* NodeDeclaration::GetEventInfo(ttlib::sview name)
 {
-    if (auto it = m_events.find(name.c_str()); it != m_events.end())
+    if (auto it = m_events.find(name); it != m_events.end())
         return it->second.get();
 
     return nullptr;

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -33,7 +33,7 @@ namespace pugi
 class NodeDeclaration
 {
 public:
-    NodeDeclaration(ttlib::cview class_name, NodeType* type);
+    NodeDeclaration(ttlib::sview class_name, NodeType* type);
     ~NodeDeclaration();
 
     NodeCategory& GetCategory() { return m_category; }
@@ -43,7 +43,7 @@ public:
 
     PropDeclaration* GetPropDeclaration(size_t idx) const;
 
-    NodeEventInfo* GetEventInfo(ttlib::cview name);
+    NodeEventInfo* GetEventInfo(ttlib::sview name);
     const NodeEventInfo* GetEventInfo(size_t idx) const;
 
     PropDeclarationMap& GetPropInfoMap() { return m_properties; }
@@ -56,7 +56,7 @@ public:
     bool isType(GenType type) const noexcept { return (type == m_gen_type); }
     bool isGen(GenName name) const noexcept { return (name == m_gen_name); }
 
-    ttlib::cview DeclName() const noexcept { return ttlib::cview(m_name); }
+    ttlib::sview DeclName() const noexcept { return ttlib::sview(m_name); }
 
     size_t AddBaseClass(NodeDeclaration* base)
     {
@@ -105,7 +105,7 @@ private:
     NodeCategory m_category;
 
     PropDeclarationMap m_properties;  // std::map<std::string, PropDeclarationPtr>
-    std::map<std::string, std::unique_ptr<NodeEventInfo>> m_events;
+    std::map<std::string, std::unique_ptr<NodeEventInfo>, std::less<>> m_events;
 
     std::map<GenEnum::PropName, std::string> m_override_def_values;
     std::set<GenEnum::PropName> m_hide_properties;

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -82,11 +82,11 @@ public:
     void ParseEvents(pugi::xml_node& elem_obj, NodeCategory& category);
 
     const ttlib::cstr& GetGeneratorFlags() { return m_internal_flags; }
-    void SetGeneratorFlags(ttlib::cview flags) { m_internal_flags = flags; }
+    void SetGeneratorFlags(std::string_view flags) { m_internal_flags = flags; }
 
     int_t GetAllowableChildren(GenType child_gen_type) const;
 
-    void SetOverRideDefValue(GenEnum::PropName prop_name, ttlib::cview new_value)
+    void SetOverRideDefValue(GenEnum::PropName prop_name, std::string_view new_value)
     {
         m_override_def_values[prop_name] = new_value;
     }

--- a/src/nodes/node_event.h
+++ b/src/nodes/node_event.h
@@ -12,7 +12,7 @@ class Node;
 class NodeEventInfo
 {
 public:
-    NodeEventInfo(ttlib::cview name, ttlib::cview event_class, ttlib::cview help) :
+    NodeEventInfo(std::string_view name, std::string_view event_class, std::string_view help) :
         m_name(name), m_event_class(event_class), m_help(help)
     {
     }
@@ -32,7 +32,7 @@ class NodeEvent
 public:
     NodeEvent(const NodeEventInfo* info, Node* node) : m_info(info), m_node(node) {}
 
-    void set_value(ttlib::cview value) { m_value = value; }
+    void set_value(std::string_view value) { m_value = value; }
     const ttlib::cstr& get_value() const noexcept { return m_value; }
     const ttlib::cstr& get_name() const noexcept { return m_info->get_name(); }
 

--- a/src/nodes/node_gridbag.cpp
+++ b/src/nodes/node_gridbag.cpp
@@ -23,17 +23,17 @@ void GridBag::Initialize()
     {
         m_max_column = 0;
         m_max_row = 0;
-        for (size_t idx = 0; idx < m_gridbag->GetChildCount(); ++idx)
+        for (const auto& child: m_gridbag->GetChildNodePtrs())
         {
-            auto col = m_gridbag->GetChild(idx)->prop_as_int(prop_column);
-            auto col_span = m_gridbag->GetChild(idx)->prop_as_int(prop_colspan);
+            auto col = child->prop_as_int(prop_column);
+            auto col_span = child->prop_as_int(prop_colspan);
             if (col_span > 1)
                 col += (col_span - 1);
             if (col > m_max_column)
                 m_max_column = col;
 
-            auto row = m_gridbag->GetChild(idx)->prop_as_int(prop_row);
-            auto row_span = m_gridbag->GetChild(idx)->prop_as_int(prop_rowspan);
+            auto row = child->prop_as_int(prop_row);
+            auto row_span = child->prop_as_int(prop_rowspan);
             if (row_span > 1)
                 row += (row_span - 1);
             if (row > m_max_row)
@@ -127,9 +127,9 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
 size_t GridBag::IncrementRows(int row, Node* gbsizer)
 {
     size_t insert_position = tt::npos;
-    for (size_t idx = 0; idx < gbsizer->GetChildCount(); ++idx)
+    for (size_t idx = 0; const auto& child: gbsizer->GetChildNodePtrs())
     {
-        if (gbsizer->GetChild(idx)->prop_as_int(prop_row) == row)
+        if (child->prop_as_int(prop_row) == row)
         {
             insert_position = idx;
             while (idx < gbsizer->GetChildCount())
@@ -139,6 +139,7 @@ size_t GridBag::IncrementRows(int row, Node* gbsizer)
             }
             break;
         }
+        ++idx;
     }
 
     return insert_position;
@@ -147,10 +148,9 @@ size_t GridBag::IncrementRows(int row, Node* gbsizer)
 size_t GridBag::IncrementColumns(int row, int column, Node* gbsizer)
 {
     size_t insert_position = tt::npos;
-    for (size_t idx = 0; idx < gbsizer->GetChildCount(); ++idx)
+    for (size_t idx = 0; const auto& child: gbsizer->GetChildNodePtrs())
     {
-        if (gbsizer->GetChild(idx)->prop_as_int(prop_row) == row &&
-            gbsizer->GetChild(idx)->prop_as_int(prop_column) == column)
+        if (child->prop_as_int(prop_row) == row && child->prop_as_int(prop_column) == column)
         {
             insert_position = idx;
             while (idx < gbsizer->GetChildCount())
@@ -162,6 +162,7 @@ size_t GridBag::IncrementColumns(int row, int column, Node* gbsizer)
             }
             break;
         }
+        ++idx;
     }
 
     return insert_position;

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -429,7 +429,7 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview xml_data)
     auto generator = root.child("gen");
     while (generator)
     {
-        auto class_name = generator.attribute("class").as_string();
+        auto class_name = generator.attribute("class").as_std_str();
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
         if (rmap_GenNames.find(class_name) == rmap_GenNames.end())
         {
@@ -437,11 +437,11 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview xml_data)
         }
 #endif  // _DEBUG
 
-        auto type_name = generator.attribute("type").as_cview();
+        auto type_name = generator.attribute("type").as_std_str();
         GenType type { gen_type_unknown };
         for (auto& iter: map_GenTypes)
         {
-            if (type_name.is_sameas(iter.second))
+            if (type_name == iter.second)
             {
                 type = iter.first;
                 break;
@@ -463,12 +463,12 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview xml_data)
         auto declaration = new NodeDeclaration(class_name, GetNodeType(type));
         m_a_declarations[declaration->gen_name()] = declaration;
 
-        if (auto flags = generator.attribute("flags").as_cview(); flags.size())
+        if (auto flags = generator.attribute("flags").as_string(); flags.size())
         {
             declaration->SetGeneratorFlags(flags);
         }
 
-        auto image_name = generator.attribute("image").as_cview();
+        auto image_name = generator.attribute("image").as_string();
         if (image_name.size())
         {
             auto image = GetInternalImage(image_name);
@@ -501,13 +501,13 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview xml_data)
         auto elem_obj = root.child("gen");
         while (elem_obj)
         {
-            auto class_name = elem_obj.attribute("class").as_cview();
+            auto class_name = elem_obj.attribute("class").as_string();
             auto class_info = GetNodeDeclaration(class_name);
 
             auto elem_base = elem_obj.child("inherits");
             while (elem_base)
             {
-                auto base_name = elem_base.attribute("class").as_cview();
+                auto base_name = elem_base.attribute("class").as_string();
 
                 // Add a reference to its base class
                 auto base_info = GetNodeDeclaration(base_name);
@@ -526,7 +526,7 @@ void NodeCreator::ParseGeneratorFile(ttlib::cview xml_data)
                             inheritedProperty = inheritedProperty.next_sibling("property");
                             continue;
                         }
-                        class_info->SetOverRideDefValue(lookup_name->second, inheritedProperty.text().as_cview());
+                        class_info->SetOverRideDefValue(lookup_name->second, inheritedProperty.text().as_string());
                         inheritedProperty = inheritedProperty.next_sibling("property");
                     }
 
@@ -558,10 +558,10 @@ void NodeCreator::ParseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
     auto elem_category = elem_obj.child("category");
     while (elem_category)
     {
-        auto name = elem_category.attribute("name").as_cview();
+        auto name = elem_category.attribute("name").as_string();
         auto& new_cat = category.AddCategory(name);
 
-        if (auto base_name = elem_category.attribute("base_name").value(); *base_name)
+        if (auto base_name = elem_category.attribute("base_name").value(); base_name.size())
         {
             if (auto node = m_interfaces.find(base_name); node != m_interfaces.end())
             {
@@ -579,7 +579,7 @@ void NodeCreator::ParseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
     auto elem_prop = elem_obj.child("property");
     while (elem_prop)
     {
-        auto name = elem_prop.attribute("name").as_string();
+        auto name = elem_prop.attribute("name").as_std_str();
         GenEnum::PropName prop_name;
         auto lookup_name = rmap_PropNames.find(name);
         if (lookup_name == rmap_PropNames.end())
@@ -592,15 +592,15 @@ void NodeCreator::ParseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
 
         category.AddProperty(prop_name);
 
-        auto description = elem_prop.attribute("help").as_cview();
-        auto customEditor = elem_prop.attribute("editor").as_cview();
+        auto description = elem_prop.attribute("help").as_string();
+        auto customEditor = elem_prop.attribute("editor").as_string();
 
-        auto prop_type = elem_prop.attribute("type").as_cview();
+        auto prop_type = elem_prop.attribute("type").as_string();
 
         GenEnum::PropType property_type { type_unknown };
         for (auto& iter: map_PropTypes)
         {
-            if (prop_type.is_sameas(iter.second))
+            if (prop_type == iter.second)
             {
                 property_type = iter.first;
                 break;
@@ -634,8 +634,8 @@ void NodeCreator::ParseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
             while (elem_opt)
             {
                 auto& opt = opts.emplace_back();
-                opt.name = elem_opt.attribute("name").as_string();
-                opt.help = elem_opt.attribute("help").as_string();
+                opt.name.assign_view(elem_opt.attribute("name").as_string());
+                opt.help.assign_view(elem_opt.attribute("help").as_string());
 
                 elem_opt = elem_opt.next_sibling("option");
             }
@@ -700,7 +700,7 @@ void NodeDeclaration::ParseEvents(pugi::xml_node& elem_obj, NodeCategory& catego
         // Only create the category if there is at least one event.
         if (elem_category.child("event"))
         {
-            auto name = elem_category.attribute("name").as_cview();
+            auto name = elem_category.attribute("name").as_string();
             auto& new_cat = category.AddCategory(name);
 
             ParseEvents(elem_category, new_cat);
@@ -711,11 +711,11 @@ void NodeDeclaration::ParseEvents(pugi::xml_node& elem_obj, NodeCategory& catego
     auto nodeEvent = elem_obj.child("event");
     while (nodeEvent)
     {
-        auto evt_name = nodeEvent.attribute("name").as_string();
+        auto evt_name = nodeEvent.attribute("name").as_std_str();
         category.AddEvent(evt_name);
 
-        auto evt_class = nodeEvent.attribute("class").as_cview("wxEvent");
-        auto description = nodeEvent.attribute("help").as_cview();
+        auto evt_class = nodeEvent.attribute("class").as_std_str("wxEvent");
+        auto description = nodeEvent.attribute("help").as_std_str();
 
         m_events[evt_name] = std::make_unique<NodeEventInfo>(evt_name, evt_class, description);
 

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -64,7 +64,7 @@ int NodeProperty::as_mockup(std::string_view prefix) const
         case type_editoption:
         case type_option:
         case type_id:
-            if (m_value.is_sameprefix("wx"))
+            if (m_value.starts_with("wx"))
             {
                 return g_NodeCreator.GetConstantAsInt(m_value, 0);
             }
@@ -95,7 +95,7 @@ int NodeProperty::as_mockup(std::string_view prefix) const
                 int value = 0;
                 for (auto& iter: mstr)
                 {
-                    if (iter.is_sameprefix("wx"))
+                    if (iter.starts_with("wx"))
                     {
                         value |= g_NodeCreator.GetConstantAsInt(iter);
                     }
@@ -126,7 +126,7 @@ const ttlib::cstr& NodeProperty::as_constant(std::string_view prefix)
         case type_editoption:
         case type_option:
         case type_id:
-            if (m_value.is_sameprefix("wx"))
+            if (m_value.starts_with("wx"))
             {
                 return m_value;
             }
@@ -165,7 +165,7 @@ const ttlib::cstr& NodeProperty::as_constant(std::string_view prefix)
                 m_constant.clear();
                 for (auto& iter: mstr)
                 {
-                    if (iter.is_sameprefix("wx"))
+                    if (iter.starts_with("wx"))
                     {
                         if (m_constant.size())
                         {
@@ -236,7 +236,7 @@ wxSize NodeProperty::as_size() const
 wxColour NodeProperty::as_color() const
 {
     // check for system colour
-    if (m_value.is_sameprefix("wx"))
+    if (m_value.starts_with("wx"))
     {
         return wxSystemSettings::GetColour(ConvertToSystemColour(m_value));
     }

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -38,8 +38,7 @@ public:
     bool as_bool() const { return (as_int() != 0); };
     double as_float() const;
 
-    // REVIEW: [KeyWorks - 12-30-2021] Why do we need this? This just adds ctor/dtor code.
-    auto as_cview() const { return ttlib::cview(m_value.c_str(), m_value.length()); }
+    // ttlib::sview as_sview() const { return m_value; }
 
     // Use with caution! This allows you to modify the property string directly.
     auto as_raw_ptr() { return &m_value; }
@@ -93,7 +92,7 @@ public:
     Node* GetNode() { return m_node; }
 
     // Returns a char pointer to the name. Use get_name() if you want the enum value.
-    ttlib::cview DeclName() const noexcept { return m_declaration->DeclName(); }
+    ttlib::sview DeclName() const noexcept { return m_declaration->DeclName(); }
 
     bool isProp(PropName name) const noexcept { return m_declaration->isProp(name); }
     bool isType(PropType type) const noexcept { return m_declaration->isType(type); }

--- a/src/nodes/prop_decl.h
+++ b/src/nodes/prop_decl.h
@@ -45,7 +45,7 @@ public:
     }
 
     // Returns a char pointer to the name. Use get_name() if you want the enum value.
-    ttlib::cview DeclName() const noexcept { return ttlib::cview(m_name_str); }
+    ttlib::sview DeclName() const noexcept { return m_name_str; }
 
     const ttlib::cstr& GetDefaultValue() const noexcept { return m_def_value; }
     const ttlib::cstr& GetDescription() const noexcept { return m_help; }

--- a/src/nodes/prop_decl.h
+++ b/src/nodes/prop_decl.h
@@ -32,8 +32,8 @@ struct PropChildDeclaration
 class PropDeclaration : public PropChildDeclaration
 {
 public:
-    PropDeclaration(GenEnum::PropName prop_name, GenEnum::PropType prop_type, ttlib::cview def_value, ttlib::cview help,
-                    ttlib::cview customEditor)
+    PropDeclaration(GenEnum::PropName prop_name, GenEnum::PropType prop_type, std::string_view def_value,
+                    std::string_view help, std::string_view customEditor)
     {
         m_def_value = def_value;
         m_help = help;
@@ -54,8 +54,8 @@ public:
     // These get used to setup wxPGProperty, so both key and value need to be a wxString
     struct Options
     {
-        wxString name;
-        wxString help;
+        ttString name;
+        ttString help;
     };
 
     std::vector<Options>& GetOptions() { return m_options; }

--- a/src/nodes/tool_creator.cpp
+++ b/src/nodes/tool_creator.cpp
@@ -16,6 +16,46 @@
 
 using namespace GenEnum;
 
+static void PostProcessBook(Node* book_node)
+{
+    auto page_node = book_node->CreateChildNode(gen_BookPage);
+    if (page_node->FixDuplicateName())
+        wxGetFrame().FirePropChangeEvent(page_node->get_prop_ptr(prop_var_name));
+
+    if (auto sizer = page_node->CreateChildNode(gen_VerticalBoxSizer); sizer)
+    {
+        sizer->prop_set_value(prop_var_name, "page_sizer");
+        sizer->FixDuplicateName();
+        wxGetFrame().FirePropChangeEvent(sizer->get_prop_ptr(prop_var_name));
+    }
+}
+
+static void PostProcessPage(Node* page_node)
+{
+    if (page_node->FixDuplicateName())
+        wxGetFrame().FirePropChangeEvent(page_node->get_prop_ptr(prop_var_name));
+
+    if (auto sizer = page_node->CreateChildNode(gen_VerticalBoxSizer); sizer)
+    {
+        sizer->prop_set_value(prop_var_name, "page_sizer");
+        sizer->FixDuplicateName();
+        wxGetFrame().FirePropChangeEvent(sizer->get_prop_ptr(prop_var_name));
+    }
+}
+
+static void PostProcessPanel(Node* panel_node)
+{
+    if (panel_node->FixDuplicateName())
+        wxGetFrame().FirePropChangeEvent(panel_node->get_prop_ptr(prop_var_name));
+
+    if (auto sizer = panel_node->CreateChildNode(gen_VerticalBoxSizer); sizer)
+    {
+        sizer->prop_set_value(prop_var_name, "panel_sizer");
+        sizer->FixDuplicateName();
+        wxGetFrame().FirePropChangeEvent(sizer->get_prop_ptr(prop_var_name));
+    }
+}
+
 bool Node::CreateToolNode(GenName name)
 {
     if (isGen(gen_Project))
@@ -131,44 +171,4 @@ bool Node::CreateToolNode(GenName name)
     }
 
     return true;
-}
-
-void Node::PostProcessBook(Node* book_node)
-{
-    auto page_node = book_node->CreateChildNode(gen_BookPage);
-    if (page_node->FixDuplicateName())
-        wxGetFrame().FirePropChangeEvent(page_node->get_prop_ptr(prop_var_name));
-
-    if (auto sizer = page_node->CreateChildNode(gen_VerticalBoxSizer); sizer)
-    {
-        sizer->prop_set_value(prop_var_name, "page_sizer");
-        sizer->FixDuplicateName();
-        wxGetFrame().FirePropChangeEvent(sizer->get_prop_ptr(prop_var_name));
-    }
-}
-
-void Node::PostProcessPage(Node* page_node)
-{
-    if (page_node->FixDuplicateName())
-        wxGetFrame().FirePropChangeEvent(page_node->get_prop_ptr(prop_var_name));
-
-    if (auto sizer = page_node->CreateChildNode(gen_VerticalBoxSizer); sizer)
-    {
-        sizer->prop_set_value(prop_var_name, "page_sizer");
-        sizer->FixDuplicateName();
-        wxGetFrame().FirePropChangeEvent(sizer->get_prop_ptr(prop_var_name));
-    }
-}
-
-void Node::PostProcessPanel(Node* panel_node)
-{
-    if (panel_node->FixDuplicateName())
-        wxGetFrame().FirePropChangeEvent(panel_node->get_prop_ptr(prop_var_name));
-
-    if (auto sizer = panel_node->CreateChildNode(gen_VerticalBoxSizer); sizer)
-    {
-        sizer->prop_set_value(prop_var_name, "panel_sizer");
-        sizer->FixDuplicateName();
-        wxGetFrame().FirePropChangeEvent(sizer->get_prop_ptr(prop_var_name));
-    }
 }

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -73,7 +73,7 @@ CodeDisplay::CodeDisplay(wxWindow* parent, bool is_XML) : CodeDisplayBase(parent
                 continue;
             }
 
-            if (!iter->DeclName().is_sameprefix("wx") || iter->DeclName().is_sameas("wxContextMenuEvent"))
+            if (!iter->DeclName().starts_with("wx") || iter->DeclName().is_sameas("wxContextMenuEvent"))
                 continue;
             widget_keywords << ' ' << iter->DeclName();
         }

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -522,7 +522,7 @@ void NavigationPanel::OnNodeSelected(CustomEvent& event)
     }
     else
     {
-        if (node->HasValue(prop_var_name) && !node->prop_as_string(prop_class_access).is_sameprefix("none"))
+        if (node->HasValue(prop_var_name) && !node->prop_as_string(prop_class_access).starts_with("none"))
             wxGetFrame().setStatusText(node->prop_as_string(prop_var_name));
         else
             wxGetFrame().setStatusText(tt_empty_cstr);

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -360,7 +360,7 @@ void NavigationPanel::AddAllChildren(Node* node_parent)
     auto tree_parent = m_node_tree_map[node_parent];
     ASSERT(tree_parent.IsOk());
 
-    for (auto& iter_child: node_parent->GetChildNodePtrs())
+    for (const auto& iter_child: node_parent->GetChildNodePtrs())
     {
         auto node = iter_child.get();
         auto new_item = m_tree_ctrl->AppendItem(tree_parent, GetDisplayName(node).wx_str(), GetImageIndex(node), -1);

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -171,9 +171,9 @@ void NavigationPanel::OnProjectUpdated()
         ExpandAllNodes(project);
 
         // Now we collapse all the project's immediate children
-        for (size_t index = 0; index < project->GetChildCount(); ++index)
+        for (const auto& form: project->GetChildNodePtrs())
         {
-            if (auto result = m_node_tree_map.find(project->GetChild(index)); result != m_node_tree_map.end())
+            if (auto result = m_node_tree_map.find(form.get()); result != m_node_tree_map.end())
             {
                 m_tree_ctrl->Collapse(result->second);
             }
@@ -480,9 +480,10 @@ void NavigationPanel::ExpandAllNodes(Node* node)
             m_tree_ctrl->Expand(item_it->second);
     }
 
-    auto count = node->GetChildCount();
-    for (size_t i = 0; i < count; i++)
-        ExpandAllNodes(node->GetChild(i));
+    for (const auto& child: node->GetChildNodePtrs())
+    {
+        ExpandAllNodes(child.get());
+    }
 }
 
 void NavigationPanel::DeleteNode(Node* node)
@@ -496,9 +497,9 @@ void NavigationPanel::EraseAllMaps(Node* node)
     // If you delete a parent tree item it will automatically delete all children, but our maps won't reflect that. To keep
     // the treeview control and our maps in sync, we need to delete children before we delete the actual item.
 
-    for (size_t idx = 0; idx < node->GetChildCount(); idx++)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        EraseAllMaps(node->GetChild(idx));
+        EraseAllMaps(child.get());
     }
 
     if (auto result = m_node_tree_map.find(node); result != m_node_tree_map.end())
@@ -691,11 +692,12 @@ void NavigationPanel::ChangeExpansion(Node* node, bool include_children, bool ex
 {
     if (include_children)
     {
-        for (size_t child_index = 0; child_index < node->GetChildCount(); ++child_index)
+        for (const auto& child: node->GetChildNodePtrs())
         {
-            auto child = node->GetChild(child_index);
             if (child->GetChildCount())
-                ChangeExpansion(child, include_children, expand);
+            {
+                ChangeExpansion(child.get(), include_children, expand);
+            }
         }
     }
     if (node->GetChildCount())
@@ -741,9 +743,9 @@ void NavigationPanel::OnCollapse(wxCommandEvent&)
     auto parent = node->GetParent();
     if (parent && parent->GetChildCount())
     {
-        for (size_t child_index = 0; child_index < parent->GetChildCount(); ++child_index)
+        for (const auto& child: parent->GetChildNodePtrs())
         {
-            ChangeExpansion(parent->GetChild(child_index), false, false);
+            ChangeExpansion(child.get(), false, false);
         }
     }
     else
@@ -769,10 +771,12 @@ void NavigationPanel::ExpandCollapse(Node* node)
     auto parent = node->GetParent();
     if (parent && parent->GetChildCount())
     {
-        for (size_t child_index = 0; child_index < parent->GetChildCount(); ++child_index)
+        for (const auto& child: parent->GetChildNodePtrs())
         {
-            if (parent->GetChild(child_index) != node)
-                ChangeExpansion(parent->GetChild(child_index), false, false);
+            if (child.get() != node)
+            {
+                ChangeExpansion(child.get(), false, false);
+            }
         }
     }
 

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -716,7 +716,7 @@ void NavPopupMenu::MenuAddStandardCommands(Node* node)
     }
 }
 
-void NavPopupMenu::CreateSizerParent(Node* node, ttlib::cview widget)
+void NavPopupMenu::CreateSizerParent(Node* node, ttlib::sview widget)
 {
     auto parent = node->GetParent();
     if (!parent)

--- a/src/panels/navpopupmenu.h
+++ b/src/panels/navpopupmenu.h
@@ -126,7 +126,7 @@ protected:
     void MenuAddMoveCommands(Node* node);
 
     void ChangeSizer(GenEnum::GenName new_sizer_gen);
-    void CreateSizerParent(Node* node, ttlib::cview widget);
+    void CreateSizerParent(Node* node, ttlib::sview widget);
 
 private:
     Node* m_node { nullptr };

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -509,13 +509,23 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
     {
         new_pg_property = new wxStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_string());
         new_pg_property->SetAttribute(wxPG_BOOL_USE_DOUBLE_CLICK_CYCLING, wxVariant(true, "true"));
-        MSG_ERROR(ttlib::cstr("NodeProperty type is unsupported: ") << map_PropTypes[type]);
+
+#if defined(INTERNAL_TESTING)
+        for (auto& iter: umap_PropTypes)
+        {
+            if (iter.second == type)
+            {
+                MSG_ERROR(ttlib::cstr("NodeProperty type is unsupported: ") << iter.first);
+                break;
+            }
+        }
+#endif
     }
 
     return new_pg_property;
 }
 
-void PropGridPanel::AddProperties(ttlib::cview name, Node* node, NodeCategory& category, PropNameSet& prop_set,
+void PropGridPanel::AddProperties(ttlib::sview name, Node* node, NodeCategory& category, PropNameSet& prop_set,
                                   bool is_child_cat)
 {
     size_t propCount = category.GetPropNameCount();
@@ -701,7 +711,7 @@ inline constexpr const char* lst_mouse_events[] = {
 };
 // clang-format on
 
-void PropGridPanel::AddEvents(ttlib::cview name, Node* node, NodeCategory& category, EventSet& event_set)
+void PropGridPanel::AddEvents(ttlib::sview name, Node* node, NodeCategory& category, EventSet& event_set)
 {
     auto& eventList = category.GetEvents();
     for (auto& eventName: eventList)
@@ -1398,7 +1408,7 @@ void PropGridPanel::ModifyProperty(NodeProperty* prop, const wxString& str)
     m_isPropChangeSuspended = false;
 }
 
-void PropGridPanel::modifyProperty(NodeProperty* prop, ttlib::cview str)
+void PropGridPanel::modifyProperty(NodeProperty* prop, ttlib::sview str)
 {
     m_isPropChangeSuspended = true;
     wxGetFrame().ModifyProperty(prop, str);
@@ -1468,7 +1478,7 @@ wxString PropGridPanel::GetCategoryDisplayName(const wxString& original)
     return category_name;
 }
 
-void PropGridPanel::CreatePropCategory(ttlib::cview name, Node* node, NodeDeclaration* declaration, PropNameSet& prop_set)
+void PropGridPanel::CreatePropCategory(ttlib::sview name, Node* node, NodeDeclaration* declaration, PropNameSet& prop_set)
 {
     auto& category = declaration->GetCategory();
 
@@ -1598,7 +1608,7 @@ void PropGridPanel::CreateLayoutCategory(Node* node)
     m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#e1f3f8"));
 }
 
-void PropGridPanel::CreateEventCategory(ttlib::cview name, Node* node, NodeDeclaration* declaration, EventSet& event_set)
+void PropGridPanel::CreateEventCategory(ttlib::sview name, Node* node, NodeDeclaration* declaration, EventSet& event_set)
 {
     auto& category = declaration->GetCategory();
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -979,7 +979,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                         // Conversely, if the name is changed from local to a class member, a "m_" is added as a prefix (if
                         // it doesn't already have one).
                         ttlib::cstr name = node->prop_as_string(prop_var_name);
-                        if (value == "none" && name.is_sameprefix("m_"))
+                        if (value == "none" && name.starts_with("m_"))
                         {
                             name.erase(0, 2);
                             auto final_name = node->GetUniqueName(name);
@@ -990,7 +990,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                             grid_property->SetValueFromString(name, 0);
                             modifyProperty(propChange, name);
                         }
-                        else if (value != "none" && !name.is_sameprefix("m_"))
+                        else if (value != "none" && !name.starts_with("m_"))
                         {
                             name.insert(0, "m_");
                             auto final_name = node->GetUniqueName(name);

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -54,12 +54,12 @@ protected:
     // needed.
     void OnPostPropChange(CustomEvent& event);
 
-    void CreatePropCategory(ttlib::cview name, Node* node, NodeDeclaration* obj_info, PropNameSet& prop_set);
-    void CreateEventCategory(ttlib::cview name, Node* node, NodeDeclaration* obj_info, EventSet& event_set);
+    void CreatePropCategory(ttlib::sview name, Node* node, NodeDeclaration* obj_info, PropNameSet& prop_set);
+    void CreateEventCategory(ttlib::sview name, Node* node, NodeDeclaration* obj_info, EventSet& event_set);
     void CreateLayoutCategory(Node* node);
 
-    void AddEvents(ttlib::cview name, Node* node, NodeCategory& category, EventSet& event_set);
-    void AddProperties(ttlib::cview name, Node* node, NodeCategory& category, PropNameSet& prop_set,
+    void AddEvents(ttlib::sview name, Node* node, NodeCategory& category, EventSet& event_set);
+    void AddProperties(ttlib::sview name, Node* node, NodeCategory& category, PropNameSet& prop_set,
                        bool is_child_cat = false);
 
     void ReplaceDerivedName(const wxString& formName, NodeProperty* propType);
@@ -76,7 +76,7 @@ protected:
     void ReselectItem();
 
     void ModifyProperty(NodeProperty* prop, const wxString& str);
-    void modifyProperty(NodeProperty* prop, ttlib::cview str);
+    void modifyProperty(NodeProperty* prop, ttlib::sview str);
 
     int GetBitlistValue(const wxString& strVal, wxPGChoices& bit_flags);
 

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -77,16 +77,17 @@ void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node)
 
         auto filename = newValue.sub_cstr();
         auto project = wxGetApp().GetProject();
-        for (size_t child_idx = 0; child_idx < project->GetChildCount(); ++child_idx)
+
+        for (const auto& child: project->GetChildNodePtrs())
         {
-            if (project->GetChild(child_idx) == node)
+            if (child.get() == node)
                 continue;
-            if (project->GetChild(child_idx)->prop_as_string(prop_base_file).filename() == filename)
+            if (child->prop_as_string(prop_base_file).filename() == filename)
             {
                 auto focus = wxWindow::FindFocus();
 
                 wxMessageBox(wxString() << "The base filename \"" << filename << "\" is already in use by "
-                                        << project->GetChild(child_idx)->prop_as_string(prop_class_name)
+                                        << child->prop_as_string(prop_class_name)
                                         << "\n\nEither change the name, or press ESC to restore the original name.",
                              "Duplicate base filename", wxICON_STOP);
                 if (focus)
@@ -190,7 +191,7 @@ void ChangeBaseDirectory(ttlib::cstr& path)
     auto undo_derived = std::make_shared<ModifyProperties>("Base directory");
     undo_derived->AddProperty(wxGetApp().GetProject()->get_prop_ptr(prop_base_directory), path);
 
-    for (auto& form: wxGetApp().GetProject()->GetChildNodePtrs())
+    for (const auto& form: wxGetApp().GetProject()->GetChildNodePtrs())
     {
         if (form->HasValue(prop_base_file))
         {

--- a/src/pch.h
+++ b/src/pch.h
@@ -97,10 +97,10 @@
 
 // Currently, the order of the ttLib includes is critical, so use blank lines to keep clang-format from reordering them.
 
-#include "ttstr.h"       // ttString -- wxString with ttlib::cstr equivalent functions
+#include "ttstr.h"  // ttString -- wxString with ttlib::cstr equivalent functions
 
-#include "ttcview.h"     // ttlib::cview -- std::string_view functionality on a zero-terminated char string.
-#include "ttsview.h"     // ttlib::sview -- std::string_view with additional methods
+#include "ttcview.h"  // ttlib::cview -- std::string_view functionality on a zero-terminated char string.
+#include "ttsview.h"  // ttlib::sview -- std::string_view with additional methods
 
 #include "ttcstr.h"      // ttlib::cstr -- std::string with additional functions
 #include "ttmultistr.h"  // ttlib::multistr -- breaks a single string into multiple strings

--- a/src/pch.h
+++ b/src/pch.h
@@ -22,6 +22,9 @@
 #define wxUSE_NO_MANIFEST 1
 #define wxUSE_UNICODE     1
 
+// Allows ttLib additions to pugixml
+#define TTLIB_ADDITIONS 1
+
 #ifdef _MSC_VER
     #pragma warning(push)
 #endif

--- a/src/pch.h
+++ b/src/pch.h
@@ -95,11 +95,15 @@
 
 #include "ttlibspace.h"  // This must be included before any other ttLib header files
 
-#include "ttcstr.h"      // ttlib::cstr -- std::string with additional functions
-#include "ttcview.h"     // ttlib::cview -- std::string_view functionality on a zero-terminated char string.
-#include "ttmultistr.h"  // ttlib::multistr -- breaks a single string into multiple strings
+// Currently, the order of the ttLib includes is critical, so use blank lines to keep clang-format from reordering them.
+
 #include "ttstr.h"       // ttString -- wxString with ttlib::cstr equivalent functions
+
+#include "ttcview.h"     // ttlib::cview -- std::string_view functionality on a zero-terminated char string.
 #include "ttsview.h"     // ttlib::sview -- std::string_view with additional methods
+
+#include "ttcstr.h"      // ttlib::cstr -- std::string with additional functions
+#include "ttmultistr.h"  // ttlib::multistr -- breaks a single string into multiple strings
 
 #if !defined(int_t)
 

--- a/src/pjtsettings.cpp
+++ b/src/pjtsettings.cpp
@@ -505,9 +505,9 @@ bool ProjectSettings::UpdateEmbedNodes()
     bool is_changed = false;
     auto project = wxGetApp().GetProject();
 
-    for (size_t idx_form = 0; idx_form < project->GetChildCount(); ++idx_form)
+    for (const auto& form: project->GetChildNodePtrs())
     {
-        if (CheckNode(project->GetChild(idx_form)))
+        if (CheckNode(form))
             is_changed = true;
     }
     return is_changed;
@@ -517,7 +517,7 @@ bool ProjectSettings::UpdateEmbedNodes()
 // all nodes initially, and the only reason this would be needed is if adding or changing a bitmap property did not get set
 // up correctly (highly unlikely).
 
-bool ProjectSettings::CheckNode(Node* node)
+bool ProjectSettings::CheckNode(const NodeSharedPtr& node)
 {
     bool is_changed = false;
 
@@ -568,9 +568,9 @@ bool ProjectSettings::CheckNode(Node* node)
         }
     }
 
-    for (size_t idx_child = 0; idx_child < node->GetChildCount(); idx_child++)
+    for (const auto& child: node->GetChildNodePtrs())
     {
-        if (CheckNode(node->GetChild(idx_child)))
+        if (CheckNode(child))
             is_changed = true;
     }
 

--- a/src/pjtsettings.h
+++ b/src/pjtsettings.h
@@ -13,7 +13,8 @@
 
 #include "image_bundle.h"  // This will #include wx/bmpbndl.h and wx/bitmap.h
 
-class Node;
+#include "node_classes.h"  // Forward defintions of Node classes
+
 class wxAnimation;
 
 struct EmbeddedImage
@@ -103,9 +104,9 @@ public:
     void CollectBundles();
 
 protected:
-    bool CheckNode(Node* node);
+    bool CheckNode(const NodeSharedPtr& node);
 
-    void CollectNodeBundles(Node* node, Node* form);
+    void CollectNodeBundles(const NodeSharedPtr& node, const NodeSharedPtr& form);
 
     bool AddNewEmbeddedBundle(const ttlib::multistr& parts, ttlib::cstr path, Node* form);
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -191,12 +191,12 @@ static const auto lstStdButtonEvents = {
 
 NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
 {
-    auto class_name = xml_obj.attribute("class").as_cview();
+    auto class_name = xml_obj.attribute("class").as_std_str();
     if (class_name.empty())
         return NodeSharedPtr();
 
     // This should never be the case, but let's switch it in the off chance it slips through
-    if (class_name.is_sameas("wxListCtrl"))
+    if (class_name == "wxListCtrl")
         class_name = "wxListView";
 
     auto new_node = CreateNode(class_name, parent);
@@ -208,10 +208,10 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
 
     for (auto& iter: xml_obj.attributes())
     {
-        if (iter.cname().is_sameas("class"))
+        if (iter.name() == "class")
             continue;
 
-        if (iter.cname().is_sameprefix("wxEVT_"))
+        if (iter.name().starts_with("wxEVT_"))
         {
             if (auto event = new_node->GetEvent(iter.name()); event)
             {
@@ -348,7 +348,7 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
             if (is_event)
                 continue;
 
-            if (auto value = iter.value(); *value)
+            if (auto value = iter.value(); value.size())
             {
                 {
                     // REVIEW: [KeyWorks - 11-30-2021] This code block deals with changes to the 1.2 project format prior to
@@ -465,7 +465,7 @@ bool App::Import(ImportXML& import, ttString& file, bool append)
         auto& doc = import.GetDocument();
         auto root = doc.first_child();
         auto project = root.child("node");
-        if (!project || !project.attribute("class").as_cview().is_sameas("Project"))
+        if (!project || project.attribute("class").as_string() != "Project")
         {
             ASSERT_MSG(project, ttlib::cstr() << "Failed trying to load converted xml document: " << file.wx_str());
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -313,7 +313,7 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent)
                                     parts[1].backslashestoforward();
                                     ttlib::cstr description(parts[0]);
                                     description << ';' << parts[1];
-                                    if (parts[0].is_sameprefix("SVG"))
+                                    if (parts[0].starts_with("SVG"))
                                         description << ';' << parts[2];
                                     prop->set_value(description);
                                 }

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -668,10 +668,10 @@ void App::AppendWinRes(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>& dia
     WinResource winres;
     if (winres.ImportRc(rc_file, dialogs))
     {
-        auto project = winres.GetProjectPtr();
-        for (size_t idx_child = 0; idx_child < project->GetChildCount(); ++idx_child)
+        const auto& project = winres.GetProjectPtr();
+        for (const auto& child: project->GetChildNodePtrs())
         {
-            auto new_node = g_NodeCreator.MakeCopy(project->GetChildPtr(idx_child));
+            auto new_node = g_NodeCreator.MakeCopy(child);
             m_project->Adopt(new_node);
         }
 
@@ -682,18 +682,18 @@ void App::AppendWinRes(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>& dia
 
 void App::AppendCrafter(wxArrayString& files)
 {
-    for (size_t pos = 0; pos < files.size(); ++pos)
+    for (const auto& file: files)
     {
         WxCrafter crafter;
 
-        if (crafter.Import(files[pos]))
+        if (crafter.Import(file))
         {
             auto& doc = crafter.GetDocument();
             auto root = doc.first_child();
             auto project = root.child("node");
             if (!project || project.attribute("class").as_cstr() != "Project")
             {
-                wxMessageBox(wxString("The project file ") << files[pos] << " is invalid and cannot be opened.",
+                wxMessageBox(wxString("The project file ") << file << " is invalid and cannot be opened.",
                              "Import wxCrafter project");
                 return;
             }
@@ -712,18 +712,18 @@ void App::AppendCrafter(wxArrayString& files)
 
 void App::AppendFormBuilder(wxArrayString& files)
 {
-    for (size_t pos = 0; pos < files.size(); ++pos)
+    for (auto& file: files)
     {
         FormBuilder fb;
 
-        if (fb.Import(files[pos]))
+        if (fb.Import(file))
         {
             auto& doc = fb.GetDocument();
             auto root = doc.first_child();
             auto project = root.child("node");
             if (!project || project.attribute("class").as_cstr() != "Project")
             {
-                wxMessageBox(wxString("The project file ") << files[pos] << " is invalid and cannot be opened.",
+                wxMessageBox(wxString("The project file ") << file << " is invalid and cannot be opened.",
                              "Import wxFormBuilder project");
                 return;
             }
@@ -742,18 +742,18 @@ void App::AppendFormBuilder(wxArrayString& files)
 
 void App::AppendGlade(wxArrayString& files)
 {
-    for (size_t pos = 0; pos < files.size(); ++pos)
+    for (auto& file: files)
     {
         WxGlade glade;
 
-        if (glade.Import(files[pos]))
+        if (glade.Import(file))
         {
             auto& doc = glade.GetDocument();
             auto root = doc.first_child();
             auto project = root.child("node");
             if (!project || project.attribute("class").as_cstr() != "Project")
             {
-                wxMessageBox(wxString("The project file ") << files[pos] << " is invalid and cannot be opened.",
+                wxMessageBox(wxString("The project file ") << file << " is invalid and cannot be opened.",
                              "Import wxGlade project");
                 return;
             }
@@ -772,18 +772,18 @@ void App::AppendGlade(wxArrayString& files)
 
 void App::AppendSmith(wxArrayString& files)
 {
-    for (size_t pos = 0; pos < files.size(); ++pos)
+    for (auto& file: files)
     {
         WxSmith smith;
 
-        if (smith.Import(files[pos]))
+        if (smith.Import(file))
         {
             auto& doc = smith.GetDocument();
             auto root = doc.first_child();
             auto project = root.child("node");
             if (!project || project.attribute("class").as_cstr() != "Project")
             {
-                wxMessageBox(wxString("The project file ") << files[pos] << " is invalid and cannot be opened.",
+                wxMessageBox(wxString("The project file ") << file << " is invalid and cannot be opened.",
                              "Import wxSmith project");
                 return;
             }
@@ -802,19 +802,19 @@ void App::AppendSmith(wxArrayString& files)
 
 void App::AppendXRC(wxArrayString& files)
 {
-    for (size_t pos = 0; pos < files.size(); ++pos)
+    for (auto& file: files)
     {
         // wxSmith files are a superset of XRC files, so we use the wxSmith class to process both
         WxSmith smith;
 
-        if (smith.Import(files[pos]))
+        if (smith.Import(file))
         {
             auto& doc = smith.GetDocument();
             auto root = doc.first_child();
             auto project = root.child("node");
             if (!project || project.attribute("class").as_cstr() != "Project")
             {
-                wxMessageBox(wxString("The project file ") << files[pos] << " is invalid and cannot be opened.",
+                wxMessageBox(wxString("The project file ") << file << " is invalid and cannot be opened.",
                              "Import XRC project");
                 return;
             }

--- a/src/project/saveproject.cpp
+++ b/src/project/saveproject.cpp
@@ -87,9 +87,8 @@ void Node::AddNodeToDoc(pugi::xml_node& node)
         }
     }
 
-    for (size_t i = 0; i < GetChildCount(); i++)
+    for (const auto& child: m_children)
     {
-        auto child = GetChild(i);
         auto child_element = node.append_child("node");
         child->AddNodeToDoc(child_element);
     }

--- a/src/project/saveproject.cpp
+++ b/src/project/saveproject.cpp
@@ -25,7 +25,7 @@ void Node::CreateDoc(pugi::xml_document& doc)
 
 void Node::AddNodeToDoc(pugi::xml_node& node)
 {
-    node.append_attribute("class") = DeclName().c_str();
+    node.append_attribute("class") = DeclName();
 
     for (auto& iter: m_properties)
     {
@@ -78,11 +78,13 @@ void Node::AddNodeToDoc(pugi::xml_node& node)
         }
     }
 
-    for (auto& iter: m_events)
+    for (auto& iter: m_map_events)
     {
-        auto& value = iter.get_value();
+        auto& value = iter.second.get_value();
         if (value.size())
-            node.append_attribute(iter.get_name().c_str()) = value.c_str();
+        {
+            node.append_attribute(iter.second.get_name()) = value;
+        }
     }
 
     for (size_t i = 0; i < GetChildCount(); i++)

--- a/src/project/saveproject.cpp
+++ b/src/project/saveproject.cpp
@@ -55,7 +55,7 @@ void Node::AddNodeToDoc(pugi::xml_node& node)
                     parts[1].backslashestoforward();
                     description << ';' << parts[1];
 
-                    if (parts.size() > 2 && parts[0].is_sameprefix("SVG"))
+                    if (parts.size() > 2 && parts[0].starts_with("SVG"))
                     {
                         description << ';' << parts[2];
                     }

--- a/src/ui/import_dlg.cpp
+++ b/src/ui/import_dlg.cpp
@@ -406,7 +406,7 @@ void ImportDlg::CheckResourceFiles(wxArrayString& files)
                 // dialog may not actually exist. So instead, we look for a trailing space which should indicate the
                 // statement is followed by dimensions.
 
-                if (type.is_sameprefix("DIALOG ") || type.is_sameprefix("DIALOGEX ") || type.is_sameprefix("MENU"))
+                if (type.starts_with("DIALOG ") || type.starts_with("DIALOGEX ") || type.starts_with("MENU"))
                 {
                     found = true;
                     break;

--- a/src/ui/importwinresdlg.cpp
+++ b/src/ui/importwinresdlg.cpp
@@ -53,7 +53,7 @@ void ImportWinRes::ReadRcFile()
         // not actually exist. So instead, we look for a trailing space which should indicate the statement is followed by
         // dimensions.
 
-        if (type.is_sameprefix("DIALOG ") || type.is_sameprefix("DIALOGEX ") || type.is_sameprefix("MENU"))
+        if (type.starts_with("DIALOG ") || type.starts_with("DIALOGEX ") || type.starts_with("MENU"))
         {
             auto pos_end = iter.find(' ');
             auto name = iter.substr(0, pos_end);

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -114,7 +114,7 @@ void RemoveNodeAction::Revert()
 
 ///////////////////////////////// ModifyPropertyAction ////////////////////////////////////
 
-ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, ttlib::cview value) : m_property(prop)
+ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, ttlib::sview value) : m_property(prop)
 {
     m_undo_string << "change " << prop->DeclName();
 
@@ -148,14 +148,14 @@ void ModifyPropertyAction::Revert()
 
 ///////////////////////////////// ModifyProperties ////////////////////////////////////
 
-ModifyProperties::ModifyProperties(ttlib::cview undo_string, bool fire_events) : UndoAction(undo_string)
+ModifyProperties::ModifyProperties(ttlib::sview undo_string, bool fire_events) : UndoAction(undo_string)
 {
     m_fire_events = fire_events;
     m_RedoEventGenerated = true;
     m_UndoEventGenerated = true;
 }
 
-void ModifyProperties::AddProperty(NodeProperty* prop, ttlib::cview value)
+void ModifyProperties::AddProperty(NodeProperty* prop, ttlib::sview value)
 {
     auto& entry = m_properties.emplace_back();
     entry.property = prop;
@@ -195,7 +195,7 @@ void ModifyProperties::Revert()
 
 ///////////////////////////////// ModifyEventAction ////////////////////////////////////
 
-ModifyEventAction::ModifyEventAction(NodeEvent* event, ttlib::cview value) : m_event(event), m_change_value(value)
+ModifyEventAction::ModifyEventAction(NodeEvent* event, ttlib::sview value) : m_event(event), m_change_value(value)
 {
     m_undo_string << "change " << event->get_name() << " handler";
 

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -277,7 +277,7 @@ ChangeSizerType::ChangeSizerType(Node* node, GenEnum::GenName new_gen_sizer)
             }
         }
 
-        for (auto& iter: m_old_node->GetChildNodePtrs())
+        for (const auto& iter: m_old_node->GetChildNodePtrs())
         {
             m_node->Adopt(g_NodeCreator.MakeCopy(iter.get()));
         }
@@ -449,9 +449,9 @@ GridBagAction::GridBagAction(Node* cur_gbsizer, const ttlib::cstr& undo_str) : U
     // Thaw() is called when GridBagAction::Update() is called
     nav_panel->Freeze();
 
-    for (size_t idx = 0; idx < cur_gbsizer->GetChildCount(); idx++)
+    for (const auto& child: cur_gbsizer->GetChildNodePtrs())
     {
-        nav_panel->EraseAllMaps(cur_gbsizer->GetChild(idx));
+        nav_panel->EraseAllMaps(child.get());
     }
 }
 
@@ -462,16 +462,17 @@ void GridBagAction::Change()
         auto nav_panel = wxGetFrame().GetNavigationPanel();
         wxWindowUpdateLocker freeze(nav_panel);
 
-        for (size_t idx = 0; idx < m_cur_gbsizer->GetChildCount(); idx++)
+        for (const auto& child: m_cur_gbsizer->GetChildNodePtrs())
         {
-            nav_panel->EraseAllMaps(m_cur_gbsizer->GetChild(idx));
+            nav_panel->EraseAllMaps(child.get());
         }
 
         auto save = g_NodeCreator.MakeCopy(m_cur_gbsizer);
         m_cur_gbsizer->RemoveAllChildren();
-        for (size_t idx = 0; idx < m_old_gbsizer->GetChildCount(); ++idx)
+
+        for (const auto& child: m_old_gbsizer->GetChildNodePtrs())
         {
-            m_cur_gbsizer->Adopt(g_NodeCreator.MakeCopy(m_old_gbsizer->GetChild(idx)));
+            m_cur_gbsizer->Adopt(g_NodeCreator.MakeCopy(child.get()));
         }
         m_old_gbsizer = std::move(save);
         m_isReverted = false;
@@ -489,16 +490,16 @@ void GridBagAction::Revert()
     auto nav_panel = wxGetFrame().GetNavigationPanel();
     wxWindowUpdateLocker freeze(nav_panel);
 
-    for (size_t idx = 0; idx < m_cur_gbsizer->GetChildCount(); idx++)
+    for (const auto& child: m_cur_gbsizer->GetChildNodePtrs())
     {
-        nav_panel->EraseAllMaps(m_cur_gbsizer->GetChild(idx));
+        nav_panel->EraseAllMaps(child.get());
     }
 
     auto save = g_NodeCreator.MakeCopy(m_cur_gbsizer);
     m_cur_gbsizer->RemoveAllChildren();
-    for (size_t idx = 0; idx < m_old_gbsizer->GetChildCount(); ++idx)
+    for (const auto& child: m_old_gbsizer->GetChildNodePtrs())
     {
-        m_cur_gbsizer->Adopt(g_NodeCreator.MakeCopy(m_old_gbsizer->GetChild(idx)));
+        m_cur_gbsizer->Adopt(g_NodeCreator.MakeCopy(child.get()));
     }
     m_old_gbsizer = std::move(save);
     m_isReverted = true;
@@ -514,9 +515,9 @@ void GridBagAction::Update()
 {
     auto nav_panel = wxGetFrame().GetNavigationPanel();
 
-    for (size_t idx = 0; idx < m_cur_gbsizer->GetChildCount(); idx++)
+    for (const auto& child: m_cur_gbsizer->GetChildNodePtrs())
     {
-        nav_panel->EraseAllMaps(m_cur_gbsizer->GetChild(idx));
+        nav_panel->EraseAllMaps(child.get());
     }
 
     nav_panel->AddAllChildren(m_cur_gbsizer.get());
@@ -559,9 +560,9 @@ void SortProjectAction::Revert()
 {
     auto project = wxGetApp().GetProject();
     project->RemoveAllChildren();
-    for (size_t idx = 0; idx < m_old_project->GetChildCount(); ++idx)
+    for (const auto& child: m_old_project->GetChildNodePtrs())
     {
-        project->Adopt(g_NodeCreator.MakeCopy(m_old_project->GetChild(idx)));
+        project->Adopt(g_NodeCreator.MakeCopy(child.get()));
     }
 
     wxGetFrame().FireProjectUpdatedEvent();

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -55,7 +55,7 @@ private:
 class ModifyPropertyAction : public UndoAction
 {
 public:
-    ModifyPropertyAction(NodeProperty* prop, ttlib::cview value);
+    ModifyPropertyAction(NodeProperty* prop, ttlib::sview value);
     ModifyPropertyAction(NodeProperty* prop, int value);
     void Change() override;
     void Revert() override;
@@ -72,9 +72,9 @@ private:
 class ModifyProperties : public UndoAction
 {
 public:
-    ModifyProperties(ttlib::cview undo_string, bool fire_events = true);
+    ModifyProperties(ttlib::sview undo_string, bool fire_events = true);
 
-    void AddProperty(NodeProperty* prop, ttlib::cview value);
+    void AddProperty(NodeProperty* prop, ttlib::sview value);
     void AddProperty(NodeProperty* prop, int value);
 
     void Change() override;
@@ -98,7 +98,7 @@ private:
 class ModifyEventAction : public UndoAction
 {
 public:
-    ModifyEventAction(NodeEvent* event, ttlib::cview value);
+    ModifyEventAction(NodeEvent* event, ttlib::sview value);
     void Change() override;
     void Revert() override;
 

--- a/src/undo_stack.h
+++ b/src/undo_stack.h
@@ -10,10 +10,12 @@
 class UndoAction
 {
 public:
-    UndoAction(const char* ptr_undo_string = nullptr)
+    UndoAction(ttlib::sview undo_string = tt_empty_cstr)
     {
-        if (ptr_undo_string)
-            m_undo_string = ptr_undo_string;
+        if (undo_string.size())
+        {
+            m_undo_string = undo_string;
+        }
     }
 
     virtual ~UndoAction() = default;
@@ -25,7 +27,7 @@ public:
     virtual void Revert() = 0;
 
     ttlib::cstr GetUndoString() { return m_undo_string; }
-    void SetUndoString(ttlib::cview str) { m_undo_string = str; }
+    void SetUndoString(ttlib::sview str) { m_undo_string = str; }
 
     bool wasUndoEventGenerated() { return m_UndoEventGenerated; }
     bool wasRedoEventGenerated() { return m_RedoEventGenerated; }

--- a/src/utils/font_prop.cpp
+++ b/src/utils/font_prop.cpp
@@ -72,7 +72,7 @@ FontProperty::FontProperty(const wxFont& font)
 
 FontProperty::FontProperty(wxVariant font) { Convert(ttlib::cstr() << font.GetString().wx_str()); }
 
-FontProperty::FontProperty(ttlib::cview font) { Convert(font); }
+FontProperty::FontProperty(ttlib::sview font) { Convert(font); }
 
 FontProperty::FontProperty(NodeProperty* prop) { Convert(prop->as_string()); }
 

--- a/src/utils/font_prop.cpp
+++ b/src/utils/font_prop.cpp
@@ -90,7 +90,7 @@ FontProperty::FontProperty(NodeProperty* prop) { Convert(prop->as_string()); }
 // facename font (point is a floating-point number)
 //     facename, point size, family, style, weight, underlined, strikethrough
 
-void FontProperty::Convert(ttlib::cview font)
+void FontProperty::Convert(ttlib::sview font)
 {
     if (font.empty())
     {

--- a/src/utils/font_prop.h
+++ b/src/utils/font_prop.h
@@ -22,7 +22,7 @@ class FontProperty
 public:
     FontProperty();
     FontProperty(const wxFont& font);
-    FontProperty(ttlib::cview font);
+    FontProperty(ttlib::sview font);
     FontProperty(NodeProperty* prop);
     FontProperty(wxVariant font);
 

--- a/src/utils/font_prop.h
+++ b/src/utils/font_prop.h
@@ -28,7 +28,7 @@ public:
 
     wxFont GetFont() const;
 
-    void Convert(ttlib::cview font);
+    void Convert(ttlib::sview font);
     wxString as_wxString() const;
     ttlib::cstr as_string() const;
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -247,7 +247,7 @@ wxSystemColour ConvertToSystemColour(ttlib::sview value)
 wxColour ConvertToColour(ttlib::sview value)
 {
     // check for system colour
-    if (ttlib::is_sameprefix(value, "wx"))
+    if (value.starts_with("wx"))
     {
         return wxSystemSettings::GetColour(ConvertToSystemColour(value));
     }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -27,7 +27,7 @@ ttlib::cstr DoubleToStr(double val)
     return result;
 }
 
-ttlib::cstr ClearPropFlag(ttlib::sview flag, ttlib::cview currentValue)
+ttlib::cstr ClearPropFlag(ttlib::sview flag, ttlib::sview currentValue)
 {
     ttlib::cstr result;
     if (flag.empty() || currentValue.empty())
@@ -49,7 +49,7 @@ ttlib::cstr ClearPropFlag(ttlib::sview flag, ttlib::cview currentValue)
     return result;
 }
 
-ttlib::cstr ClearMultiplePropFlags(ttlib::cview flags, ttlib::cview currentValue)
+ttlib::cstr ClearMultiplePropFlags(ttlib::sview flags, ttlib::sview currentValue)
 {
     ttlib::cstr result;
     if (flags.empty() || currentValue.empty())
@@ -83,7 +83,7 @@ ttlib::cstr ClearMultiplePropFlags(ttlib::cview flags, ttlib::cview currentValue
     return result;
 }
 
-ttlib::cstr SetPropFlag(ttlib::cview flag, ttlib::cview currentValue)
+ttlib::cstr SetPropFlag(ttlib::sview flag, ttlib::sview currentValue)
 {
     ttlib::cstr result(currentValue);
     if (flag.empty())
@@ -105,7 +105,7 @@ ttlib::cstr SetPropFlag(ttlib::cview flag, ttlib::cview currentValue)
     return result;
 }
 
-bool isPropFlagSet(ttlib::cview flag, ttlib::cview currentValue)
+bool isPropFlagSet(ttlib::sview flag, ttlib::sview currentValue)
 {
     if (flag.empty() || currentValue.empty())
     {
@@ -123,7 +123,7 @@ bool isPropFlagSet(ttlib::cview flag, ttlib::cview currentValue)
     return false;
 }
 
-int ConvertBitlistToInt(ttlib::cview list)
+int ConvertBitlistToInt(ttlib::sview list)
 {
     int result = 0;
     if (list.size())
@@ -197,12 +197,12 @@ ttlib::cstr ConvertSystemColourToString(long colour)
     return str;
 }
 
-wxSystemColour ConvertToSystemColour(ttlib::cview value)
+wxSystemColour ConvertToSystemColour(ttlib::sview value)
 {
     // clang-format off
 
-    #define IS_SYSCOLOUR(name) if (value.is_sameas(#name)) return name;
-    #define ELSE_IS_SYSCOLOUR(name) else if (value.is_sameas(#name)) return name;
+    #define IS_SYSCOLOUR(name) if (value == #name) return name;
+    #define ELSE_IS_SYSCOLOUR(name) else if (value == #name) return name;
 
     IS_SYSCOLOUR(wxSYS_COLOUR_SCROLLBAR)
 
@@ -244,7 +244,7 @@ wxSystemColour ConvertToSystemColour(ttlib::cview value)
     // clang-format on
 }
 
-wxColour ConvertToColour(ttlib::cview value)
+wxColour ConvertToColour(ttlib::sview value)
 {
     // check for system colour
     if (ttlib::is_sameprefix(value, "wx"))
@@ -313,7 +313,7 @@ const char* ConvertFontFamilyToString(wxFontFamily family)
     return result;
 }
 
-ttlib::cstr ConvertEscapeSlashes(ttlib::cview str)
+ttlib::cstr ConvertEscapeSlashes(ttlib::sview str)
 {
     ttlib::cstr result;
 
@@ -359,7 +359,7 @@ ttlib::cstr ConvertEscapeSlashes(ttlib::cview str)
     return result;
 }
 
-ttlib::cstr CreateEscapedText(ttlib::cview str)
+ttlib::cstr CreateEscapedText(ttlib::sview str)
 {
     ttlib::cstr result;
 
@@ -392,7 +392,7 @@ ttlib::cstr CreateEscapedText(ttlib::cview str)
     return result;
 }
 
-std::vector<ttlib::cstr> ConvertToArrayString(ttlib::cview value)
+std::vector<ttlib::cstr> ConvertToArrayString(ttlib::sview value)
 {
     std::vector<ttlib::cstr> array;
     if (value.empty())
@@ -411,7 +411,7 @@ std::vector<ttlib::cstr> ConvertToArrayString(ttlib::cview value)
     return array;
 }
 
-wxArrayString ConvertToWxArrayString(ttlib::cview value)
+wxArrayString ConvertToWxArrayString(ttlib::sview value)
 {
     wxArrayString array;
     if (value.empty())

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -29,35 +29,35 @@ enum PropIndex
     IndexSize
 };
 
-ttlib::cstr ClearPropFlag(ttlib::sview flag, ttlib::cview currentValue);
-ttlib::cstr ClearMultiplePropFlags(ttlib::cview flags, ttlib::cview currentValue);
-ttlib::cstr SetPropFlag(ttlib::cview flag, ttlib::cview currentValue);
+ttlib::cstr ClearPropFlag(ttlib::sview flag, ttlib::sview currentValue);
+ttlib::cstr ClearMultiplePropFlags(ttlib::sview flags, ttlib::sview currentValue);
+ttlib::cstr SetPropFlag(ttlib::sview flag, ttlib::sview currentValue);
 
 // Convert a double to a string without needing to switch locales
 ttlib::cstr DoubleToStr(double val);
 
-bool isPropFlagSet(ttlib::cview flag, ttlib::cview currentValue);
+bool isPropFlagSet(ttlib::sview flag, ttlib::sview currentValue);
 
-wxSystemColour ConvertToSystemColour(ttlib::cview value);
-int ConvertBitlistToInt(ttlib::cview list);
+wxSystemColour ConvertToSystemColour(ttlib::sview value);
+int ConvertBitlistToInt(ttlib::sview list);
 
 ttlib::cstr ConvertColourToString(const wxColour& colour);
 ttlib::cstr ConvertSystemColourToString(long colour);
 const char* ConvertFontFamilyToString(wxFontFamily family);
 
 // Used to add escapes to a string that will be handed off to a wxWidgets property editor
-ttlib::cstr CreateEscapedText(ttlib::cview str);
+ttlib::cstr CreateEscapedText(ttlib::sview str);
 
 // if value begins with 'wx' then it is assumed to be a wxSystemColour
-wxColour ConvertToColour(ttlib::cview value);
+wxColour ConvertToColour(ttlib::sview value);
 
 // Replace escape slashes with the actual character. Affects \\, \\n, \\r, and \\t
-ttlib::cstr ConvertEscapeSlashes(ttlib::cview str);
+ttlib::cstr ConvertEscapeSlashes(ttlib::sview str);
 
-std::vector<ttlib::cstr> ConvertToArrayString(ttlib::cview value);
+std::vector<ttlib::cstr> ConvertToArrayString(ttlib::sview value);
 
 // Use ConvertToArrayString() to get a vector, this function to get a wxArrayString
-wxArrayString ConvertToWxArrayString(ttlib::cview value);
+wxArrayString ConvertToWxArrayString(ttlib::sview value);
 
 // Converts an unsigned char array into an image. This is typically used for loading internal
 // #included images

--- a/src/winres/ctrl_utils.cpp
+++ b/src/winres/ctrl_utils.cpp
@@ -159,7 +159,7 @@ ttlib::sview resCtrl::GetID(ttlib::sview line)
     else
         m_node->prop_set_value(prop_id, "wxID_ANY");
 
-    if (m_node->prop_as_string(prop_id) != "wxID_ANY" || !id.is_sameprefix("IDC_STATIC"))
+    if (m_node->prop_as_string(prop_id) != "wxID_ANY" || !id.starts_with("IDC_STATIC"))
     {
         m_node->prop_set_value(prop_var_comment, id);
     }

--- a/src/winres/ctrl_utils.cpp
+++ b/src/winres/ctrl_utils.cpp
@@ -10,7 +10,7 @@
 #include "import_winres.h"  // WinResource -- Parse a Windows resource file
 #include "utils.h"          // Utility functions that work with properties
 
-void resCtrl::ParseCommonStyles(ttlib::cview line)
+void resCtrl::ParseCommonStyles(ttlib::sview line)
 {
     if (line.contains("WS_DISABLED"))
         m_node->prop_set_value(prop_disabled, true);
@@ -23,7 +23,7 @@ void resCtrl::ParseCommonStyles(ttlib::cview line)
         AppendStyle(prop_window_style, "wxVSCROLL");
 }
 
-bool resCtrl::ParseDimensions(ttlib::cview line, wxRect& duRect, wxRect& pixelRect)
+bool resCtrl::ParseDimensions(ttlib::sview line, wxRect& duRect, wxRect& pixelRect)
 {
     duRect = { 0, 0, 0, 0 };
     pixelRect = { 0, 0, 0, 0 };
@@ -104,7 +104,7 @@ bool resCtrl::ParseDimensions(ttlib::cview line, wxRect& duRect, wxRect& pixelRe
     return true;
 }
 
-ttlib::cview resCtrl::GetID(ttlib::cview line)
+ttlib::sview resCtrl::GetID(ttlib::sview line)
 {
     line.moveto_nonspace();
 
@@ -168,7 +168,7 @@ ttlib::cview resCtrl::GetID(ttlib::cview line)
     return line;
 }
 
-ttlib::cview resCtrl::GetLabel(ttlib::cview line)
+ttlib::sview resCtrl::GetLabel(ttlib::sview line)
 {
     line.moveto_nonspace();
 
@@ -253,7 +253,7 @@ ttlib::cview resCtrl::GetLabel(ttlib::cview line)
     return line;
 }
 
-ttlib::cview resCtrl::StepOverQuote(ttlib::cview line, ttlib::cstr& str)
+ttlib::sview resCtrl::StepOverQuote(ttlib::sview line, ttlib::cstr& str)
 {
     ASSERT(line.at(0) == '"');
 
@@ -283,7 +283,7 @@ ttlib::cview resCtrl::StepOverQuote(ttlib::cview line, ttlib::cstr& str)
     return line.subview(idx);
 }
 
-ttlib::cview resCtrl::StepOverComma(ttlib::cview line, ttlib::cstr& str)
+ttlib::sview resCtrl::StepOverComma(ttlib::sview line, ttlib::cstr& str)
 {
     auto pos = str.AssignSubString(line, ',', ',');
     if (!ttlib::is_found(pos))
@@ -301,7 +301,7 @@ ttlib::cview resCtrl::StepOverComma(ttlib::cview line, ttlib::cstr& str)
     return line;
 }
 
-void resCtrl::AppendStyle(GenEnum::PropName prop_name, ttlib::cview style)
+void resCtrl::AppendStyle(GenEnum::PropName prop_name, ttlib::sview style)
 {
     ttlib::cstr updated_style = m_node->prop_as_string(prop_name);
     if (updated_style.size())

--- a/src/winres/form_utils.cpp
+++ b/src/winres/form_utils.cpp
@@ -176,7 +176,7 @@ void resForm::SortCtrls()
 // This is almost identical to the function of the same name in resCtrl -- however that one needs to access m_node in order
 // to handle a wxComboBox which has a different height then specified in the resource file.
 
-bool resForm::ParseDimensions(ttlib::cview line, wxRect& duRect, wxRect& pixelRect)
+bool resForm::ParseDimensions(ttlib::sview line, wxRect& duRect, wxRect& pixelRect)
 {
     duRect = { 0, 0, 0, 0 };
     pixelRect = { 0, 0, 0, 0 };

--- a/src/winres/import_winres.cpp
+++ b/src/winres/import_winres.cpp
@@ -184,11 +184,11 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
             for (m_curline = 0; m_curline < file.size(); ++m_curline)
             {
                 auto curline = file[m_curline].view_nonspace();
-                if (curline.is_sameprefix("STRINGTABLE"))
+                if (curline.starts_with("STRINGTABLE"))
                 {
                     ParseStringTable(file);
                 }
-                else if (curline.is_sameprefix("#pragma code_page"))
+                else if (curline.starts_with("#pragma code_page"))
                 {
                     auto code = curline.find('(');
                     m_codepage = std::atoi(curline.subview(code + 1));
@@ -206,10 +206,10 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
             {
                 auto directive = curline.subview(curline.find_nonspace(start + 1));
 
-                if (directive.is_sameprefix("ifdef"))
+                if (directive.starts_with("ifdef"))
                 {
                     directive.moveto_nextword();
-                    if (ttlib::is_sameprefix(directive, "APSTUDIO_INVOKED"))
+                    if (directive.starts_with("APSTUDIO_INVOKED"))
                     {
                         // Step over any APSTUDIO_INVOKED section.
                         for (++m_curline; m_curline < file.size(); ++m_curline)
@@ -220,7 +220,7 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
                                 continue;
                             if (line[start] == '#')
                             {
-                                if (auto tmp = line.subview(line.find_nonspace() + 1); tmp.is_sameprefix("endif"))
+                                if (auto tmp = line.subview(line.find_nonspace() + 1); tmp.starts_with("endif"))
                                 {
                                     break;
                                 }
@@ -238,19 +238,19 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
                         for (auto erase_position = m_curline; erase_position < file.size(); ++erase_position)
                         {
                             curline = file[erase_position].view_nonspace();
-                            if (curline.is_sameprefix("#else"))
+                            if (curline.starts_with("#else"))
                             {
                                 do
                                 {
                                     file.RemoveLine(erase_position);
                                     curline = file[erase_position].view_nonspace();
-                                    if (curline.is_sameprefix("#endif"))
+                                    if (curline.starts_with("#endif"))
                                     {
                                         break;
                                     }
                                 } while (erase_position < file.size());
                             }
-                            if (curline.is_sameprefix("#endif"))
+                            if (curline.starts_with("#endif"))
                             {
                                 file.RemoveLine(erase_position);
 
@@ -267,7 +267,7 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
                         }
                     }
                 }
-                else if (directive.is_sameprefix("pragma"))
+                else if (directive.starts_with("pragma"))
                 {
                     if (curline.contains(" code_page("))
                     {
@@ -308,7 +308,7 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
                 }
                 ParseMenu(file);
             }
-            else if (curline.is_sameprefix("STRINGTABLE"))
+            else if (curline.starts_with("STRINGTABLE"))
             {
                 ParseStringTable(file);
             }
@@ -350,7 +350,7 @@ void WinResource::ParseDialog(ttlib::textfile& file)
 
         auto settings = line.subview(line.find_nonspace(end));
 
-        if (!settings.is_sameprefix("DIALOG"))  // verify this is a dialog
+        if (!settings.starts_with("DIALOG"))  // verify this is a dialog
             throw std::invalid_argument("Expected an ID then a DIALOG or DIALOGEX.");
 
         auto pos = ttlib::stepover_pos(settings);
@@ -381,7 +381,7 @@ void WinResource::ParseMenu(ttlib::textfile& file)
 
         auto settings = line.subview(line.find_nonspace(end));
 
-        if (!settings.is_sameprefix("MENU"))  // verify this is a dialog
+        if (!settings.starts_with("MENU"))  // verify this is a dialog
             throw std::invalid_argument("Expected an ID then a MENU.");
 
         auto& form = m_forms.emplace_back();
@@ -405,11 +405,11 @@ void WinResource::ParseStringTable(ttlib::textfile& file)
         if (line.empty() || line.at(0) == '/')  // ignore blank lines and comments
             continue;
 
-        if (line.is_sameprefix("END") || line.is_sameprefix("}"))
+        if (line.starts_with("END") || line.starts_with("}"))
         {
             break;
         }
-        if (line.is_sameprefix("BEGIN") || line.is_sameprefix("{"))
+        if (line.starts_with("BEGIN") || line.starts_with("{"))
         {
             continue;
         }

--- a/src/winres/import_winres.cpp
+++ b/src/winres/import_winres.cpp
@@ -30,7 +30,7 @@ bool WinResource::Import(const ttString& filename, bool write_doc)
 }
 
 // clang-format off
-static constexpr const auto lst_ignored_includes = {
+static const std::set<std::string_view> lst_ignored_includes = {
 
     "afxres.h",
     "windows.h",
@@ -71,28 +71,19 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
     // First step though the file to find all #includes. Local header files get stored to an array to add to forms.
     // #included resource files get added to the end of file.
 
-    for (size_t idx = 0; idx < file.size(); ++idx)
+    for (auto& iter: file)
     {
-        if (file[idx].contains("#include"))
+        if (iter.contains("#include"))
         {
             ttlib::cstr name;
-            auto curline = file[idx].view_nonspace();
+            auto curline = iter.view_nonspace();
             name.ExtractSubString(curline, curline.stepover());
             if (name.size())
             {
                 auto ext = name.extension();
                 if (ext.is_sameas(".h"))
                 {
-                    bool ignore_file = false;
-                    for (auto& iter: lst_ignored_includes)
-                    {
-                        if (name.is_sameas(iter))
-                        {
-                            ignore_file = true;
-                            break;
-                        }
-                    }
-                    if (!ignore_file)
+                    if (!lst_ignored_includes.contains(name))
                     {
                         m_include_lines.emplace(curline);
                     }

--- a/src/winres/winres_ctrl.cpp
+++ b/src/winres/winres_ctrl.cpp
@@ -119,7 +119,7 @@ void resCtrl::ParseDirective(WinResource* pWinResource, ttlib::sview line)
 #endif  // _DEBUG
 
     m_pWinResource = pWinResource;
-    bool is_control = line.is_sameprefix("CONTROL");
+    bool is_control = line.starts_with("CONTROL");
     m_add_wrap_property = false;
     m_add_min_width_property = false;
 
@@ -253,48 +253,48 @@ void resCtrl::ParseDirective(WinResource* pWinResource, ttlib::sview line)
             }
         }
 
-        else if (line.is_sameprefix("AUTORADIOBUTTON"))
+        else if (line.starts_with("AUTORADIOBUTTON"))
         {
             m_node = g_NodeCreator.NewNode(gen_wxRadioButton);
             if (line.contains("WX_GROUP"))
                 AppendStyle(prop_style, "wxRB_GROUP");
         }
-        else if (line.is_sameprefix("CTEXT"))
+        else if (line.starts_with("CTEXT"))
         {
             m_node = g_NodeCreator.NewNode(gen_wxStaticText);
             // We don't know if this will be in a horizontal or vertical sizer, so we just use wxALIGN_CENTER which works for
             // either.
             m_node->prop_set_value(prop_style, "wxALIGN_CENTER_HORIZONTAL");
         }
-        else if (line.is_sameprefix("DEFPUSHBUTTON"))
+        else if (line.starts_with("DEFPUSHBUTTON"))
         {
             m_node = g_NodeCreator.NewNode(gen_wxButton);
             m_node->prop_set_value(prop_default, true);
         }
-        else if (line.is_sameprefix("LTEXT"))
+        else if (line.starts_with("LTEXT"))
         {
             m_node = g_NodeCreator.NewNode(gen_wxStaticText);
             // m_node->prop_set_value(prop_style, "wxALIGN_LEFT");
         }
-        else if (line.is_sameprefix("RTEXT"))
+        else if (line.starts_with("RTEXT"))
         {
             m_node = g_NodeCreator.NewNode(gen_wxStaticText);
             m_node->prop_set_value(prop_style, "wxALIGN_RIGHT");
         }
-        else if (line.is_sameprefix("RADIOBUTTON "))
+        else if (line.starts_with("RADIOBUTTON "))
         {
             m_node = g_NodeCreator.NewNode(gen_wxRadioButton);
             if (line.contains("WX_GROUP"))
                 AppendStyle(prop_style, "wxRB_GROUP");
         }
-        else if (line.is_sameprefix("SCROLLBAR"))
+        else if (line.starts_with("SCROLLBAR"))
         {
             m_node = g_NodeCreator.NewNode(gen_wxScrollBar);
             label_required = false;
             if (line.contains("SBS_VERT"))
                 m_node->prop_set_value(prop_style, "wxSB_VERTICAL");
         }
-        else if (line.is_sameprefix("ICON"))
+        else if (line.starts_with("ICON"))
         {
             ParseIconControl(line);
             return;

--- a/src/winres/winres_ctrl.cpp
+++ b/src/winres/winres_ctrl.cpp
@@ -93,7 +93,7 @@ static const ClassGenPair lst_name_gen[] = {
 
 */
 
-void resCtrl::ParseDirective(WinResource* pWinResource, ttlib::cview line)
+void resCtrl::ParseDirective(WinResource* pWinResource, ttlib::sview line)
 {
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
     // Create a copy of the original line without the extra spaces that can be used to send to our log window if there are

--- a/src/winres/winres_ctrl.h
+++ b/src/winres/winres_ctrl.h
@@ -19,7 +19,7 @@ public:
     auto GetNode() const { return m_node.get(); }
     auto GetNodePtr() const { return m_node; }
 
-    void ParseDirective(WinResource* pWinResource, ttlib::cview line);
+    void ParseDirective(WinResource* pWinResource, ttlib::sview line);
 
     // left position in pixels
     auto GetLeft() const { return m_pixel_rect.GetLeft(); }
@@ -63,7 +63,7 @@ public:
         GetNode()->prop_set_value(name, value);
     }
 
-    bool ParseDimensions(ttlib::cview line, wxRect& duRect, wxRect& pixelRect);
+    bool ParseDimensions(ttlib::sview line, wxRect& duRect, wxRect& pixelRect);
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
     auto& GetOrginalLine() { return m_original_line; }
 #endif
@@ -76,38 +76,38 @@ public:
 
 protected:
     // This will map window styles to wxWidgets styles and append them to prop_style
-    void ParseStyles(ttlib::cview line);
+    void ParseStyles(ttlib::sview line);
 
-    void ParseListViewStyles(ttlib::cview line);
-    void ParseButtonStyles(ttlib::cview line);
+    void ParseListViewStyles(ttlib::sview line);
+    void ParseButtonStyles(ttlib::sview line);
 
-    void AddSpecialStyles(ttlib::cview line);
-    void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
+    void AddSpecialStyles(ttlib::sview line);
+    void AppendStyle(GenEnum::PropName prop_name, ttlib::sview style);
 
     // Set prop_ to common values (disabled, hidden, scroll, etc.)
-    void ParseCommonStyles(ttlib::cview line);
+    void ParseCommonStyles(ttlib::sview line);
 
-    // This will set prop_id, and return a cview to the position past the id
-    ttlib::cview GetID(ttlib::cview line);
+    // This will set prop_id, and return a sview to the position past the id
+    ttlib::sview GetID(ttlib::sview line);
 
-    // This will set prop_label, and return a cview to the position past the id
-    ttlib::cview GetLabel(ttlib::cview line);
+    // This will set prop_label, and return a sview to the position past the id
+    ttlib::sview GetLabel(ttlib::sview line);
 
     // Returns a view past the closing quote, or an empty view if there was no closing quote
-    ttlib::cview StepOverQuote(ttlib::cview line, ttlib::cstr& str);
+    ttlib::sview StepOverQuote(ttlib::sview line, ttlib::cstr& str);
 
     // Retrieves any string between commas, returns view past the closing comma
-    ttlib::cview StepOverComma(ttlib::cview line, ttlib::cstr& str);
+    ttlib::sview StepOverComma(ttlib::sview line, ttlib::cstr& str);
 
     // Similar to ParseIconControl only in this case line is pointing to the id, and the Node
     // has already been created.
     //
     // Works with either SS_BITMAP or SS_ICON.
-    void ParseImageControl(ttlib::cview line);
+    void ParseImageControl(ttlib::sview line);
 
     // Icon controls require too much special processing to be inside the ParseDirective()
     // function.
-    void ParseIconControl(ttlib::cview line);
+    void ParseIconControl(ttlib::sview line);
 
 private:
     NodeSharedPtr m_node;

--- a/src/winres/winres_dlg.cpp
+++ b/src/winres/winres_dlg.cpp
@@ -24,9 +24,9 @@ void resForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, s
 
     bool isDialog = true;
 
-    for (size_t idx = curTxtLine; idx < txtfile.size(); ++idx)
+    for (auto& iter: txtfile)
     {
-        line = txtfile[idx].subview(txtfile[idx].find_nonspace());
+        line = iter.subview(iter.find_nonspace());
         if (line.starts_with("STYLE"))
         {
             if (line.contains("DS_CONTROL"))

--- a/src/winres/winres_dlg.cpp
+++ b/src/winres/winres_dlg.cpp
@@ -27,7 +27,7 @@ void resForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, s
     for (size_t idx = curTxtLine; idx < txtfile.size(); ++idx)
     {
         line = txtfile[idx].subview(txtfile[idx].find_nonspace());
-        if (line.is_sameprefix("STYLE"))
+        if (line.starts_with("STYLE"))
         {
             if (line.contains("DS_CONTROL"))
                 isDialog = false;  // This is a panel dialog, typically used by a wizard
@@ -66,23 +66,23 @@ void resForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, s
     for (++curTxtLine; curTxtLine < txtfile.size(); ++curTxtLine)
     {
         line = txtfile[curTxtLine].subview(txtfile[curTxtLine].find_nonspace());
-        if (line.is_sameprefix("STYLE"))
+        if (line.starts_with("STYLE"))
         {
             AddStyle(txtfile, curTxtLine);
         }
-        else if (line.is_sameprefix("CAPTION"))
+        else if (line.starts_with("CAPTION"))
         {
             line.moveto_nextword();
             value.ExtractSubString(line);
             m_form_node->prop_set_value(prop_title, m_pWinResource->ConvertCodePageString(value));
         }
-        else if (line.is_sameprefix("FONT"))
+        else if (line.starts_with("FONT"))
         {
             line.moveto_nextword();
             // TODO: [KeyWorks - 10-18-2020] This needs to be ignored for all "standard" fonts, but might be critical
             // for fonts used for non-English dialogs.
         }
-        else if (line.is_sameprefix("BEGIN") || line.is_sameprefix("{"))
+        else if (line.starts_with("BEGIN") || line.starts_with("{"))
         {
             ++curTxtLine;
             ParseControls(txtfile, curTxtLine);
@@ -190,7 +190,7 @@ void resForm::ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine)
         if (line.empty() || line.at(0) == '/')  // ignore blank lines and comments
             continue;
 
-        if (line.is_sameprefix("END") || line.is_sameprefix("}"))
+        if (line.starts_with("END") || line.starts_with("}"))
             break;
 
         auto& control = m_ctrls.emplace_back();
@@ -243,7 +243,7 @@ ttlib::cstr resForm::ConvertFormID(ttlib::sview id)
 
     value.RightTrim();
 
-    if (value.is_sameprefix("IDD_"))
+    if (value.starts_with("IDD_"))
         value.erase(0, sizeof("IDD_") - 1);
 
     if (value.size() > 1 && std::isupper(value[1]))

--- a/src/winres/winres_dlg.cpp
+++ b/src/winres/winres_dlg.cpp
@@ -215,7 +215,7 @@ void resForm::ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine)
     }
 }
 
-void resForm::AppendStyle(GenEnum::PropName prop_name, ttlib::cview style)
+void resForm::AppendStyle(GenEnum::PropName prop_name, ttlib::sview style)
 {
     ttlib::cstr updated_style = m_form_node->prop_as_string(prop_name);
     if (updated_style.size())
@@ -224,7 +224,7 @@ void resForm::AppendStyle(GenEnum::PropName prop_name, ttlib::cview style)
     m_form_node->prop_set_value(prop_name, updated_style);
 }
 
-ttlib::cstr resForm::ConvertFormID(ttlib::cview id)
+ttlib::cstr resForm::ConvertFormID(ttlib::sview id)
 {
     id.moveto_nonspace();
     ttlib::cstr value;

--- a/src/winres/winres_form.h
+++ b/src/winres/winres_form.h
@@ -35,7 +35,7 @@ public:
 
     // Remove outer quotes, prefix a digit with id_ -- this is how the id gets stored in the
     // dialog.
-    ttlib::cstr ConvertFormID(ttlib::cview id);
+    ttlib::cstr ConvertFormID(ttlib::sview id);
 
     // Call this after
     void CreateDialogLayout();
@@ -91,7 +91,7 @@ protected:
 
     void AddStaticBoxChildren(const resCtrl& box, size_t idx_group_box);
     void AddStyle(ttlib::textfile& txtfile, size_t& curTxtLine);
-    void AppendStyle(GenEnum::PropName prop_name, ttlib::cview style);
+    void AppendStyle(GenEnum::PropName prop_name, ttlib::sview style);
     void ParseControls(ttlib::textfile& txtfile, size_t& curTxtLine);
     void ParseMenus(ttlib::textfile& txtfile, size_t& curTxtLine);
     void ParseMenuItem(Node* parent, ttlib::textfile& txtfile, size_t& curTxtLine);
@@ -152,7 +152,7 @@ protected:
 
     void CreateStdButton();
 
-    bool ParseDimensions(ttlib::cview line, wxRect& duRect, wxRect& pixelRect);
+    bool ParseDimensions(ttlib::sview line, wxRect& duRect, wxRect& pixelRect);
 
     // This will search through m_ctrls and find the index of the control matching the node
     // parameter. Returns -1 if not found.

--- a/src/winres/winres_images.cpp
+++ b/src/winres/winres_images.cpp
@@ -54,7 +54,7 @@ static std::map<std::string, const char*> map_win_wx_stock = {
 
 // clang-format on
 
-void resCtrl::ParseIconControl(ttlib::cview line)
+void resCtrl::ParseIconControl(ttlib::sview line)
 {
     line.moveto_nextword();
 
@@ -128,7 +128,7 @@ void resCtrl::ParseIconControl(ttlib::cview line)
 // has already been created.
 //
 // Works with either SS_BITMAP or SS_ICON.
-void resCtrl::ParseImageControl(ttlib::cview line)
+void resCtrl::ParseImageControl(ttlib::sview line)
 {
     ttlib::cstr image_name;
 

--- a/src/winres/winres_menu.cpp
+++ b/src/winres/winres_menu.cpp
@@ -29,7 +29,7 @@ void resForm::ParseMenu(WinResource* pWinResource, ttlib::textfile& txtfile, siz
         if (menu_line.empty() || menu_line.at(0) == '/')  // ignore blank lines and comments
             continue;
 
-        if (menu_line.is_sameprefix("END") || menu_line.is_sameprefix("}"))
+        if (menu_line.starts_with("END") || menu_line.starts_with("}"))
         {
             --nesting;
             if (nesting > 0)
@@ -37,12 +37,12 @@ void resForm::ParseMenu(WinResource* pWinResource, ttlib::textfile& txtfile, siz
             else
                 break;
         }
-        else if (menu_line.is_sameprefix("BEGIN") || menu_line.is_sameprefix("{"))
+        else if (menu_line.starts_with("BEGIN") || menu_line.starts_with("{"))
         {
             ++nesting;
             continue;
         }
-        if (menu_line.is_sameprefix("POPUP"))
+        if (menu_line.starts_with("POPUP"))
         {
             ++popups;
 
@@ -81,7 +81,7 @@ void resForm::ParseMenu(WinResource* pWinResource, ttlib::textfile& txtfile, siz
     for (++curTxtLine; curTxtLine < txtfile.size(); ++curTxtLine)
     {
         line = txtfile[curTxtLine].subview(txtfile[curTxtLine].find_nonspace());
-        if (line.is_sameprefix("BEGIN") || line.is_sameprefix("{"))
+        if (line.starts_with("BEGIN") || line.starts_with("{"))
         {
             ++curTxtLine;
             ParseMenus(txtfile, curTxtLine);
@@ -100,12 +100,12 @@ void resForm::ParseMenus(ttlib::textfile& txtfile, size_t& curTxtLine)
         if (line.empty() || line.at(0) == '/')  // ignore blank lines and comments
             continue;
 
-        if (line.is_sameprefix("END") || line.is_sameprefix("}"))
+        if (line.starts_with("END") || line.starts_with("}"))
         {
             break;
         }
 
-        if (line.is_sameprefix("BEGIN") || line.is_sameprefix("{"))
+        if (line.starts_with("BEGIN") || line.starts_with("{"))
         {
             if (parent)
             {
@@ -116,7 +116,7 @@ void resForm::ParseMenus(ttlib::textfile& txtfile, size_t& curTxtLine)
             continue;
         }
 
-        if (line.is_sameprefix("POPUP") && !m_is_popup_menu)
+        if (line.starts_with("POPUP") && !m_is_popup_menu)
         {
             auto& control = m_ctrls.emplace_back();
             parent = control.SetNodePtr(g_NodeCreator.NewNode(gen_wxMenu));
@@ -136,12 +136,12 @@ void resForm::ParseMenuItem(Node* parent, ttlib::textfile& txtfile, size_t& curT
         if (line.empty() || line.at(0) == '/')  // ignore blank lines and comments
             continue;
 
-        else if (line.is_sameprefix("END") || line.is_sameprefix("}"))
+        else if (line.starts_with("END") || line.starts_with("}"))
         {
             break;
         }
 
-        else if (line.is_sameprefix("BEGIN") || line.is_sameprefix("{"))
+        else if (line.starts_with("BEGIN") || line.starts_with("{"))
         {
             if (sub_parent)
             {
@@ -152,7 +152,7 @@ void resForm::ParseMenuItem(Node* parent, ttlib::textfile& txtfile, size_t& curT
             continue;
         }
 
-        else if (line.is_sameprefix("POPUP"))
+        else if (line.starts_with("POPUP"))
         {
             auto& control = m_ctrls.emplace_back();
             sub_parent = control.SetNodePtr(g_NodeCreator.NewNode(gen_submenu));
@@ -160,10 +160,10 @@ void resForm::ParseMenuItem(Node* parent, ttlib::textfile& txtfile, size_t& curT
             line.moveto_nextword();
             sub_parent->prop_set_value(prop_label, m_pWinResource->ConvertCodePageString(line.view_substr(0)));
         }
-        else if (line.is_sameprefix("MENUITEM"))
+        else if (line.starts_with("MENUITEM"))
         {
             line.moveto_nextword();
-            if (line.is_sameprefix("SEPARATOR"))
+            if (line.starts_with("SEPARATOR"))
             {
                 auto& control = m_ctrls.emplace_back();
                 auto separator = control.SetNodePtr(g_NodeCreator.NewNode(gen_separator));

--- a/src/winres/winres_menu.cpp
+++ b/src/winres/winres_menu.cpp
@@ -23,9 +23,9 @@ void resForm::ParseMenu(WinResource* pWinResource, ttlib::textfile& txtfile, siz
     m_is_popup_menu = false;
     size_t popups = 0;
     int nesting = 0;
-    for (size_t pos = curTxtLine + 1; pos < txtfile.size(); ++pos)
+    for (auto& iter: txtfile)
     {
-        auto menu_line = txtfile[pos].subview(txtfile[pos].find_nonspace());
+        auto menu_line = iter.subview(iter.find_nonspace());
         if (menu_line.empty() || menu_line.at(0) == '/')  // ignore blank lines and comments
             continue;
 

--- a/src/winres/winres_styles.cpp
+++ b/src/winres/winres_styles.cpp
@@ -57,7 +57,7 @@ static const StylePair lst_styles[] = {
 
 // clang-format on
 
-void resCtrl::ParseStyles(ttlib::cview line)
+void resCtrl::ParseStyles(ttlib::sview line)
 {
     for (auto& iter: lst_styles)
     {
@@ -66,7 +66,7 @@ void resCtrl::ParseStyles(ttlib::cview line)
     }
 }
 
-void resCtrl::ParseButtonStyles(ttlib::cview line)
+void resCtrl::ParseButtonStyles(ttlib::sview line)
 {
     if (line.contains("BS_RIGHTBUTTON"))
     {
@@ -115,7 +115,7 @@ void resCtrl::ParseButtonStyles(ttlib::cview line)
         AppendStyle(prop_window_style, "wxBORDER_STATIC");
 }
 
-void resCtrl::ParseListViewStyles(ttlib::cview line)
+void resCtrl::ParseListViewStyles(ttlib::sview line)
 {
     m_node->prop_set_value(prop_style, "");
 
@@ -149,7 +149,7 @@ void resCtrl::ParseListViewStyles(ttlib::cview line)
         AppendStyle(prop_style, "wxLC_SORT_DESCENDING");
 }
 
-void resCtrl::AddSpecialStyles(ttlib::cview line)
+void resCtrl::AddSpecialStyles(ttlib::sview line)
 {
     //////////// Edit control styles ////////////
 

--- a/src/winres/winres_styles.cpp
+++ b/src/winres/winres_styles.cpp
@@ -18,7 +18,7 @@ struct StylePair
 // lst_styles maps a window style to a wxWidgets style that is appended to prop_style.
 static const StylePair lst_styles[] = {
 
-    { "CBS_DROPDOWN", "wxCB_DROPDOWN" },
+    { .win_style = "CBS_DROPDOWN", .wx_style = "wxCB_DROPDOWN" },
     { "CBS_DROPDOWNLIST", "wxCB_READONLY" },
     { "CBS_SIMPLE", "wxCB_SIMPLE" },
     { "CBS_SORT", "wxCB_SORT" },


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR does not change any functionality, but is a major refactoring due primarily to the switch to a C++20 minimum compiler. I also took the opportunity to convert a lot of the `for` loops into the ranged version since it makes the code a lot easier to read.

Change highlights:

- pugixml was updated from a fork that returns strings as std::string_view instead of char*
- std::unordered_map can now call find() and contains() with a std::string_view. That made it possible to change some of our vector/map pairs to a single unordered_map, and to change some of our std::map to the unordered variant for a likely performance gain.
- ttlib::cview replaced with ttlib::sview wherever possible. With pugixml returning string_view and unordered_map being able to search using string_view, the need for a zero terminated string is mostly gone.
- Some of the code predates our switch to C++17, so some of the older code was refactored as well.
