### PR TITLE
First form

### DIFF
--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -162,9 +162,9 @@ private:
     std::vector<const EmbeddedImage*> m_embedded_images;
     std::set<wxBitmapType> m_type_generated;
 
-    Node* m_form_node;
-    Node* m_ImagesForm;
-    Node* m_project;
+    Node* m_form_node { nullptr };
+    Node* m_ImagesForm { nullptr };
+    Node* m_project { nullptr };
 
     PANEL_PAGE m_panel_type { NOT_PANEL };
 

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -436,16 +436,26 @@ std::string GenerateXrcStr(Node* node_start, bool add_comments, bool is_preview)
 void BaseCodeGenerator::GenerateXrcClass(Node* form_node, PANEL_PAGE panel_type)
 {
     m_project = wxGetApp().GetProject();
-    m_form_node = form_node;
-
     m_panel_type = panel_type;
 
     m_header->Clear();
     m_source->Clear();
 
+    if (form_node)
+    {
+        m_form_node = form_node;
+    }
+    else
+    {
+        m_form_node = wxGetApp().GetFirstFormChild();
+    }
+
+    if (!m_form_node)
+        return;
+
     if (m_panel_type != HDR_PANEL)
     {
-        auto doc_str = GenerateXrcStr(form_node ? form_node : m_project, m_panel_type == CPP_PANEL);
+        auto doc_str = GenerateXrcStr(m_form_node, m_panel_type == CPP_PANEL);
         m_source->doWrite(doc_str);
     }
 
@@ -453,7 +463,7 @@ void BaseCodeGenerator::GenerateXrcClass(Node* form_node, PANEL_PAGE panel_type)
     {
         if (form_node != m_project)
         {
-            m_header->writeLine(ttlib::cstr("Resource name is ") << form_node->prop_as_string(prop_class_name));
+            m_header->writeLine(ttlib::cstr("Resource name is ") << m_form_node->prop_as_string(prop_class_name));
             m_header->writeLine();
         }
         m_header->writeLine("Required handlers:");
@@ -461,7 +471,7 @@ void BaseCodeGenerator::GenerateXrcClass(Node* form_node, PANEL_PAGE panel_type)
         m_header->Indent();
 
         std::set<std::string> handlers;
-        CollectHandlers(form_node, handlers);
+        CollectHandlers(m_form_node, handlers);
         for (auto& iter: handlers)
         {
             m_header->writeLine(iter);

--- a/src/internal/mockup_preview.cpp
+++ b/src/internal/mockup_preview.cpp
@@ -26,7 +26,8 @@
 // This function is almost identical to MockupContent::CreateChildren. However, the Mockup version assumes the top window is
 // a wxPanel, whereas this version assumes the top version is a form.
 
-void CreateMockupChildren(Node* node, wxWindow* parent, wxObject* parent_object, wxSizer* parent_sizer, wxWindow* form_window)
+void CreateMockupChildren(Node* node, wxWindow* parent, wxObject* parent_object, wxSizer* parent_sizer,
+                          wxWindow* form_window)
 {
     auto generator = node->GetGenerator();
     ASSERT_MSG(generator, ttlib::cstr() << "Missing component for " << node->DeclName());

--- a/src/internal/mockup_preview.cpp
+++ b/src/internal/mockup_preview.cpp
@@ -215,7 +215,7 @@ void MainFrame::OnMockupPreview(wxCommandEvent& /* event */)
     {
         if (form_node->isGen(gen_Project) && form_node->GetChildCount())
         {
-            form_node = form_node->GetChild(0);
+            form_node = wxGetApp().GetFirstFormChild();
         }
         else
         {

--- a/src/internal/xrccompare.cpp
+++ b/src/internal/xrccompare.cpp
@@ -46,7 +46,7 @@ void MainFrame::OnCompareXrcDlg(wxCommandEvent& /* event */)
     {
         if (form_node->isGen(gen_Project) && form_node->GetChildCount())
         {
-            form_node = form_node->GetChild(0);
+            form_node = wxGetApp().GetFirstFormChild();
         }
         else
         {

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -342,6 +342,22 @@ ttlib::cstr App::GetBundleFuncName(const ttlib::cstr& description)
     return name;
 }
 
+Node* App::GetFirstFormChild()
+{
+    if (m_project)
+    {
+        for (const auto& child: m_project->GetChildNodePtrs())
+        {
+            if (child->IsForm())
+            {
+                return child.get();
+            }
+        }
+    }
+
+    return nullptr;
+}
+
 ttString App::GetArtDirectory()
 {
     if (m_project->HasValue(prop_art_directory))

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -50,6 +50,9 @@ public:
     const NodeSharedPtr& GetProjectPtr() { return m_project; };
     Node* GetProject() { return m_project.get(); };
 
+    // Returns the first project child that is a form, or nullptr if not form children found.
+    Node* GetFirstFormChild();
+
     const ttlib::cstr& getProjectFileName();
     const ttlib::cstr& getProjectPath();
     ttString GetProjectFileName();

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -165,7 +165,7 @@ void BasePanel::GenerateBaseClass()
     {
         if (project->GetChildCount() > 0)
         {
-            m_cur_form = project->GetChild(0);
+            m_cur_form = wxGetApp().GetFirstFormChild();
         }
         else
         {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The right-side panels are supported to default to the first form if the project is selected. However, previously the code would simply get the first project child. That first child could be the embedded image list, and there might not be any forms.

This PR adds `GetFirstFormChild()` to `App` to return either the first form or a null pointer.
