### PR TITLE
Fix save/restore mainframe on Windows 11

### DIFF
--- a/src/internal/debugsettings.cpp
+++ b/src/internal/debugsettings.cpp
@@ -67,6 +67,7 @@ void DebugSettings::OnOK(wxCommandEvent& event)
         auto config = wxConfig::Get();
         config->SetPath("/preferences");
         config->Write("flags", m_orgFlags);
+        config->SetPath("/");
     }
 
     event.Skip();  // Need to call this for Persist to work


### PR DESCRIPTION
This deals with a special circumstance where the saved position on
Windows 11 is incorrect. See PR description for details.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
When `wxPersistentRegisterAndRestore` is used to save/restore a main window, it calls `wxTLWGeometry::Save()` when the window is destroyed. It gets the current dimensions of the window by using the underlying `m_placement.rcNormalPosition` rather than making any calls to the window to get the position and size (since this is in the destructor, the window dimensions may not be available). The assumption is that when the window is resized, the current dimensions are always stored, so `m_placement.rcNormalPosition` should be accurate.

On Windows 11, a user can drag the bottom of the window to the tray or bottom of the screen and the top of the window will be automatically moved to the top of the screen. Unfortunately, this doesn't generate a normal WM_SIZE event (it sends it, but with the SW_RESTORE flag set), and most apps (including Windows Notepad) don't support this special case (including wxWidgets).

The workaround is to call `GetPosition()` and `GetSize()` in the `wxCloseEvent`, and save the parameters directly into `wxConfig` rather than using the `wxPersist` functionality. This only affects the main window, the splitter information is saved normally.