### PR TITLE
Remove smart_size property

### DIFF
--- a/src/xml/buttons_xml.xml
+++ b/src/xml/buttons_xml.xml
@@ -100,7 +100,7 @@ inline const char* buttons_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="CloseButton" image="close_btn" type="widget">
 		<inherits class="wxWindow">
-			<hide name="smart_size" />
+			<!-- <hide name="smart_size" /> -->
 			<hide name="variant" />
 			<hide name="foreground_colour" />
 			<hide name="background_colour" />

--- a/src/xml/window_interfaces_xml.xml
+++ b/src/xml/window_interfaces_xml.xml
@@ -30,8 +30,8 @@ inline const char* window_interfaces_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="wxWindow" type="interface">
 		<property name="id" type="id">wxID_ANY</property>
-		<property name="smart_size" type="wxSize"
-			help="If a positive value is used, the minimum size of the window will be set to that if it is larger then what automatic layout would have calculated. A -1 indicates that the value should always be calculated automatically." />
+		<!-- <property name="smart_size" type="wxSize"
+			help="If a positive value is used, the minimum size of the window will be set to that if it is larger then what automatic layout would have calculated. A -1 indicates that the value should always be calculated automatically." /> -->
 		<property name="minimum_size" type="wxSize"
 			help="Sets the minimum size of the window. Any positive value will override the automatic size calculation that would normally be done. This property is ignored if the smart_size property is used." />
 		<property name="variant" type="option"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The problem with this specific case is that `GetBestSize()` is returning 130 which is larger than the 120 specified. Apparently, this gets changed later on when the entire dialog is being laid out.

The reason for adding smart_size was because minimum_size forces the size rather than allowing it to grow if the layout can handle a larger size. Whether or not that will work is going to be entirely dependent on the layout of controls after the entire form is laid out. Sadly, that means it will never be reliable.

I have commented out the property in the XML files, so that it could be added back if a better implementation for this is created. All the code handling it is still in place, but since the property isn't there anymore, the code won't be generated or the property saved.

Closes #551
