### PR TITLE
Update ttlib_wx with UNIX updates, replace %kv

### DIFF
--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -265,7 +265,7 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
                 // Add a comment to the header that specifies the generated header and source filenames
                 baseFile.replace_extension(header_ext);
                 derived_file.replace_extension(header_ext);
-                inc.Format("#include %kv", derived_file.subview());
+                inc.Format("#include %ks", derived_file.c_str());
 
                 ttlib::cstr comment(ttlib::cstr(header_ext) << "\"  // auto-generated: ");
                 comment << baseFile << " and ";
@@ -293,7 +293,7 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
             {
                 baseFile.replace_extension(header_ext);
                 ttlib::cstr inc;
-                inc.Format("#include %kv", baseFile.subview());
+                inc.Format("#include %ks", baseFile.c_str());
                 m_source->writeLine("// Non-generated additions to base class (virtual events is unchecked)");
                 m_source->writeLine("// Copy and paste into your own code as needed.");
                 m_source->writeLine();


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates ttLib_wx with changes supporting UNIX compilers. It also replaces use of `ttLib::cstr.Format("%kv", ...)` with `ttLib::cstr.Format("%ks", ...)` passing .c_str() as the argument instead of std::stringview. While this works in the Microsoft c++20 compilers, it fails under gcc 11 and clang 12 due to changes in the specification in C++20. The easiest solution is simply to pass a const char* pointer.