### PR TITLE
Add support for xrc_directory

### DIFF
--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -55,11 +55,7 @@ using OptionalIncludes = std::optional<std::vector<std::string>>;
         item.append_child(name_child).text().set("1"); \
     }
 
-#define ADD_ITEM_COMMENT(text)                                 \
-    if (add_comments)                                          \
-    {                                                          \
-        item.append_child(pugi::node_comment).set_value(text); \
-    }
+#define ADD_ITEM_COMMENT(text) item.append_child(pugi::node_comment).set_value(text);
 
 // This is the interface class that all generators derive from.
 class BaseGenerator
@@ -93,7 +89,7 @@ public:
     // Add attributes to object, and all properties
     //
     // Return an xrc_ enum (e.g. xrc_sizer_item_created)
-    virtual int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) { return xrc_not_supported; }
+    virtual int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) { return xrc_not_supported; }
 
     // Return the required wxXmlResourceHandler
     virtual void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) {}

--- a/src/generate/btn_widgets.cpp
+++ b/src/generate/btn_widgets.cpp
@@ -203,7 +203,7 @@ std::optional<ttlib::cstr> ButtonGenerator::GenSettings(Node* node, size_t& auto
     return code;
 }
 
-int ButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -219,7 +219,7 @@ int ButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_c
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_markup))
         {

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -149,7 +149,7 @@ bool DataViewCtrl::GetIncludes(Node* node, std::set<std::string>& set_src, std::
 // ../../../wxWidgets/src/xrc/xh_dataview.cpp
 // See HandleCtrl()
 
-int DataViewCtrl::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int DataViewCtrl::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -159,7 +159,7 @@ int DataViewCtrl::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comm
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -269,7 +269,7 @@ bool DataViewListCtrl::GetIncludes(Node* node, std::set<std::string>& set_src, s
 // ../../../wxWidgets/src/xrc/xh_dataview.cpp
 // See HandleListCtrl()
 
-int DataViewListCtrl::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int DataViewListCtrl::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -279,7 +279,7 @@ int DataViewListCtrl::GenXrcObject(Node* node, pugi::xml_node& object, bool add_
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -331,7 +331,7 @@ bool DataViewTreeCtrl::GetIncludes(Node* node, std::set<std::string>& set_src, s
 // ../../../wxWidgets/src/xrc/xh_dataview.cpp
 // See HandleTreeCtrl()
 
-int DataViewTreeCtrl::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int DataViewTreeCtrl::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -343,7 +343,7 @@ int DataViewTreeCtrl::GenXrcObject(Node* node, pugi::xml_node& object, bool add_
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/dataview_widgets.h
+++ b/src/generate/dataview_widgets.h
@@ -20,7 +20,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
@@ -35,7 +35,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
@@ -49,7 +49,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 

--- a/src/generate/gen_activity.cpp
+++ b/src/generate/gen_activity.cpp
@@ -62,7 +62,7 @@ bool ActivityIndicatorGenerator::GetIncludes(Node* node, std::set<std::string>& 
     return true;
 }
 
-int ActivityIndicatorGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ActivityIndicatorGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -74,7 +74,7 @@ int ActivityIndicatorGenerator::GenXrcObject(Node* node, pugi::xml_node& object,
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_activity.h
+++ b/src/generate/gen_activity.h
@@ -17,6 +17,6 @@ public:
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -83,7 +83,7 @@ std::optional<ttlib::cstr> AnimationGenerator::GenSettings(Node* node, size_t& /
     }
 }
 
-int AnimationGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int AnimationGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -116,7 +116,7 @@ int AnimationGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_animation.h
+++ b/src/generate/gen_animation.h
@@ -17,6 +17,6 @@ public:
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_aui_notebook.cpp
+++ b/src/generate/gen_aui_notebook.cpp
@@ -100,7 +100,7 @@ bool AuiNotebookGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
 // ../../../wxWidgets/src/xrc/xh_aui.cpp
 // wxAuiNotebook handler is near the end of this file.
 
-int AuiNotebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int AuiNotebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -113,7 +113,7 @@ int AuiNotebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_aui_notebook.h
+++ b/src/generate/gen_aui_notebook.h
@@ -22,7 +22,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -238,11 +238,11 @@ std::optional<ttlib::cstr> AuiToolGenerator::GenEvents(NodeEvent* event, const s
     return GenEventCode(event, class_name);
 }
 
-int AuiToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+int AuiToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "tool");
-    GenXrcToolProps(node, item);
+    GenXrcToolProps(node, item, xrc_flags);
 
     return BaseGenerator::xrc_updated;
 }

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -158,7 +158,7 @@ void AuiToolBarGenerator::OnTool(wxCommandEvent& WXUNUSED(event))
 // ../../wxSnapShot/src/xrc/xh_auitoolb.cpp
 // ../../../wxWidgets/src/xrc/xh_auitoolb.cpp
 
-int AuiToolBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int AuiToolBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -174,7 +174,7 @@ int AuiToolBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -238,7 +238,7 @@ std::optional<ttlib::cstr> AuiToolGenerator::GenEvents(NodeEvent* event, const s
     return GenEventCode(event, class_name);
 }
 
-int AuiToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int AuiToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "tool");

--- a/src/generate/gen_aui_toolbar.h
+++ b/src/generate/gen_aui_toolbar.h
@@ -24,7 +24,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:
@@ -37,5 +37,5 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };

--- a/src/generate/gen_banner_window.cpp
+++ b/src/generate/gen_banner_window.cpp
@@ -105,7 +105,7 @@ bool BannerWindowGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
     return true;
 }
 
-int BannerWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int BannerWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -134,7 +134,7 @@ int BannerWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool
     GenXrcBitmap(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_banner_window.cpp
+++ b/src/generate/gen_banner_window.cpp
@@ -131,7 +131,7 @@ int BannerWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size
 
     GenXrcStylePosSize(node, item);
 
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
     GenXrcWindowSettings(node, item);
 
     if (xrc_flags & xrc::add_comments)

--- a/src/generate/gen_banner_window.h
+++ b/src/generate/gen_banner_window.h
@@ -17,6 +17,6 @@ public:
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_bitmap_combo.cpp
+++ b/src/generate/gen_bitmap_combo.cpp
@@ -176,7 +176,7 @@ bool BitmapComboBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set
 // ../../wxSnapShot/src/xrc/xh_bmpcbox.cpp
 // ../../../wxWidgets/src/xrc/xh_bmpcbox.cpp
 
-int BitmapComboBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int BitmapComboBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -194,7 +194,7 @@ int BitmapComboBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bo
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_bitmap_combo.h
+++ b/src/generate/gen_bitmap_combo.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_book_page.cpp
+++ b/src/generate/gen_book_page.cpp
@@ -347,7 +347,7 @@ int BookPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t x
     GenXrcObjectAttributes(node, item, page_type);
     // if (depth > 0)
     // item.append_child("depth").text().set(depth);
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
 
     ADD_ITEM_PROP(prop_label, "label")
     ADD_ITEM_BOOL(prop_select, "selected")

--- a/src/generate/gen_book_page.cpp
+++ b/src/generate/gen_book_page.cpp
@@ -289,7 +289,7 @@ std::optional<ttlib::cstr> BookPageGenerator::GenConstruction(Node* node)
 // ../../wxSnapShot/src/xrc/xh_bookctrlbase.cpp
 // ../../../wxWidgets/src/xrc/xh_bookctrlbase.cpp
 
-int BookPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int BookPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
 #if 0
     int depth = 0;
@@ -355,7 +355,7 @@ int BookPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_book_page.h
+++ b/src/generate/gen_book_page.h
@@ -17,6 +17,6 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -96,7 +96,7 @@ bool BoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 // ../../wxSnapShot/src/xrc/xh_sizer.cpp
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 
-int BoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int BoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_box_sizer.h
+++ b/src/generate/gen_box_sizer.h
@@ -20,6 +20,6 @@ public:
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_button.cpp
+++ b/src/generate/gen_button.cpp
@@ -226,7 +226,7 @@ std::optional<ttlib::cstr> ButtonGenerator::GenSettings(Node* node, size_t& auto
     return code;
 }
 
-int ButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -242,7 +242,7 @@ int ButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_c
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_markup))
         {

--- a/src/generate/gen_button.cpp
+++ b/src/generate/gen_button.cpp
@@ -237,7 +237,7 @@ int ButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc
     ADD_ITEM_BOOL(prop_markup, "markup")
     ADD_ITEM_BOOL(prop_default, "default")
 
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
     GenXrcStylePosSize(node, item);
 
     GenXrcWindowSettings(node, item);

--- a/src/generate/gen_button.h
+++ b/src/generate/gen_button.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_calendar_ctrl.cpp
+++ b/src/generate/gen_calendar_ctrl.cpp
@@ -72,7 +72,7 @@ bool CalendarCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
 // ../../wxSnapShot/src/xrc/xh_cald.cpp
 // ../../../wxWidgets/src/xrc/xh_cald.cpp
 
-int CalendarCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int CalendarCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -82,7 +82,7 @@ int CalendarCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_calendar_ctrl.h
+++ b/src/generate/gen_calendar_ctrl.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_check_listbox.cpp
+++ b/src/generate/gen_check_listbox.cpp
@@ -156,7 +156,7 @@ bool CheckListBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
 // ../../wxSnapShot/src/xrc/xh_chckl.cpp
 // ../../../wxWidgets/src/xrc/xh_chckl.cpp
 
-int CheckListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int CheckListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -185,7 +185,7 @@ int CheckListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool
     GenXrcStylePosSize(node, item, prop_type);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_check_listbox.h
+++ b/src/generate/gen_check_listbox.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_checkbox.cpp
+++ b/src/generate/gen_checkbox.cpp
@@ -91,7 +91,7 @@ bool CheckBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
     return true;
 }
 
