### PR TITLE
Var name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [Unreleased (1.0.1)]
 
 Release summary...
 
@@ -10,3 +10,5 @@ Release summary...
 ### Fixed
 
 ### Changed
+
+A user can no longer enter an invalid C++ variable name.

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -18,6 +18,7 @@
 #include "node_decl.h"      // NodeDeclaration class
 #include "node_prop.h"      // NodeProperty -- NodeProperty class
 #include "project_class.h"  // Project class
+#include "utils.h"          // Utility functions that work with properties
 
 #include "../mockup/mockup_parent.h"  // Top-level MockUp Parent window
 
@@ -124,6 +125,13 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
         ttlib::cstr newValue = property->ValueToString(variant).utf8_string();
         if (newValue.empty())
             return true;
+
+        if (!isValidVarName(newValue))
+        {
+            event->SetValidationFailureMessage("The name you have specified is not a valid C++ variable name.");
+            event->Veto();
+            return false;
+        }
         auto unique_name = node->GetUniqueName(newValue);
         // GetUniqueName() won't check the current node so if the name is unique, we still need to check within the same node
         bool is_duplicate = !newValue.is_sameas(unique_name);

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -24,18 +24,18 @@
 #include "write_code.h"     // Write code to Scintilla or file
 
 // These are used everywhere we use scintilla to edit C++ code
-const char* g_u8_cpp_keywords = "alignas alignof and and_eq atomic_cancel atomic_commit atomic_noexcept auto \
-                              bitand bitor bool break case catch char char8_t char16_t char32_t \
-                              class compl concept const consteval constexpr constinit const_cast \
-                              continue co_await co_return co_yield __declspec \
-	                          decltype default delete dllexport do double dynamic_cast else enum explicit \
-	                          export extern false float for friend goto if inline int long \
-	                          mutable namespace new noexcept not not_eq nullptr operator private or or_eq \
-                              private protected public reflexpr register reinterpret_cast requires \
-	                          return short signed sizeof static static_assert static_cast \
-	                          struct switch synchronized template this thread_local throw true try typedef typeid \
-	                          typename union unsigned using virtual void volatile wchar_t \
-	                          while xor xor_eq";
+const char* g_u8_cpp_keywords = "alignas alignof and and_eq atomic_cancel atomic_commit atomic_noexcept auto"
+                                " bitand bitor bool break case catch char char8_t char16_t char32_t"
+                                " class compl concept const consteval constexpr constinit const_cast"
+                                " continue co_await co_return co_yield __declspec"
+                                " decltype default delete dllexport do double dynamic_cast else enum explicit"
+                                " export extern false float for friend goto if inline int long"
+                                " mutable namespace new noexcept not not_eq nullptr operator private or or_eq"
+                                " private protected public reflexpr register reinterpret_cast requires"
+                                " return short signed sizeof static static_assert static_cast"
+                                " struct switch synchronized template this thread_local throw true try typedef typeid"
+                                " typename union unsigned using virtual void volatile wchar_t"
+                                " while xor xor_eq";
 
 BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, int panel_type) : wxPanel(parent)
 {

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <charconv>
+#include <set>
 
 #include <wx/gdicmn.h>   // Common GDI classes, types and declarations
 #include <wx/mstream.h>  // Memory stream classes
@@ -505,5 +506,38 @@ bool isConvertibleMime(const ttString& suffix)
         if (suffix.is_sameas(iter))
             return false;
     }
+    return true;
+}
+
+extern const char* g_u8_cpp_keywords;  // defined in ../panels/base_panel.cpp
+std::set<std::string> g_set_cpp_keywords;
+
+bool isValidVarName(const std::string& str)
+{
+    // variable names must start with an alphabetic character or underscore character
+    if (!((str[0] >= 'a' && str[0] <= 'z') || (str[0] >= 'A' && str[0] <= 'Z') || str[0] == '_'))
+        return false;
+
+    for (auto iter: str)
+    {
+        if (!((iter >= 'a' && iter <= 'z') || (iter >= 'A' && iter <= 'Z') || (iter >= '0' && iter <= '9') || iter == '_'))
+            return false;
+    }
+
+    // Ensure that the variable name is not a C++ keyword
+
+    // The set is only initialized the first time this function is called.
+    if (g_set_cpp_keywords.empty())
+    {
+        ttlib::multistr keywords(g_u8_cpp_keywords, ' ');
+        for (auto& iter: keywords)
+        {
+            g_set_cpp_keywords.emplace(iter);
+        }
+    }
+
+    if (g_set_cpp_keywords.contains(str))
+        return false;
+
     return true;
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -82,3 +82,6 @@ extern std::map<std::string, const char*> g_sys_colour_pair;
 extern std::map<std::string, const char*> g_stc_wrap_mode;
 
 bool isConvertibleMime(const ttString& suffix);
+
+// Checks whether a string is a valid C++ variable name.
+bool isValidVarName(const std::string& str);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR is designed to prevent the user from entering an invalid C++ variable name that cannot be compiled. The new `isValidVarName()` checkes the following:

- first character may only be an underscore or an alphabetic character
- variable name can only contain alphanumeric characters or an underscore
- variable name cannot be the same as a C++ keyword

Closes #734
