### PR TITLE
Add project-wide and form XRC properties, support saving XRC files

### DIFF
--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -6,9 +6,9 @@
 
 Options:
     Project:          wxUiEditor
-    Exe_type:         lib         # This is just for clang-cl to verify compilation, so we don't need an executable
-    Pch:              pch.h       # will add -FI to force include if filename specified
-    Ms_linker:        true        # true means use link.exe even when compiling with clang-cl
+    Exe_type:         lib      # This is just for clang-cl to verify compilation, so we don't need an executable
+    Pch:              pch.h    # will add -FI to force include if filename specified
+    Ms_linker:        true     # true means use link.exe even when compiling with clang-cl
 
     Optimize:         space    # [space | speed] optimization to use in release builds
     Warn:             4        # [1-4] warning level
@@ -16,10 +16,10 @@ Options:
     Crt_dbg:          dll      # [static | dll] type of CRT to link to in debug builds
 
     CFlags_cmn:       /std:c++20 /Zc:__cplusplus /utf-8 /DUNICODE /DINTERNAL_TESTING
-    CFlags_rel:       /DNDEBUG # static wxWidgets libraries in release build
+    CFlags_rel:       /DNDEBUG
 
-    TargetDir:        ../build/CMakeFiles/CMakeTmp   # just a temporary location for the library
-    Natvis:           wxui.natvis # MSVC Debug visualizer
+    TargetDir:        ../build/CMakeFiles/CMakeTmp  # just a temporary location for the psuedo library
+    Natvis:           wxui.natvis                   # MSVC Debug visualizer
 
     IncDirs:          ./;nodes;generate;utils;customprops;ui;wxui;../pugixml;../ttLib/include;../wxSnapshot/include;../wxSnapshot/win
 
@@ -289,15 +289,16 @@ Docs:
     ../docs/import_winres.md
     ../docs/xrc.md
     nodes/README.md
-
-    # The following are the XML files we use for interfaces and generators
-
     xml/README.md
+
+    # interface declarations
 
     xml/interface_xml.xml
     xml/sizer_child_xml.xml
     xml/validators_xml.xml
     xml/window_interfaces_xml.xml
+
+    # generator declarations
 
     xml/aui_xml.xml
     xml/bars_xml.xml

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -123,6 +123,8 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_column, "column" },
     { prop_column_labels, "column_labels" },
     { prop_column_sizes, "column_sizes" },
+    { prop_combine_all_forms, "combine_all_forms" },
+    { prop_combined_xrc_file, "combined_xrc_file" },
     { prop_compiler_standard, "compiler_standard" },
     { prop_contents, "contents" },
     { prop_context_help, "context_help" },
@@ -386,6 +388,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_wrap, "wrap" },
     { prop_wrap_flags, "wrap_flags" },
     { prop_wxWidgets_version, "wxWidgets_version" },
+    { prop_xrc_art_directory, "xrc_art_directory" },
 
 };
 std::map<std::string_view, GenEnum::PropName, std::less<>> GenEnum::rmap_PropNames;
@@ -477,6 +480,7 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_sizeritem_settings, "sizeritem_settings" },
     { gen_wxTopLevelWindow, "wxTopLevelWindow" },
     { gen_wxWindow, "wxWindow" },
+    { gen_XRC, "XRC" },
 
     // The following are the regular generators
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -389,6 +389,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_wrap_flags, "wrap_flags" },
     { prop_wxWidgets_version, "wxWidgets_version" },
     { prop_xrc_art_directory, "xrc_art_directory" },
+    { prop_xrc_file, "xrc_file" },
 
 };
 std::map<std::string_view, GenEnum::PropName, std::less<>> GenEnum::rmap_PropNames;

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -395,6 +395,7 @@ namespace GenEnum
         prop_wrap_flags,
         prop_wxWidgets_version,
         prop_xrc_art_directory,
+        prop_xrc_file,
 
         // This must always be the last item as it is used to calculate the array size needed to store all items
         prop_name_array_size,

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -129,6 +129,8 @@ namespace GenEnum
         prop_column,
         prop_column_labels,
         prop_column_sizes,
+        prop_combine_all_forms,
+        prop_combined_xrc_file,
         prop_compiler_standard,
         prop_contents,
         prop_context_help,