-int CheckBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int CheckBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -104,7 +104,7 @@ int CheckBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -229,7 +229,7 @@ bool Check3StateGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
     return true;
 }
 
-int Check3StateGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int Check3StateGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -257,7 +257,7 @@ int Check3StateGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_checkbox.h
+++ b/src/generate/gen_checkbox.h
@@ -21,7 +21,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
@@ -37,6 +37,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_choice.cpp
+++ b/src/generate/gen_choice.cpp
@@ -158,7 +158,7 @@ bool ChoiceGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, st
     return true;
 }
 
-int ChoiceGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ChoiceGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -186,7 +186,7 @@ int ChoiceGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_c
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->HasValue(prop_selection_string))
         {

--- a/src/generate/gen_choice.h
+++ b/src/generate/gen_choice.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_choicebook.cpp
+++ b/src/generate/gen_choicebook.cpp
@@ -65,7 +65,7 @@ bool ChoicebookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 // ../../wxSnapShot/src/xrc/xh_choicbk.cpp
 // ../../../wxWidgets/src/xrc/xh_choicbk.cpp
 
-int ChoicebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ChoicebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -83,7 +83,7 @@ int ChoicebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcPreStylePosSize(node, item, styles);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_choicebook.h
+++ b/src/generate/gen_choicebook.h
@@ -21,7 +21,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_close_btn.cpp
+++ b/src/generate/gen_close_btn.cpp
@@ -56,7 +56,7 @@ bool CloseButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
     return true;
 }
 
-int CloseButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int CloseButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;
@@ -79,7 +79,7 @@ int CloseButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_close_btn.h
+++ b/src/generate/gen_close_btn.h
@@ -24,6 +24,6 @@ public:
     ttlib::cstr GetHelpText(Node*) override { return ttlib::cstr("CreateCloseButton"); }
     ttlib::cstr GetHelpURL(Node*) override { return ttlib::cstr("wx_bitmap_button.html#a558bf8e66279a784260950d9e585baf7"); }
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_clr_picker.cpp
+++ b/src/generate/gen_clr_picker.cpp
@@ -56,7 +56,7 @@ bool ColourPickerGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
 // ../../wxSnapShot/src/xrc/xh_clrpicker.cpp
 // ../../../wxWidgets/src/xrc/xh_clrpicker.cpp
 
-int ColourPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ColourPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -69,7 +69,7 @@ int ColourPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_clr_picker.h
+++ b/src/generate/gen_clr_picker.h
@@ -19,6 +19,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_cmd_link_btn.cpp
+++ b/src/generate/gen_cmd_link_btn.cpp
@@ -126,7 +126,7 @@ int CommandLinkBtnGenerator::GenXrcObject(Node* node, pugi::xml_node& object, si
     ADD_ITEM_PROP(prop_note, "note")
     ADD_ITEM_BOOL(prop_default, "default")
 
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 

--- a/src/generate/gen_cmd_link_btn.cpp
+++ b/src/generate/gen_cmd_link_btn.cpp
@@ -115,7 +115,7 @@ bool CommandLinkBtnGenerator::GetIncludes(Node* node, std::set<std::string>& set
     return true;
 }
 
-int CommandLinkBtnGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int CommandLinkBtnGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -130,7 +130,7 @@ int CommandLinkBtnGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bo
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_cmd_link_btn.h
+++ b/src/generate/gen_cmd_link_btn.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_collapsible.cpp
+++ b/src/generate/gen_collapsible.cpp
@@ -110,7 +110,7 @@ bool CollapsiblePaneGenerator::GetIncludes(Node* node, std::set<std::string>& se
 // ../../wxSnapShot/src/xrc/xh_collpane.cpp
 // ../../../wxWidgets/src/xrc/xh_collpane.cpp
 
-int CollapsiblePaneGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int CollapsiblePaneGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -123,7 +123,7 @@ int CollapsiblePaneGenerator::GenXrcObject(Node* node, pugi::xml_node& object, b
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_collapsible.h
+++ b/src/generate/gen_collapsible.h
@@ -24,6 +24,6 @@ public:
 
     void OnCollapse(wxCollapsiblePaneEvent& event);
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_combobox.cpp
+++ b/src/generate/gen_combobox.cpp
@@ -171,7 +171,7 @@ bool ComboBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
     return true;
 }
 
-int ComboBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ComboBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -199,7 +199,7 @@ int ComboBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->HasValue(prop_selection_string))
         {

--- a/src/generate/gen_combobox.h
+++ b/src/generate/gen_combobox.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -60,7 +60,7 @@ std::optional<ttlib::cstr> CustomControl::GenEvents(NodeEvent* event, const std:
     return GenEventCode(event, class_name);
 }
 
-int CustomControl::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int CustomControl::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);

--- a/src/generate/gen_custom_ctrl.h
+++ b/src/generate/gen_custom_ctrl.h
@@ -18,5 +18,5 @@ public:
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };

--- a/src/generate/gen_date_picker.cpp
+++ b/src/generate/gen_date_picker.cpp
@@ -69,7 +69,7 @@ bool DatePickerCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set
 // ../../wxSnapShot/src/xrc/xh_datectrl.cpp
 // ../../../wxWidgets/src/xrc/xh_datectrl.cpp
 
-int DatePickerCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int DatePickerCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -82,7 +82,7 @@ int DatePickerCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bo
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_date_picker.h
+++ b/src/generate/gen_date_picker.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_dialog.cpp
+++ b/src/generate/gen_dialog.cpp
@@ -232,7 +232,7 @@ bool DialogFormGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
     return true;
 }
 
-int DialogFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int DialogFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     // We use item so that the macros in base_generator.h work, and the code looks the same
     // as other widget XRC generatorsl
