### PR TITLE
Add ability to change some widget types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Release summary...
 - Menu items can now contain multiple accelerators (requires wxWidgets 3.1.6 or later)
 - XRC now generates XML for toolbar separators.
 
+The right-click menu for a widget in the Navigation Panel will sometimes have a `Change to` option. The 1.0 release supported changing most sizers. New to 1.1 is the ability to change some widgets as well. The following widgets can be changed to another widget in the group:
+
+- 2-state wxCheckBox, 3-state wxCheckBox, wxRadioBox
+- wxChoice, wxComboBox, wxListBox
+- wxAuibook, wxChoicebook, wxListbook, wxNotebook, wxSimplebook
+
 ### Changed
 
 - A user can no longer enter an invalid C++ variable name.

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -232,6 +232,50 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
             ChangeSizer(gen_wxFlexGridSizer);
             break;
 
+        case MenuChangeTo_AUI_BOOK:
+            ChangeNode(gen_wxAuiNotebook);
+            break;
+
+        case MenuChangeTo_CHOICE_BOOK:
+            ChangeNode(gen_wxChoicebook);
+            break;
+
+        case MenuChangeTo_LIST_BOOK:
+            ChangeNode(gen_wxListbook);
+            break;
+
+        case MenuChangeTo_NOTE_BOOK:
+            ChangeNode(gen_wxNotebook);
+            break;
+
+        case MenuChangeTo_SIMPLE_BOOK:
+            ChangeNode(gen_wxSimplebook);
+            break;
+
+        case MenuChangeTo_2STATE_CHECKBOX:
+            ChangeNode(gen_wxCheckBox);
+            break;
+
+        case MenuChangeTo_3STATE_CHECKBOX:
+            ChangeNode(gen_Check3State);
+            break;
+
+        case MenuChangeTo_RADIO_BUTTON:
+            ChangeNode(gen_wxRadioButton);
+            break;
+
+        case MenuChangeTo_CHOICE_BOX:
+            ChangeNode(gen_wxChoice);
+            break;
+
+        case MenuChangeTo_COMBO_BOX:
+            ChangeNode(gen_wxComboBox);
+            break;
+
+        case MenuChangeTo_LIST_BOX:
+            ChangeNode(gen_wxListBox);
+            break;
+
         case MenuChangeTo_GRID_SIZER:
             ChangeSizer(gen_wxGridSizer);
             break;
@@ -669,6 +713,126 @@ void NavPopupMenu::MenuAddMoveCommands(Node* node)
 
         AppendSubMenu(sub_menu, "&Move into new sizer");
     }
