### PR TITLE
Code generation helper class

### DIFF
--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -50,6 +50,7 @@ set (file_list
 
     # Code generation modules
 
+    generate/code.cpp              # Helper class for generating code
     generate/gen_base.cpp          # Generate Src and Hdr files for Base and Derived Class
     generate/gen_construction.cpp  # Top level Object construction code
     generate/gen_cmake.cpp         # Auto-generate a .cmake file

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Base widget generator class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -22,6 +22,8 @@ class wxObject;
 class wxPropertyGridEvent;
 class wxPropertyGridManager;
 class wxWindow;
+
+class Code;
 
 namespace pugi
 {
@@ -75,6 +77,7 @@ public:
     MockupParent* GetMockup();
 
     // Generate the code used to construct the object
+    virtual std::optional<ttlib::cstr> CommonConstruction(Code&) { return {}; }
     virtual std::optional<ttlib::cstr> GenConstruction(Node*) { return {}; }
     virtual std::optional<ttlib::cstr> GenPythonConstruction(Node*) { return {}; }
 
@@ -99,6 +102,7 @@ public:
     // Generate code after any children have been constructed
     //
     // Code will be written with indent::none set
+    virtual std::optional<ttlib::cstr> CommonAfterChildren(Code&) { return {}; }
     virtual std::optional<ttlib::cstr> GenAfterChildren(Node* /* node */) { return {}; }
     virtual std::optional<ttlib::cstr> GenPythonAfterChildren(Node* /* node */) { return {}; }
 

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -127,3 +127,8 @@ Code& Code::ParentName()
     m_code << m_node->GetParent()->get_node_name();
     return *this;
 }
+
+bool Code::is_local_var() const
+{
+    return m_node->IsLocal();
+}

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1,0 +1,129 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Helper class for generating code
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include <ttmultistr_wx.h>  // ttMultiString -- Class for handling multiple strings
+
+#include "code.h"
+
+#include "node.h"  // Node class
+
+Code& Code::Tab(int tabs)
+{
+    while (tabs)
+    {
+        m_code << '\t';
+        --tabs;
+    }
+    return *this;
+}
+
+Code& Code::Add(ttlib::sview text)
+{
+    if (m_language == GEN_LANG_CPLUSPLUS)
+    {
+        m_code << text;
+    }
+    else
+    {
+        if (text.is_sameprefix("wx"))
+        {
+            m_code << "wx." << text.substr(2);
+        }
+        else
+        {
+            m_code << text;
+        }
+    }
+    return *this;
+}
+
+Code& Code::Function(ttlib::sview text)
+{
+    if (m_language == GEN_LANG_CPLUSPLUS)
+    {
+        m_code << "->" << text;
+    }
+    else
+    {
+        m_code << '.';
+        if (text.is_sameprefix("wx"))
+        {
+            m_code << "wx." << text.substr(2);
+        }
+        else
+        {
+            m_code << text;
+        }
+    }
+    return *this;
+}
+
+Code& Code::Assign(ttlib::sview class_name)
+{
+    m_code << " = ";
+    if (m_language == GEN_LANG_CPLUSPLUS)
+    {
+        m_code << "new " << class_name;
+    }
+    else
+    {
+        m_code << "wx." << class_name.substr(2);
+    }
+    return *this;
+}
+
+Code& Code::EndFunction()
+{
+    if (m_language == GEN_LANG_CPLUSPLUS)
+    {
+        m_code << ");";
+    }
+    else
+    {
+        m_code << ')';
+    }
+    return *this;
+}
+
+Code& Code::as_string(PropName prop_name)
+{
+    if (m_language == GEN_LANG_CPLUSPLUS)
+    {
+        m_code << m_node->prop_as_string(prop_name);
+    }
+    else
+    {
+        ttlib::multiview multistr(m_node->prop_as_string(prop_name), "|", tt::TRIM::both);
+        bool first = true;
+        for (auto& iter: multistr)
+        {
+            if (iter.empty())
+                continue;
+            if (!first)
+                m_code << '|';
+            else
+                first = false;
+            if (iter == "wxEmptyString")
+                m_code << "\"\"";
+            else
+                m_code << "wx." << iter.substr(2);
+        }
+    }
+    return *this;
+}
+
+Code& Code::NodeName()
+{
+    m_code << m_node->get_node_name();
+    return *this;
+}
+
+Code& Code::ParentName()
+{
+    m_code << m_node->GetParent()->get_node_name();
+    return *this;
+}

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -23,6 +23,10 @@ public:
     void clear() { m_code.clear(); }
     auto size() { return m_code.size(); }
 
+    bool is_cpp() const { return m_language == GEN_LANG_CPLUSPLUS; }
+    bool is_python() const { return m_language == GEN_LANG_PYTHON; }
+    bool is_local_var() const;
+
     Code& Eol()
     {
         m_code << '\n';

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -1,0 +1,74 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Helper class for generating code
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "gen_enums.h"  // Enumerations for generators
+
+class Node;
+
+class Code
+{
+public:
+    ttlib::cstr m_code;
+    Node* m_node;
+    int m_language;
+
+    Code(Node* node, int language = GEN_LANG_CPLUSPLUS) : m_node(node), m_language(language) {}
+
+    void clear() { m_code.clear(); }
+    auto size() { return m_code.size(); }
+
+    Code& Eol()
+    {
+        m_code << '\n';
+        return *this;
+    }
+
+    // Adds as many '\t' as specified
+    Code& Tab(int tabs = 1);
+
+    // If string starts with "wx" and language is not C++, then this will add "wx." and then
+    // the string without the "wx" prefix.
+    Code& Add(ttlib::sview text);
+
+    // Adds -> or . to the string, then wxFunction or wx.Function
+    Code& Function(ttlib::sview text);
+
+    // Adds " = new wxClass" or " = wx.Class'
+    Code& Assign(ttlib::sview class_name);
+
+    // Adds ");" or ")"
+    Code& EndFunction();
+
+    // m_code << m_node->get_node_name();
+    Code& NodeName();
+
+    // m_code << m_node->GetParent()->get_node_name();
+    Code& ParentName();
+
+    // Handles regular or or'd styles for C++ or Python
+    Code& as_string(GenEnum::PropName prop_name);
+
+    Code& operator<<(std::string_view str)
+    {
+        m_code += str;
+        return *this;
+    }
+
+    Code& operator<<(char ch)
+    {
+        m_code += ch;
+        return *this;
+    }
+
+    Code& operator<<(int i)
+    {
+        m_code << i;
+        return *this;
+    }
+};

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -27,8 +27,11 @@ wxObject* BoxSizerGenerator::CreateMockup(Node* node, wxObject* parent)
     return sizer;
 }
 
-void BoxSizerGenerator::CommonConstruction(Code& code)
+std::optional<ttlib::cstr> BoxSizerGenerator::CommonConstruction(Code& code)
 {
+    if (code.is_cpp() && code.is_local_var())
+        code << "auto* ";
+
     code.NodeName().Assign("wxBoxSizer(").as_string(prop_orientation).EndFunction();
 
     auto min_size = code.m_node->prop_as_wxSize(prop_minimum_size);
@@ -37,23 +40,6 @@ void BoxSizerGenerator::CommonConstruction(Code& code)
         code.Eol().Tab().NodeName().Function("SetMinSize(") << min_size.GetX() << ", " << min_size.GetY();
         code.EndFunction();
     }
-}
-
-std::optional<ttlib::cstr> BoxSizerGenerator::GenConstruction(Node* node)
-{
-    Code code(node);
-    if (node->IsLocal())
-        code << "auto* ";
-
-    CommonConstruction(code);
-
-    return code.m_code;
-}
-
-std::optional<ttlib::cstr> BoxSizerGenerator::GenPythonConstruction(Node* node)
-{
-    Code code(node, GEN_LANG_PYTHON);
-    CommonConstruction(code);
 
     return code.m_code;
 }