@@ -243,7 +243,7 @@ int DialogFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
 
     if (node->HasValue(prop_style))
     {
-        if (add_comments && node->prop_as_string(prop_style).contains("wxWANTS_CHARS"))
+        if ((xrc_flags & xrc::add_comments) && node->prop_as_string(prop_style).contains("wxWANTS_CHARS"))
         {
             item.append_child(pugi::node_comment)
                 .set_value("The wxWANTS_CHARS style will be ignored when the XRC is loaded.");
@@ -270,7 +270,7 @@ int DialogFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
         if (node->prop_as_string(prop_center).is_sameas("wxVERTICAL") ||
             node->prop_as_string(prop_center).is_sameas("wxHORIZONTAL"))
         {
-            if (add_comments)
+            if (xrc_flags & xrc::add_comments)
             {
                 item.append_child(pugi::node_comment)
                     .set_value((ttlib::cstr(node->prop_as_string(prop_center)) << " cannot be be set in the XRC file."));
@@ -301,7 +301,7 @@ int DialogFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
         }
     }
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_persist))
             item.append_child(pugi::node_comment).set_value(" persist is not supported in the XRC file. ");

--- a/src/generate/gen_dialog.h
+++ b/src/generate/gen_dialog.h
@@ -22,6 +22,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_dir_ctrl.cpp
+++ b/src/generate/gen_dir_ctrl.cpp
@@ -103,7 +103,7 @@ bool GenericDirCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set
 // ../../wxSnapShot/src/xrc/xh_gdctl.cpp
 // ../../../wxWidgets/src/xrc/xh_gdctl.cpp
 
-int GenericDirCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int GenericDirCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -117,7 +117,7 @@ int GenericDirCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bo
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_dir_ctrl.h
+++ b/src/generate/gen_dir_ctrl.h
@@ -23,6 +23,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_dir_picker.cpp
+++ b/src/generate/gen_dir_picker.cpp
@@ -104,7 +104,7 @@ bool DirPickerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 // ../../wxSnapShot/src/xrc/xh_dirpicker.cpp
 // ../../../wxWidgets/src/xrc/xh_dirpicker.cpp
 
-int DirPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int DirPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -117,7 +117,7 @@ int DirPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_dir_picker.h
+++ b/src/generate/gen_dir_picker.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_edit_listbox.cpp
+++ b/src/generate/gen_edit_listbox.cpp
@@ -88,7 +88,7 @@ bool EditListBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
 // ../../wxSnapShot/src/xrc/xh_editlbox.cpp
 // ../../../wxWidgets/src/xrc/xh_editlbox.cpp
 
-int EditListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int EditListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -110,7 +110,7 @@ int EditListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_edit_listbox.h
+++ b/src/generate/gen_edit_listbox.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_file_ctrl.cpp
+++ b/src/generate/gen_file_ctrl.cpp
@@ -113,7 +113,7 @@ bool FileCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 // ../../wxSnapShot/src/xrc/xh_filectrl.cpp
 // ../../../wxWidgets/src/xrc/xh_filectrl.cpp
 
-int FileCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int FileCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -127,7 +127,7 @@ int FileCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_int(prop_filter_index) > 0)
             ADD_ITEM_COMMENT("XRC does not support calling SetFilterIndex()")

--- a/src/generate/gen_file_ctrl.h
+++ b/src/generate/gen_file_ctrl.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_file_picker.cpp
+++ b/src/generate/gen_file_picker.cpp
@@ -142,7 +142,7 @@ std::optional<ttlib::cstr> FilePickerGenerator::GetPropertyDescription(NodePrope
 // ../../wxSnapShot/src/xrc/xh_filepicker.cpp
 // ../../../wxWidgets/src/xrc/xh_filepicker.cpp
 
-int FilePickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int FilePickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -156,7 +156,7 @@ int FilePickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_file_picker.h
+++ b/src/generate/gen_file_picker.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_flexgrid_sizer.cpp
+++ b/src/generate/gen_flexgrid_sizer.cpp
@@ -224,7 +224,7 @@ bool FlexGridSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 // See Handle_wxFlexGridSizer()
 
-int FlexGridSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int FlexGridSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_flexgrid_sizer.h
+++ b/src/generate/gen_flexgrid_sizer.h
@@ -19,6 +19,6 @@ public:
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_font_picker.cpp
+++ b/src/generate/gen_font_picker.cpp
@@ -106,7 +106,7 @@ bool FontPickerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 // ../../wxSnapShot/src/xrc/xh_fontpicker.cpp
 // ../../../wxWidgets/src/xrc/xh_fontpicker.cpp
 
-int FontPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int FontPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -118,7 +118,7 @@ int FontPickerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_int(prop_min_point_size) != 0)
             ADD_ITEM_COMMENT("XRC does not support calling SetMinPointSize().")

--- a/src/generate/gen_font_picker.h
+++ b/src/generate/gen_font_picker.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -38,7 +38,7 @@ std::optional<ttlib::cstr> FrameFormGenerator::GenConstruction(Node* node)
     return code;
 }
 
-int FrameFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int FrameFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     object.append_attribute("class").set_value("wxFrame");
     object.append_attribute("name").set_value(node->prop_as_string(prop_class_name));
@@ -79,7 +79,7 @@ int FrameFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
 
     GenXrcWindowSettings(node, object);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, object);
 

--- a/src/generate/gen_frame.h
+++ b/src/generate/gen_frame.h
@@ -23,6 +23,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_gauge.cpp
+++ b/src/generate/gen_gauge.cpp
@@ -87,7 +87,7 @@ bool GaugeGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std
     return true;
 }
 
-int GaugeGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int GaugeGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -100,7 +100,7 @@ int GaugeGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_co
     GenXrcStylePosSize(node, item, prop_orientation);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_gauge.h
+++ b/src/generate/gen_gauge.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_grid.cpp
+++ b/src/generate/gen_grid.cpp
@@ -346,7 +346,7 @@ bool GridGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std:
 // ../../wxSnapShot/src/xrc/xh_wizrd.cpp
 // ../../../wxWidgets/src/xrc/xh_wizrd.cpp
 
-int GridGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int GridGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -356,7 +356,7 @@ int GridGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_com
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         ADD_ITEM_COMMENT(" XRC doesn't support any properties for wxGrid. ")
         GenXrcComments(node, item);

--- a/src/generate/gen_grid.h
+++ b/src/generate/gen_grid.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_grid_sizer.cpp
+++ b/src/generate/gen_grid_sizer.cpp
@@ -117,7 +117,7 @@ bool GridSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 // See Handle_wxGridSizer()
 
-int GridSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int GridSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_grid_sizer.h
+++ b/src/generate/gen_grid_sizer.h
@@ -19,6 +19,6 @@ public:
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_gridbag_sizer.cpp
+++ b/src/generate/gen_gridbag_sizer.cpp
@@ -315,7 +315,7 @@ wxGBSizerItem* GridBagSizerGenerator::GetGBSizerItem(Node* sizeritem, const wxGB
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 // See Handle_wxGridBagSizer()
 
-int GridBagSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int GridBagSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_gridbag_sizer.h
+++ b/src/generate/gen_gridbag_sizer.h
@@ -24,7 +24,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_html_listbox.cpp
+++ b/src/generate/gen_html_listbox.cpp
@@ -128,7 +128,7 @@ bool HtmlListBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
 // ../../wxSnapShot/src/xrc/xh_simplehtmllbox.cpp
 // ../../../wxWidgets/src/xrc/xh_simplehtmllbox.cpp
 
-int HtmlListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int HtmlListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -148,7 +148,7 @@ int HtmlListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_html_listbox.h
+++ b/src/generate/gen_html_listbox.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_html_window.cpp
+++ b/src/generate/gen_html_window.cpp
@@ -109,7 +109,7 @@ std::optional<ttlib::cstr> HtmlWindowGenerator::GenEvents(NodeEvent* event, cons
     return GenEventCode(event, class_name);
 }
 
-int HtmlWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int HtmlWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -124,7 +124,7 @@ int HtmlWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_html_window.h
+++ b/src/generate/gen_html_window.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_hyperlink.cpp
+++ b/src/generate/gen_hyperlink.cpp
@@ -130,7 +130,7 @@ std::optional<ttlib::cstr> HyperlinkGenerator::GenSettings(Node* node, size_t& /
     return code;
 }
 
-int HyperlinkGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int HyperlinkGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -172,7 +172,7 @@ int HyperlinkGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
 #if !defined(WIDGETS_FORK)
         if (node->HasValue(prop_hover_color))

--- a/src/generate/gen_hyperlink.h
+++ b/src/generate/gen_hyperlink.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_infobar.cpp
+++ b/src/generate/gen_infobar.cpp
@@ -83,7 +83,7 @@ bool InfoBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, s
 // ../../wxSnapShot/src/xrc/xh_infobar.cpp
 // ../../../wxWidgets/src/xrc/xh_infobar.cpp
 
-int InfoBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int InfoBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -104,7 +104,7 @@ int InfoBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_infobar.h
+++ b/src/generate/gen_infobar.h
@@ -24,7 +24,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_listbook.cpp
+++ b/src/generate/gen_listbook.cpp
@@ -72,7 +72,7 @@ bool ListbookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 // ../../wxSnapShot/src/xrc/xh_listbk.cpp
 // ../../../wxWidgets/src/xrc/xh_listbk.cpp
 
-int ListbookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ListbookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -90,7 +90,7 @@ int ListbookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcPreStylePosSize(node, item, styles);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_persist))
             item.append_child(pugi::node_comment).set_value(" persist is not supported in XRC. ");