+
+    if (node->isGen(gen_wxRadioButton))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_2STATE_CHECKBOX, "2-state wxCheckBox");
+        menu_item->SetBitmap(GetInternalImage("wxCheckBox"));
+        menu_item = sub_menu->Append(MenuChangeTo_3STATE_CHECKBOX, "3-state wxCheckBox");
+        menu_item->SetBitmap(GetInternalImage("check3state"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxCheckBox))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_3STATE_CHECKBOX, "3-state wxCheckBox");
+        menu_item->SetBitmap(GetInternalImage("check3state"));
+        menu_item = sub_menu->Append(MenuChangeTo_RADIO_BUTTON, "wxRadioButton");
+        menu_item->SetBitmap(GetInternalImage("wxRadioButton"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_Check3State))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_2STATE_CHECKBOX, "2-state wxCheckBox");
+        menu_item->SetBitmap(GetInternalImage("wxCheckBox"));
+        menu_item = sub_menu->Append(MenuChangeTo_RADIO_BUTTON, "wxRadioButton");
+        menu_item->SetBitmap(GetInternalImage("wxRadioButton"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxChoice))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_COMBO_BOX, "wxComboBox");
+        menu_item->SetBitmap(GetInternalImage("wxComboBox"));
+        menu_item = sub_menu->Append(MenuChangeTo_LIST_BOX, "wxListBox");
+        menu_item->SetBitmap(GetInternalImage("wxListBox"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxComboBox))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_CHOICE_BOX, "wxChoice");
+        menu_item->SetBitmap(GetInternalImage("wxChoice"));
+        menu_item = sub_menu->Append(MenuChangeTo_LIST_BOX, "wxListBox");
+        menu_item->SetBitmap(GetInternalImage("wxListBox"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxListBox))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_CHOICE_BOX, "wxChoice");
+        menu_item->SetBitmap(GetInternalImage("wxChoice"));
+        menu_item = sub_menu->Append(MenuChangeTo_COMBO_BOX, "wxComboBox");
+        menu_item->SetBitmap(GetInternalImage("wxComboBox"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxAuiNotebook))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_CHOICE_BOOK, "wxChoicebook");
+        menu_item->SetBitmap(GetInternalImage("wxChoicebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_LIST_BOOK, "wxListbook");
+        menu_item->SetBitmap(GetInternalImage("wxListbook"));
+        menu_item = sub_menu->Append(MenuChangeTo_NOTE_BOOK, "wxNotebook");
+        menu_item->SetBitmap(GetInternalImage("wxNotebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_SIMPLE_BOOK, "wxSimplebook");
+        menu_item->SetBitmap(GetInternalImage("wxSimplebook"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxChoicebook))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_AUI_BOOK, "wxAuiNotebook");
+        menu_item->SetBitmap(GetInternalImage("auinotebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_LIST_BOOK, "wxListbook");
+        menu_item->SetBitmap(GetInternalImage("wxListbook"));
+        menu_item = sub_menu->Append(MenuChangeTo_NOTE_BOOK, "wxNotebook");
+        menu_item->SetBitmap(GetInternalImage("wxNotebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_SIMPLE_BOOK, "wxSimplebook");
+        menu_item->SetBitmap(GetInternalImage("wxSimplebook"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxListbook))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_AUI_BOOK, "wxAuiNotebook");
+        menu_item->SetBitmap(GetInternalImage("auinotebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_CHOICE_BOOK, "wxChoicebook");
+        menu_item->SetBitmap(GetInternalImage("wxChoicebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_NOTE_BOOK, "wxNotebook");
+        menu_item->SetBitmap(GetInternalImage("wxNotebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_SIMPLE_BOOK, "wxSimplebook");
+        menu_item->SetBitmap(GetInternalImage("wxSimplebook"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxNotebook))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_AUI_BOOK, "wxAuiNotebook");
+        menu_item->SetBitmap(GetInternalImage("auinotebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_CHOICE_BOOK, "wxChoicebook");
+        menu_item->SetBitmap(GetInternalImage("wxChoicebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_LIST_BOOK, "wxListbook");
+        menu_item->SetBitmap(GetInternalImage("wxListbook"));
+        menu_item = sub_menu->Append(MenuChangeTo_SIMPLE_BOOK, "wxSimplebook");
+        menu_item->SetBitmap(GetInternalImage("wxSimplebook"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
+    else if (node->isGen(gen_wxSimplebook))
+    {
+        sub_menu = new wxMenu;
+        menu_item = sub_menu->Append(MenuChangeTo_AUI_BOOK, "wxAuiNotebook");
+        menu_item->SetBitmap(GetInternalImage("auinotebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_CHOICE_BOOK, "wxChoicebook");
+        menu_item->SetBitmap(GetInternalImage("wxChoicebook"));
+        menu_item = sub_menu->Append(MenuChangeTo_LIST_BOOK, "wxListbook");
+        menu_item->SetBitmap(GetInternalImage("wxListbook"));
+        menu_item = sub_menu->Append(MenuChangeTo_NOTE_BOOK, "wxNotebook");
+        menu_item->SetBitmap(GetInternalImage("wxNotebook"));
+        AppendSubMenu(sub_menu, "&Change widget to");
+    }
 }
 
 void NavPopupMenu::MenuAddStandardCommands(Node* node)
@@ -771,6 +935,12 @@ void NavPopupMenu::ChangeSizer(GenEnum::GenName new_sizer_gen)
 {
     wxWindowUpdateLocker freeze(wxGetFrame().GetWindow());
     wxGetFrame().PushUndoAction(std::make_shared<ChangeSizerType>(m_node, new_sizer_gen));
+}
+
+void NavPopupMenu::ChangeNode(GenEnum::GenName new_node_gen)
+{
+    wxWindowUpdateLocker freeze(wxGetFrame().GetWindow());
+    wxGetFrame().PushUndoAction(std::make_shared<ChangeNodeType>(m_node, new_node_gen));
 }
 
 void NavPopupMenu::AddToolbarCommands(Node* node)

--- a/src/panels/navpopupmenu.h
+++ b/src/panels/navpopupmenu.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Context-menu for Navigation Panel
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -60,6 +60,34 @@ public:
         MenuChangeTo_GRID_SIZER,
         MenuChangeTo_STATIC_SIZER,
         MenuChangeTo_WRAP_SIZER,
+
+        // This can only be used if there is just one possibility
+        MenuChangeTo_NEW_NODE,
+
+        // 2-state wxCheckBox, 3-state wxCheckBox, wxRadioBox
+
+        MenuChangeTo_2STATE_CHECKBOX,
+        MenuChangeTo_3STATE_CHECKBOX,
+        MenuChangeTo_RADIO_BUTTON,
+
+        // wxChoice, wxComboBox, wxListBox
+
+        MenuChangeTo_CHOICE_BOX,
+        MenuChangeTo_COMBO_BOX,
+        MenuChangeTo_LIST_BOX,
+
+        // wxAuiNotebook, wxChoicebook
+        MenuChangeTo_AUI_BOOK,
+        MenuChangeTo_CHOICE_BOOK,
+        MenuChangeTo_LIST_BOOK,
+        MenuChangeTo_NOTE_BOOK,
+        MenuChangeTo_SIMPLE_BOOK,
+
+        // REVIEW: [Randalphwa - 11-16-2022] Because the children are so different, I don't think
+        // switching these is going to work.
+
+        // MenuChangeTo_TOOL_BOOK,
+        // MenuChangeTo_TREE_BOOK,
 
         MenuNEW_CHILD_SPACER,
         MenuNEW_SIBLING_SPACER,
@@ -140,6 +168,7 @@ protected:
     // into new sizer.
     void MenuAddMoveCommands(Node* node);
 
+    void ChangeNode(GenEnum::GenName new_node_gen);
     void ChangeSizer(GenEnum::GenName new_sizer_gen);
     void CreateSizerParent(Node* node, ttlib::sview widget);
 

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Undoable command classes derived from UndoAction
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -164,6 +164,24 @@ private:
     NodeSharedPtr m_old_node;
     NodeSharedPtr m_parent;
     GenEnum::GenName m_new_gen_sizer;
+};
+
+// Specify current node and new node gen_ name.
+class ChangeNodeType : public UndoAction
+{
+public:
+    ChangeNodeType(Node* node, GenEnum::GenName new_node);
+    void Change() override;
+    void Revert() override;
+
+    Node* GetOldNode() { return m_old_node.get(); }
+    Node* GetNode() { return m_node.get(); }
+
+private:
+    NodeSharedPtr m_node;
+    NodeSharedPtr m_old_node;
+    NodeSharedPtr m_parent;
+    GenEnum::GenName m_new_gen_node;
 };
 
 // Specify node and parent node, and optional position


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability to change some widgets to a different widget:

- 2-state wxCheckBox, 3-state wxCheckBox, wxRadioBox
- wxChoice, wxComboBox, wxListBox
- wxAuibook, wxChoicebook, wxListbook, wxNotebook, wxSimplebook

This is accessed via the right-click menu in the Navigation pane.