### PR TITLE
Add use_generic property to wxAnimationCtrl

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -370,6 +370,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_underlined, "underlined" },
     { prop_url, "url" },
     { prop_use_derived_class, "use_derived_class" },
+    { prop_use_generic, "use_generic" },
     { prop_use_tabs, "use_tabs" },
     { prop_user_cpp_code, "user_cpp_code" },
     { prop_validator_data_type, "validator_data_type" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -376,6 +376,7 @@ namespace GenEnum
         prop_underlined,
         prop_url,
         prop_use_derived_class,
+        prop_use_generic,
         prop_use_tabs,
         prop_user_cpp_code,
         prop_validator_data_type,

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -1084,6 +1084,7 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
         return NodeSharedPtr();
 
     bool isBitmapButton = (object_name == "wxBitmapButton");
+    bool is_generic_version = false;
     auto gen_name = ConvertToGenName(object_name, parent);
     if (gen_name == gen_unknown)
     {
@@ -1091,6 +1092,12 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
         {
             gen_name = gen_BookPage;
         }
+        else if (object_name == "wxGenericAnimationCtrl")
+        {
+            is_generic_version = true;
+            gen_name = gen_wxAnimationCtrl;
+        }
+
         else
         {
             MSG_INFO(ttlib::cstr() << "Unrecognized object: " << object_name);
@@ -1124,6 +1131,10 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
     }
 
     auto new_node = g_NodeCreator.CreateNode(gen_name, parent);
+    if (new_node && is_generic_version)
+    {
+        new_node->set_value(prop_use_generic, true);
+    }
     while (!new_node)
     {
         if (sizeritem && sizeritem->isGen(gen_oldbookpage))

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -31,6 +31,8 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 				help="By default, the control will adjust its size to exactly fit the size of the animation. If this style flag is set, the control will not change its size." />
 			wxAC_DEFAULT_STYLE
 		</property>
+		<property name="use_generic" type="bool"
+			help="If checked, wxGenericAnimationCtrl will be used instead of wxAnimationCtrl." />
 		<property name="animation" type="animation" />
 		<property name="inactive_bitmap" type="image" />
 	</gen>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `use_generic` property to **wxAnimationCtrl**, primarily so that we can correctly import **wxGenericAnimationCtrl** from an XRC file (in XRC, either control can be specified). Issue #732 suggests setting this to a bit flag rather than a boolean so that it can be platform specific. For this control, however, I'm not sure a platform-specific flag is necessary, since the generic control is a drop-in replacement for the native control.