--- a/src/generate/gen_listbook.h
+++ b/src/generate/gen_listbook.h
@@ -21,7 +21,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_listbox.cpp
+++ b/src/generate/gen_listbox.cpp
@@ -152,7 +152,7 @@ bool ListBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, s
 // ../../wxSnapShot/src/xrc/xh_listb.cpp
 // ../../../wxWidgets/src/xrc/xh_listb.cpp
 
-int ListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -181,7 +181,7 @@ int ListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_
     GenXrcStylePosSize(node, item, prop_type);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_listbox.h
+++ b/src/generate/gen_listbox.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_listview.cpp
+++ b/src/generate/gen_listview.cpp
@@ -125,7 +125,7 @@ bool ListViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
     return true;
 }
 
-int ListViewGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ListViewGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -145,7 +145,7 @@ int ListViewGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
         text.text().set(iter);
     }
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_listview.h
+++ b/src/generate/gen_listview.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_notebook.cpp
+++ b/src/generate/gen_notebook.cpp
@@ -71,7 +71,7 @@ bool NotebookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 // ../../wxSnapShot/src/xrc/xh_notbk.cpp
 // ../../../wxWidgets/src/xrc/xh_notbk.cpp
 
-int NotebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int NotebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -89,7 +89,7 @@ int NotebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcPreStylePosSize(node, item, styles);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_notebook.h
+++ b/src/generate/gen_notebook.h
@@ -21,7 +21,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_panel.cpp
+++ b/src/generate/gen_panel.cpp
@@ -44,7 +44,7 @@ bool PanelGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std
     return true;
 }
 
-int PanelGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int PanelGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -53,7 +53,7 @@ int PanelGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_co
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_panel.h
+++ b/src/generate/gen_panel.h
@@ -18,6 +18,6 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_panel_form.cpp
+++ b/src/generate/gen_panel_form.cpp
@@ -204,7 +204,7 @@ std::optional<ttlib::cstr> PanelFormGenerator::GenAdditionalCode(GenEnum::GenCod
     return {};
 }
 
-int PanelFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int PanelFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -215,7 +215,7 @@ int PanelFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_panel_form.h
+++ b/src/generate/gen_panel_form.h
@@ -22,6 +22,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_popup_trans_win.cpp
+++ b/src/generate/gen_popup_trans_win.cpp
@@ -71,9 +71,9 @@ bool PopupWinGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
     return true;
 }
 
-int PopupWinGenerator::GenXrcObject(Node*, pugi::xml_node& object, bool add_comments)
+int PopupWinGenerator::GenXrcObject(Node*, pugi::xml_node& object, size_t xrc_flags)
 {
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         object.append_child(pugi::node_comment).set_value(" wxPopupTransientWindow is not supported by XRC. ");
     }

--- a/src/generate/gen_popup_trans_win.h
+++ b/src/generate/gen_popup_trans_win.h
@@ -20,7 +20,7 @@ public:
     ttlib::cstr GetHelpText(Node*) override { return ttlib::cstr("wxPopupTransientWindow"); }
     ttlib::cstr GetHelpURL(Node*) override { return ttlib::cstr("wx_popup_transient_window.html"); }
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };

--- a/src/generate/gen_radio_box.cpp
+++ b/src/generate/gen_radio_box.cpp
@@ -162,7 +162,7 @@ bool RadioBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 // ../../wxSnapShot/src/xrc/xh_radbx.cpp
 // ../../../wxWidgets/src/xrc/xh_radbx.cpp
 
-int RadioBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int RadioBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -186,7 +186,7 @@ int RadioBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcPreStylePosSize(node, item, (node->value(prop_style) == "columns") ? "wxRA_HORIZONTAL" : "wxRA_VERTICAL");
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_radio_box.h
+++ b/src/generate/gen_radio_box.h
@@ -23,6 +23,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_radio_btn.cpp
+++ b/src/generate/gen_radio_btn.cpp
@@ -100,7 +100,7 @@ std::optional<ttlib::cstr> RadioButtonGenerator::GenEvents(NodeEvent* event, con
     return GenEventCode(event, class_name);
 }
 
-int RadioButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int RadioButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -113,7 +113,7 @@ int RadioButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_radio_btn.h
+++ b/src/generate/gen_radio_btn.h
@@ -24,7 +24,7 @@ public:
     bool AllowPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*) override;
     void ChangeEnableState(wxPropertyGridManager*, NodeProperty*) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 private:

--- a/src/generate/gen_rich_text.cpp
+++ b/src/generate/gen_rich_text.cpp
@@ -92,7 +92,7 @@ std::optional<ttlib::cstr> RichTextCtrlGenerator::GenEvents(NodeEvent* event, co
     return GenEventCode(event, class_name);
 }
 
-int RichTextCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int RichTextCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -104,7 +104,7 @@ int RichTextCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_rich_text.h
+++ b/src/generate/gen_rich_text.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_scrollbar.cpp
+++ b/src/generate/gen_scrollbar.cpp
@@ -50,7 +50,7 @@ std::optional<ttlib::cstr> ScrollBarGenerator::GenEvents(NodeEvent* event, const
     return GenEventCode(event, class_name);
 }
 
-int ScrollBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ScrollBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -65,7 +65,7 @@ int ScrollBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_scrollbar.h
+++ b/src/generate/gen_scrollbar.h
@@ -19,6 +19,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_search_ctrl.cpp
+++ b/src/generate/gen_search_ctrl.cpp
@@ -107,7 +107,7 @@ bool SearchCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 // ../../wxSnapShot/src/xrc/xh_srchctrl.cpp
 // ../../../wxWidgets/src/xrc/xh_srchctrl.cpp
 
-int SearchCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int SearchCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -123,7 +123,7 @@ int SearchCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_search_button))
             ADD_ITEM_COMMENT("XRC does not support ShowSearchButton()")

--- a/src/generate/gen_search_ctrl.h
+++ b/src/generate/gen_search_ctrl.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_simplebook.cpp
+++ b/src/generate/gen_simplebook.cpp
@@ -91,7 +91,7 @@ bool SimplebookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 // ../../wxSnapShot/src/xrc/xh_simplebook.cpp
 // ../../../wxWidgets/src/xrc/xh_simplebook.cpp
 
-int SimplebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int SimplebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -101,7 +101,7 @@ int SimplebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (!node->isPropValue(prop_show_effect, "no effects") || !node->isPropValue(prop_show_effect, "no effects"))
             item.append_child(pugi::node_comment).set_value("SetEffects() are not supported in XRC");

--- a/src/generate/gen_simplebook.h
+++ b/src/generate/gen_simplebook.h
@@ -22,7 +22,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_slider.cpp
+++ b/src/generate/gen_slider.cpp
@@ -170,7 +170,7 @@ bool SliderGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, st
     return true;
 }
 
-int SliderGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int SliderGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -194,7 +194,7 @@ int SliderGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_c
     GenXrcStylePosSize(node, item, prop_orientation);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_slider.h
