### PR TITLE
Add disabled property to toolbar tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release summary...
 
 - Stretchable space can now be added to toolbars.
 - Added support for dropdown toolbar items that contain menu items.
+- wxToolBar and wxAuiToolBar individual tools now have a disabled property.
 - wxStatusBar `fields` property now supports unique width and style for each field.
 - New `platforms` property for most controls that inherit from **wxWindow**. This gives you the option of limiting the creation of a control to specific platforms.
 - Menu items can now contain multiple accelerators (requires wxWidgets 3.1.6 or later)

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -48,15 +48,16 @@ void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent
     size_t idx_child = 0;
     for (auto& childObj: node->GetChildNodePtrs())
     {
+        wxAuiToolBarItem* added_tool = nullptr;
         if (childObj->isGen(gen_auitool))
         {
             auto bmp = childObj->prop_as_wxBitmapBundle(prop_bitmap);
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
 
-            toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
-                             (wxItemKind) childObj->prop_as_int(prop_kind), childObj->prop_as_wxString(prop_help),
-                             wxEmptyString, nullptr);
+            added_tool = toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
+                                          (wxItemKind) childObj->prop_as_int(prop_kind),
+                                          childObj->prop_as_wxString(prop_help), wxEmptyString, nullptr);
         }
         else if (childObj->isGen(gen_auitool_label))
         {
@@ -84,9 +85,15 @@ void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent
 
             if (auto* control = wxDynamicCast(child, wxControl); control)
             {
-                toolbar->AddControl(control);
+                added_tool = toolbar->AddControl(control);
             }
         }
+
+        if (added_tool && childObj->prop_as_bool(prop_disabled))
+        {
+            toolbar->EnableTool(added_tool->GetId(), false);
+        }
+
         ++idx_child;
     }
     toolbar->Realize();

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1817,7 +1817,7 @@ ttlib::cstr GenToolCode(Node* node, ttlib::sview BitmapCode)
     ttlib::cstr code;
     code << '\t';
 
-    if (node->prop_as_string(prop_id) == "wxID_ANY" && node->GetInUseEventCount())
+    if (node->prop_as_bool(prop_disabled) || (node->prop_as_string(prop_id) == "wxID_ANY" && node->GetInUseEventCount()))
     {
         if (node->IsLocal())
             code << "auto* ";
@@ -1870,12 +1870,9 @@ ttlib::cstr GenToolCode(Node* node, ttlib::sview BitmapCode)
         {
             code << ", wxEmptyString, " << node->prop_as_string(prop_kind);
         }
-
-        code << ");";
-        return code;
     }
 
-    if (node->HasValue(prop_tooltip) && !node->HasValue(prop_statusbar))
+    else if (node->HasValue(prop_tooltip) && !node->HasValue(prop_statusbar))
     {
         code << ",\n\t\t\t" << GenerateQuotedString(node->prop_as_string(prop_tooltip));
         if (node->isGen(gen_tool_dropdown))
@@ -1906,6 +1903,11 @@ ttlib::cstr GenToolCode(Node* node, ttlib::sview BitmapCode)
     }
 
     code << ");";
+
+    if (node->prop_as_bool(prop_disabled))
+    {
+        code << "\n\t" << node->get_node_name() << "->Enable(false);";
+    }
 
     return code;
 }

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -50,15 +50,16 @@ void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparen
     for (size_t i = 0; i < count; ++i)
     {
         auto childObj = node->GetChild(i);
+        wxToolBarToolBase* added_tool = nullptr;
         if (childObj->isGen(gen_tool))
         {
             auto bmp = childObj->prop_as_wxBitmapBundle(prop_bitmap);
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
 
-            toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
-                             (wxItemKind) childObj->prop_as_int(prop_kind), childObj->prop_as_wxString(prop_help),
-                             wxEmptyString, nullptr);
+            added_tool = toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
+                                          (wxItemKind) childObj->prop_as_int(prop_kind),
+                                          childObj->prop_as_wxString(prop_help), wxEmptyString, nullptr);
         }
         else if (childObj->isGen(gen_tool_dropdown))
         {
@@ -66,8 +67,8 @@ void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparen
             if (!bmp.IsOk())
                 bmp = GetInternalImage("default");
 
-            toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap, wxITEM_DROPDOWN,
-                             childObj->prop_as_wxString(prop_help), wxEmptyString, nullptr);
+            added_tool = toolbar->AddTool(wxID_ANY, childObj->prop_as_wxString(prop_label), bmp, wxNullBitmap,
+                                          wxITEM_DROPDOWN, childObj->prop_as_wxString(prop_help), wxEmptyString, nullptr);
         }
         else if (childObj->isGen(gen_toolSeparator))
         {
@@ -87,8 +88,13 @@ void ToolBarFormGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparen
 
             if (auto control = wxDynamicCast(child, wxControl); control)
             {
-                toolbar->AddControl(control);
+                added_tool = toolbar->AddControl(control);
             }
+        }
+
+        if (added_tool && childObj->prop_as_bool(prop_disabled))
+        {
+            toolbar->EnableTool(added_tool->GetId(), false);
         }
     }
     toolbar->Realize();

--- a/src/xml/aui_xml.xml
+++ b/src/xml/aui_xml.xml
@@ -106,6 +106,8 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 				help="A checkable tool which makes part of a radio group of tools each of which is automatically unchecked whenever another button in the group is checked." />
 			wxITEM_NORMAL
 		</property>
+		<property name="disabled" type="bool"
+			help="Creates the tool in a disabled state. Some platforms will change the visible state of the tool to indicate that it is disabled.">0</property>
 		<property name="context_menu" type="bool"
 			help="Specifies that a drop-down menu button will appear next to the tool button. Used only with wxAuiToolBar.">0</property>
 		<property name="tooltip" type="string_edit"

--- a/src/xml/toolbars_xml.xml
+++ b/src/xml/toolbars_xml.xml
@@ -98,6 +98,8 @@ inline const char* toolbars_xml = R"===(<?xml version="1.0"?>
 				help="A checkable tool which makes part of a radio group of tools each of which is automatically unchecked whenever another button in the group is checked." />
 			wxITEM_NORMAL
 		</property>
+		<property name="disabled" type="bool"
+			help="Creates the tool in a disabled state. Some platforms will change the visible state of the tool to indicate that it is disabled.">0</property>
 		<property name="tooltip" type="string_edit"
 			help="String to display in the tooltip." />
 		<property name="statusbar" type="string_edit"


### PR DESCRIPTION
Closes #748

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a disabled property to tools added to wxToolbar and wxAuitoolbar. It does _not_ add them to wxRibbonToolbar because that requires creating a non-wxID_ANY id for the tool. Unlike the other toolbars, the return from `wxRibbonToolBar->AddTool` does not return a class pointer that is defined in any header file (it's defined in ribbon/toolbar.cpp). In the toolbar header, it's just a forward definition. That means you cannot call GetId() to get an id to pass to the EnableTool() function.
