### PR TITLE
Switch submodules from ttLib to ttLib_wx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
-[submodule "ttLib"]
-	path = ttLib
-	url = https://github.com/KeyWorksRW/ttLib.git
-
 [submodule "wxSnapshot"]
 	path = wxSnapshot
 	url = https://github.com/KeyWorksRW/wxSnapshot.git
+[submodule "ttLib_wx"]
+	path = ttLib_wx
+	url = https://github.com/KeyWorksRW/ttLib_wx.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,16 @@ endif()
 
 add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
 
-# Comment the following line out for a non-beta Release
-add_compile_definitions(BETA)
+# Instructions for building the ttlib_wx library using this project's precompiled header
+include(ttLib_wx/src/ttlib_file_list.cmake)
+add_library(ttLib_wx STATIC ${ttlib_file_list})
+target_precompile_headers(ttLib_wx PRIVATE "src/pch.h")
+target_include_directories(ttLib_wx PRIVATE
+    ${widget_dir}/include
+    ${setup_dir}
+    src/
+    ttLib_wx/src
+)
 
 # Setting CMAKE_MODULE_PATH causes ninja to fail rebuilding until CMake re-generates. Specifying the full path and extension
 # means ninja sees this as a normal dependency that didn't change any time one of the files it specifies changes.
@@ -127,9 +135,9 @@ add_library(check_build STATIC EXCLUDE_FROM_ALL
 )
 
 if (WIN32)
-    target_link_libraries(wxUiEditor PRIVATE wxWidgets wxCLib comctl32 Imm32 Shlwapi Version UxTheme)
+    target_link_libraries(wxUiEditor PRIVATE ttLib_wx wxWidgets wxCLib comctl32 Imm32 Shlwapi Version UxTheme)
 else()
-    target_link_libraries(wxUiEditor PRIVATE wxWidgets wxCLib)
+    target_link_libraries(wxUiEditor PRIVATE ttLib_wx wxWidgets wxCLib)
 endif()
 
 if (MSVC)