+++ b/src/generate/gen_slider.h
@@ -23,6 +23,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_spacer_sizer.cpp
+++ b/src/generate/gen_spacer_sizer.cpp
@@ -78,7 +78,7 @@ std::optional<ttlib::cstr> SpacerGenerator::GenConstruction(Node* node)
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 // See Handle_spacer()
 
-int SpacerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int SpacerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item = object;
     auto result = BaseGenerator::xrc_updated;

--- a/src/generate/gen_spacer_sizer.h
+++ b/src/generate/gen_spacer_sizer.h
@@ -15,6 +15,6 @@ class SpacerGenerator : public BaseGenerator
 public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_spin_btn.cpp
+++ b/src/generate/gen_spin_btn.cpp
@@ -75,7 +75,7 @@ bool SpinButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
     return true;
 }
 
-int SpinButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int SpinButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -102,7 +102,7 @@ int SpinButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_spin_btn.h
+++ b/src/generate/gen_spin_btn.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_spin_ctrl.cpp
+++ b/src/generate/gen_spin_ctrl.cpp
@@ -105,7 +105,7 @@ std::optional<ttlib::cstr> SpinCtrlGenerator::GenEvents(NodeEvent* event, const 
     return GenEventCode(event, class_name);
 }
 
-int SpinCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int SpinCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -135,7 +135,7 @@ int SpinCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -223,7 +223,7 @@ std::optional<ttlib::cstr> SpinCtrlDoubleGenerator::GenEvents(NodeEvent* event, 
     return GenEventCode(event, class_name);
 }
 
-int SpinCtrlDoubleGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int SpinCtrlDoubleGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -251,7 +251,7 @@ int SpinCtrlDoubleGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bo
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_spin_ctrl.h
+++ b/src/generate/gen_spin_ctrl.h
@@ -21,7 +21,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
@@ -38,6 +38,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_split_win.cpp
+++ b/src/generate/gen_split_win.cpp
@@ -223,7 +223,7 @@ bool SplitterWindowGenerator::GetIncludes(Node* node, std::set<std::string>& set
 // ../../wxSnapShot/src/xrc/xh_split.cpp
 // ../../../wxWidgets/src/xrc/xh_split.cpp
 
-int SplitterWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int SplitterWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -242,7 +242,7 @@ int SplitterWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bo
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_int(prop_sashsize) >= 0)
             ADD_ITEM_COMMENT(" XRC does not support calling SetSashSize() ")

--- a/src/generate/gen_split_win.h
+++ b/src/generate/gen_split_win.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -214,7 +214,7 @@ bool StaticCheckboxBoxSizerGenerator::GetIncludes(Node* node, std::set<std::stri
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 // See Handle_wxStaticBoxSizer()
 
-int StaticCheckboxBoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int StaticCheckboxBoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_statchkbox_sizer.h
+++ b/src/generate/gen_statchkbox_sizer.h
@@ -26,7 +26,7 @@ public:
 
     bool OnPropertyChange(wxObject* widget, Node* node, NodeProperty* prop) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 private:

--- a/src/generate/gen_static_bmp.cpp
+++ b/src/generate/gen_static_bmp.cpp
@@ -180,7 +180,7 @@ bool StaticBitmapGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
     return true;
 }
 
-int StaticBitmapGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int StaticBitmapGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -191,7 +191,7 @@ int StaticBitmapGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->HasValue(prop_scale_mode) && node->prop_as_string(prop_scale_mode) != "None")
         {

--- a/src/generate/gen_static_bmp.cpp
+++ b/src/generate/gen_static_bmp.cpp
@@ -186,7 +186,7 @@ int StaticBitmapGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size
     auto item = InitializeXrcObject(node, object);
 
     GenXrcObjectAttributes(node, item, "wxStaticBitmap");
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
 
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);

--- a/src/generate/gen_static_bmp.h
+++ b/src/generate/gen_static_bmp.h
@@ -20,6 +20,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_static_box.cpp
+++ b/src/generate/gen_static_box.cpp
@@ -50,7 +50,7 @@ std::optional<ttlib::cstr> StaticBoxGenerator::GenConstruction(Node* node)
     return code;
 }
 
-int StaticBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int StaticBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -61,7 +61,7 @@ int StaticBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_markup))
         {

--- a/src/generate/gen_static_box.h
+++ b/src/generate/gen_static_box.h
@@ -17,6 +17,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_static_line.cpp
+++ b/src/generate/gen_static_line.cpp
@@ -69,7 +69,7 @@ bool StaticLineGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
     return true;
 }
 
-int StaticLineGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int StaticLineGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -78,7 +78,7 @@ int StaticLineGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_static_line.h
+++ b/src/generate/gen_static_line.h
@@ -16,6 +16,6 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_static_text.cpp
+++ b/src/generate/gen_static_text.cpp
@@ -131,7 +131,7 @@ std::optional<ttlib::cstr> StaticTextGenerator::GenSettings(Node* node, size_t& 
     return code;
 }
 
-int StaticTextGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int StaticTextGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -155,7 +155,7 @@ int StaticTextGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_markup))
         {

--- a/src/generate/gen_static_text.h
+++ b/src/generate/gen_static_text.h
@@ -22,6 +22,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -160,7 +160,7 @@ bool StaticBoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 // See Handle_wxStaticBoxSizer()
 
-int StaticBoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int StaticBoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_staticbox_sizer.h
+++ b/src/generate/gen_staticbox_sizer.h
@@ -22,6 +22,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -204,7 +204,7 @@ bool StaticRadioBtnBoxSizerGenerator::GetIncludes(Node* node, std::set<std::stri
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 // See Handle_wxStaticBoxSizer()
 
-int StaticRadioBtnBoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int StaticRadioBtnBoxSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_statradiobox_sizer.h
+++ b/src/generate/gen_statradiobox_sizer.h
@@ -26,7 +26,7 @@ public:
 
     bool OnPropertyChange(wxObject* widget, Node* node, NodeProperty* prop) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 private:

--- a/src/generate/gen_status_bar.cpp
+++ b/src/generate/gen_status_bar.cpp
@@ -73,7 +73,7 @@ bool StatusBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
     return true;
 }
 
-int StatusBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int StatusBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -85,7 +85,7 @@ int StatusBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_status_bar.h
+++ b/src/generate/gen_status_bar.h
@@ -19,6 +19,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_std_dlgbtn_sizer.cpp
+++ b/src/generate/gen_std_dlgbtn_sizer.cpp
@@ -200,7 +200,7 @@ std::optional<ttlib::cstr> StdDialogButtonSizerGenerator::GenConstruction(Node* 
     return code;
 }
 
-int StdDialogButtonSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int StdDialogButtonSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_std_dlgbtn_sizer.h
+++ b/src/generate/gen_std_dlgbtn_sizer.h
@@ -17,6 +17,6 @@ public:
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -245,7 +245,7 @@ bool TextCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
     return true;
 }
 
-int TextCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int TextCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -268,7 +268,7 @@ int TextCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->HasValue(prop_auto_complete))
         {

--- a/src/generate/gen_text_ctrl.h
+++ b/src/generate/gen_text_ctrl.h
@@ -24,6 +24,6 @@ public:
 
     void ChangeEnableState(wxPropertyGridManager*, NodeProperty*) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_time_picker.cpp
+++ b/src/generate/gen_time_picker.cpp
@@ -53,7 +53,7 @@ bool TimePickerCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set
 // ../../wxSnapShot/src/xrc/xh_timectrl.cpp
 // ../../../wxWidgets/src/xrc/xh_timectrl.cpp
 
-int TimePickerCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int TimePickerCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -63,7 +63,7 @@ int TimePickerCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bo
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_time_picker.h
+++ b/src/generate/gen_time_picker.h
@@ -19,6 +19,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_toggle_btn.cpp
+++ b/src/generate/gen_toggle_btn.cpp
@@ -170,7 +170,7 @@ bool ToggleButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
     return true;
 }
 
