### PR TITLE
And and reorganize Project properties

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -240,7 +240,6 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_line_numbers, "line_numbers" },  // previously used in wxStyledTextCtrl, but now uses margins
     { prop_line_size, "line_size" },
     { prop_local_pch_file, "local_pch_file" },
-    { prop_lua_directory, "lua_directory" },
     { prop_lua_file, "lua_file" },
     { prop_main_label, "main_label" },
     { prop_majorDimension, "majorDimension" },
@@ -290,7 +289,6 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_paste_multiple, "paste_multiple" },
     { prop_persist, "persist" },
     { prop_persist_name, "persist_name" },
-    { prop_php_directory, "php_directory" },
     { prop_php_file, "php_file" },
     { prop_pin_button, "pin_button" },
     { prop_platforms, "platforms" },
@@ -301,7 +299,6 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_pressed_bmp, "pressed_bmp" },
     { prop_private_members, "private_members" },
     { prop_proportion, "proportion" },
-    { prop_python_directory, "python_directory" },
     { prop_python_file, "python_file" },
     { prop_radiobtn_var_name, "radiobtn_var_name" },
     { prop_range, "range" },
@@ -407,6 +404,24 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_xrc_directory, "xrc_directory" },
     { prop_xrc_file, "xrc_file" },
 
+    { prop_python_combine_forms, "python_combine_forms" },
+    { prop_python_combined_file, "python_combined_file" },
+    { prop_python_copy_art, "python_copy_art" },
+    { prop_python_output_folder, "python_output_folder" },
+    { prop_python_use_xrc, "python_use_xrc" },
+
+    { prop_lua_combine_forms, "lua_combine_forms" },
+    { prop_lua_combined_file, "lua_combined_file" },
+    { prop_lua_copy_art, "lua_copy_art" },
+    { prop_lua_output_folder, "lua_output_folder" },
+    { prop_lua_use_xrc, "lua_use_xrc" },
+
+    { prop_php_combine_forms, "php_combine_forms" },
+    { prop_php_combined_file, "php_combined_file" },
+    { prop_php_copy_art, "php_copy_art" },
+    { prop_php_output_folder, "php_output_folder" },
+    { prop_php_use_xrc, "php_use_xrc" },
+
 };
 std::map<std::string_view, GenEnum::PropName, std::less<>> GenEnum::rmap_PropNames;
 
@@ -484,9 +499,8 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
 
     { gen_Bitmaps, "Bitmaps" },
     { gen_Boolean_Validator, "Boolean Validator" },
-    { gen_CMake, "CMake" },
     { gen_Choice_Validator, "Choice Validator" },
-    { gen_Code, "Code" },
+    { gen_Code, "C++" },
     { gen_Code_Generation, "Code Generation" },
     { gen_Command_Bitmaps, "Command Bitmaps" },
     { gen_Integer_Validator, "Integer Validator" },
@@ -494,12 +508,15 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_String_Validator, "String Validator" },
     { gen_Text_Validator, "Text Validator" },
     { gen_Window_Events, "Window Events" },
+    { gen_XRC, "XRC" },
     { gen_flexgridsizerbase, "flexgridsizerbase" },
     { gen_sizer_child, "sizer_child" },
     { gen_sizeritem_settings, "sizeritem_settings" },
+    { gen_wxLua, "wxLua" },
+    { gen_wxPHP, "wxPHP" },
+    { gen_wxPython, "wxPython" },
     { gen_wxTopLevelWindow, "wxTopLevelWindow" },
     { gen_wxWindow, "wxWindow" },
-    { gen_XRC, "XRC" },
 
     // The following are the regular generators
 

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -246,7 +246,6 @@ namespace GenEnum
         prop_line_numbers,
         prop_line_size,
         prop_local_pch_file,
-        prop_lua_directory,
         prop_lua_file,
         prop_main_label,
         prop_majorDimension,
@@ -296,7 +295,6 @@ namespace GenEnum
         prop_paste_multiple,
         prop_persist,
         prop_persist_name,
-        prop_php_directory,
         prop_php_file,
         prop_pin_button,
         prop_platforms,
@@ -307,7 +305,6 @@ namespace GenEnum
         prop_pressed_bmp,
         prop_private_members,
         prop_proportion,
-        prop_python_directory,
         prop_python_file,
         prop_radiobtn_var_name,
         prop_range,
@@ -413,6 +410,24 @@ namespace GenEnum
         prop_xrc_directory,
         prop_xrc_file,
 