@@ -67,7 +53,7 @@ void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/
     }
 }
 
-void BoxSizerGenerator::CommonAfterChildren(Code& code)
+std::optional<ttlib::cstr> BoxSizerGenerator::CommonAfterChildren(Code& code)
 {
     if (code.m_node->as_bool(prop_hide_children))
     {
@@ -94,22 +80,7 @@ void BoxSizerGenerator::CommonAfterChildren(Code& code)
             code.Add("SetSizerAndFit(").NodeName().EndFunction();
         }
     }
-}
 
-std::optional<ttlib::cstr> BoxSizerGenerator::GenAfterChildren(Node* node)
-{
-    Code code(node);
-    CommonAfterChildren(code);
-    if (code.size())
-        return code.m_code;
-    else
-        return {};
-}
-
-std::optional<ttlib::cstr> BoxSizerGenerator::GenPythonAfterChildren(Node* node)
-{
-    Code code(node, GEN_LANG_PYTHON);
-    CommonAfterChildren(code);
     if (code.size())
         return code.m_code;
     else

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -27,35 +27,35 @@ wxObject* BoxSizerGenerator::CreateMockup(Node* node, wxObject* parent)
     return sizer;
 }
 
-std::optional<ttlib::cstr> BoxSizerGenerator::GenConstruction(Node* node)
+void BoxSizerGenerator::CommonConstruction(Code& code)
 {
-    ttlib::cstr code;
-    if (node->IsLocal())
-        code << "auto* ";
-    code << node->get_node_name() << " = new wxBoxSizer(" << node->prop_as_string(prop_orientation) << ");";
+    code.NodeName().Assign("wxBoxSizer(").as_string(prop_orientation).EndFunction();
 
-    auto min_size = node->prop_as_wxSize(prop_minimum_size);
+    auto min_size = code.m_node->prop_as_wxSize(prop_minimum_size);
     if (min_size.GetX() != -1 || min_size.GetY() != -1)
     {
-        code << "\n\t" << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
+        code.Eol().Tab().NodeName().Function("SetMinSize(") << min_size.GetX() << ", " << min_size.GetY();
+        code.EndFunction();
     }
+}
 