-int ToggleButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ToggleButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -184,7 +184,7 @@ int ToggleButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_toggle_btn.cpp
+++ b/src/generate/gen_toggle_btn.cpp
@@ -180,7 +180,7 @@ int ToggleButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size
     ADD_ITEM_PROP(prop_label, "label")
     ADD_ITEM_BOOL(prop_pressed, "checked")
 
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 

--- a/src/generate/gen_toggle_btn.h
+++ b/src/generate/gen_toggle_btn.h
@@ -21,6 +21,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -167,7 +167,7 @@ void ToolBarFormGenerator::OnTool(wxCommandEvent& event)
 // ../../wxSnapShot/src/xrc/xh_toolb.cpp
 // ../../../wxWidgets/src/xrc/xh_toolb.cpp
 
-int ToolBarFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ToolBarFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -183,7 +183,7 @@ int ToolBarFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -366,7 +366,7 @@ void ToolBarGenerator::OnTool(wxCommandEvent& event)
 // ../../wxSnapShot/src/xrc/xh_toolb.cpp
 // ../../../wxWidgets/src/xrc/xh_toolb.cpp
 
-int ToolBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ToolBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -382,7 +382,7 @@ int ToolBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -446,7 +446,7 @@ std::optional<ttlib::cstr> ToolGenerator::GenEvents(NodeEvent* event, const std:
     return GenEventCode(event, class_name);
 }
 
-int ToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int ToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "tool");

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -446,11 +446,11 @@ std::optional<ttlib::cstr> ToolGenerator::GenEvents(NodeEvent* event, const std:
     return GenEventCode(event, class_name);
 }
 
-int ToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+int ToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "tool");
-    GenXrcToolProps(node, item);
+    GenXrcToolProps(node, item, xrc_flags);
 
     return BaseGenerator::xrc_updated;
 }

--- a/src/generate/gen_toolbar.h
+++ b/src/generate/gen_toolbar.h
@@ -22,7 +22,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:
@@ -42,7 +42,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:
@@ -55,7 +55,7 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class ToolSeparatorGenerator : public BaseGenerator

--- a/src/generate/gen_toolbook.cpp
+++ b/src/generate/gen_toolbook.cpp
@@ -75,7 +75,7 @@ bool ToolbookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 // ../../wxSnapShot/src/xrc/xh_toolbk.cpp
 // ../../../wxWidgets/src/xrc/xh_toolbk.cpp
 
-int ToolbookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ToolbookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -84,7 +84,7 @@ int ToolbookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_toolbook.h
+++ b/src/generate/gen_toolbook.h
@@ -21,7 +21,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_tree_ctrl.cpp
+++ b/src/generate/gen_tree_ctrl.cpp
@@ -53,7 +53,7 @@ bool TreeCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 // ../../wxSnapShot/src/xrc/xh_tree.cpp
 // ../../../wxWidgets/src/xrc/xh_tree.cpp
 
-int TreeCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int TreeCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -63,7 +63,7 @@ int TreeCtrlGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_tree_ctrl.h
+++ b/src/generate/gen_tree_ctrl.h
@@ -19,6 +19,6 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_treebook.cpp
+++ b/src/generate/gen_treebook.cpp
@@ -70,7 +70,7 @@ bool TreebookGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 // ../../wxSnapShot/src/xrc/xh_treebk.cpp
 // ../../../wxWidgets/src/xrc/xh_treebk.cpp
 
-int TreebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int TreebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -87,7 +87,7 @@ int TreebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
     GenXrcPreStylePosSize(node, item, styles);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_persist))
             item.append_child(pugi::node_comment).set_value(" persist is not supported in XRC. ");

--- a/src/generate/gen_treebook.h
+++ b/src/generate/gen_treebook.h
@@ -21,7 +21,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -274,7 +274,7 @@ int WizardFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t
     GenXrcObjectAttributes(node, item, "wxWizard");
 
     ADD_ITEM_PROP(prop_title, "title")
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
 
     if (node->HasValue(prop_center))
     {
@@ -443,7 +443,7 @@ int WizardPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t
     auto item = InitializeXrcObject(node, object);
 
     GenXrcObjectAttributes(node, item, "wxWizardPageSimple");
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -266,7 +266,7 @@ bool WizardFormGenerator::PopupMenuAddCommands(NavPopupMenu* menu, Node* node)
 // ../../wxSnapShot/src/xrc/xh_wizrd.cpp
 // ../../../wxWidgets/src/xrc/xh_wizrd.cpp
 
-int WizardFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int WizardFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     // We use item so that the macros in base_generator.h work, and the code looks the same
     // as other widget XRC generatorsl
@@ -281,7 +281,7 @@ int WizardFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
         if (node->prop_as_string(prop_center).is_sameas("wxVERTICAL") ||
             node->prop_as_string(prop_center).is_sameas("wxHORIZONTAL"))
         {
-            if (add_comments)
+            if (xrc_flags & xrc::add_comments)
             {
                 item.append_child(pugi::node_comment)
                     .set_value((ttlib::cstr(node->prop_as_string(prop_center)) << " cannot be be set in the XRC file."));
@@ -296,7 +296,7 @@ int WizardFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
 
     if (node->HasValue(prop_style))
     {
-        if (add_comments && node->prop_as_string(prop_style).contains("wxWANTS_CHARS"))
+        if ((xrc_flags & xrc::add_comments) && node->prop_as_string(prop_style).contains("wxWANTS_CHARS"))
         {
             item.append_child(pugi::node_comment)
                 .set_value("The wxWANTS_CHARS style will be ignored when the XRC is loaded.");
@@ -332,7 +332,7 @@ int WizardFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
                 .set(node->prop_as_wxColour(prop_bmp_background_colour).GetAsString(wxC2S_HTML_SYNTAX).ToUTF8().data());
     }
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         if (node->prop_as_bool(prop_persist))
             item.append_child(pugi::node_comment).set_value(" persist is not supported in the XRC file. ");
@@ -437,7 +437,7 @@ bool WizardPageGenerator::PopupMenuAddCommands(NavPopupMenu* menu, Node* node)
     return true;
 }
 
-int WizardPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int WizardPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -447,7 +447,7 @@ int WizardPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/gen_wizard.h
+++ b/src/generate/gen_wizard.h
@@ -25,7 +25,7 @@ public:
 
     std::vector<Node*> GetChildPanes(Node* parent);
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
@@ -38,6 +38,6 @@ public:
 
     bool PopupMenuAddCommands(NavPopupMenu*, Node*) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_wrap_sizer.cpp
+++ b/src/generate/gen_wrap_sizer.cpp
@@ -102,7 +102,7 @@ bool WrapSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 // ../../../wxWidgets/src/xrc/xh_sizer.cpp
 // See Handle_wxWrapSizer()
 
-int WrapSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int WrapSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     pugi::xml_node item;
     auto result = BaseGenerator::xrc_sizer_item_created;

--- a/src/generate/gen_wrap_sizer.h
+++ b/src/generate/gen_wrap_sizer.h
@@ -19,6 +19,6 @@ public:
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_xrc.h
+++ b/src/generate/gen_xrc.h
@@ -17,9 +17,9 @@ namespace pugi
 // Generate a string containing the XRC of the starting node and all of it's children.
 //
 // Use project node to generate an XRC string of the entire project.
-std::string GenerateXrcStr(Node* node_start, bool add_comments = false, bool is_preview = false);
+std::string GenerateXrcStr(Node* node_start, size_t xrc_flags);
 
-int GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments);
+int GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags);
 
 // If out_file contains a file, it will override project xrc_file and combine_xrc settings.
 //

--- a/src/generate/gen_xrc_utils.h
+++ b/src/generate/gen_xrc_utils.h
@@ -35,7 +35,7 @@ void GenXrcWindowSettings(Node* node, pugi::xml_node& object);
 void GenXrcComments(Node* node, pugi::xml_node& object, size_t supported_flags = xrc::all_unsupported);
 
 // Specify the XRC param name if it doesn't match the property name
-void GenXrcBitmap(Node* node, pugi::xml_node& item, std::string_view param_name = {});
+void GenXrcBitmap(Node* node, pugi::xml_node& item, size_t xrc_flags, std::string_view param_name = {});
 
 // Generates class and name attributes for the object.
 //
@@ -54,4 +54,4 @@ void GenXrcFont(pugi::xml_node& object, FontProperty& font_prop);
 void GenXrcFont(pugi::xml_node& item, std::string_view param_name, Node* node, PropName prop);
 
 // Can be used for either wxToolBar or wxAuiToolBar
-void GenXrcToolProps(Node* node, pugi::xml_node& item);
+void GenXrcToolProps(Node* node, pugi::xml_node& item, size_t xrc_flags);

--- a/src/generate/gen_xrc_utils.h
+++ b/src/generate/gen_xrc_utils.h
@@ -19,17 +19,6 @@ class FontProperty;
 
 extern const char* g_xrc_keywords;
 
-namespace xrc
-{
-    enum : size_t
-    {
-        all_unsupported = 0,
-        min_size_supported = 1 << 0,
-        max_size_supported = 1 << 1,
-        hidden_supported = 1 << 2,
-    };
-}
-
 // Write sizeritem XRC code
 void GenXrcSizerItem(Node* node, pugi::xml_node& object);
 

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -202,7 +202,7 @@ bool MenuBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, s
 // ../../wxSnapShot/src/xrc/xh_menu.cpp
 // ../../../wxWidgets/src/xrc/xh_menu.cpp
 
-int MenuBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int MenuBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -212,7 +212,7 @@ int MenuBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -275,7 +275,7 @@ bool MenuBarFormGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
 // ../../wxSnapShot/src/xrc/xh_menu.cpp
 // ../../../wxWidgets/src/xrc/xh_menu.cpp
 
-int MenuBarFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int MenuBarFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -285,7 +285,7 @@ int MenuBarFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -414,7 +414,7 @@ bool MenuGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std:
 // ../../wxSnapShot/src/xrc/xh_menu.cpp
 // ../../../wxWidgets/src/xrc/xh_menu.cpp
 
-int MenuGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int MenuGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
 
@@ -537,7 +537,7 @@ bool SubMenuGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, s
     return true;
 }
 
