### PR TITLE
Update wxAuiNotebook generator

### DIFF
--- a/src/generate/gen_aui_notebook.cpp
+++ b/src/generate/gen_aui_notebook.cpp
@@ -107,14 +107,14 @@ int AuiNotebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
 
     GenXrcObjectAttributes(node, item, "wxAuiNotebook");
 
+    if (node->value(prop_art_provider) == "wxAuiSimpleTabArt")
+        item.append_child("art-provider").text().set("simple");
+
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
     if (add_comments)
     {
-        ADD_ITEM_COMMENT("XRC does not support calling SetArtProvider()")
-        if (node->as_int(prop_tab_height) >= 0)
-            ADD_ITEM_COMMENT("XRC does not support calling SetTabCtrlHeight()")
         GenXrcComments(node, item);
     }
 

--- a/src/winres/winres_ctrl.h
+++ b/src/winres/winres_ctrl.h
@@ -65,7 +65,10 @@ public:
 
     bool ParseDimensions(ttlib::sview line, wxRect& duRect, wxRect& pixelRect);
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
-    auto& GetOrginalLine() { return m_original_line; }
+    auto& GetOrginalLine()
+    {
+        return m_original_line;
+    }
 #endif
 
     NodeSharedPtr SetNodePtr(NodeSharedPtr node)

--- a/src/xml/aui_xml.xml
+++ b/src/xml/aui_xml.xml
@@ -12,7 +12,6 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 			help="If a name is specified, wxPersistenceManager will be used to save/restore the currently selected page." />
 		<property name="art_provider" type="option">
 			<option name="wxAuiDefaultTabArt" help="Use art and colour scheme that is adapted to the major platforms' look." />
-			<option name="wxAuiGenericTabArt" help="Use a generic art and colour scheme." />
 			<option name="wxAuiSimpleTabArt" help="Use a simple art and colour scheme." />
 			wxAuiDefaultTabArt
 		</property>
@@ -31,7 +30,7 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 			<option name="wxAUI_NB_WINDOWLIST_BUTTON" help="With this style, a drop-down list of windows is available." />
 			wxAUI_NB_TOP|wxAUI_NB_TAB_SPLIT|wxAUI_NB_TAB_MOVE|wxAUI_NB_SCROLL_BUTTONS|wxAUI_NB_CLOSE_ON_ACTIVE_TAB|wxAUI_NB_MIDDLE_CLICK_CLOSE
 		</property>
-		<property name="tab_height" type="int" help="Sets the tab height. Use -1 for automatic calculation of the height.">-1</property>
+		<!-- <property name="tab_height" type="int" help="Sets the tab height. Use -1 for automatic calculation of the height.">-1</property> -->
 		<event name="wxEVT_AUINOTEBOOK_PAGE_CLOSE" class="wxAuiNotebookEvent" help="A page is about to be closed." />
 		<event name="wxEVT_AUINOTEBOOK_PAGE_CLOSED" class="wxAuiNotebookEvent" help="A page has been closed." />
 		<event name="wxEVT_AUINOTEBOOK_PAGE_CHANGED" class="wxAuiNotebookEvent" help="The page selection was changed." />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Added support for XRC art-provider in wxAuiNotebook -- this will be available in wxWidgets 3.2.0.

I removed wxAuiGenericTabArt from the list of art providers for wxAuiNotebook. This setting has no effect on MAC, and doesn't have a standard UI appearance on either GTK or MSW.

I removed tab_height from wxAuiNotebook because it is buggy. Use it with wxAuiSimpleArt and the text appears above the tab. For wxAuiDefaultTabArt on MSW, it doesn't prevent the text from jumping if one tab has a bitmap and the other does not.