@@ -392,6 +394,7 @@ namespace GenEnum
         prop_wrap,
         prop_wrap_flags,
         prop_wxWidgets_version,
+        prop_xrc_art_directory,
 
         // This must always be the last item as it is used to calculate the array size needed to store all items
         prop_name_array_size,
@@ -504,6 +507,7 @@ namespace GenEnum
         gen_sizeritem_settings,
         gen_wxTopLevelWindow,
         gen_wxWindow,
+        gen_XRC,
 
         // The following are the rergular generators
 

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -58,7 +58,7 @@ int WriteCMakeFile(bool test_only = true);  // See gen_cmake.cpp
 
 // If NeedsGenerateCheck is true, this will not write any files, but will return true if at
 // least one file needs to be generated. If pClassList is non-null, it will contain the base
-// class name over every form that needs updating.
+// class name of every form that needs updating.
 bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck = false, std::vector<ttlib::cstr>* pClassList = nullptr);
 
 #if defined(INTERNAL_TESTING)

--- a/src/generate/gen_xrc.h
+++ b/src/generate/gen_xrc.h
@@ -7,21 +7,27 @@
 
 #pragma once
 
-class WriteCode;
 class Node;
+
+namespace pugi
+{
+    class xml_node;
+}
 
 // Generate a string containing the XRC of the starting node and all of it's children.
 //
 // Use project node to generate an XRC string of the entire project.
 std::string GenerateXrcStr(Node* node_start, bool add_comments = false, bool is_preview = false);
 
-class BaseXrcGenerator
-{
-public:
-    BaseXrcGenerator();
+int GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments);
 
-    void SetSrcWriteCode(WriteCode* cw) { m_source = cw; }
+// If out_file contains a file, it will override project xrc_file and combine_xrc settings.
+//
+// If NeedsGenerateCheck is true, this will not write any files, but will return true if at
+// least one file needs to be generated.
+//
+// If pClassList is non-null, it will contain the base class name of every form that needs
+// updating.
+bool GenerateXrcFiles(ttlib::cstr out_file = {}, bool NeedsGenerateCheck = false);
 
-private:
-    WriteCode* m_source;
-};
+extern const char* txt_dlg_name;  // "_wxue_temp_dlg";

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1511,6 +1511,14 @@ void PropGridPanel::CreatePropCategory(ttlib::sview name, Node* node, NodeDeclar
     {
         m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#fff1d2"));
     }
+    else if (name.contains("Code"))
+    {
+        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#e7f4e4"));
+    }
+    else if (name.contains("XRC"))
+    {
+        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#e1f3f8"));
+    }
 
     if (auto it = m_expansion_map.find(GetCategoryDisplayName(category.GetName()).ToStdString());
         it != m_expansion_map.end())

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -77,9 +77,6 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     menu_item2->SetBitmap(wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE_AS, wxART_MENU));
     m_menuFile->Append(menu_item2);
 
-    auto menu_item_9 = new wxMenuItem(m_menuFile, wxID_ANY, "Export XRC...");
-    m_menuFile->Append(menu_item_9);
-
     m_menuFile->AppendSeparator();
 
     auto submenu = new wxMenu();
@@ -259,14 +256,17 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     m_menuTools = new wxMenu();
 
-    auto menu_item19 = new wxMenuItem(m_menuTools, id_GenerateCode, "&Generate Base Code",
+    auto menu_item19 = new wxMenuItem(m_menuTools, id_GenerateCode, "Generate &Base Code",
         "Generates C++ Code for each top level form", wxITEM_NORMAL);
     menu_item19->SetBitmap(wxueBundleSVG(wxue_img::generate_svg, 780, 2716, wxSize(16, 16)));
     m_menuTools->Append(menu_item19);
 
-    auto menu_item20 = new wxMenuItem(m_menuTools, id_GenerateDerived, "Create &Derived Code",
+    auto menu_item20 = new wxMenuItem(m_menuTools, id_GenerateDerived, "Generate &Derived Code",
         "Creates the files and classes that derive from the generated base classes", wxITEM_NORMAL);
     m_menuTools->Append(menu_item20);
+
+    auto menu_item_10 = new wxMenuItem(m_menuTools, wxID_ANY, "Generate &XRC files");
+    m_menuTools->Append(menu_item_10);
 
     m_menuTools->AppendSeparator();
 
@@ -402,7 +402,6 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
         },
         wxID_SAVE);
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveAsProject, this, id_SaveProjectAs);
-    Bind(wxEVT_MENU, &MainFrameBase::OnExportXRC, this, menu_item_9->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendCrafter, this, id_AppendCrafter);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendFormBuilder, this, id_AppendFormBuilder);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendGlade, this, id_AppendGlade);
@@ -502,6 +501,7 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     Bind(wxEVT_MENU, &MainFrameBase::OnToggleExpandLayout, this, id_Expand);
     Bind(wxEVT_MENU, &MainFrameBase::OnGenerateCode, this, id_GenerateCode);
     Bind(wxEVT_MENU, &MainFrameBase::OnGenInhertedClass, this, id_GenerateDerived);
