### PR TITLE
Support sizers hiding all children, refactor after children code generation

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -201,6 +201,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_hexadecimal, "hexadecimal" },
     { prop_hgap, "hgap" },
     { prop_hidden, "hidden" },
+    { prop_hide_children, "hide_children" },
     { prop_hide_effect, "hide_effect" },
     { prop_hint, "hint" },
     { prop_hover_color, "hover_color" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -207,6 +207,7 @@ namespace GenEnum
         prop_hexadecimal,
         prop_hgap,
         prop_hidden,
+        prop_hide_children,
         prop_hide_effect,
         prop_hint,
         prop_hover_color,

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -82,7 +82,7 @@ public:
     virtual wxObject* CreateMockup(Node* /*node*/, wxObject* /*parent*/) { return nullptr; }
 
     // Called by Mockup after all children have been created
-    virtual void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/) {}
+    virtual void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) {}
 
     // Generate the code used to construct the object
     virtual std::optional<ttlib::cstr> GenConstruction(Node*) { return {}; }

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -81,7 +81,7 @@ public:
     // Create an object to use in the Mockup panel (typically a sizer or widget).
     virtual wxObject* CreateMockup(Node* /*node*/, wxObject* /*parent*/) { return nullptr; }
 
-    // Called after all children have been created
+    // Called by Mockup after all children have been created
     virtual void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/) {}
 
     // Generate the code used to construct the object
@@ -103,6 +103,11 @@ public:
 
     // Generate specific additional code
     virtual std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType /* command */, Node* /* node */) { return {}; }