+        prop_python_combine_forms,
+        prop_python_combined_file,
+        prop_python_copy_art,  // Copy art files to output folder
+        prop_python_output_folder,
+        prop_python_use_xrc,
+
+        prop_lua_combine_forms,
+        prop_lua_combined_file,
+        prop_lua_copy_art,
+        prop_lua_output_folder,
+        prop_lua_use_xrc,
+
+        prop_php_combine_forms,
+        prop_php_combined_file,
+        prop_php_copy_art,
+        prop_php_output_folder,
+        prop_php_use_xrc,
+
         // This must always be the last item as it is used to calculate the array size needed to store all items
         prop_name_array_size,
         prop_unknown = prop_name_array_size,
@@ -511,7 +526,6 @@ namespace GenEnum
 
         gen_Bitmaps,
         gen_Boolean_Validator,
-        gen_CMake,
         gen_Choice_Validator,
         gen_Code,
         gen_Code_Generation,
@@ -521,12 +535,15 @@ namespace GenEnum
         gen_String_Validator,
         gen_Text_Validator,
         gen_Window_Events,
+        gen_XRC,
         gen_flexgridsizerbase,
         gen_sizer_child,
         gen_sizeritem_settings,
+        gen_wxLua,
+        gen_wxPHP,
+        gen_wxPython,
         gen_wxTopLevelWindow,
         gen_wxWindow,
-        gen_XRC,
 
         // The following are the rergular generators
 