+    Bind(wxEVT_MENU, &MainFrameBase::OnExportXRC, this, menu_item_10->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnPreviewXrc, this, id_PreviewXRC);
     Bind(wxEVT_MENU, &MainFrameBase::OnAbout, this, wxID_ABOUT);
     Bind(wxEVT_MENU, &MainFrameBase::OnBrowseDocs, this, menu_item_6->GetId());

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -839,11 +839,6 @@
             var_name="menu_item2"
             wxEVT_MENU="OnSaveAsProject" />
           <node
-            class="wxMenuItem"
-            label="Export XRC..."
-            var_name="menu_item_9"
-            wxEVT_MENU="OnExportXRC" />
-          <node
             class="separator"
             var_name="separator2" />
           <node
@@ -1167,16 +1162,21 @@
             bitmap="SVG;../art_src/generate.svg;[16,16]"
             help="Generates C++ Code for each top level form"
             id="id_GenerateCode"
-            label="&amp;Generate Base Code"
+            label="Generate &amp;Base Code"
             var_name="menu_item19"
             wxEVT_MENU="OnGenerateCode" />
           <node
             class="wxMenuItem"
             help="Creates the files and classes that derive from the generated base classes"
             id="id_GenerateDerived"
-            label="Create &amp;Derived Code"
+            label="Generate &amp;Derived Code"
             var_name="menu_item20"
             wxEVT_MENU="OnGenInhertedClass" />
+          <node
+            class="wxMenuItem"
+            label="Generate &amp;XRC files"
+            var_name="menu_item_10"
+            wxEVT_MENU="OnExportXRC" />
           <node
             class="separator"
             var_name="separator_2" />

--- a/src/xml/interface_xml.xml
+++ b/src/xml/interface_xml.xml
@@ -158,6 +158,8 @@ inline const char* interface_xml = R"===(<?xml version="1.0"?>
 			help="This specifies the keyword or macro to add to the class declaration (such as __declspec(dllexport) )." />
 		<property name="generate_ids" type="bool"
 			help="If checked, any non-wxWidgets ids will be created as an enumerated list. If you want to use your own id values, uncheck this and add the header file containing the ids to either base_src_includes or base_hdr_includes.">1</property>
+		<property name="xrc_file" type="file"
+			help="The filename of the XRC if not combining all forms." />
 	</gen>
 
 </GeneratorDefinitions>)===";

--- a/src/xml/interface_xml.xml
+++ b/src/xml/interface_xml.xml
@@ -118,7 +118,7 @@ inline const char* interface_xml = R"===(<?xml version="1.0"?>
 			help="Bitmap shown when the button has keyboard focus but is not pressed." />
 		<property name="current" type="image"
 			help="Bitmap shown when the mouse is over the button (but it is not pressed). Notice that if hover bitmap is not specified but the current platform UI uses hover images for the buttons (such as Windows XP or GTK+), then the focus bitmap is used for the hover state as well. This makes it possible to set just the focus bitmap to get reasonably good behaviour on all platforms." />
-		<!-- This should work, but fails on Windows 10 			
+		<!-- This should work, but fails on Windows 10
 		<property name="position" type="option">
 			<option name="" />
 			<option name="wxLEFT"
@@ -131,7 +131,7 @@ inline const char* interface_xml = R"===(<?xml version="1.0"?>
 				help="Positions the bitmap at the bottom" />
 		</property>
  		-->
-		<!-- This should work, but fails on Windows 10 			
+		<!-- This should work, but fails on Windows 10
 		<property name="margins" type="wxSize"
 			help="The margins between the bitmap and the text of the button. This is currently only implemented under MSW. If it is not specified, a default margin is used around the bitmap." />
  		-->
