### PR TITLE
Fix select node event problems

### DIFF
--- a/src/cstm_event.cpp
+++ b/src/cstm_event.cpp
@@ -37,6 +37,12 @@ void MainFrame::FireProjectLoadedEvent()
     {
         handler->ProcessEvent(event);
     }
+
+    CustomEvent node_event(EVT_NodeSelected, m_selected_node.get());
+    for (auto handler: m_custom_event_handlers)
+    {
+        handler->ProcessEvent(node_event);
+    }
 }
 
 void MainFrame::FireSelectedEvent(Node* node, size_t flags)

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -758,8 +758,6 @@ void MainFrame::ProjectLoaded()
     }
 
     m_selected_node = wxGetApp().GetProjectPtr();
-    // Queue the event so that everyone finishes process project loaded event.
-    FireSelectedEvent(m_selected_node, evt_flags::queue_event);
 }
 
 void MainFrame::ProjectSaved()
@@ -771,7 +769,7 @@ void MainFrame::ProjectSaved()
 void MainFrame::OnNodeSelected(CustomEvent& event)
 {
     // This event is normally only fired if the current selection has changed. We dismiss any previous infobar message, and
-    // check to see if the current selection has any kind of issu that we should warn the user about.
+    // check to see if the current selection has any kind of issue that we should warn the user about.
     m_info_bar->Dismiss();
 
     auto evt_flags = event.GetNode();
@@ -1439,7 +1437,7 @@ void MainFrame::PasteNode(Node* parent)
     auto pos = parent->FindInsertionPos(m_selected_node);
     PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, pos));
     FireCreatedEvent(new_node);
-    SelectNode(new_node, evt_flags::fire_event & evt_flags::force_selection);
+    SelectNode(new_node, evt_flags::fire_event | evt_flags::force_selection);
 }
 
 void MainFrame::DuplicateNode(Node* node)
@@ -1461,8 +1459,9 @@ void MainFrame::DuplicateNode(Node* node)
         undo_str << node->DeclName();
         auto pos = parent->FindInsertionPos(m_selected_node);
         PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, pos));
+        m_selected_node = new_node;
         FireCreatedEvent(new_node);
-        SelectNode(new_node, evt_flags::queue_event);
+        SelectNode(new_node);
     }
 }
 
@@ -1871,7 +1870,7 @@ void MainFrame::OnFindWidget(wxCommandEvent& WXUNUSED(event))
             auto found_node = FindChildNode(start_node, result->second);
             if (found_node)
             {
-                SelectNode(found_node, evt_flags::fire_event & evt_flags::force_selection);
+                SelectNode(found_node, evt_flags::fire_event | evt_flags::force_selection);
             }
             else
             {

--- a/src/newdialogs/new_dialog.cpp
+++ b/src/newdialogs/new_dialog.cpp
@@ -86,7 +86,7 @@ void NewDialog::CreateNode()
     ttlib::cstr undo_str("New wxDialog");
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), project, undo_str, -1));
     wxGetFrame().FireCreatedEvent(form_node);
-    wxGetFrame().SelectNode(form_node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(form_node, evt_flags::fire_event | evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);
 }
 

--- a/src/newdialogs/new_frame.cpp
+++ b/src/newdialogs/new_frame.cpp
@@ -71,7 +71,7 @@ void NewFrame::CreateNode()
     ttlib::cstr undo_str("New wxFrame");
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), project, undo_str, -1));
     wxGetFrame().FireCreatedEvent(form_node);
-    wxGetFrame().SelectNode(form_node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(form_node, evt_flags::fire_event | evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);
 
     // If it's a mainframe then bars were probably added, so it makes sense to switch to the Bars ribbon bar page since

--- a/src/newdialogs/new_panel.cpp
+++ b/src/newdialogs/new_panel.cpp
@@ -106,7 +106,7 @@ void NewPanel::CreateNode()
     }
 
     wxGetFrame().FireCreatedEvent(new_node);
-    wxGetFrame().SelectNode(new_node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(new_node, evt_flags::fire_event | evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(new_node.get(), true, true);
 }
 

--- a/src/newdialogs/new_ribbon.cpp
+++ b/src/newdialogs/new_ribbon.cpp
@@ -106,7 +106,7 @@ void NewRibbon::CreateNode()
     }
 
     wxGetFrame().FireCreatedEvent(bar_node);
-    wxGetFrame().SelectNode(bar_node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(bar_node, evt_flags::fire_event | evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(bar_node.get(), true, true);
 
     // This probably already is activated, but let's be sure

--- a/src/newdialogs/new_wizard.cpp
+++ b/src/newdialogs/new_wizard.cpp
@@ -67,7 +67,7 @@ void NewWizard::CreateNode()
     ttlib::cstr undo_str("New wxWizard");
     wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), project, undo_str, -1));
     wxGetFrame().FireCreatedEvent(new_node);
-    wxGetFrame().SelectNode(new_node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(new_node, evt_flags::fire_event | evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(new_node.get(), true, true);
 }
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -759,7 +759,7 @@ Node* Node::CreateChildNode(GenName name)
     if (new_node)
     {
         frame.FireCreatedEvent(new_node.get());
-        frame.SelectNode(new_node.get(), evt_flags::fire_event & evt_flags::force_selection);
+        frame.SelectNode(new_node.get(), evt_flags::fire_event | evt_flags::force_selection);
     }
     return new_node.get();
 }

