### PR TITLE
Add evt_flags to SelectNode and FireSelectedEvent

### DIFF
--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -21,6 +21,7 @@ wxDEFINE_EVENT(EVT_PositionChanged, CustomEvent);
 wxDEFINE_EVENT(EVT_NodeCreated, CustomEvent);
 wxDEFINE_EVENT(EVT_NodeDeleted, CustomEvent);
 wxDEFINE_EVENT(EVT_NodeSelected, CustomEvent);
+wxDEFINE_EVENT(EVT_QueueSelect, CustomEvent);
 
 wxDEFINE_EVENT(EVT_NodePropChange, CustomEvent);
 wxDEFINE_EVENT(EVT_MultiPropChange, CustomEvent);
@@ -38,12 +39,23 @@ void MainFrame::FireProjectLoadedEvent()
     }
 }
 
-void MainFrame::FireSelectedEvent(Node* node)
+void MainFrame::FireSelectedEvent(Node* node, size_t flags)
 {
     CustomEvent node_event(EVT_NodeSelected, node);
-    for (auto handler: m_custom_event_handlers)
+
+    if (flags & evt_flags::queue_event)
     {
-        handler->ProcessEvent(node_event);
+        for (auto handler: m_custom_event_handlers)
+        {
+            handler->QueueEvent(node_event.Clone());
+        }
+    }
+    else
+    {
+        for (auto handler: m_custom_event_handlers)
+        {
+            handler->ProcessEvent(node_event);
+        }
     }
 }
 

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -50,20 +50,20 @@ void XrcPreview::OnCreate(wxCommandEvent& WXUNUSED(event))
 
 void XrcPreview::OnXrcCopy(wxCommandEvent& WXUNUSED(event))
 {
-    auto sel_node = wxGetFrame().GetSelectedNode();
+    auto evt_flags = wxGetFrame().GetSelectedNode();
 
-    if (!sel_node)
+    if (!evt_flags)
     {
         wxMessageBox("You need to select a form first.", "XRC Dialog Preview");
         return;
     }
 
-    if (!sel_node->IsForm())
+    if (!evt_flags->IsForm())
     {
-        sel_node = sel_node->get_form();
+        evt_flags = evt_flags->get_form();
     }
 
-    auto doc_str = GenerateXrcStr(sel_node, sel_node->isGen(gen_PanelForm) ? xrc::previewing : 0);
+    auto doc_str = GenerateXrcStr(evt_flags, evt_flags->isGen(gen_PanelForm) ? xrc::previewing : 0);
 
     m_scintilla->ClearAll();
     m_scintilla->AddTextRaw(doc_str.c_str(), (to_int) doc_str.size());
@@ -73,19 +73,19 @@ void XrcPreview::OnXrcCopy(wxCommandEvent& WXUNUSED(event))
     m_view.ReadString(doc_str);
 
     ttlib::cstr search("name=\"");
-    sel_node = wxGetFrame().GetSelectedNode();
+    evt_flags = wxGetFrame().GetSelectedNode();
 
-    if (sel_node->HasProp(prop_id) && sel_node->prop_as_string(prop_id) != "wxID_ANY")
+    if (evt_flags->HasProp(prop_id) && evt_flags->prop_as_string(prop_id) != "wxID_ANY")
     {
-        search << sel_node->prop_as_string(prop_id);
+        search << evt_flags->prop_as_string(prop_id);
     }
-    else if (sel_node->HasValue(prop_var_name))
+    else if (evt_flags->HasValue(prop_var_name))
     {
-        search << sel_node->prop_as_string(prop_var_name);
+        search << evt_flags->prop_as_string(prop_var_name);
     }
     else
     {
-        search << sel_node->prop_as_string(prop_class_name);
+        search << evt_flags->prop_as_string(prop_class_name);
     }
 
     int line = (to_int) m_view.FindLineContaining(search);

--- a/src/mockup/mockup_wizard.cpp
+++ b/src/mockup/mockup_wizard.cpp
@@ -190,7 +190,7 @@ void MockupWizard::OnBackOrNext(wxCommandEvent& event)
 
     if (m_cur_page_index < m_wizard_node->GetChildCount())
     {
-        wxGetFrame().SelectNode(m_wizard_node->GetChild(m_cur_page_index), false, true);
+        wxGetFrame().SelectNode(m_wizard_node->GetChild(m_cur_page_index), evt_flags::fire_event);
     }
 }
 

--- a/src/newdialogs/new_dialog.cpp
+++ b/src/newdialogs/new_dialog.cpp
@@ -86,7 +86,7 @@ void NewDialog::CreateNode()
     ttlib::cstr undo_str("New wxDialog");
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), project, undo_str, -1));
     wxGetFrame().FireCreatedEvent(form_node);
-    wxGetFrame().SelectNode(form_node, true, true);
+    wxGetFrame().SelectNode(form_node, evt_flags::fire_event & evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);
 }
 

--- a/src/newdialogs/new_frame.cpp
+++ b/src/newdialogs/new_frame.cpp
@@ -71,7 +71,7 @@ void NewFrame::CreateNode()
     ttlib::cstr undo_str("New wxFrame");
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), project, undo_str, -1));
     wxGetFrame().FireCreatedEvent(form_node);
-    wxGetFrame().SelectNode(form_node, true, true);
+    wxGetFrame().SelectNode(form_node, evt_flags::fire_event & evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);
 
     // If it's a mainframe then bars were probably added, so it makes sense to switch to the Bars ribbon bar page since