@@ -158,15 +158,6 @@ inline const char* interface_xml = R"===(<?xml version="1.0"?>
 			help="This specifies the keyword or macro to add to the class declaration (such as __declspec(dllexport) )." />
 		<property name="generate_ids" type="bool"
 			help="If checked, any non-wxWidgets ids will be created as an enumerated list. If you want to use your own id values, uncheck this and add the header file containing the ids to either base_src_includes or base_hdr_includes.">1</property>
-	</gen>
-
-	<gen class="CMake" type="interface">
-		<property name="generate_cmake" type="bool"
-			help="If checked, this will auto-generate a .cmake file whenever the Generate Base Code command is chosen.">0</property>
-		<property name="cmake_file" type="file"
-			help="The filename of the cmake file to create. By default, this will be created in the same directory as the project file.">wxui_code.cmake</property>
-		<property name="cmake_varname" type="string"
-			help="The variable name to set in the .cmake file. This will contain paths to every generated class.">wxue_generated_code</property>
 	</gen>
 
 </GeneratorDefinitions>)===";

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -1,7 +1,20 @@
 inline const char* project_xml = R"===(<?xml version="1.0"?>
 <!DOCTYPE GeneratorDefinitions SYSTEM "gen.dtd">
 <GeneratorDefinitions>
+	<gen class="CMake" type="interface">
+		<property name="generate_cmake" type="bool"
+			help="If checked, this will auto-generate a .cmake file whenever the Generate Base Code command is chosen.">0</property>
+		<property name="cmake_file" type="file"
+			help="The filename of the cmake file to create. By default, this will be created in the same directory as the project file.">wxui_code.cmake</property>
+		<property name="cmake_varname" type="string"
+			help="The variable name to set in the .cmake file. This will contain paths to every generated class.">wxue_generated_code</property>
+	</gen>
+
 	<gen class="Code" type="interface">
+		<property name="base_directory" type="path"
+			help="The generated base class output directory. Leave blank to generate them in the same directory as the project file." />
+		<property name="derived_directory" type="path"
+			help="The generated derived class output directory. Leave blank to generate them in the same directory as the project file." />
 		<property name="source_ext" type="option" help="Specifies the file extension to use when create source files.">
 			<option name=".cpp" />
 			<option name=".cc" />
@@ -22,19 +35,25 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 		</property>
 	</gen>
 
+	<gen class="XRC" type="interface">
+		<property name="combine_all_forms" type="bool"
+			help="If checked, Export XRC (File menu) will create a single XRC file containing all forms.">1</property>
+		<property name="combined_xrc_file" type="file"
+			help="This filename will be used to write all XRC content to unless you unchecked the combine_all_forms property above." />
+		<property name="xrc_art_directory" type="path"
+			help="The directory containing the images your XRC file will load." />
+	</gen>
+
 	<gen class="Project" type="project" image="project">
 		<inherits class="CMake" />
 		<inherits class="Code" />
+		<inherits class="XRC" />
 		<property name="local_pch_file" type="file"
 			help="The filename of a local precompiled header file. The file will be included in quotes." />
 		<property name="src_preamble" type="code_edit"
 			help="Code to generate at the top of the source file after the inclusion of any local precompiled header file. This can include header files, comments, macros, etc." />
 		<property name="art_directory" type="path"
 			help="The directory containing your images (png, ico, xpm, etc.)." />
-		<property name="base_directory" type="path"
-			help="The generated base class output directory. Leave blank to generate them in the same directory as the project file." />
-		<property name="derived_directory" type="path"
-			help="The generated derived class output directory. Leave blank to generate them in the same directory as the project file." />
 		<property name="internationalize" type="bool"
 			help="Wrap strings in a _() macro which expands into a call to wxGetTranslation().">0</property>
 		<property name="help_provider" type="option"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds XRC project-wide properties to Project in a new XRC category, and a `xrc_file` property to all forms. The Tools menu now has a "Generate XRC files" command and it will create either a single combined XRC file, or individual files

While there is a property for setting a different location for XRC image files, there's no code supporting it yet. Also, while forms that lack an `xrc_file` will be ignored, there is nothing currently in place to ignore unsupported forms like `wxPopupTransientWindow`.