-    return code;
+std::optional<ttlib::cstr> BoxSizerGenerator::GenConstruction(Node* node)
+{
+    Code code(node);
+    if (node->IsLocal())
+        code << "auto* ";
+
+    CommonConstruction(code);
+
+    return code.m_code;
 }
 
 std::optional<ttlib::cstr> BoxSizerGenerator::GenPythonConstruction(Node* node)
 {
-    ttlib::cstr code;
-    code << node->get_node_name() << " = wx.BoxSizer(";
-    code << GetPythonName(node->prop_as_string(prop_orientation)) << ")";
+    Code code(node, GEN_LANG_PYTHON);
+    CommonConstruction(code);
 
-    auto min_size = node->prop_as_wxSize(prop_minimum_size);
-    if (min_size.GetX() != -1 || min_size.GetY() != -1)
-    {
-        code << "\n\t" << node->get_node_name() << ".SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ")";
-    }
-
-    return code;
+    return code.m_code;
 }
 
 void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
@@ -67,71 +67,51 @@ void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/
     }
 }
 
-std::optional<ttlib::cstr> BoxSizerGenerator::GenAfterChildren(Node* node)
+void BoxSizerGenerator::CommonAfterChildren(Code& code)
 {
-    ttlib::cstr code;
-    if (node->as_bool(prop_hide_children))
+    if (code.m_node->as_bool(prop_hide_children))
     {
-        code << "\t" << node->get_node_name() << "->ShowItems(false);";
+        code.Tab().NodeName().Function("ShowItems(false").EndFunction();
     }
-
-    auto parent = node->GetParent();
+    auto parent = code.m_node->GetParent();
     if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
     {
         if (code.size())
-            code << '\n';
-        code << "\n\t";
+            code.Eol();
+        code.Eol().Tab();
 
         // The parent node is not a sizer -- which is expected if this is the parent sizer underneath a form or
         // wxPanel.
 
         if (parent->isGen(gen_wxRibbonPanel))
         {
-            code << parent->get_node_name() << "->SetSizerAndFit(" << node->get_node_name() << ");";
+            code.Add(parent->get_node_name()).Function("SetSizerAndFit(").NodeName().EndFunction();
         }
         else
         {
-            if (GetParentName(node) != "this")
-                code << GetParentName(node) << "->";
-            code << "SetSizerAndFit(" << node->get_node_name() << ");";
+            if (GetParentName(code.m_node) != "this")
+                code.Add(GetParentName(code.m_node)).Function("");
+            code.Add("SetSizerAndFit(").NodeName().EndFunction();
         }
     }
+}
 
+std::optional<ttlib::cstr> BoxSizerGenerator::GenAfterChildren(Node* node)
+{
+    Code code(node);
+    CommonAfterChildren(code);
     if (code.size())
-        return code;
+        return code.m_code;
     else
         return {};
 }
 
 std::optional<ttlib::cstr> BoxSizerGenerator::GenPythonAfterChildren(Node* node)
 {
-    ttlib::cstr code;
-    if (node->as_bool(prop_hide_children))
-    {
-        code << "\t" << node->get_node_name() << ".ShowItems(false)";
-    }
-
-    auto parent = node->GetParent();
-    if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
-    {
-        if (code.size())
-            code << '\n';
-        code << "\n\t";
-
-        if (parent->isGen(gen_wxRibbonPanel))
-        {
-            code << parent->get_node_name() << ".SetSizerAndFit(" << node->get_node_name() << ")";
-        }
-        else
-        {
-            if (GetParentName(node) != "this")
-                code << GetPythonParentName(node) << '.';
-            code << ".SetSizerAndFit(" << node->get_node_name() << ")";
-        }
-    }
-
+    Code code(node, GEN_LANG_PYTHON);
+    CommonAfterChildren(code);
     if (code.size())
-        return code;
+        return code.m_code;
     else
         return {};
 }

--- a/src/generate/gen_box_sizer.h
+++ b/src/generate/gen_box_sizer.h
@@ -15,11 +15,8 @@ class BoxSizerGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenPythonConstruction(Node* node) override;
-
-    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
-    std::optional<ttlib::cstr> GenPythonAfterChildren(Node* node) override;
+    std::optional<ttlib::cstr> CommonConstruction(Code& code) override;
+    std::optional<ttlib::cstr> CommonAfterChildren(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
@@ -28,6 +25,4 @@ public:
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
 protected:
-    void CommonConstruction(Code& code);
-    void CommonAfterChildren(Code& code);
 };

--- a/src/generate/gen_box_sizer.h
+++ b/src/generate/gen_box_sizer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "base_generator.h"  // BaseGenerator -- Base Generator class
+#include "code.h"            // Code -- Helper class for generating code
 
 class BoxSizerGenerator : public BaseGenerator
 {
@@ -25,4 +26,8 @@ public:
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
+
+protected:
+    void CommonConstruction(Code& code);
+    void CommonAfterChildren(Code& code);
 };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new Code class that can be used in a common function that will generate either C++ or Python code (depending on the language `Code` is constructed with).

Going forward with this change, all generators should supply these functions when being updated to support Python. If the differences between the languages are too great (such as the form classes) the Common function should simply call the individual language functions rather than requiring the caller to call them.