### PR TITLE
Support stock id for wxButton label

### DIFF
--- a/src/mockup/mockup_parent.cpp
+++ b/src/mockup/mockup_parent.cpp
@@ -399,6 +399,8 @@ void MockupParent::OnNodePropModified(CustomEvent& event)
         {
             if (prop->isProp(prop_message) && prop->GetNode()->isGen(gen_wxBannerWindow))
                 break;  // In this case, Mockup does need to be redrawn
+            else if (prop->isProp(prop_id) && prop->GetNode()->isGen(gen_wxButton))
+                break;  // In this case, Mockup does need to be redrawn since label could have changed
             else
                 return;
         }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -332,6 +332,14 @@ int Node::prop_as_int(PropName name) const
         return 0;
 }
 
+int Node::prop_as_id(PropName name) const
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_id();
+    else
+        return wxID_ANY;
+}
+
 int Node::prop_as_mockup(PropName name, std::string_view prefix) const
 {
     if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -175,6 +175,11 @@ public:
     int prop_as_int(PropName name) const;
     int prop_as_mockup(PropName name, std::string_view prefix) const;
 
+    // Looks up wx constant, returns it's numerical value.
+    //
+    // Returns wxID_ANY if constant is not found
+    int prop_as_id(PropName name) const;
+
     wxColour prop_as_wxColour(PropName name) const;
     wxFont prop_as_font(PropName name) const;
     wxPoint prop_as_wxPoint(PropName name) const;

--- a/src/nodes/node_constants.cpp
+++ b/src/nodes/node_constants.cpp
@@ -713,6 +713,8 @@ void NodeCreator::AddAllConstants()
     ADD_CONSTANT(wxRIBBON_BUTTON_HYBRID)
     ADD_CONSTANT(wxRIBBON_BUTTON_TOGGLE)
 
+    ADD_CONSTANT(wxID_ANY)
+
     // The following stock ids are taken from wxWidgets/src/common/stockitem.cpp
 
     ADD_CONSTANT(wxID_ABOUT)

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -57,6 +57,11 @@ int NodeProperty::as_int() const
     }
 }
 
+int NodeProperty::as_id() const
+{
+    return g_NodeCreator.GetConstantAsInt(m_value, wxID_ANY);
+}
+
 int NodeProperty::as_mockup(std::string_view prefix) const
 {
     switch (type())

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -38,6 +38,11 @@ public:
     bool as_bool() const { return (as_int() != 0); };
     double as_float() const;
 
+    // Looks up wx constant, returns it's numerical value.
+    //
+    // Returns wxID_ANY if constant is not found
+    int as_id() const;
+
     // ttlib::sview as_sview() const { return m_value; }
 
     // Use with caution! This allows you to modify the property string directly.

--- a/src/xml/buttons_xml.xml
+++ b/src/xml/buttons_xml.xml
@@ -70,7 +70,8 @@ inline const char* buttons_xml = R"===(<?xml version="1.0"?>
 		<inherits class="String Validator" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_btn</property>
-		<property name="label" type="string_escapes">MyButton</property>
+		<property name="label" type="string_escapes"
+			help="Leave this property blank if you are using a stock id. A stock id will automatically display a label matching the id.">MyButton</property>
 		<property name="markup" type="bool"
 			help="This can be used to apply fonts or colours to different parts of the label.">0</property>
 		<property name="default" type="bool"


### PR DESCRIPTION
See PR for description.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
When a stock id is used for a **wxButton**, the button's label will be automatically supplied by the stock id. Calling SetLabel() will override this behavior even if the label is blank. This PR changes the code so that it doesn't make that call, the mockup gets recreated if the stock id changes or the label is cleared, and the XRC generation switches to the id instead of the name.
