### PR TITLE
Improve handling of base_directory property

### DIFF
--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -64,6 +64,12 @@ bool GenerateCodeFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<tt
             // generated.
             if (path == "filename_base")
                 continue;
+            path.backslashestoforward();
+            if (GetProject()->HasValue(prop_base_directory) && !path.contains("/"))
+            {
+                path = GetProject()->GetBaseDirectory().utf8_string();
+                path.append_filename(base_file);
+            }
             path.make_absolute();
             path.backslashestoforward();
         }
@@ -232,7 +238,13 @@ void MainFrame::OnGenInhertedClass(wxCommandEvent& WXUNUSED(e))
             path = file;
             if (path.empty())
                 continue;
-            path.make_relative(GetProject()->getProjectPath());
+            path.backslashestoforward();
+            if (GetProject()->HasValue(prop_derived_directory) && !path.contains("/"))
+            {
+                path = GetProject()->as_string(prop_derived_directory);
+                path.append_filename(file);
+            }
+            path.make_absolute();
             path.backslashestoforward();
             path.replace_extension(source_ext);
             if (path.file_exists())

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -75,7 +75,13 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
     if (m_is_derived_class && m_form_node->HasValue(prop_derived_file))
     {
         derived_file = m_form_node->prop_as_string(prop_derived_file);
-        derived_file.make_relative(GetProject()->getProjectPath());
+        derived_file.backslashestoforward();
+        if (GetProject()->HasValue(prop_derived_directory) && !derived_file.contains("/"))
+        {
+            derived_file = GetProject()->as_string(prop_derived_directory);
+            derived_file.append_filename(m_form_node->prop_as_string(prop_derived_file));
+        }
+        derived_file.make_absolute();
         derived_file.backslashestoforward();
     }
     else
@@ -107,6 +113,13 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
     if (auto& file = m_form_node->prop_as_string(prop_base_file); file.size())
     {
         baseFile = file;
+        baseFile.backslashestoforward();
+        if (GetProject()->HasValue(prop_base_directory) && !baseFile.contains("/"))
+        {
+            baseFile = GetProject()->GetBaseDirectory();
+            baseFile.append_filename(file);
+        }
+
         baseFile.replace_extension(header_ext);
         ttlib::cstr root(derived_file);
         root.remove_filename();
@@ -265,7 +278,7 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
                 // Add a comment to the header that specifies the generated header and source filenames
                 baseFile.replace_extension(header_ext);
                 derived_file.replace_extension(header_ext);
-                inc.Format("#include %ks", derived_file.c_str());
+                inc.Format("#include %ks", std::string(derived_file.filename()).c_str());
 
                 ttlib::cstr comment(ttlib::cstr(header_ext) << "\"  // auto-generated: ");
                 comment << baseFile << " and ";

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -24,7 +24,7 @@
 #include <wx/utils.h>             // Miscellaneous utilities
 #include <wx/wupdlock.h>          // wxWindowUpdateLocker prevents window redrawing
 
-// auto-generated: ui/mainframe_base.h and ui/mainframe_base.cpp
+// auto-generated: wxui/mainframe_base.h and wxui/mainframe_base.cpp
 
 #include "mainframe.h"
 
@@ -604,6 +604,8 @@ void MainFrame::OnImportProject(wxCommandEvent&)
     wxGetApp().NewProject();
 }
 
+// This generates the base class files. For the derived class files, see OnGenInhertedClass()
+// in generate/gen_codefiles.cpp
 void MainFrame::OnGenerateCode(wxCommandEvent&)
 {
     GetProject()->UpdateEmbedNodes();

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -12,7 +12,7 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="Code" type="interface">
 		<property name="base_directory" type="path"
-			help="The generated base class output directory. Leave blank to generate them in the same directory as the project file." />
+			help="The generated base class output directory. If a form's base_file contains only a filename (without a path), the files will be generated in this directory. Leave blank to generate the in the same directory as the project file." />
 		<property name="derived_directory" type="path"
 			help="The generated derived class output directory. Leave blank to generate them in the same directory as the project file." />
 		<property name="source_ext" type="option" help="Specifies the file extension to use when create source files.">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the functionality of the project's base_directory property. The code now looks to see if a form's base_file contains just a filename, or if it contains a path. If it contains a path, the path is used to determine the base_directory. If it contains just a filename, the base_directory is set to the project's base_directory.

This also fixes a bug in the derived code generation that did not reflect a relative path to the base files if they were generated in a different directory.

This is related to #772 but needs more testing before that issue can be closed.