### PR TITLE
Check for duplicate XRC filenames

### DIFF
--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -64,7 +64,7 @@ void AllowDirectoryChange(wxPropertyGridEvent& event, NodeProperty* /* prop */, 
 
 void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node)
 {
-    if (prop->isProp(prop_base_file))
+    if (prop->isProp(prop_base_file) || prop->isProp(prop_xrc_file))
     {
         ttString newValue = event.GetPropertyValue().GetString();
         if (newValue.empty())
@@ -81,23 +81,51 @@ void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node)
         {
             if (child.get() == node)
                 continue;
-            if (child->prop_as_string(prop_base_file).filename() == filename)
+            if (prop->isProp(prop_base_file))
             {
-                auto focus = wxWindow::FindFocus();
-
-                wxMessageBox(wxString() << "The base filename \"" << filename << "\" is already in use by "
-                                        << child->prop_as_string(prop_class_name)
-                                        << "\n\nEither change the name, or press ESC to restore the original name.",
-                             "Duplicate base filename", wxICON_STOP);
-                if (focus)
+                if (child->prop_as_string(prop_base_file).filename() == filename)
                 {
-                    focus->SetFocus();
-                }
+                    auto focus = wxWindow::FindFocus();
 
-                event.Veto();
-                event.SetValidationFailureBehavior(wxPG_VFB_MARK_CELL | wxPG_VFB_STAY_IN_PROPERTY);
-                wxGetFrame().SetStatusField("Either change the name, or press ESC to restore the original value.");
-                return;
+                    wxMessageBox(wxString() << "The base filename \"" << filename << "\" is already in use by "
+                                            << child->prop_as_string(prop_class_name)
+                                            << "\n\nEither change the name, or press ESC to restore the original name.",
+                                 "Duplicate base filename", wxICON_STOP);
+                    if (focus)
+                    {
+                        focus->SetFocus();
+                    }
+
+                    event.Veto();
+                    event.SetValidationFailureBehavior(wxPG_VFB_MARK_CELL | wxPG_VFB_STAY_IN_PROPERTY);
+                    wxGetFrame().SetStatusField("Either change the name, or press ESC to restore the original value.");
+                    return;
+                }
+            }
+            else
+            {
+                // Currently, XRC files don't have a directory property, so the full path
+                // relative to the project file is what we check. It *is* valid to have the
+                // same filename provided it is in a different directory.
+                if (child->prop_as_string(prop_xrc_file) == filename)
+                {
+                    auto focus = wxWindow::FindFocus();
+
+                    wxMessageBox(wxString() << "The xrc filename \"" << filename << "\" is already in use by "
+                                            << child->prop_as_string(prop_class_name)
+                                            << "\n\nEither change the name, or press ESC to restore the original name.",
+                                 "Duplicate xrc filename", wxICON_STOP);
+
+                    if (focus)
+                    {
+                        focus->SetFocus();
+                    }
+
+                    event.Veto();
+                    event.SetValidationFailureBehavior(wxPG_VFB_MARK_CELL | wxPG_VFB_STAY_IN_PROPERTY);
+                    wxGetFrame().SetStatusField("Either change the name, or press ESC to restore the original value.");
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR prevents entering a duplicate filename and path for an XRC file. Since XRC files do not have a property setting a default directory, it is allowed to have the same filename but in a different directory.

I do _not_ check for a duplicate filename between the individual form filenames and the combined XRC file. Since wxUE only allows create a combined or individual XRC files (never both), I think it's probably safe to allow this one to be a duplicate.

Closes #802