--- a/src/generate/gen_lua.cpp
+++ b/src/generate/gen_lua.cpp
@@ -41,9 +41,9 @@ bool GenerateLuaFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<ttl
         {
             path = base_file;
             path.backslashestoforward();
-            if (GetProject()->HasValue(prop_lua_directory) && !path.contains("/"))
+            if (GetProject()->HasValue(prop_lua_output_folder) && !path.contains("/"))
             {
-                path = GetProject()->GetBaseDirectory().utf8_string();
+                path = GetProject()->GetBaseDirectory(GEN_LANG_LUA).utf8_string();
                 path.append_filename(base_file);
             }
             path.make_absolute();

--- a/src/generate/gen_php.cpp
+++ b/src/generate/gen_php.cpp
@@ -41,9 +41,9 @@ bool GeneratePhpFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<ttl
         {
             path = base_file;
             path.backslashestoforward();
-            if (GetProject()->HasValue(prop_php_directory) && !path.contains("/"))
+            if (GetProject()->HasValue(prop_php_output_folder) && !path.contains("/"))
             {
-                path = GetProject()->GetBaseDirectory().utf8_string();
+                path = GetProject()->GetBaseDirectory(GEN_LANG_PHP).utf8_string();
                 path.append_filename(base_file);
             }
             path.make_absolute();

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -41,9 +41,9 @@ bool GeneratePythonFiles(wxWindow* parent, bool NeedsGenerateCheck, std::vector<
         {
             path = base_file;
             path.backslashestoforward();
-            if (GetProject()->HasValue(prop_python_directory) && !path.contains("/"))
+            if (GetProject()->HasValue(prop_php_output_folder) && !path.contains("/"))
             {
-                path = GetProject()->GetBaseDirectory().utf8_string();
+                path = GetProject()->GetBaseDirectory(GEN_LANG_PYTHON).utf8_string();
                 path.append_filename(base_file);
             }
             path.make_absolute();

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -444,14 +444,6 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
             new_pg_property->SetAttribute(wxPG_FILE_DIALOG_STYLE, wxFD_SAVE);
             new_pg_property->SetAttribute(wxPG_FILE_WILDCARD, "C++ Files|*.cpp;*.cc;*.cxx");
         }
-        else if (prop->isProp(prop_xrc_file) || prop->isProp(prop_combined_xrc_file))
-        {
-            new_pg_property->SetAttribute(wxPG_DIALOG_TITLE, "XRC filename");
-            new_pg_property->SetAttribute(wxPG_FILE_INITIAL_PATH, GetProject()->GetBaseDirectory());
-            new_pg_property->SetAttribute(wxPG_FILE_SHOW_RELATIVE_PATH, GetProject()->GetProjectPath());
-            new_pg_property->SetAttribute(wxPG_FILE_DIALOG_STYLE, wxFD_SAVE);
-            new_pg_property->SetAttribute(wxPG_FILE_WILDCARD, "XRC Files|*.xrc");
-        }
         else if (prop->isProp(prop_derived_file))
         {
             new_pg_property->SetAttribute(wxPG_DIALOG_TITLE, "Derived class filename");
@@ -459,6 +451,38 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
             new_pg_property->SetAttribute(wxPG_FILE_SHOW_RELATIVE_PATH, GetProject()->GetProjectPath());
             new_pg_property->SetAttribute(wxPG_FILE_DIALOG_STYLE, wxFD_SAVE);
             new_pg_property->SetAttribute(wxPG_FILE_WILDCARD, "C++ Files|*.cpp;*.cc;*.cxx");
+        }
+        else if (prop->isProp(prop_xrc_file) || prop->isProp(prop_combined_xrc_file))
+        {
+            new_pg_property->SetAttribute(wxPG_DIALOG_TITLE, "XRC filename");
+            new_pg_property->SetAttribute(wxPG_FILE_INITIAL_PATH, GetProject()->GetBaseDirectory(GEN_LANG_XRC));
+            new_pg_property->SetAttribute(wxPG_FILE_SHOW_RELATIVE_PATH, GetProject()->GetProjectPath());
+            new_pg_property->SetAttribute(wxPG_FILE_DIALOG_STYLE, wxFD_SAVE);
+            new_pg_property->SetAttribute(wxPG_FILE_WILDCARD, "XRC Files|*.xrc");
+        }
+        else if (prop->isProp(prop_python_file) || prop->isProp(prop_python_combined_file))
+        {
+            new_pg_property->SetAttribute(wxPG_DIALOG_TITLE, "Python filename");
+            new_pg_property->SetAttribute(wxPG_FILE_INITIAL_PATH, GetProject()->GetBaseDirectory(GEN_LANG_PYTHON));
+            new_pg_property->SetAttribute(wxPG_FILE_SHOW_RELATIVE_PATH, GetProject()->GetProjectPath());
+            new_pg_property->SetAttribute(wxPG_FILE_DIALOG_STYLE, wxFD_SAVE);
+            new_pg_property->SetAttribute(wxPG_FILE_WILDCARD, "Python Files|*.py");
+        }
+        else if (prop->isProp(prop_lua_file) || prop->isProp(prop_lua_combined_file))
+        {
+            new_pg_property->SetAttribute(wxPG_DIALOG_TITLE, "Lua filename");
+            new_pg_property->SetAttribute(wxPG_FILE_INITIAL_PATH, GetProject()->GetBaseDirectory(GEN_LANG_LUA));
+            new_pg_property->SetAttribute(wxPG_FILE_SHOW_RELATIVE_PATH, GetProject()->GetProjectPath());
+            new_pg_property->SetAttribute(wxPG_FILE_DIALOG_STYLE, wxFD_SAVE);
+            new_pg_property->SetAttribute(wxPG_FILE_WILDCARD, "Lua Files|*.lua");
+        }
+        else if (prop->isProp(prop_php_file) || prop->isProp(prop_php_combined_file))
+        {
+            new_pg_property->SetAttribute(wxPG_DIALOG_TITLE, "PHP filename");
+            new_pg_property->SetAttribute(wxPG_FILE_INITIAL_PATH, GetProject()->GetBaseDirectory(GEN_LANG_PHP));
+            new_pg_property->SetAttribute(wxPG_FILE_SHOW_RELATIVE_PATH, GetProject()->GetProjectPath());
+            new_pg_property->SetAttribute(wxPG_FILE_DIALOG_STYLE, wxFD_SAVE);
+            new_pg_property->SetAttribute(wxPG_FILE_WILDCARD, "PHP Files|*.php");
         }
         else if (prop->isProp(prop_header))
         {
@@ -1533,11 +1557,11 @@ void PropGridPanel::CreatePropCategory(ttlib::sview name, Node* node, NodeDeclar
         if (node->isGen(gen_wxButton) || node->isGen(gen_wxStaticText))
             m_prop_grid->Collapse(id);
     }
-    else if (name.contains("CMake"))
+    else if (name.contains("wxPython") || name.contains("wxLua") || name.contains("wxPHP"))
     {
         m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#fff1d2"));
     }
-    else if (node->isGen(gen_Project) && name.contains("Code"))
+    else if (node->isGen(gen_Project) && name.contains("C++"))
     {
         m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#e7f4e4"));
     }

--- a/src/project_class.cpp
+++ b/src/project_class.cpp
@@ -598,10 +598,18 @@ ttString Project::GetArtDirectory()
         return ttString() << m_projectPath.wx_str();
 }
 
-ttString Project::GetBaseDirectory()
+ttString Project::GetBaseDirectory(int language)
 {
-    if (HasValue(prop_base_directory))
+    if (language == GEN_LANG_CPLUSPLUS && HasValue(prop_base_directory))
         return as_wxString(prop_base_directory);
+    else if (language == GEN_LANG_LUA && HasValue(prop_lua_output_folder))
+        return as_wxString(prop_lua_output_folder);
+    else if (language == GEN_LANG_PYTHON && HasValue(prop_python_output_folder))
+        return as_wxString(prop_python_output_folder);
+    else if (language == GEN_LANG_PHP && HasValue(prop_php_output_folder))
+        return as_wxString(prop_php_output_folder);
+    else if (language == GEN_LANG_XRC && HasValue(prop_xrc_directory))
+        return as_wxString(prop_xrc_directory);
     else
         return GetProjectPath();
 }

--- a/src/project_class.h
+++ b/src/project_class.h
@@ -62,7 +62,7 @@ public:
     ttlib::cstr getArtDirectory();
     ttString GetArtDirectory();
 
-    ttString GetBaseDirectory();
+    ttString GetBaseDirectory(int language = GEN_LANG_CPLUSPLUS);
     ttString GetDerivedDirectory();
 
     // Returns the first project child that is a form, or nullptr if not form children found.

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -1,28 +1,11 @@
 inline const char* project_xml = R"===(<?xml version="1.0"?>
 <!DOCTYPE GeneratorDefinitions SYSTEM "gen.dtd">
 <GeneratorDefinitions>
-	<gen class="CMake" type="interface">
-		<property name="generate_cmake" type="bool"
-			help="If checked, this will auto-generate a .cmake file whenever the Generate Base Code command is chosen.">0</property>
-		<property name="cmake_file" type="file"
-			help="The filename of the cmake file to create. By default, this will be created in the same directory as the project file.">wxui_code.cmake</property>
-		<property name="cmake_varname" type="string"
-			help="The variable name to set in the .cmake file. This will contain paths to every generated class.">wxue_generated_code</property>
-	</gen>
-
-	<gen class="Code" type="interface">
+	<gen class="C++" type="interface">
 		<property name="base_directory" type="path"
 			help="The generated base class output directory. If a form's base_file contains only a filename (without a path), the files will be generated in this directory. Leave blank to generate the in the same directory as the project file." />
 		<property name="derived_directory" type="path"
 			help="The generated derived class output directory. Leave blank to generate them in the same directory as the project file." />
-		<property name="python_directory" type="path"
-			help="The directory to generate python files in. Leave blank to generate them in the same directory as the project file." />
-		<property name="lua_directory" type="path"
-			help="The directory to generate lua files in. Leave blank to generate them in the same directory as the project file." />
-		<property name="php_directory" type="path"
-			help="The directory to generate php files in. Leave blank to generate them in the same directory as the project file." />
-		<property name="xrc_directory" type="path"
-			help="The directory to generate xrc files in. Leave blank to generate them in the same directory as the project file." />
 		<property name="source_ext" type="option" help="Specifies the file extension to use when creating C++ source files.">
 			<option name=".cpp" />
 			<option name=".cc" />
@@ -36,14 +19,23 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 			<option name=".hxx" />
 			.h
 		</property>
-		<property name="wxWidgets_version" type="option" help="If you specify a control or property that requires a wxWidgets version later than this number, then the code will be generated within a conditional block.">
-			<option name="3.1" />
-			<option name="3.2.0" />
-			3.1
-		</property>
+		<property name="local_pch_file" type="file"
+			help="The filename of a local precompiled header file. The file will be included in quotes." />
+		<property name="src_preamble" type="code_edit"
+			help="Code to generate at the top of the source file after the inclusion of any local precompiled header file. This can include header files, comments, macros, etc." />
+		<property name="name_space" type="string"
+			help="Namespace to enclose class declarations in. Separate nested namespaces with a double colon (e.g. company::app::subname)" />
+		<property name="generate_cmake" type="bool"
+			help="If checked, this will auto-generate a .cmake file whenever C++ code is generated.">0</property>
+		<property name="cmake_file" type="file"
+			help="The filename of the cmake file to create. By default, this will be created in the same directory as the project file.">wxui_code.cmake</property>
+		<property name="cmake_varname" type="string"
+			help="The variable name to set in the .cmake file. This will contain paths to every generated class.">wxue_generated_code</property>
 	</gen>
 
 	<gen class="XRC" type="interface">
+		<property name="xrc_directory" type="path"
+			help="The directory to generate xrc files in. Leave blank to generate them in the same directory as the project file." />
 		<property name="combine_all_forms" type="bool"
 			help="If checked, Export XRC (File menu) will create a single XRC file containing all forms.">1</property>
 		<property name="combined_xrc_file" type="file"
@@ -52,18 +44,61 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 			help="The directory containing the images your XRC file will load." />
 	</gen>
 
+	<gen class="wxPython" type="interface">
+		<property name="python_output_folder" type="path"
+			help="If a folder name is specified, it will be used for all python code. It will also be used for generated xrc and art files if the matching options below are checked." />
+		<property name="python_combined_file" type="file"
+			help="This filename will be used to write all python code to unless you unchecked the python_combine_forms property above." />
+		<property name="python_combine_forms" type="bool"
+			help="If checked, will create a single file containing all python generated forms.">0</property>
+		<property name="python_copy_art" type="bool"
+			help="If checked, art files will be copied to the python_output_folder. BMP files will be converted to PNG, XPM and SVG files may be reduced in size." />
+		<property name="python_use_xrc" type="bool"
+			help="If checked, python code generation will use XRC file(s) which will be generated in the python_output_folder specified above. This will use the settings in the XRC category above for determining if a combined or individual XRC files should be created, and what the combined filename will be if XRC combining is chosen." />
+	</gen>
+
+	<gen class="wxLua" type="interface">
+		<property name="lua_output_folder" type="path"
+			help="If a folder name is specified, it will be used for all lua code. It will also be used for generated xrc and art files if the matching options below are checked." />
+		<property name="lua_combined_file" type="file"
+			help="This filename will be used to write all lua code to unless you unchecked the lua_combine_forms property above." />
+		<property name="lua_combine_forms" type="bool"
+			help="If checked, will create a single file containing all lua generated forms.">0</property>
+		<property name="lua_copy_art" type="bool"
+			help="If checked, art files will be copied to the lua_output_folder. BMP files will be converted to PNG, XPM and SVG files may be reduced in size." />
+		<property name="lua_use_xrc" type="bool"
+			help="If checked, lua code generation will use XRC file(s) which will be generated in the lua_output_folder specified above. This will use the settings in the XRC category above for determining if a combined or individual XRC files should be created, and what the combined filename will be if XRC combining is chosen." />
+	</gen>
+
+	<gen class="wxPHP" type="interface">
+		<property name="php_output_folder" type="path"
+			help="If a folder name is specified, it will be used for all php code. It will also be used for generated xrc and art files if the matching options below are checked." />
+		<property name="php_combined_file" type="file"
+			help="This filename will be used to write all php code to unless you unchecked the php_combine_forms property above." />
+		<property name="php_combine_forms" type="bool"
+			help="If checked, will create a single file containing all php generated forms.">0</property>
+		<property name="php_copy_art" type="bool"
+			help="If checked, art files will be copied to the php_output_folder. BMP files will be converted to PNG, XPM and SVG files may be reduced in size." />
+		<property name="php_use_xrc" type="bool"
+			help="If checked, php code generation will use XRC file(s) which will be generated in the php_output_folder specified above. This will use the settings in the XRC category above for determining if a combined or individual XRC files should be created, and what the combined filename will be if XRC combining is chosen." />
+	</gen>
+
 	<gen class="Project" type="project" image="project">
-		<inherits class="CMake" />
-		<inherits class="Code" />
+		<inherits class="C++" />
+		<inherits class="wxPython" />
+		<inherits class="wxLua" />
+		<inherits class="wxPHP" />
 		<inherits class="XRC" />
-		<property name="local_pch_file" type="file"
-			help="The filename of a local precompiled header file. The file will be included in quotes." />
-		<property name="src_preamble" type="code_edit"
-			help="Code to generate at the top of the source file after the inclusion of any local precompiled header file. This can include header files, comments, macros, etc." />
 		<property name="art_directory" type="path"
 			help="The directory containing your images (png, ico, xpm, etc.)." />
 		<property name="internationalize" type="bool"
 			help="Wrap strings in a _() macro which expands into a call to wxGetTranslation().">0</property>
+		<property name="wxWidgets_version" type="option"
+			help="If you specify a control or property that requires a wxWidgets version later than this number, then the code will be generated within a conditional block.">
+			<option name="3.1" />
+			<option name="3.2.0" />
+			3.1
+		</property>
 		<property name="help_provider" type="option"
 			help="The class of help provider to use for context-sensitive help.">
 			<option name="none"
@@ -74,7 +109,5 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 				help="Use wxHelpControllerHelpProvider to provide context-sensitive help." />
 			none
 		</property>
-		<property name="name_space" type="string"
-			help="Namespace to enclose class declarations in. Separate nested namespaces with a double colon (e.g. company::app::subname)" />
 	</gen>
 </GeneratorDefinitions>)===";


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR creates a number of new properties for the new language code generators. The Project property grid has been changed so that all C++ properties are in it's own category (renamed from `Code` to `C++`). The other languages have their own categories.

For the most part, none of the new properties are hooked up -- they will need to be hooked up in the various output UI and functions.