@@ -179,7 +187,7 @@ target_include_directories(wxUiEditor PRIVATE
     src/ui
     src/wxui
     pugixml
-    ttLib/include
+    ttLib_wx/src
 
     ${widget_dir}/include
     ${setup_dir}
@@ -194,7 +202,7 @@ target_include_directories(check_build PRIVATE
     src/ui
     src/wxui
     pugixml
-    ttLib/include
+    ttLib_wx/src
 
     ${widget_dir}/include
     ${setup_dir}

--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -21,7 +21,7 @@ Options:
     TargetDir:        ../build/CMakeFiles/CMakeTmp  # just a temporary location for the psuedo library
     Natvis:           wxui.natvis                   # MSVC Debug visualizer
 
-    IncDirs:          ./;nodes;generate;utils;customprops;ui;wxui;../pugixml;../ttLib/include;../wxSnapshot/include;../wxSnapshot/win
+    IncDirs:          ./;nodes;generate;utils;customprops;ui;wxui;../pugixml;../ttLib_wx/src;../wxSnapshot/include;../wxSnapshot/win
 
     Libs_dbg:         ../build/wxSnapshot/Debug/wxCLib.lib;../build/wxSnapshot/Debug/wxWidgets.lib
     Libs_rel:         ../build/wxSnapshot/Release/wxCLib.lib;../build/wxSnapshot/Release/wxWidgets.lib
@@ -268,16 +268,16 @@ Files:
     internal/xrccompare.cpp      # C++/XRC UI Comparison dialog
     internal/import_panel.cpp    # Panel to display original imported file
 
-    # ttLib submodule files (see https://github.com/KeyWorksRW/ttLib repository)
+    # ttLib_wx submodule files (see https://github.com/KeyWorksRW/ttLib_wx repository)
 
-    ../ttLib/src/ttcstr.cpp      # Class for handling zero-terminated char strings.
-    ../ttLib/src/ttcview.cpp     # string_view functionality on a zero-terminated char string.
-    ../ttLib/src/ttsview.cpp     # std::string_view with additional methods
-    ../ttLib/src/ttmultistr.cpp  # Breaks a single string into multiple strings
-    ../ttLib/src/ttparser.cpp    # Command line parser
-    ../ttLib/src/ttstr.cpp       # Enhanced version of wxString
-    ../ttLib/src/ttlibspace.cpp  # ttlib namespace functions
-    ../ttLib/src/tttextfile.cpp  # Classes for reading and writing text files.
+    ../ttLib_wx/src/ttlib_wx.cpp       # ttlib namespace functions
+    ../ttLib_wx/src/ttcstr_wx.cpp      # std::string with additional methods
+    ../ttLib_wx/src/ttsview_wx.cpp     # std::string_view with additional methods
+    ../ttLib_wx/src/ttmultistr_wx.cpp  # Breaks a single string into multiple strings or views
+    ../ttLib_wx/src/tttextfile_wx.cpp  # Classes for reading and writing text files
+    ../ttLib_wx/src/ttcvector_wx.cpp   # Vector class for storing ttlib::cstr strings
+    ../ttLib_wx/src/ttparser_wx.cpp    # Command line parser
+    ../ttLib_wx/src/ttstring_wx.cpp    # Enhanced version of wxString
 
 Docs:
     # ttBld will ignore this section -- it's here just for convenience as a shortcut to open some of the documentation

--- a/src/appoptions.h
+++ b/src/appoptions.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include "ttstr.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
-
 class AppOptions
 {
 public:

--- a/src/customprops/art_prop_dlg.cpp
+++ b/src/customprops/art_prop_dlg.cpp
@@ -32,7 +32,7 @@ ArtBrowserDialog::ArtBrowserDialog(wxWindow* parent, const ImageProperties& img_
 
     if (auto pos = img_props.image.find('|'); ttlib::is_found(pos))
     {
-        m_client = img_props.image.subview(pos + 1);
+        m_client = img_props.image.subview(pos + 1).wx_str();
     }
     else
     {

--- a/src/customprops/font_prop_dlg.h
+++ b/src/customprops/font_prop_dlg.h
@@ -9,8 +9,6 @@
 
 #include <wx/fontenum.h>
 
-#include "ttstr.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
-
 #include "font_prop.h"  // FontProperty class
 
 #include "wxui/fontpropdlg_base.h"  // FontPropDlgBase

--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -7,8 +7,6 @@
 
 #include <wx/propgrid/propgrid.h>  // wxPropertyGrid
 
-#include <ttmultistr.h>  // multistr -- Breaks a single string into multiple strings
-
 #include "pg_point.h"
 
 #include "node.h"   // Node -- Node class

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -235,17 +235,6 @@ set (file_list
     ${CMAKE_CURRENT_LIST_DIR}/ui/insertwidget.cpp         # Dialog to lookup and insert a widget
     ${CMAKE_CURRENT_LIST_DIR}/ui/optionsdlg.cpp           # Dialog containing special Debugging commands
 
-    # ttLib submodule files
-
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/ttcstr.cpp      # Class for handling zero-terminated char strings.
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/ttcview.cpp     # string_view functionality on a zero-terminated char string.
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/ttsview.cpp     # std::string_view with additional methods
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/ttmultistr.cpp  # Breaks a single string into multiple strings
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/ttparser.cpp    # Command line parser
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/ttstr.cpp       # Enhanced version of wxString
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/ttlibspace.cpp  # ttlib namespace functions
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/tttextfile.cpp  # Classes for reading and writing text files.
-
     # Debug-only files
     $<$<CONFIG:Debug>:${CMAKE_CURRENT_LIST_DIR}/internal/code_compare.cpp>    # Compare code generation
     $<$<CONFIG:Debug>:${CMAKE_CURRENT_LIST_DIR}/internal/convert_img.cpp>     # Convert image

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -11,7 +11,7 @@
 
 #include <wx/filename.h>  // wxFileName - encapsulates a file path
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "gen_base.h"
 
@@ -2004,7 +2004,7 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
                 {
                     if (iter.type() == type_animation)
                         m_NeedAnimationFunction = true;
-                    else if (!parts[IndexImage].extension().is_sameas(".xpm", tt::CASE::either))
+                    else if (!ttlib::is_sameas(parts[IndexImage].extension(), ".xpm", tt::CASE::either))
                         m_NeedHeaderFunction = true;
                 }
             }

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -7,8 +7,8 @@
 
 #include <fstream>
 
-#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <ttcwd_wx.h>       // cwd -- Class for storing and optionally restoring the current directory
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "gen_base.h"       // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "node.h"           // Node class
@@ -43,7 +43,7 @@ int WriteCMakeFile(bool test_only)
     ttlib::cwd cur_dir;
     cur_dir.make_absolute();
 
-    cmake_file.make_relative(cur_dir);
+    cmake_file.make_relative(cur_dir.utf8_string());
 
     ttlib::viewfile current;
     if (!current.ReadFile(cmake_file) && test_only)
@@ -73,7 +73,7 @@ int WriteCMakeFile(bool test_only)
 
     for (auto base_file: base_files)
     {
-        base_file.make_relative(cur_dir);
+        base_file.make_relative(cur_dir.utf8_string());
         base_file.backslashestoforward();
         base_file.remove_extension();
 

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttcwd.h"  // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd_wx.h"  // cwd -- Class for storing and optionally restoring the current directory
 
 #include "mainframe.h"
 

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -25,7 +25,7 @@
 #include <wx/xrc/xh_richtext.h>        // XML resource handler for wxRichTextCtrl
 #include <wx/xrc/xh_styledtextctrl.h>  // XML resource handler for wxStyledTextCtrl
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "gen_base.h"  // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 

--- a/src/generate/images_form.cpp
+++ b/src/generate/images_form.cpp
@@ -10,7 +10,7 @@
 #include <wx/statbmp.h>   // wxStaticBitmap class interface
 #include <wx/stattext.h>  // wxStaticText base header
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "images_form.h"
 

--- a/src/image_bundle.cpp
+++ b/src/image_bundle.cpp
@@ -313,8 +313,8 @@ bool Project::AddEmbeddedBundleImage(ttlib::cstr path, Node* form)
             wxImage image;
             if (handler->LoadFile(&image, stream))
             {
-                m_map_embedded[path.filename().c_str()] = std::make_unique<EmbeddedImage>();
-                auto embed = m_map_embedded[path.filename().c_str()].get();
+                m_map_embedded[path.filename().as_str()] = std::make_unique<EmbeddedImage>();
+                auto embed = m_map_embedded[path.filename().as_str()].get();
                 InitializeArrayName(embed, path.filename());
                 embed->form = form;
 
@@ -587,8 +587,8 @@ bool Project::AddSvgBundleImage(ttlib::cstr path, Node* form)
 
     wxMemoryOutputStream memory_stream;
     wxZlibOutputStream save_strem(memory_stream, wxZ_BEST_COMPRESSION);
-    m_map_embedded[path.filename().c_str()] = std::make_unique<EmbeddedImage>();
-    auto embed = m_map_embedded[path.filename().c_str()].get();
+    m_map_embedded[path.filename().as_str()] = std::make_unique<EmbeddedImage>();
+    auto embed = m_map_embedded[path.filename().as_str()].get();
     InitializeArrayName(embed, path.filename());
     embed->form = form;
 
@@ -615,7 +615,7 @@ bool Project::AddSvgBundleImage(ttlib::cstr path, Node* form)
         auto file_size = file_original.Length();
         ttlib::cstr size_comparison;
         int percent = static_cast<int>(100 - (100 / (file_size / compressed_size)));
-        size_comparison.Format("%s -- Original: %ku, compressed: %ku, %u percent", path.filename().c_str(), file_size,
+        size_comparison.Format("%v -- Original: %ku, compressed: %ku, %u percent", path.filename(), file_size,
                                compressed_size, percent);
         MSG_INFO(size_comparison)
     }

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -924,7 +924,7 @@ void FormBuilder::BitmapProperty(pugi::xml_node& xml_prop, NodeProperty* prop)
         if (!ttlib::is_found(pos_semi))
             return;
         ttlib::cstr filename;
-        if (org_value.subview(pos_semi).is_sameas("; Load From File"))
+        if (org_value.subview(pos_semi) == "; Load From File")
         {
             // Older version of wxFB placed the filename first
             org_value.erase(pos_semi);

--- a/src/import/import_formblder.h
+++ b/src/import/import_formblder.h
@@ -9,8 +9,6 @@
 
 #include <map>
 
-#include "ttstr.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
-
 #include "node_classes.h"  // Forward defintions of Node classes
 
 #include "import_xml.h"  // ImportXML -- Base class for XML importing

--- a/src/import/import_wxcrafter.h
+++ b/src/import/import_wxcrafter.h
@@ -9,8 +9,6 @@
 
 #include <map>
 
-#include "ttstr.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
-
 #include "gen_enums.h"     // Enumerations for generators
 #include "node_classes.h"  // Forward defintions of Node classes
 

--- a/src/internal/code_compare.cpp
+++ b/src/internal/code_compare.cpp
@@ -11,7 +11,7 @@
 
 #include <wx/dir.h>  // wxDir is a class for enumerating the files in a directory
 
-#include "ttcwd.h"  // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd_wx.h"  // cwd -- Class for storing and optionally restoring the current directory
 
 #include "internal/code_compare_base.h"
 
@@ -103,7 +103,7 @@ void CodeCompare::OnWinMerge(wxCommandEvent& /* event */)
 
     // /e -- terminate with escape
     // /u -- don't add files to MRU
-    winShellRun("WinMergeU.exe", "/e /u ~wxue_.WinMerge", cwd);
+    winShellRun("WinMergeU.exe", "/e /u ~wxue_.WinMerge", cwd.sub_cstr().c_str());
 }
 
 #endif  // _WIN32

--- a/src/internal/convert_img.cpp
+++ b/src/internal/convert_img.cpp
@@ -19,7 +19,7 @@
 #include <wx/wfstream.h>  // File stream classes
 #include <wx/wupdlock.h>  // wxWindowUpdateLocker prevents window redrawing
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "convert_img.h"  // auto-generated: convert_img_base.h and convert_img_base.cpp
 
@@ -457,7 +457,7 @@ void ConvertImageDlg::ImgageInHeaderOut()
 
     ttlib::textfile file;
 
-    file.addEmptyLine().Format("static const unsigned char %s[%zu] = {", string_name.filename().c_str(),
+    file.addEmptyLine().Format("static const unsigned char %v[%zu] = {", string_name.filename(),
                                read_stream->GetBufferSize());
 
     read_stream->Seek(0, wxFromStart);

--- a/src/internal/convert_img.h
+++ b/src/internal/convert_img.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include "ttstr.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
-
 #include "internal/convert_img_base.h"  // ConvertImageBase
 
 class ConvertImageDlg : public ConvertImageBase

--- a/src/internal/import_panel.h
+++ b/src/internal/import_panel.h
@@ -8,7 +8,7 @@
 #include <wx/panel.h>
 #include <wx/scrolwin.h>  // wxScrolledWindow, wxScrolledControl and wxScrollHelper
 
-#include "tttextfile.h"  // ttlib::viewfile
+#include <tttextfile_wx.h>  // ttlib::viewfile
 
 class MainFrame;
 class wxStyledTextCtrl;

--- a/src/internal/msgframe.cpp
+++ b/src/internal/msgframe.cpp
@@ -9,7 +9,7 @@
 #include <wx/filedlg.h>           // wxFileDialog base header
 #include <wx/persist/toplevel.h>  // persistence support for wxTLW
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "msgframe.h"  // auto-generated: msgframe_base.h and msgframe_base.cpp
 

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -14,7 +14,7 @@
 #include <wx/xml/xml.h>     // wxXmlDocument - XML parser & data holder class
 #include <wx/xrc/xmlres.h>  // XML resources
 
-#include "tttextfile.h"  // ttlib::viewfile
+#include <tttextfile_wx.h>  // ttlib::viewfile
 
 #include "gen_xrc.h"        // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "mainframe.h"      // MainFrame -- Main window frame

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -681,8 +681,7 @@ void MainFrame::ProjectLoaded()
 
 void MainFrame::ProjectSaved()
 {
-    ttlib::cstr str(GetProject()->getProjectFile().filename() + " saved");
-    setStatusText(str);
+    setStatusText(ttlib::cstr(GetProject()->getProjectFile().filename()) << " saved");
     UpdateFrame();
 }
 

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -5,9 +5,6 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttcstr.h"      // cstr -- std::string with additional methods
-#include "ttlibspace.h"  // ttlib namespace functions and declarations
-
 #include "node_creator.h"
 
 #include "gen_enums.h"  // Enumerations for nodes

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -9,7 +9,7 @@
 
 #include <wx/panel.h>
 
-#include "tttextfile.h"  // ttlib::viewfile
+#include <tttextfile_wx.h>  // ttlib::viewfile
 
 #include "codedisplay_base.h"
 

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -7,8 +7,7 @@
 
 // This module handles changes to art_directory, base_directory, and derived_directory
 
-#include "ttcwd.h"  // cwd -- Class for storing and optionally restoring the current directory
-#include "ttstr.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
+#include <ttcwd_wx.h>  // cwd -- Class for storing and optionally restoring the current directory
 
 #include "paths.h"
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -96,17 +96,12 @@
 #include <string_view>
 #include <vector>
 
-#include "ttlibspace.h"  // This must be included before any other ttLib header files
+#include <ttlib_wx.h>  // This must be included before any other ttLib header files
 
-// Currently, the order of the ttLib includes is critical, so use blank lines to keep clang-format from reordering them.
-
-#include "ttstr.h"  // ttString -- wxString with ttlib::cstr equivalent functions
-
-#include "ttcview.h"  // ttlib::cview -- std::string_view functionality on a zero-terminated char string.
-#include "ttsview.h"  // ttlib::sview -- std::string_view with additional methods
-
-#include "ttcstr.h"      // ttlib::cstr -- std::string with additional functions
-#include "ttmultistr.h"  // ttlib::multistr -- breaks a single string into multiple strings
+#include <ttcstr_wx.h>      // ttlib::cstr -- std::string with additional functions
+#include <ttmultistr_wx.h>  // ttlib::multistr -- breaks a single string into multiple strings
+#include <ttstring_wx.h>    // ttString -- wxString with ttlib::cstr equivalent functions
+#include <ttsview_wx.h>     // ttlib::sview -- std::string_view with additional methods
 
 #if !defined(int_t)
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -8,8 +8,6 @@
 #include <wx/stc/stc.h>  // A wxWidgets implementation of Scintilla.
 #include <wx/utils.h>    // Miscellaneous utilities
 
-#include "ttcwd.h"  // cwd -- Class for storing and optionally restoring the current directory
-
 #include "../nodes/node_creator.h"  // NodeCreator class
 #include "base_generator.h"         // BaseGenerator -- Base widget generator class
 #include "gen_enums.h"              // Enumerations for generators

--- a/src/project_class.cpp
+++ b/src/project_class.cpp
@@ -327,7 +327,7 @@ bool Project::AddEmbeddedImage(ttlib::cstr path, Node* form, bool is_animation)
         }
     }
 
-    if (m_map_embedded.find(path.filename().c_str()) != m_map_embedded.end())
+    if (m_map_embedded.find(path.filename().as_str()) != m_map_embedded.end())
         return false;
 
     auto final_result = AddNewEmbeddedImage(path, form, add_lock);
@@ -409,8 +409,8 @@ bool Project::AddNewEmbeddedImage(ttlib::cstr path, Node* form, std::unique_lock
             wxImage image;
             if (handler->LoadFile(&image, stream))
             {
-                m_map_embedded[path.filename().c_str()] = std::make_unique<EmbeddedImage>();
-                auto embed = m_map_embedded[path.filename().c_str()].get();
+                m_map_embedded[path.filename().as_str()] = std::make_unique<EmbeddedImage>();
+                auto embed = m_map_embedded[path.filename().as_str()].get();
                 InitializeArrayName(embed, path.filename());
                 embed->form = form;
 

--- a/src/ui/import_dlg.cpp
+++ b/src/ui/import_dlg.cpp
@@ -11,8 +11,8 @@
 #include <wx/filedlg.h>   // wxFileDialog base header
 #include <wx/filename.h>  // wxFileName - encapsulates a file path
 
-#include "pugixml.hpp"   // xml processing
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include "pugixml.hpp"      // xml processing
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "import_dlg.h"  // auto-generated: import_base.h and import_base.cpp
 

--- a/src/ui/import_dlg.h
+++ b/src/ui/import_dlg.h
@@ -13,8 +13,6 @@
 
 #include "import_base.h"
 
-#include "ttstr.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
-
 class ImportDlg : public ImportBase
 {
 public:

--- a/src/ui/importwinresdlg.cpp
+++ b/src/ui/importwinresdlg.cpp
@@ -7,7 +7,7 @@
 
 #include <wx/dir.h>
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "importwinres_base.h"  // auto-generated: importwinres_base.h and importwinres_base.cpp
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -9,9 +9,6 @@
 
 #include <wx/settings.h>
 
-#include "ttcstr.h"   // ttlib::cstr -- std::string with additional methods
-#include "ttsview.h"  // sview -- std::string_view with additional methods
-
 #include "gen_enums.h"  // Enumerations for generators
 
 class wxColour;

--- a/src/winres/import_winres.cpp
+++ b/src/winres/import_winres.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "tttextfile.h"  // ttTextFile -- Similar to wxTextFile, but uses UTF8 strings
+#include <tttextfile_wx.h>  // ttTextFile -- Similar to wxTextFile, but uses UTF8 strings
 
 #include "import_winres.h"
 
@@ -76,11 +76,11 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
         if (iter.contains("#include"))
         {
             ttlib::cstr name;
-            auto curline = iter.view_nonspace();
+            ttlib::sview curline = iter.view_nonspace();
             name.ExtractSubString(curline, curline.stepover());
             if (name.size())
             {
-                auto ext = name.extension();
+                ttlib::sview ext = name.extension();
                 if (ext.is_sameas(".h"))
                 {
                     if (!lst_ignored_includes.contains(name))
@@ -133,7 +133,7 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
 
         if (file[idx].contains("ICON") || file[idx].contains("BITMAP"))
         {
-            auto line = file[idx].view_nonspace();
+            ttlib::sview line = file[idx].view_nonspace();
             ttlib::cstr id;
             if (line.at(0) == '"')
                 id.AssignSubString(line);
@@ -174,7 +174,7 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
             // We have to restart at zero in order to pickup code page changes
             for (m_curline = 0; m_curline < file.size(); ++m_curline)
             {
-                auto curline = file[m_curline].view_nonspace();
+                ttlib::sview curline = file[m_curline].view_nonspace();
                 if (curline.starts_with("STRINGTABLE"))
                 {
                     ParseStringTable(file);
@@ -182,14 +182,14 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
                 else if (curline.starts_with("#pragma code_page"))
                 {
                     auto code = curline.find('(');
-                    m_codepage = std::atoi(curline.subview(code + 1));
+                    m_codepage = ttlib::atoi(curline.subview(code + 1));
                 }
             }
         }
 
         for (m_curline = 0; m_curline < file.size(); ++m_curline)
         {
-            auto curline = file[m_curline].view_nonspace();
+            ttlib::sview curline = file[m_curline].view_nonspace();
             auto start = curline.find_nonspace();
             if (curline.empty() || curline[start] == '/')  // Ignore blank lines and comments.
                 continue;
@@ -263,7 +263,7 @@ bool WinResource::ImportRc(const ttlib::cstr& rc_file, std::vector<ttlib::cstr>&
                     if (curline.contains(" code_page("))
                     {
                         auto code = curline.find('(');
-                        m_codepage = std::atoi(curline.subview(code + 1));
+                        m_codepage = ttlib::atoi(curline.subview(code + 1));
                     }
                 }
             }

--- a/src/winres/import_winres.h
+++ b/src/winres/import_winres.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "tttextfile.h"
+#include <tttextfile_wx.h>
 
 #include "../import/import_xml.h"  // ImportXML -- Base class for XML importing
 #include "winres_form.h"           // resForm -- Process a Windows Resource form  (usually a dialog)

--- a/src/winres/winres_ctrl.cpp
+++ b/src/winres/winres_ctrl.cpp
@@ -106,7 +106,7 @@ void resCtrl::ParseDirective(WinResource* pWinResource, ttlib::sview line)
     // First copy the diretive name without the leading whitespace
     temp_view.moveto_nonspace();
     auto pos_space = temp_view.find_space();
-    if (ttlib::is_error(pos_space))
+    if (!ttlib::is_found(pos_space))
     {
         MSG_ERROR(ttlib::cstr() << "Invalid directive: " << line);
         return;

--- a/src/winres/winres_dlg.cpp
+++ b/src/winres/winres_dlg.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "winres_form.h"
 
@@ -17,7 +17,7 @@ resForm::resForm() {}
 void resForm::ParseDialog(WinResource* pWinResource, ttlib::textfile& txtfile, size_t& curTxtLine)
 {
     m_pWinResource = pWinResource;
-    auto line = txtfile[curTxtLine].subview();
+    ttlib::sview line = txtfile[curTxtLine].subview();
     auto end = line.find_space();
     if (end == tt::npos)
         throw std::invalid_argument("Expected an ID then a DIALOG or DIALOGEX.");

--- a/src/winres/winres_form.h
+++ b/src/winres/winres_form.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "gen_enums.h"    // Enumerations for generators
 #include "node.h"         // Node class

--- a/src/winres/winres_layout.cpp
+++ b/src/winres/winres_layout.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "winres_form.h"
 

--- a/src/winres/winres_menu.cpp
+++ b/src/winres/winres_menu.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 #include "winres_form.h"
 


### PR DESCRIPTION
ttLib_wx is the successor to ttLib. It retains all of the function wxUiEditor uses
with a bit more support for wxWidgets and without all the old Windows API
code and classes.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Work on ttLib had pretty much stopped, and instead shifted over to it's successor, ttLib_wx. The `_wx` suffix to the library and source files is both to prevent mixing it up with older ttLib files, while indicating it's additional support for wxWidgets.

Note that ttlib::cview is no longer available in this library.

THe code is now built as a library instead of being built inline. That minimizes the effect of using new ttLib_wx functionality while still not linking in unused functionality.