--- a/src/nodes/node_gridbag.cpp
+++ b/src/nodes/node_gridbag.cpp
@@ -122,7 +122,7 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
     new_node->SetParent(gbsizer);
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(new_node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(new_node, evt_flags::fire_event | evt_flags::force_selection);
 
     return true;
 }
@@ -306,7 +306,7 @@ void GridBag::MoveLeft(Node* node)
     // This needs to be called once the gbsizer has been modified
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(node, evt_flags::fire_event | evt_flags::force_selection);
 }
 
 void GridBag::MoveRight(Node* node)
@@ -352,7 +352,7 @@ void GridBag::MoveRight(Node* node)
 
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(node, evt_flags::fire_event | evt_flags::force_selection);
 }
 
 void GridBag::MoveUp(Node* node)
@@ -396,7 +396,7 @@ void GridBag::MoveUp(Node* node)
             ++begin_position;
         }
         undo_cmd->Update();
-        wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
+        wxGetFrame().SelectNode(node, evt_flags::fire_event | evt_flags::force_selection);
         return;
     }
 
@@ -426,7 +426,7 @@ void GridBag::MoveUp(Node* node)
 
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(node, evt_flags::fire_event | evt_flags::force_selection);
 }
 
 void GridBag::MoveDown(Node* node)
@@ -470,7 +470,7 @@ void GridBag::MoveDown(Node* node)
             ++begin_position;
         }
         undo_cmd->Update();
-        wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
+        wxGetFrame().SelectNode(node, evt_flags::fire_event | evt_flags::force_selection);
         return;
     }
 
@@ -495,5 +495,5 @@ void GridBag::MoveDown(Node* node)
 
     undo_cmd->Update();
     wxGetFrame().FireGridBagActionEvent(undo_cmd.get());
-    wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(node, evt_flags::fire_event | evt_flags::force_selection);
 }

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -193,18 +193,19 @@ void NavigationPanel::OnSelChanged(wxTreeEvent& event)
 
     if (auto iter = m_tree_node_map.find(id); iter != m_tree_node_map.end())
     {
-        // Selecting a node can result in multiple selection events getting fired as the Mockup selects the current dialog,
-        // and the current book or page. In some cases a generator will also fire off a selection even when mockup set the
-        // current page (e.g., wxEVT_NOTEBOOK_PAGE_CHANGED). There's no reason for the property grid to update itself until
-        // we're done, so we lock it before the initial selection event.
+        // Selecting a node can result in multiple selection events getting fired as the
+        // Mockup selects the current dialog, and the current book or page. In some cases a
+        // generator will also fire off a selection event when mockup sets the current page
+        // (e.g., wxEVT_NOTEBOOK_PAGE_CHANGED). There's no reason for the property grid to
+        // update itself until we're done, so we lock it before the initial selection event.
 
         m_isSelChangeSuspended = true;
         m_pMainFrame->GetPropPanel()->Lock();
         m_pMainFrame->SelectNode(iter->second);
         m_pMainFrame->GetPropPanel()->UnLock();
 
-        // It's possible for Mockup to select a page, so we need to be certain everything is synced after the initial
-        // selection.
+        // It's possible for Mockup to select a page, so we need to be certain everything is
+        // synced after the initial selection.
 
         if (iter->second != m_pMainFrame->GetSelectedNode())
             m_pMainFrame->SelectNode(iter->second);

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -762,7 +762,7 @@ void NavPopupMenu::CreateSizerParent(Node* node, ttlib::sview widget)
         wxGetFrame().GetNavigationPanel()->InsertNode(new_sizer.get());
 
         wxGetFrame().PushUndoAction(std::make_shared<ChangeParentAction>(node, new_sizer.get()));
-        wxGetFrame().SelectNode(node, evt_flags::fire_event & evt_flags::force_selection);
+        wxGetFrame().SelectNode(node, evt_flags::fire_event | evt_flags::force_selection);
         wxGetFrame().Thaw();
     }
 }

--- a/src/tests/test_xrc_import.cpp
+++ b/src/tests/test_xrc_import.cpp
@@ -145,7 +145,7 @@ void MainFrame::OnTestXrcDuplicate(wxCommandEvent& /* event */)
         auto pos = GetProject()->FindInsertionPos(form_node);
         PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), GetProject(), undo_str, pos));
         FireCreatedEvent(new_node);
-        SelectNode(new_node, evt_flags::queue_event);
+        SelectNode(new_node);
     }
     else
     {

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -420,7 +420,7 @@ void AppendGridBagAction::Change()
     }
 
     wxGetFrame().FireCreatedEvent(m_node);
-    wxGetFrame().SelectNode(m_node, evt_flags::fire_event & evt_flags::force_selection);
+    wxGetFrame().SelectNode(m_node, evt_flags::fire_event | evt_flags::force_selection);
 }
 
 void AppendGridBagAction::Revert()


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Closes #795

Adding evt_flags::queue_event resulted in the current node not being selected in the navigation pane which made the selection problem worse, not better. I left the processing code in place in case we need it in the future, but the the Fire event functions no longer use it.

The switch to an enumerated list of flag values was not implemented correctly, which is what caused the bug reported in #795.