### PR TITLE
Refactor and enhance property grid property help description

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -698,3 +698,21 @@ std::map<GenEnum::PropName, const char*> map_PropMacros = {
 
 // This is the opposite of map_PropMacros, and is initialized in NodeCreator::Initialize()
 std::map<std::string_view, GenEnum::PropName, std::less<>> map_MacroProps;
+
+// In order to sort the left column, everything needs to be on one line. Since these can be
+// very long lines, we can't let clang-format wrap them.
+
+// clang-format off
+
+// These can be used for any type of property. The generator can override this using
+// GetPropertyDescription(). If neither this map or the generator supply a description, it
+// will be retrieved from the XML interface file.
+std::map<GenEnum::PropName, const char*> GenEnum::map_PropHelp = {
+
+    // Use \\n to add a line break
+
+    { prop_persist, "Use wxPersistentRegisterAndRestore to save/restore the size and position of the form.\\n\\nOnly available for C++ code." },
+
+};
+
+// clang-format on

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -439,6 +439,7 @@ namespace GenEnum
         prop_processed  // special value used by some importers
     };
     extern std::map<GenEnum::PropName, const char*> map_PropNames;
+    extern std::map<GenEnum::PropName, const char*> map_PropHelp;
     extern std::map<std::string_view, GenEnum::PropName, std::less<>> rmap_PropNames;
     inline GenEnum::PropName FindProp(std::string_view name)
     {

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -46,6 +46,7 @@ public:
     void Create();
 
 protected:
+    wxString GetPropHelp(NodeProperty* prop);
     wxString GetCategoryDisplayName(const wxString& original);
 
     // Called to determine if a property should be displayed or not

--- a/src/xml/dialogs_xml.xml
+++ b/src/xml/dialogs_xml.xml
@@ -12,8 +12,7 @@ inline const char* dialogs_xml = R"===(<?xml version="1.0"?>
 			help="The name of the base class.">MyDialogBase</property>
 		<property name="title" type="string_escapes"
 			help="The text to display on the dialog's title bar." />
-		<property name="persist" type="bool"
-			help="Use wxPersistentRegisterAndRestore to save/restore the size and position of the dialog.">0</property>
+		<property name="persist" type="bool">0</property>
 		<property name="style" type="bitlist">
 			<option name="wxCAPTION"
 				help="Puts a caption on the dialog box." />

--- a/src/xml/forms_xml.xml
+++ b/src/xml/forms_xml.xml
@@ -12,8 +12,7 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 			help="The name of the base class.">MyFrameBase</property>
 		<property name="title" type="string_escapes"
 			help="The text to display on the frame's title bar." />
-		<property name="persist" type="bool"
-			help="Use wxPersistentRegisterAndRestore to save/restore the size and position of the window.">0</property>
+		<property name="persist" type="bool">0</property>
 		<property name="style" type="bitlist">
 			<option name="wxDEFAULT_FRAME_STYLE"
 				help="Defined as wxMINIMIZE_BOX | wxMAXIMIZE_BOX | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR creates a new `map_PropHelp` which can be used to map a property to it's help description. I also added a new `GetPropHelp()` function to the `PropGridPanel` class to retrieve help informtion using this algoritm:

- First see if the generator supplied help for this property
- If not above, see if map_PropHelp has help for this property
- If neither of the above, get help from the property declartion (created from the XML interface)

I created a single entry in the help property map to verify that this works -- and to clearly identify a property (`persist`) that is only available in C++ code (wxPython and XRC don't support it).

This is related to issue #857