--- a/src/newdialogs/new_panel.cpp
+++ b/src/newdialogs/new_panel.cpp
@@ -106,7 +106,7 @@ void NewPanel::CreateNode()
     }
 
     wxGetFrame().FireCreatedEvent(new_node);
-    wxGetFrame().SelectNode(new_node, true, true);
+    wxGetFrame().SelectNode(new_node, evt_flags::fire_event & evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(new_node.get(), true, true);
 }
 

--- a/src/newdialogs/new_ribbon.cpp
+++ b/src/newdialogs/new_ribbon.cpp
@@ -106,7 +106,7 @@ void NewRibbon::CreateNode()
     }
 
     wxGetFrame().FireCreatedEvent(bar_node);
-    wxGetFrame().SelectNode(bar_node, true, true);
+    wxGetFrame().SelectNode(bar_node, evt_flags::fire_event & evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(bar_node.get(), true, true);
 
     // This probably already is activated, but let's be sure

--- a/src/newdialogs/new_wizard.cpp
+++ b/src/newdialogs/new_wizard.cpp
@@ -67,7 +67,7 @@ void NewWizard::CreateNode()
     ttlib::cstr undo_str("New wxWizard");
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), project, undo_str, -1));
     wxGetFrame().FireCreatedEvent(new_node);
-    wxGetFrame().SelectNode(new_node, true, true);
+    wxGetFrame().SelectNode(new_node, evt_flags::fire_event & evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(new_node.get(), true, true);
 }
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -759,7 +759,7 @@ Node* Node::CreateChildNode(GenName name)
     if (new_node)
     {
         frame.FireCreatedEvent(new_node.get());
-        frame.SelectNode(new_node.get(), true, true);
+        frame.SelectNode(new_node.get(), evt_flags::fire_event & evt_flags::force_selection);
     }
     return new_node.get();
 }

--- a/src/nodes/node_gridbag.cpp
+++ b/src/nodes/node_gridbag.cpp
@@ -122,7 +122,7 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
     new_node->SetParent(gbsizer);
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(new_node, true, true);
+    wxGetFrame().SelectNode(new_node, evt_flags::fire_event & evt_flags::force_selection);
 
     return true;
 }
@@ -306,7 +306,7 @@ void GridBag::MoveLeft(Node* node)
     // This needs to be called once the gbsizer has been modified
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(node, true, true);
+    wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
 }
 
 void GridBag::MoveRight(Node* node)
@@ -352,7 +352,7 @@ void GridBag::MoveRight(Node* node)
 
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(node, true, true);
+    wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
 }
 
 void GridBag::MoveUp(Node* node)
@@ -396,7 +396,7 @@ void GridBag::MoveUp(Node* node)
             ++begin_position;
         }
         undo_cmd->Update();
-        wxGetFrame().SelectNode(node, true, true);
+        wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
         return;
     }
 
@@ -426,7 +426,7 @@ void GridBag::MoveUp(Node* node)
 
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(node, true, true);
+    wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
 }
 
 void GridBag::MoveDown(Node* node)
@@ -470,7 +470,7 @@ void GridBag::MoveDown(Node* node)
             ++begin_position;
         }
         undo_cmd->Update();
-        wxGetFrame().SelectNode(node, true, true);
+        wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
         return;
     }
 
@@ -495,5 +495,5 @@ void GridBag::MoveDown(Node* node)
 
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(node, true, true);
+    wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
 }

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -757,7 +757,7 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::sview widget)
         wxGetFrame().GetNavigationPanel()->InsertNode(new_sizer.get());
 
         wxGetFrame().PushUndoAction(std::make_shared<ChangeParentAction>(node, new_sizer.get()));
-        wxGetFrame().SelectNode(node, true, true);
+        wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
         wxGetFrame().Thaw();
     }
 }

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -58,7 +58,7 @@ void InsertNodeAction::Change()
 
     // Probably not necessary, but with both parameters set to false, this simply ensures the mainframe has it's selection
     // node set correctly.
-    wxGetFrame().SelectNode(m_node.get(), false, false);
+    wxGetFrame().SelectNode(m_node.get(), evt_flags::no_event);
 }
 
 void InsertNodeAction::Revert()
@@ -110,7 +110,7 @@ void RemoveNodeAction::Revert()
     m_node->SetParent(m_parent);
     m_parent->ChangeChildPosition(m_node, m_old_pos);
 
-    wxGetFrame().SelectNode(m_old_selected.get(), true, false);
+    wxGetFrame().SelectNode(m_old_selected.get(), evt_flags::force_selection);
 }
 
 ///////////////////////////////// ModifyPropertyAction ////////////////////////////////////
@@ -421,7 +421,7 @@ void AppendGridBagAction::Change()
     }
 
     wxGetFrame().FireCreatedEvent(m_node);
-    wxGetFrame().SelectNode(m_node, true, true);
+    wxGetFrame().SelectNode(m_node, evt_flags::fire_event & evt_flags::force_selection);
 }
 
 void AppendGridBagAction::Revert()


### PR DESCRIPTION
The flags make the SelectNode easier to understand (the previous boolean
flags required looking up what the flags did). It also adds the ability for
either function to queue the event rather than calling it immediately.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds an `evt_flags` namespace with an enum that can be used in calls to SelectNode() and FireSelectedEvent(). Included in the flags is `queue_event` which will call `handler->QueueEvent()` instead of `handler->ProcessEvent()`.

Adding the ability to queue the selection events is an alternative to the proposed change in issue #777. This should make it easier for panels to queue selections using the existing function calls rather then making and entirely different call.

I added queued processing to the Duplicate() function, but have not made other changes yet until this gets used and tested for a bit.