-int SubMenuGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int SubMenuGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
 
@@ -749,7 +749,7 @@ bool MenuItemGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
     return true;
 }
 
-int MenuItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int MenuItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -770,7 +770,7 @@ int MenuItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add
 
     GenXrcBitmap(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -799,7 +799,7 @@ bool SeparatorGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
     return true;
 }
 
-int SeparatorGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int SeparatorGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "separator");

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -414,14 +414,14 @@ bool MenuGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std:
 // ../../wxSnapShot/src/xrc/xh_menu.cpp
 // ../../../wxWidgets/src/xrc/xh_menu.cpp
 
-int MenuGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+int MenuGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto item = InitializeXrcObject(node, object);
 
     GenXrcObjectAttributes(node, item, "wxMenu");
 
     ADD_ITEM_PROP(prop_label, "label")
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
 
     return BaseGenerator::xrc_updated;
 }
@@ -537,14 +537,14 @@ bool SubMenuGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, s
     return true;
 }
 
-int SubMenuGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+int SubMenuGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto item = InitializeXrcObject(node, object);
 
     GenXrcObjectAttributes(node, item, "wxMenu");
 
     ADD_ITEM_PROP(prop_label, "label")
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
 
     return BaseGenerator::xrc_updated;
 }
@@ -768,7 +768,7 @@ int MenuItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t x
     else if (node->value(prop_kind) == "wxITEM_CHECK")
         item.append_child("checkable").text().set("1");
 
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
 
     if (xrc_flags & xrc::add_comments)
     {

--- a/src/generate/menu_widgets.h
+++ b/src/generate/menu_widgets.h
@@ -34,7 +34,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
@@ -46,7 +46,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
@@ -67,7 +67,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 
@@ -80,7 +80,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class MenuItemGenerator : public BaseGenerator
@@ -92,7 +92,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class SeparatorGenerator : public BaseGenerator
@@ -102,7 +102,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class CtxMenuGenerator : public BaseGenerator

--- a/src/generate/ribbon_widgets.cpp
+++ b/src/generate/ribbon_widgets.cpp
@@ -195,7 +195,7 @@ bool RibbonBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 // ../../../wxWidgets/src/xrc/xh_ribbon.cpp
 // See Handle_bar()
 
-int RibbonBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int RibbonBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -215,7 +215,7 @@ int RibbonBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool ad
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -291,7 +291,7 @@ bool RibbonPageGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 // ../../../wxWidgets/src/xrc/xh_wizrd.cpp
 // See Handle_page()
 
-int RibbonPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int RibbonPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -304,7 +304,7 @@ int RibbonPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -380,7 +380,7 @@ bool RibbonPanelGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
 // ../../../wxWidgets/src/xrc/xh_wizrd.cpp
 // See Handle_panel()
 
-int RibbonPanelGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int RibbonPanelGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -396,7 +396,7 @@ int RibbonPanelGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool 
 
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }
@@ -457,7 +457,7 @@ bool RibbonButtonBarGenerator::GetIncludes(Node* node, std::set<std::string>& se
     return true;
 }
 
-int RibbonButtonBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int RibbonButtonBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "wxRibbonButtonBar");
@@ -501,7 +501,7 @@ std::optional<ttlib::cstr> RibbonButtonGenerator::GenEvents(NodeEvent* event, co
     return GenEventCode(event, class_name);
 }
 
-int RibbonButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int RibbonButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "button");
@@ -609,7 +609,7 @@ bool RibbonToolBarGenerator::GetIncludes(Node* /* node */, std::set<std::string>
     return true;
 }
 
-int RibbonToolBarGenerator::GenXrcObject(Node* /* node */, pugi::xml_node& /* object */, bool /* add_comments */)
+int RibbonToolBarGenerator::GenXrcObject(Node* /* node */, pugi::xml_node& /* object */, size_t /* xrc_flags */)
 {
     return BaseGenerator::xrc_not_supported;
 }
@@ -649,7 +649,7 @@ std::optional<ttlib::cstr> RibbonToolGenerator::GenEvents(NodeEvent* event, cons
     return GenEventCode(event, class_name);
 }
 
-int RibbonToolGenerator::GenXrcObject(Node* /* node */, pugi::xml_node& /* object */, bool /* add_comments */)
+int RibbonToolGenerator::GenXrcObject(Node* /* node */, pugi::xml_node& /* object */, size_t /* xrc_flags */)
 {
     return BaseGenerator::xrc_not_supported;
 }
@@ -709,7 +709,7 @@ bool RibbonGalleryGenerator::GetIncludes(Node* node, std::set<std::string>& set_
     return true;
 }
 
-int RibbonGalleryGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int RibbonGalleryGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "wxRibbonGallery");
@@ -740,7 +740,7 @@ std::optional<ttlib::cstr> RibbonGalleryItemGenerator::GenEvents(NodeEvent* even
     return GenEventCode(event, class_name);
 }
 
-int RibbonGalleryItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool /* add_comments */)
+int RibbonGalleryItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "item");

--- a/src/generate/ribbon_widgets.cpp
+++ b/src/generate/ribbon_widgets.cpp
@@ -299,7 +299,7 @@ int RibbonPageGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t
     GenXrcObjectAttributes(node, item, "wxRibbonPage");
 
     ADD_ITEM_PROP(prop_label, "label")
-    GenXrcBitmap(node, item, "icon");
+    GenXrcBitmap(node, item, xrc_flags, "icon");
 
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
@@ -388,7 +388,7 @@ int RibbonPanelGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_
     GenXrcObjectAttributes(node, item, "wxRibbonPanel");
 
     ADD_ITEM_PROP(prop_label, "label")
-    GenXrcBitmap(node, item, "icon");
+    GenXrcBitmap(node, item, xrc_flags, "icon");
 
     // Up through wxWidgets 3.1.7, no styles are accepted
     // GenXrcStylePosSize(node, item);
