### PR TITLE
Refactor data_version in project file

### DIFF
--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -97,6 +97,11 @@ public:
     // Return true if the Generic version of the control is being used.
     virtual bool IsGeneric(Node*) { return false; }
 
+    // Return the lowest required version of wxUiEditor to support this generator. Override
+    // this if the generator or any of it's non-default properties require a newer version of
+    // wxUiEditor.
+    virtual int GetRequiredVersion(Node* /*node*/) { return minRequiredVer; }
+
     // Generate specific additional code
     virtual std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType /* command */, Node* /* node */) { return {}; }
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1319,7 +1319,10 @@ void MainFrame::CopyNode(Node* node)
         {
             pugi::xml_document doc;
             auto clip_node = doc.append_child("node");
-            m_clipboard->AddNodeToDoc(clip_node);
+            int project_version = minRequiredVer;
+            m_clipboard->AddNodeToDoc(clip_node, project_version);
+            // REVIEW: [Randalphwa - 08-24-2022] project_version is ignored, assuming that the same version of
+            // wxClipboard will be used to paste the clipboard node.
             auto u8_data = new wxUtf8DataObject();
             std::stringstream strm;
             doc.save(strm, "", pugi::format_raw);

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -310,7 +310,7 @@ public:
     size_t GetNodeSize() const;
 
     // This writes XML files in the 1.1 layout using attributes for properties
-    void AddNodeToDoc(pugi::xml_node& object);
+    void AddNodeToDoc(pugi::xml_node& object, int& project_version);
 
     void CalcNodeHash(size_t& hash) const;
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -124,10 +124,14 @@ constexpr const char* txtVersion = "wxUiEditor 1.0.1";
 constexpr const char* txtCopyRight = "Copyright (c) 2019-2022 KeyWorks Software";
 constexpr const char* txtAppname = "wxUiEditor";
 
-// Current version of wxUiEditor project files
-constexpr const auto curWxuiMajorVer = 1;
-constexpr const auto curWxuiMinorVer = 5;
-constexpr const auto curCombinedVer = 15;
+// This is the highest project number supported by this build of wxUiEditor. It should be
+// updated after every release, if there are any changes to the project format that might
+// require a newer version.
+constexpr const int curSupportedVer = 16;
+
+// This is the default minimum required version for all generators. It is the version used by
+// the 1.0.0 release.
+constexpr const int minRequiredVer = 15;
 
 // Use when you need to return an empty const ttlib::cstr&
 extern ttlib::cstr tt_empty_cstr;

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -52,9 +52,9 @@ bool App::LoadProject(const ttString& file)
 
     ProjectSharedPtr project;
 
-    m_ProjectVersion = root.attribute("data_version").as_int((curWxuiMajorVer * 10) + curWxuiMinorVer);
+    m_ProjectVersion = root.attribute("data_version").as_int(curSupportedVer);
 
-    if (m_ProjectVersion > curCombinedVer)
+    if (m_ProjectVersion > curSupportedVer)
     {
         if (wxMessageBox("wxUiEditor does not recognize this version of the data file.\n"
                          "You may be able to load the file, but if you then save it you could lose data.\n\n"
@@ -70,7 +70,7 @@ bool App::LoadProject(const ttString& file)
         }
     }
 
-    else if (m_ProjectVersion < curCombinedVer)
+    else if (m_ProjectVersion < minRequiredVer)
     {
         if (!root.child("object") && !root.child("node"))
         {
@@ -126,13 +126,13 @@ bool App::LoadProject(const ttString& file)
     // Imported projects start with an older version so that they pass through the old project fixups.
     if (m_ProjectVersion == ImportProjectVersion)
     {
-        m_ProjectVersion = curCombinedVer;
+        m_ProjectVersion = minRequiredVer;
     }
 
     wxGetFrame().SetImportedFlag(false);
     wxGetFrame().FireProjectLoadedEvent();
 
-    if (m_isProject_updated || m_ProjectVersion < curCombinedVer)
+    if (m_isProject_updated || m_ProjectVersion < minRequiredVer)
         wxGetFrame().SetModified();
 
     return true;


### PR DESCRIPTION
Rather than always saving and requiring the current version number, this
allows generators to set the minimum required version to support the current
node. Even if a new property is added, it won't require a newer version unless
the user changes a non-default value, or code generation requires it.

Closes #785

Note that this PR does not introduce any higher requirements, so data_version is still written out as version 15 even though the app itself can now support version 16.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
