### PR TITLE
Convert to CommonConstruction() in statusbar

### DIFF
--- a/src/generate/gen_status_bar.h
+++ b/src/generate/gen_status_bar.h
@@ -14,7 +14,7 @@ class StatusBarGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    std::optional<ttlib::cstr> CommonConstruction(Code&) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
     std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
 


### PR DESCRIPTION
This also fixes #853 (missing comma after id) and properly places the window name in quotes.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the missing comma after the id if the addition of a style or window name requires an id to be specified. This fixes #853. It also fixes a bug in window name usage -- the name is now in quotes.

Since _all_ of the `GenConstruction()` need to be replaced with a version that generates either C++ or Python code, I went ahead and replaced it now rather than working on this function twice.