@@ -501,7 +501,7 @@ std::optional<ttlib::cstr> RibbonButtonGenerator::GenEvents(NodeEvent* event, co
     return GenEventCode(event, class_name);
 }
 
-int RibbonButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+int RibbonButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "button");
@@ -513,7 +513,7 @@ int RibbonButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size
         bmp.append_attribute("stock_client").set_value("wxART_TOOLBAR");
     }
 
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
 
     return BaseGenerator::xrc_updated;
 }
@@ -740,7 +740,7 @@ std::optional<ttlib::cstr> RibbonGalleryItemGenerator::GenEvents(NodeEvent* even
     return GenEventCode(event, class_name);
 }
 
-int RibbonGalleryItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+int RibbonGalleryItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto item = InitializeXrcObject(node, object);
     GenXrcObjectAttributes(node, item, "item");
@@ -752,7 +752,7 @@ int RibbonGalleryItemGenerator::GenXrcObject(Node* node, pugi::xml_node& object,
         bmp.append_attribute("stock_client").set_value("wxART_TOOLBAR");
     }
 
-    GenXrcBitmap(node, item);
+    GenXrcBitmap(node, item, xrc_flags);
 
     return BaseGenerator::xrc_updated;
 }

--- a/src/generate/ribbon_widgets.h
+++ b/src/generate/ribbon_widgets.h
@@ -40,7 +40,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:
@@ -58,7 +58,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class RibbonPanelGenerator : public BaseGenerator
@@ -71,7 +71,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class RibbonButtonBarGenerator : public BaseGenerator
@@ -85,7 +85,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class RibbonButtonGenerator : public BaseGenerator
@@ -94,7 +94,7 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class RibbonToolBarGenerator : public BaseGenerator
@@ -109,7 +109,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class RibbonToolGenerator : public BaseGenerator
@@ -118,7 +118,7 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class RibbonGalleryGenerator : public BaseGenerator
@@ -132,7 +132,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };
 
 class RibbonGalleryItemGenerator : public BaseGenerator
@@ -141,5 +141,5 @@ public:
     std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -1087,7 +1087,7 @@ void StyledTextGenerator::ChangeEnableState(wxPropertyGridManager* prop_grid, No
 // ../../wxSnapShot/src/xrc/xh_styledtextctrl.cpp
 // ../../../wxWidgets/src/xrc/xh_styledtextctrl.cpp
 
-int StyledTextGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int StyledTextGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -1102,7 +1102,7 @@ int StyledTextGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool a
     GenXrcStylePosSize(node, item);
     GenXrcWindowSettings(node, item);
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         ADD_ITEM_COMMENT(" The only property supported by XRC is wrap_mode. ")
         GenXrcComments(node, item);

--- a/src/generate/styled_text.h
+++ b/src/generate/styled_text.h
@@ -22,6 +22,6 @@ public:
 
     void ChangeEnableState(wxPropertyGridManager*, NodeProperty*) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -126,7 +126,7 @@ bool ScrolledWindowGenerator::GetIncludes(Node* node, std::set<std::string>& set
 // ../../wxSnapShot/src/xrc/xh_wizrd.cpp
 // ../../../wxWidgets/src/xrc/xh_wizrd.cpp
 
-int ScrolledWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bool add_comments)
+int ScrolledWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto result = node->GetParent()->IsSizer() ? BaseGenerator::xrc_sizer_item_created : BaseGenerator::xrc_updated;
     auto item = InitializeXrcObject(node, object);
@@ -143,7 +143,7 @@ int ScrolledWindowGenerator::GenXrcObject(Node* node, pugi::xml_node& object, bo
         item.append_child("scrollrate").text().set(scroll_rate);
     }
 
-    if (add_comments)
+    if (xrc_flags & xrc::add_comments)
     {
         GenXrcComments(node, item);
     }

--- a/src/generate/window_widgets.h
+++ b/src/generate/window_widgets.h
@@ -20,7 +20,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
-    int GenXrcObject(Node*, pugi::xml_node& /* object */, bool /* add_comments */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };
 

--- a/src/internal/msgframe.cpp
+++ b/src/internal/msgframe.cpp
@@ -306,7 +306,7 @@ void MsgFrame::UpdateNodeInfo()
     {
         if (m_isXrcPage)
         {
-            auto doc_str = GenerateXrcStr(cur_sel, true);
+            auto doc_str = GenerateXrcStr(cur_sel, xrc::add_comments | xrc::use_xrc_dir);
 
             m_scintilla->SetReadOnly(false);
             m_scintilla->ClearAll();

--- a/src/internal/xrccompare.cpp
+++ b/src/internal/xrccompare.cpp
@@ -30,7 +30,7 @@
 void CreateMockupChildren(Node* node, wxWindow* parent, wxObject* parentNode, wxSizer* parent_sizer, wxWindow* form_window);
 
 // Defined in gen_xrc.cpp
-std::string GenerateXrcStr(Node* node_start, bool add_comments = false, bool is_preview = false);
+std::string GenerateXrcStr(Node* node_start, size_t xrc_flags);
 
 extern const char* txt_dlg_name;
 
@@ -179,7 +179,8 @@ bool XrcCompare::DoCreate(wxWindow* parent, Node* form_node)
 
 bool XrcCompare::InitXrc(Node* form_node)
 {
-    auto doc_str = GenerateXrcStr(form_node, false, form_node->isGen(gen_wxDialog));
+    size_t xrc_flags = (form_node->isGen(gen_wxDialog) ? xrc::previewing : 0);
+    auto doc_str = GenerateXrcStr(form_node, xrc_flags);
     wxMemoryInputStream stream(doc_str.c_str(), doc_str.size());
     wxScopedPtr<wxXmlDocument> xmlDoc(new wxXmlDocument(stream, "UTF-8"));
     if (!xmlDoc->IsOk())

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -42,7 +42,7 @@ XrcPreview::XrcPreview(wxWindow* parent)
 
 void XrcPreview::OnCreate(wxCommandEvent& WXUNUSED(event))
 {
-    auto doc_str = GenerateXrcStr(nullptr, false, true);
+    auto doc_str = GenerateXrcStr(nullptr, xrc::no_flags);
 
     m_scintilla->ClearAll();
     m_scintilla->AddTextRaw(doc_str.c_str(), (to_int) doc_str.size());
@@ -63,7 +63,7 @@ void XrcPreview::OnXrcCopy(wxCommandEvent& WXUNUSED(event))
         sel_node = sel_node->get_form();
     }
 
-    auto doc_str = GenerateXrcStr(sel_node, false, sel_node->isGen(gen_PanelForm));
+    auto doc_str = GenerateXrcStr(sel_node, sel_node->isGen(gen_PanelForm) ? xrc::previewing : 0);
 
     m_scintilla->ClearAll();
     m_scintilla->AddTextRaw(doc_str.c_str(), (to_int) doc_str.size());

--- a/src/pch.h
+++ b/src/pch.h
@@ -123,6 +123,25 @@ enum class MoveDirection
     Right
 };
 
+namespace xrc
+{
+    enum : size_t
+    {
+        all_unsupported = 0,
+        min_size_supported = 1 << 0,
+        max_size_supported = 1 << 1,
+        hidden_supported = 1 << 2,
+    };
+
+    enum : size_t
+    {
+        no_flags = 0,
+        add_comments = 1 << 0,  // add comments about unsupported properties
+        use_xrc_dir = 1 << 1,   // if prop_xrc_dir is set, use that instead of prop_art_directory
+        previewing = 1 << 2,    // overrides add_comments and use_xrc_dir
+    };
+}  // namespace xrc
+
 constexpr const char* txtVersion = "wxUiEditor 0.9.3";
 constexpr const char* txtCopyRight = "Copyright (c) 2019-2022 KeyWorks Software";
 constexpr const char* txtAppname = "wxUiEditor";


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR enables support for the xrc_directory override. This allows the user to specify a different directory for XRC art files then the one used for embedding files into the C++ source modules.

A significant change is to switch the boolean parameters of various XRC functions to a size_t containing bitflags (now defined in pch.h in the xrc namespace).