+
+    // Generate code after any children have been constructed
+    //
+    // Code will be written with indent::none set
+    virtual std::optional<ttlib::cstr> GenAfterChildren(Node* /* node */) { return {}; }
 
     virtual std::optional<ttlib::cstr> GenEvents(NodeEvent*, const std::string&) { return {}; }
     virtual std::optional<ttlib::cstr> GenSettings(Node*, size_t&) { return {}; }

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxDataView component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -42,11 +42,10 @@ wxObject* DataViewCtrl::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
+void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */, Node* node, bool /* is_preview */)
 {
     auto list = wxStaticCast(wxobject, wxDataViewCtrl);
 
-    auto node = GetMockup()->GetNode(wxobject);
     size_t count = node->GetChildCount();
     for (size_t i = 0; i < count; ++i)
     {
@@ -185,11 +184,10 @@ wxObject* DataViewListCtrl::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void DataViewListCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
+void DataViewListCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */, Node* node, bool /* is_preview */)
 {
     auto list = wxStaticCast(wxobject, wxDataViewListCtrl);
 
-    auto node = GetMockup()->GetNode(wxobject);
     size_t count = node->GetChildCount();
     for (size_t i = 0; i < count; ++i)
     {

--- a/src/generate/dataview_widgets.h
+++ b/src/generate/dataview_widgets.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxDataView component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -13,7 +13,7 @@ class DataViewCtrl : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
@@ -28,7 +28,7 @@ class DataViewListCtrl : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -38,7 +38,7 @@ wxObject* AuiToolBarGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool is_preview)
 {
     auto toolbar = wxStaticCast(wxobject, wxAuiToolBar);
     ASSERT(toolbar);
@@ -46,12 +46,10 @@ void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent
     {
         return;
     }
-    auto node = GetMockup()->GetNode(wxobject);
     auto count = node->GetChildCount();
     for (size_t i = 0; i < count; ++i)
     {
         auto childObj = node->GetChild(i);
-        auto child = GetMockup()->GetChild(wxobject, i);
         if (childObj->isGen(gen_auitool))
         {
             auto bmp = childObj->prop_as_wxBitmapBundle(prop_bitmap);
@@ -60,7 +58,7 @@ void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent
 
             toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
                              (wxItemKind) childObj->prop_as_int(prop_kind), childObj->prop_as_wxString(prop_help),
-                             wxEmptyString, child);
+                             wxEmptyString, nullptr);
         }
         else if (childObj->isGen(gen_toolSeparator))
         {
@@ -68,8 +66,13 @@ void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent
         }
         else
         {
-            auto control = wxDynamicCast(child, wxControl);
-            if (control)
+            const wxObject* child;
+            if (!is_preview)
+                child = GetMockup()->GetChild(wxobject, i);
+            else
+                child = node->GetChild(i)->GetMockupObject();
+
+            if (auto control = wxDynamicCast(child, wxControl); control)
             {
                 toolbar->AddControl(control);
             }

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -94,17 +94,10 @@ std::optional<ttlib::cstr> AuiToolBarGenerator::GenConstruction(Node* node)
     return code;
 }
 
-std::optional<ttlib::cstr> AuiToolBarGenerator::GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node)
+std::optional<ttlib::cstr> AuiToolBarGenerator::GenAfterChildren(Node* node)
 {
     ttlib::cstr code;
-    if (cmd == code_after_children)
-    {
-        code << '\t' << node->get_node_name() << "->Realize();";
-    }
-    else
-    {
-        return {};
-    }
+    code << '\t' << node->get_node_name() << "->Realize();";
 
     return code;
 }

--- a/src/generate/gen_aui_toolbar.h
+++ b/src/generate/gen_aui_toolbar.h
@@ -20,7 +20,7 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
-    std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_aui_toolbar.h
+++ b/src/generate/gen_aui_toolbar.h
@@ -15,7 +15,7 @@ class AuiToolBarGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1443,8 +1443,6 @@ constexpr const GenType aftercode_types[] = {
     type_menubar,
     type_menu,
     type_submenu,
-    type_toolbar,
-    type_aui_toolbar,
     type_tool,
     type_listbook,
     type_simplebook,
@@ -1564,7 +1562,7 @@ void BaseCodeGenerator::GenConstruction(Node* node)
             return;
         }
 
-        if (parent->IsSizer() && type != type_aui_toolbar)
+        if (parent->IsSizer())
         {
             ttlib::cstr code;
             if (auto result = generator->GenAdditionalCode(code_after_children, node); result)

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxBoxSizer generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -37,9 +37,8 @@ std::optional<ttlib::cstr> BoxSizerGenerator::GenConstruction(Node* node)
     return code;
 }
 
-void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
 {
-    auto node = GetMockup()->GetNode(wxobject);
     if (node->as_bool(prop_hide_children))
     {
         if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -37,6 +37,52 @@ std::optional<ttlib::cstr> BoxSizerGenerator::GenConstruction(Node* node)
     return code;
 }
 
+void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+{
+    auto node = GetMockup()->GetNode(wxobject);
+    if (node->as_bool(prop_hide_children))
+    {
+        if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
+            sizer->ShowItems(false);
+    }
+}
+
+std::optional<ttlib::cstr> BoxSizerGenerator::GenAfterChildren(Node* node)
+{
+    ttlib::cstr code;
+    if (node->as_bool(prop_hide_children))
+    {
+        code << "\t" << node->get_node_name() << "->ShowItems(false);";
+    }
+
+    auto parent = node->GetParent();
+    if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
+    {
+        if (code.size())
+            code << '\n';
+        code << "\n\t";
+
+        // The parent node is not a sizer -- which is expected if this is the parent sizer underneath a form or
+        // wxPanel.
+
+        if (parent->isGen(gen_wxRibbonPanel))
+        {
+            code << parent->get_node_name() << "->SetSizerAndFit(" << node->get_node_name() << ");";
+        }
+        else
+        {
+            if (GetParentName(node) != "this")
+                code << GetParentName(node) << "->";
+            code << "SetSizerAndFit(" << node->get_node_name() << ");";
+        }
+    }
+
+    if (code.size())
+        return code;
+    else
+        return {};
+}
+
 bool BoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/sizer.h>", set_src, set_hdr);
@@ -65,6 +111,8 @@ int BoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* 
     item.append_attribute("class").set_value("wxBoxSizer");
     item.append_attribute("name").set_value(node->prop_as_string(prop_var_name));
     item.append_child("orient").text().set(node->prop_as_string(prop_orientation));
+
+    ADD_ITEM_BOOL(prop_hide_children, "hideitems");
 
     if (node->HasValue(prop_minimum_size))
     {

--- a/src/generate/gen_box_sizer.h
+++ b/src/generate/gen_box_sizer.h
@@ -13,8 +13,12 @@ class BoxSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
+
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/gen_box_sizer.h
+++ b/src/generate/gen_box_sizer.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxBoxSizer generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -18,7 +18,7 @@ public:
     std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
-    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/gen_flexgrid_sizer.h
+++ b/src/generate/gen_flexgrid_sizer.h
@@ -14,7 +14,10 @@ class FlexGridSizerGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/gen_grid_sizer.h
+++ b/src/generate/gen_grid_sizer.h
@@ -14,7 +14,10 @@ class GridSizerGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/gen_gridbag_sizer.cpp
+++ b/src/generate/gen_gridbag_sizer.cpp
@@ -57,10 +57,14 @@ wxObject* GridBagSizerGenerator::CreateMockup(Node* node, wxObject* /*parent*/)
     return sizer;
 }
 
-void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
+void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool is_preview)
 {
-    // BUGBUG: [Randalphwa - 06-12-2022] This isn't available if is_preview is true!
-    auto mockup = GetMockup();
+    if (node->as_bool(prop_hide_children))
+    {
+        if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
+            sizer->ShowItems(false);
+    }
+
     // For storing objects whose postion needs to be determined
     std::vector<std::pair<wxObject*, wxGBSizerItem*>> newNodes;
     wxGBPosition lastPosition(0, 0);
@@ -75,9 +79,13 @@ void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpare
     auto count = node->GetChildCount();
     for (size_t i = 0; i < count; ++i)
     {
-        // BUGBUG: [Randalphwa - 06-12-2022] can't use mockup if is_preview is true!
-        auto wxsizerItem = mockup->GetChild(wxobject, i);
-        if (!wxsizerItem)
+        const wxObject* child;
+        if (!is_preview)
+            child = GetMockup()->GetChild(wxobject, i);
+        else
+            child = node->GetChild(i)->GetMockupObject();
+
+        if (!child)
             continue;  // spacer's don't have objects
 
         // Get the location of the item
@@ -88,9 +96,9 @@ void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpare
         {
             // Needs to be auto positioned after the other children are added
 
-            if (auto item = GetGBSizerItem(node, lastPosition, span, wxsizerItem); item)
+            if (auto item = GetGBSizerItem(node, lastPosition, span, const_cast<wxObject*>(child)); item)
             {
-                newNodes.push_back(std::pair<wxObject*, wxGBSizerItem*>(wxsizerItem, item));
+                newNodes.push_back(std::pair<wxObject*, wxGBSizerItem*>(const_cast<wxObject*>(child), item));
             }
             continue;
         }
@@ -106,7 +114,7 @@ void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpare
 
         lastPosition = position;
 
-        if (auto item = GetGBSizerItem(node, position, span, wxsizerItem); item)
+        if (auto item = GetGBSizerItem(node, position, span, const_cast<wxObject*>(child)); item)
         {
             sizer->Add(item);
         }
@@ -225,6 +233,42 @@ std::optional<ttlib::cstr> GridBagSizerGenerator::GenConstruction(Node* node)
     return code;
 }
 
+std::optional<ttlib::cstr> GridBagSizerGenerator::GenAfterChildren(Node* node)
+{
+    ttlib::cstr code;
+    if (node->as_bool(prop_hide_children))
+    {
+        code << "\t" << node->get_node_name() << "->ShowItems(false);";
+    }
+
+    auto parent = node->GetParent();
+    if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
+    {
+        if (code.size())
+            code << '\n';
+        code << "\n\t";
+
+        // The parent node is not a sizer -- which is expected if this is the parent sizer underneath a form or
+        // wxPanel.
+
+        if (parent->isGen(gen_wxRibbonPanel))
+        {
+            code << parent->get_node_name() << "->SetSizerAndFit(" << node->get_node_name() << ");";
+        }
+        else
+        {
+            if (GetParentName(node) != "this")
+                code << GetParentName(node) << "->";
+            code << "SetSizerAndFit(" << node->get_node_name() << ");";
+        }
+    }
+
+    if (code.size())
+        return code;
+    else
+        return {};
+}
+
 bool GridBagSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/gbsizer.h>", set_src, set_hdr);
@@ -291,6 +335,7 @@ int GridBagSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool
     ADD_ITEM_PROP(prop_growablecols, "growablecols")
     ADD_ITEM_PROP(prop_flexible_direction, "flexibledirection")
     ADD_ITEM_PROP(prop_non_flexible_grow_mode, "nonflexiblegrowmode")
+    ADD_ITEM_BOOL(prop_hide_children, "hideitems");
 
     if (node->HasValue(prop_minimum_size))
     {

--- a/src/generate/gen_gridbag_sizer.cpp
+++ b/src/generate/gen_gridbag_sizer.cpp
@@ -57,8 +57,9 @@ wxObject* GridBagSizerGenerator::CreateMockup(Node* node, wxObject* /*parent*/)
     return sizer;
 }
 
-void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
 {
+    // BUGBUG: [Randalphwa - 06-12-2022] This isn't available if is_preview is true!
     auto mockup = GetMockup();
     // For storing objects whose postion needs to be determined
     std::vector<std::pair<wxObject*, wxGBSizerItem*>> newNodes;
@@ -71,13 +72,13 @@ void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpare
         return;
     }
 
-    auto count = mockup->GetNode(wxobject)->GetChildCount();
+    auto count = node->GetChildCount();
     for (size_t i = 0; i < count; ++i)
     {
+        // BUGBUG: [Randalphwa - 06-12-2022] can't use mockup if is_preview is true!
         auto wxsizerItem = mockup->GetChild(wxobject, i);
         if (!wxsizerItem)
             continue;  // spacer's don't have objects
-        auto node = mockup->GetNode(wxsizerItem);
 
         // Get the location of the item
         wxGBSpan span(node->prop_as_int(prop_rowspan), node->prop_as_int(prop_colspan));

--- a/src/generate/gen_gridbag_sizer.h
+++ b/src/generate/gen_gridbag_sizer.h
@@ -17,7 +17,7 @@ class GridBagSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_gridbag_sizer.h
+++ b/src/generate/gen_gridbag_sizer.h
@@ -18,7 +18,10 @@ class GridBagSizerGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
     void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
+
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;

--- a/src/generate/gen_prop_grid.cpp
+++ b/src/generate/gen_prop_grid.cpp
@@ -30,10 +30,9 @@ wxObject* PropertyGridGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void PropertyGridGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
+void PropertyGridGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */, Node* node, bool /* is_preview */)
 {
     auto pg = wxStaticCast(wxobject, wxPropertyGrid);
-    auto node = GetMockup()->GetNode(wxobject);
 
     for (const auto& child: node->GetChildNodePtrs())
     {

--- a/src/generate/gen_prop_grid.h
+++ b/src/generate/gen_prop_grid.h
@@ -13,7 +13,7 @@ class PropertyGridGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/generate/gen_split_win.cpp
+++ b/src/generate/gen_split_win.cpp
@@ -63,7 +63,7 @@ wxObject* SplitterWindowGenerator::CreateMockup(Node* node, wxObject* parent)
     return splitter;
 }
 
-void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool is_preview)
 {
     auto splitter = wxStaticCast(wxobject, wxCustomSplitterWindow);
     if (!splitter)
@@ -75,13 +75,17 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
     // Remove default panel
     auto firstChild = splitter->GetWindow1();
 
-    auto node = GetMockup()->GetNode(wxobject);
     size_t childCount = node->GetChildCount();
     switch (childCount)
     {
         case 1:
             {
-                auto subwindow = wxDynamicCast(GetMockup()->GetChild(wxobject, 0), wxWindow);
+                // BUGBUG: [Randalphwa - 06-12-2022] Don't use GetMockup() if is_preview is true!
+                wxWindow* subwindow;
+                if (!is_preview)
+                    subwindow = wxDynamicCast(GetMockup()->GetChild(wxobject, 0), wxWindow);
+                else
+                    subwindow = wxDynamicCast(node->GetChild(0)->GetMockupObject(), wxWindow);
                 if (!subwindow)
                 {
                     FAIL_MSG("Child of splitter is not derived from wxWindow class.");
@@ -97,14 +101,23 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
                 {
                     splitter->Initialize(subwindow);
                 }
-                // splitter->PushEventHandler(new ContainerBarEvtHandler(splitter));
                 break;
             }
 
         case 2:
             {
-                auto subwindow0 = wxDynamicCast(GetMockup()->GetChild(wxobject, 0), wxWindow);
-                auto subwindow1 = wxDynamicCast(GetMockup()->GetChild(wxobject, 1), wxWindow);
+                wxWindow *subwindow0, *subwindow1;
+
+                if (!is_preview)
+                {
+                    subwindow0 = wxDynamicCast(GetMockup()->GetChild(wxobject, 0), wxWindow);
+                    subwindow1 = wxDynamicCast(GetMockup()->GetChild(wxobject, 1), wxWindow);
+                }
+                else
+                {
+                    subwindow0 = wxDynamicCast(node->GetChild(0)->GetMockupObject(), wxWindow);
+                    subwindow1 = wxDynamicCast(node->GetChild(1)->GetMockupObject(), wxWindow);
+                }
 
                 if (!subwindow0 || !subwindow1)
                 {

--- a/src/generate/gen_split_win.h
+++ b/src/generate/gen_split_win.h
@@ -13,7 +13,7 @@ class SplitterWindowGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;

--- a/src/generate/gen_statchkbox_sizer.h
+++ b/src/generate/gen_statchkbox_sizer.h
@@ -15,9 +15,13 @@ class StaticCheckboxBoxSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
+
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
     bool OnPropertyChange(wxObject* widget, Node* node, NodeProperty* prop) override;

--- a/src/generate/gen_staticbox_sizer.h
+++ b/src/generate/gen_staticbox_sizer.h
@@ -13,9 +13,13 @@ class StaticBoxSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
+
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;

--- a/src/generate/gen_statradiobox_sizer.h
+++ b/src/generate/gen_statradiobox_sizer.h
@@ -15,12 +15,19 @@ class StaticRadioBtnBoxSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
+
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
     bool OnPropertyChange(wxObject* widget, Node* node, NodeProperty* prop) override;
+
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 private:
     wxRadioButton* m_radiobtn;

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -39,7 +39,7 @@ wxObject* ToolBarFormGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool is_preview)
 {
     auto toolbar = wxStaticCast(wxobject, wxToolBar);
     ASSERT(toolbar);
@@ -48,12 +48,10 @@ void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparen
         return;
     }
 
-    auto node = GetMockup()->GetNode(wxobject);
     auto count = node->GetChildCount();
     for (size_t i = 0; i < count; ++i)
     {
         auto childObj = node->GetChild(i);
-        auto child = GetMockup()->GetChild(wxobject, i);
         if (childObj->isGen(gen_tool))
         {
             auto bmp = childObj->prop_as_wxBitmapBundle(prop_bitmap);
@@ -62,7 +60,7 @@ void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparen
 
             toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
                              (wxItemKind) childObj->prop_as_int(prop_kind), childObj->prop_as_wxString(prop_help),
-                             wxEmptyString, child);
+                             wxEmptyString, nullptr);
         }
         else if (childObj->isGen(gen_toolSeparator))
         {
@@ -70,8 +68,13 @@ void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparen
         }
         else
         {
-            wxControl* control = wxDynamicCast(child, wxControl);
-            if (control)
+            const wxObject* child;
+            if (!is_preview)
+                child = GetMockup()->GetChild(wxobject, i);
+            else
+                child = node->GetChild(i)->GetMockupObject();
+
+            if (auto control = wxDynamicCast(child, wxControl); control)
             {
                 toolbar->AddControl(control);
             }
@@ -226,7 +229,7 @@ wxObject* ToolBarGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void ToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void ToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool is_preview)
 {
     auto toolbar = wxStaticCast(wxobject, wxToolBar);
     ASSERT(toolbar);
@@ -235,12 +238,10 @@ void ToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
         return;
     }
 
-    auto node = GetMockup()->GetNode(wxobject);
     auto count = node->GetChildCount();
     for (size_t i = 0; i < count; ++i)
     {
         auto childObj = node->GetChild(i);
-        auto child = GetMockup()->GetChild(wxobject, i);
         if (childObj->isGen(gen_tool))
         {
             auto bmp = childObj->prop_as_wxBitmapBundle(prop_bitmap);
@@ -249,7 +250,7 @@ void ToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
 
             toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
                              (wxItemKind) childObj->prop_as_int(prop_kind), childObj->prop_as_wxString(prop_help),
-                             wxEmptyString, child);
+                             wxEmptyString, nullptr);
         }
         else if (childObj->isGen(gen_toolSeparator))
         {
@@ -257,8 +258,13 @@ void ToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
         }
         else
         {
-            auto control = wxDynamicCast(child, wxControl);
-            if (control)
+            const wxObject* child;
+            if (!is_preview)
+                child = GetMockup()->GetChild(wxobject, i);
+            else
+                child = node->GetChild(i)->GetMockupObject();
+
+            if (auto control = wxDynamicCast(child, wxControl); control)
             {
                 toolbar->AddControl(control);
             }

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -309,17 +309,10 @@ std::optional<ttlib::cstr> ToolBarGenerator::GenConstruction(Node* node)
     return code;
 }
 
-std::optional<ttlib::cstr> ToolBarGenerator::GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node)
+std::optional<ttlib::cstr> ToolBarGenerator::GenAfterChildren(Node* node)
 {
     ttlib::cstr code;
-    if (cmd == code_after_children)
-    {
-        code << '\t' << node->get_node_name() << "->Realize();";
-    }
-    else
-    {
-        return {};
-    }
+    code << '\t' << node->get_node_name() << "->Realize();";
 
     return code;
 }

--- a/src/generate/gen_toolbar.h
+++ b/src/generate/gen_toolbar.h
@@ -13,7 +13,7 @@ class ToolBarFormGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
@@ -33,7 +33,7 @@ class ToolBarGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/generate/gen_toolbar.h
+++ b/src/generate/gen_toolbar.h
@@ -38,7 +38,7 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
-    std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_tree_list.cpp
+++ b/src/generate/gen_tree_list.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxTreeListCtrl generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -23,10 +23,9 @@ wxObject* TreeListCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void TreeListCtrlGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
+void TreeListCtrlGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */, Node* node, bool /* is_preview */)
 {
     auto widget = wxStaticCast(wxobject, wxTreeListCtrl);
-    auto node = GetMockup()->GetNode(wxobject);
 
     for (const auto& iter: node->GetChildNodePtrs())
     {

--- a/src/generate/gen_tree_list.h
+++ b/src/generate/gen_tree_list.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxTreeCtrl component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -13,7 +13,7 @@ class TreeListCtrlGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/generate/gen_wrap_sizer.cpp
+++ b/src/generate/gen_wrap_sizer.cpp
@@ -42,6 +42,51 @@ std::optional<ttlib::cstr> WrapSizerGenerator::GenConstruction(Node* node)
     return code;
 }
 
+void WrapSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
+{
+    if (node->as_bool(prop_hide_children))
+    {
+        if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
+            sizer->ShowItems(false);
+    }
+}
+
+std::optional<ttlib::cstr> WrapSizerGenerator::GenAfterChildren(Node* node)
+{
+    ttlib::cstr code;
+    if (node->as_bool(prop_hide_children))
+    {
+        code << "\t" << node->get_node_name() << "->ShowItems(false);";
+    }
+
+    auto parent = node->GetParent();
+    if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
+    {
+        if (code.size())
+            code << '\n';
+        code << "\n\t";
+
+        // The parent node is not a sizer -- which is expected if this is the parent sizer underneath a form or
+        // wxPanel.
+
+        if (parent->isGen(gen_wxRibbonPanel))
+        {
+            code << parent->get_node_name() << "->SetSizerAndFit(" << node->get_node_name() << ");";
+        }
+        else
+        {
+            if (GetParentName(node) != "this")
+                code << GetParentName(node) << "->";
+            code << "SetSizerAndFit(" << node->get_node_name() << ");";
+        }
+    }
+
+    if (code.size())
+        return code;
+    else
+        return {};
+}
+
 bool WrapSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/wrapsizer.h>", set_src, set_hdr);

--- a/src/generate/gen_wrap_sizer.h
+++ b/src/generate/gen_wrap_sizer.h
@@ -14,7 +14,10 @@ class WrapSizerGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/grid_widgets.cpp
+++ b/src/generate/grid_widgets.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Grid component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -34,11 +34,11 @@ wxObject* PropertyGridManagerGenerator::CreateMockup(Node* node, wxObject* paren
     return widget;
 }
 
-void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */)
+void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */, Node* node,
+                                                 bool /* is_preview */)
 {
     auto pgm = wxStaticCast(wxobject, wxPropertyGridManager);
 
-    auto node = GetMockup()->GetNode(wxobject);
     for (const auto& child: node->GetChildNodePtrs())
     {
         if (child->isGen(gen_propGridPage))

--- a/src/generate/grid_widgets.h
+++ b/src/generate/grid_widgets.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Grid component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -13,7 +13,7 @@ class PropertyGridManagerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/generate/ribbon_widgets.cpp
+++ b/src/generate/ribbon_widgets.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Ribbon component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -37,7 +37,8 @@ wxObject* RibbonBarFormGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void RibbonBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void RibbonBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */,
+                                           bool /* is_preview */)
 {
     auto btn_bar = wxStaticCast(wxobject, wxRibbonBar);
     btn_bar->Realize();
@@ -47,6 +48,7 @@ void RibbonBarFormGenerator::OnPageChanged(wxRibbonBarEvent& event)
 {
     auto bar = wxDynamicCast(event.GetEventObject(), wxRibbonBar);
     if (bar)
+        // BUGBUG: [Randalphwa - 06-12-2022] Don't use GetMockup() if is_preview is true!
         GetMockup()->SelectNode(event.GetPage());
     event.Skip();
 }
@@ -132,7 +134,7 @@ wxObject* RibbonBarGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void RibbonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void RibbonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */)
 {
     auto btn_bar = wxStaticCast(wxobject, wxRibbonBar);
     btn_bar->Realize();
@@ -142,6 +144,7 @@ void RibbonBarGenerator::OnPageChanged(wxRibbonBarEvent& event)
 {
     auto bar = wxDynamicCast(event.GetEventObject(), wxRibbonBar);
     if (bar)
+        // BUGBUG: [Randalphwa - 06-12-2022] Don't use GetMockup() if is_preview is true!
         GetMockup()->SelectNode(event.GetPage());
     event.Skip();
 }
@@ -413,11 +416,10 @@ wxObject* RibbonButtonBarGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void RibbonButtonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void RibbonButtonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
 {
     auto btn_bar = wxStaticCast(wxobject, wxRibbonButtonBar);
 
-    auto node = GetMockup()->GetNode(wxobject);
     for (const auto& child: node->GetChildNodePtrs())
     {
         auto bmp = child->prop_as_wxBitmap(prop_bitmap);
@@ -534,11 +536,10 @@ wxObject* RibbonToolBarGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void RibbonToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void RibbonToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
 {
     auto btn_bar = wxDynamicCast(wxobject, wxRibbonToolBar);
 
-    auto node = GetMockup()->GetNode(wxobject);
     for (const auto& child: node->GetChildNodePtrs())
     {
         if (child->isGen(gen_ribbonSeparator))
@@ -665,11 +666,10 @@ wxObject* RibbonGalleryGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-void RibbonGalleryGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/)
+void RibbonGalleryGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
 {
     auto gallery = wxStaticCast(wxobject, wxRibbonGallery);
 
-    auto node = GetMockup()->GetNode(wxobject);
     for (const auto& child: node->GetChildNodePtrs())
     {
         if (child->isGen(gen_ribbonGalleryItem))

--- a/src/generate/ribbon_widgets.h
+++ b/src/generate/ribbon_widgets.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Ribbon component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -15,7 +15,7 @@ class RibbonBarFormGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
@@ -32,7 +32,7 @@ class RibbonBarGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
@@ -78,7 +78,7 @@ class RibbonButtonBarGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
@@ -101,7 +101,7 @@ class RibbonToolBarGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
@@ -125,7 +125,7 @@ class RibbonGalleryGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/) override;
+    void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;

--- a/src/internal/mockup_preview.cpp
+++ b/src/internal/mockup_preview.cpp
@@ -66,6 +66,7 @@ void CreateMockupChildren(Node* node, wxWindow* parent, wxObject* parentNode, wx
 
         return;  // means the component doesn't create any UI element, and cannot have children
     }
+    node->SetMockupObject(created_object);
 
     wxWindow* created_window { nullptr };
     wxSizer* created_sizer { nullptr };
@@ -178,7 +179,7 @@ void CreateMockupChildren(Node* node, wxWindow* parent, wxObject* parentNode, wx
             }
         }
     }
-    generator->AfterCreation(created_object, parent);
+    generator->AfterCreation(created_object, parent, node, true);
 
     if (parent_sizer)
     {

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -314,7 +314,7 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
             }
         }
     }
-    generator->AfterCreation(created_object, parent);
+    generator->AfterCreation(created_object, parent, node, false);
 
     if (parent_sizer)
     {

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -270,7 +270,10 @@ size_t Node::GetChildPosition(Node* node)
         ++pos;
     }
 
-    FAIL_MSG("failed to find child node, returned position is invalid!")
+    // REVIEW: [Randalphwa - 06-13-2022] Actually, this is sometimes valid when using undo. What really should happen is
+    // that it should return int64_t so that -1 becomes a valid return.
+
+    // FAIL_MSG("failed to find child node, returned position is invalid!")
     return (m_children.size() - 1);
 }
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -323,6 +323,9 @@ public:
     void CopyEventsFrom(Node*);
     void CopyEventsFrom(const NodeSharedPtr& node) { return CopyEventsFrom(node.get()); }
 
+    void SetMockupObject(wxObject* object) { m_mockup_object = object; }
+    const wxObject* GetMockupObject() const { return m_mockup_object; }
+
 protected:
     void FindAllChildProperties(std::vector<NodeProperty*>& list, PropName name);
 
@@ -342,6 +345,8 @@ private:
 
     std::vector<NodeSharedPtr> m_children;
     NodeDeclaration* m_declaration;
+
+    wxObject* m_mockup_object { nullptr };
 };
 
 using NodeMapEvents = std::unordered_map<std::string, NodeEvent, str_view_hash, std::equal_to<>>;

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -178,6 +178,8 @@ private:
     NodeSharedPtr m_parent;
     NodeSharedPtr m_node;
     NodeSharedPtr m_old_selected;
+
+    // REVIEW: [Randalphwa - 06-13-2022] m_old_pos can be -1, so it really should either be an int or an int64_t.
     size_t m_old_pos;
 
     int m_pos;

--- a/src/xml/sizers_xml.xml
+++ b/src/xml/sizers_xml.xml
@@ -44,6 +44,8 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 			<option name="wxHORIZONTAL"
 				help="Align items horizontally" />
 			wxVERTICAL
+			<property name="hide_children" type="bool"
+				help="Hides all of the sizer's children.">0</property>
 		</property>
 	</gen>
 
@@ -66,6 +68,8 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 			help="Hides the sizer and it's children.">0</property>
 		<event name="wxEVT_UPDATE_UI" class="wxUpdateUIEvent"
 			help="" />
+		<property name="hide_children" type="bool"
+			help="Hides all of the sizer's children.">0</property>
 	</gen>
 
 	<gen class="StaticCheckboxBoxSizer" image="wxStaticCheckBoxSizer" type="sizer" help="Available since wxWidgets 3.1.1">
@@ -146,6 +150,8 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 				help="Removes any spacer elements from the beginning of a row" />
 			wxEXTEND_LAST_ON_EACH_LINE|wxREMOVE_LEADING_SPACES
 		</property>
+		<property name="hide_children" type="bool"
+			help="Hides all of the sizer's children.">0</property>
 	</gen>
 
 	<gen class="wxGridSizer" image="grid_sizer" type="sizer">
@@ -160,6 +166,8 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 			help="The vertical gap (in pixels) between the cells in the sizer.">0</property>
 		<property name="hgap" type="uint"
 			help="The horizontal gap (in pixels) between cells in the sizer.">0</property>
+		<property name="hide_children" type="bool"
+			help="Hides all of the sizer's children.">0</property>
 	</gen>
 
 	<gen class="wxFlexGridSizer" image="flex_grid_sizer" type="sizer">
@@ -171,6 +179,8 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 			help="Number of Rows. '0' tells wxWidgets to calculate the number of rows required to hold the supplied items. If you choose to fix the row number, set the 'cols' figure to zero instead.">0</property>
 		<property name="cols" type="uint"
 			help="Number of Columns">2</property>
+		<property name="hide_children" type="bool"
+			help="Hides all of the sizer's children.">0</property>
 	</gen>
 
 	<gen class="wxGridBagSizer" image="grid_bag_sizer" type="gbsizer">
@@ -180,6 +190,8 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 		<property name="var_name" type="string">grid_bag_sizer</property>
 		<property name="empty_cell_size" type="wxSize"
 			help="The size used for cells in the grid with no item." />
+		<property name="hide_children" type="bool"
+			help="Hides all of the sizer's children.">0</property>
 	</gen>
 
 	<gen class="TextSizer" image="text_sizer" type="widget">

--- a/src/xml/sizers_xml.xml
+++ b/src/xml/sizers_xml.xml
@@ -30,6 +30,8 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 				help="Align items horizontally" />
 			wxHORIZONTAL
 		</property>
+		<property name="hide_children" type="bool"
+			help="Hides all of the sizer's children.">0</property>
 	</gen>
 
 	<gen class="VerticalBoxSizer" image="sizer" type="sizer">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR started out implementing the hide_children property in wxBoxSizer. However, that didn't work because the logic in BaseCodeGenerator::GenConstruction() didn't handle post-child construction for sizers correctly. That required some major refactoring to fix, that will ultimately ripple through a dozen or more generators. In the meantime, it uncovered problems with putting wxToolbar into a sizer. That got fixed, but while testing it, it uncovered a bug that affects any variant of MockupPreview that calls AfterCreation(). Fixing that requires a change to the base function, along with MockupContent, and ultimately any generator that overrides this function.

All of which is to say that this started out as a simple fix, but ended up with some major refactoring as each _fix_ uncovered additional underlying problems. Hence the extent of the changes all under a single PR (which I would normally never do).

Note that StaticCheckboxBoxSizer and StaticRadioBtnBoxSizer use the existing `hidden` property instead of `hide_children` and code generation is changed to tell the sizer to do the hiding instead of the staticbox window. That means that the mockup and generated code do the same thing with `hidden` that the other sizers do with `hide_children`.
