### PR TITLE
Add platforms property allowing for platform-specific code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,20 @@ Release summary...
 ### Added
 
 - Stretchable space can now be added to toolbars.
-- Added support from dropdown toolbar items that contain menu items.
-- You can now set the style and width of each field in a wxStatusBar.
+- Added support for dropdown toolbar items that contain menu items.
+- wxStatusBar `fields` property now supports unique width and style for each field.
+- New `platforms` property for most controls that inherit from **wxWindow**. This gives you the option of limiting the creation of a control to specific platforms.
+- Menu items can now contain multiple accelerators (requires wxWidgets 3.1.6 or later)
 - XRC now generates XML for toolbar separators.
 
 ### Changed
 
 - A user can no longer enter an invalid C++ variable name.
-- wxStatusBar `fields` property now supports unique width and style for each field.
 - `contents` property for wxCheckListBox and wxRearrangeCtrl now supports setting initial checked state for each string.
 - When a form is duplicated, the class name and any filenames specified for the form are now unique within the project.
-- Menu items can now contain multiple accelerators (requires wxWidgets 3.1.6 or later)
-- XRC files now include a comment warning that regeneration will eliminate any hand edits.
 - `Generate XRC files...` on Tools menu now launches a dialog allowing you to choose between combined or individually generated XRC files.
 - Improved XRC generation of optional static line above a standard dialog button -- this now matches what the C++ version would look like.
+- XRC files now include a comment warning that regeneration will eliminate any hand edits.
 
 ### Fixed
 
@@ -32,4 +32,4 @@ Release summary...
 - Code generation for setting custom foreground colour for wxStaticText fixed.
 - Fixed browsing for an XRC output file to generate XRC to -- it now defaults to the current project directory, and can handle a relative path.
 - Fixed non-combined XRC generation.
-- Fixed several problems when importing XRC/wxSmith files.
+- Fixed several problems when importing XRC files.

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -289,6 +289,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_persist, "persist" },
     { prop_persist_name, "persist_name" },
     { prop_pin_button, "pin_button" },
+    { prop_platforms, "platforms" },
     { prop_play, "play" },
     { prop_pos, "pos" },
     { prop_position, "position" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -295,6 +295,7 @@ namespace GenEnum
         prop_persist,
         prop_persist_name,
         prop_pin_button,
+        prop_platforms,
         prop_play,
         prop_pos,
         prop_position,

--- a/src/generate/gen_xrc_utils.cpp
+++ b/src/generate/gen_xrc_utils.cpp
@@ -48,6 +48,26 @@ const char* g_xrc_keywords =
 
 void GenXrcSizerItem(Node* node, pugi::xml_node& object)
 {
+    if (node->HasValue(prop_platforms) && node->value(prop_platforms) != "Windows|Unix|Mac")
+    {
+        ttlib::cstr platforms;
+        if (node->value(prop_platforms).contains("Windows"))
+            platforms << "msw";
+        if (node->value(prop_platforms).contains("Unix"))
+        {
+            if (platforms.size())
+                platforms << "|";
+            platforms << "unix";
+        }
+        if (node->value(prop_platforms).contains("Mac"))
+        {
+            if (platforms.size())
+                platforms << "|";
+            platforms << "mac";
+        }
+        object.append_attribute("platform").set_value(platforms);
+    }
+
     object.append_attribute("class").set_value("sizeritem");
 
     if (node->GetParent()->isGen(gen_wxGridBagSizer))

--- a/src/xml/forms_xml.xml
+++ b/src/xml/forms_xml.xml
@@ -5,7 +5,9 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Code Generation" />
 		<inherits class="wxTopLevelWindow" />
 		<inherits class="Window Events" />
-		<inherits class="wxWindow" />
+		<inherits class="wxWindow">
+			<hide name="platforms" />
+		</inherits>
 		<property name="class_name" type="string"
 			help="The name of the base class.">MyFrameBase</property>
 		<property name="title" type="string_escapes"
@@ -99,7 +101,9 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="RibbonBar" image="ribbon_bar" type="ribbonbar_form">
 		<inherits class="Code Generation" />
-		<inherits class="wxWindow" />
+		<inherits class="wxWindow">
+			<hide name="platforms" />
+		</inherits>
 		<inherits class="Window Events" />
 		<property name="class_name" type="string"
 			help="The name of the base class.">MyRibbonBarBase</property>

--- a/src/xml/menus_xml.xml
+++ b/src/xml/menus_xml.xml
@@ -3,7 +3,9 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="MenuBar" image="wxMenuBar" type="menubar_form">
 		<inherits class="Code Generation" />
-		<inherits class="wxWindow" />
+		<inherits class="wxWindow">
+			<hide name="platforms" />
+		</inherits>
 		<inherits class="Window Events" />
 		<property name="class_name" type="string"
 			help="The name of the base class.">MyMenuBarBase</property>

--- a/src/xml/toolbars_xml.xml
+++ b/src/xml/toolbars_xml.xml
@@ -3,7 +3,9 @@ inline const char* toolbars_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="ToolBar" image="wxToolBar" type="toolbar_form">
 		<inherits class="Code Generation" />
-		<inherits class="wxWindow" />
+		<inherits class="wxWindow">
+			<hide name="platforms" />
+		</inherits>
 		<inherits class="Window Events" />
 		<property name="class_name" type="string"
 			help="The name of the base class.">MyToolBarBase</property>

--- a/src/xml/window_interfaces_xml.xml
+++ b/src/xml/window_interfaces_xml.xml
@@ -116,5 +116,14 @@ inline const char* window_interfaces_xml = R"===(<?xml version="1.0"?>
 			help="Specify the name of the header file that declares your derived class." />
 		<property name="window_name" type="string_escapes"
 			help="The name of the window. This parameter is used to associate a name with the item, allowing the application user to set Motif resource values for individual windows." />
+		<property name="platforms" type="bitlist">
+			<option name="Windows"
+				help="Create this control when running on Windows." />
+			<option name="Unix"
+				help="Create this control when running on Unix." />
+			<option name="Mac"
+				help="Create this control when running on Mac." />
+			Windows|Unix|Mac
+		</property>
 	</gen>
 </GeneratorDefinitions>)===";


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new `prop_platforms` property which is a bitlist containing `Windows`, `Unix` and `Mac`. The property has been added to the `wxWindow` interface, so every control that inherits from it will have the property (forms that inherit from it have the property hidden). C++ and XRC generation has been updated to support it. In the case of C++, this puts conditinals around any control's code if all three platforms are not checked. For XRC, it adds platform attributes (unless all three are checked).

See issue #810 for more details.