### PR TITLE
Add Python code generation to all sizer generators

### DIFF
--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -176,7 +176,7 @@ set (file_list
     generate/gen_gridbag_sizer.cpp      # wxGridBagSizer generator
     generate/gen_spacer_sizer.cpp       # Add space to sizer generator
     generate/gen_statchkbox_sizer.cpp   # wxStaticBoxSizer with wxCheckBox generator
-    generate/gen_staticbox_sizer.cpp    # wxStaticBoxSizer gemeratpr
+    generate/gen_staticbox_sizer.cpp    # wxStaticBoxSizer generator
     generate/gen_statradiobox_sizer.cpp # wxStaticBoxSizer with wxRadioButton generator
     generate/gen_std_dlgbtn_sizer.cpp   # wxStdDialogButtonSizer generator
     generate/gen_text_sizer.cpp         # wxTextSizerWrapper generator

--- a/src/generate/CONTENTS.md
+++ b/src/generate/CONTENTS.md
@@ -45,15 +45,14 @@ The following tables list classes, objects and functions that wxUiEditor can gen
 | Class | C++ | Python | XRC |file |
 -----------|-----|--------|------|------|
 | wxBoxSizer | yes | yes | yes | gen_box_sizer.cpp |
-| wxCheckBoxSizer | yes |  ?? | yes | gen_statchkbox_sizer.cpp |
-| wxFlexGridSizer | yes |  ?? | yes | gen_flexgrid_sizer.cpp |
-| wxGridBagSizer | yes |  ?? | yes | gen_gridbag_sizer.cpp |
-| wxGridSizer | yes |  ?? | yes | gen_grid_sizer.cpp |
-| wxRadioButtonSizer | yes |  ?? | yes | gen_statradiobox_sizer.cpp |
-| wxStaticBoxSizer | yes |  ?? | yes | gen_staticbox_sizer.cpp |
+| wxCheckBoxSizer | yes |  no | yes | gen_statchkbox_sizer.cpp |
+| wxFlexGridSizer | yes |  yes | yes | gen_flexgrid_sizer.cpp |
+| wxGridBagSizer | yes |  yes | yes | gen_gridbag_sizer.cpp |
+| wxGridSizer | yes |  yes | yes | gen_grid_sizer.cpp |
+| wxRadioButtonSizer | yes |  no | yes | gen_statradiobox_sizer.cpp |
+| wxStaticBoxSizer | yes |  yes | yes | gen_staticbox_sizer.cpp |
 | wxStdDialogButtonSizer | yes |  yes | yes | gen_std_dlgbtn_sizer.cpp |
-| wxTextSizerWrapper | yes |  ?? | no | gen_text_sizer.cpp |
-| wxWrapSizer | yes |  ?? | yes | gen_wrap_sizer.cpp |
+| wxWrapSizer | yes |  yes | yes | gen_wrap_sizer.cpp |
 
 # Classes
 

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -81,11 +81,36 @@ Code& Code::Eol(bool check_size)
             m_code.pop_back();
         m_code += '\n';
     }
+    if (m_within_braces && is_cpp())
+        m_code += '\t';
 
     if (m_auto_break)
     {
         m_break_at = m_code.size() + m_break_length;
         m_minium_length = m_code.size() + 10;
+    }
+    return *this;
+}
+
+Code& Code::OpenBrace()
+{
+    if (is_cpp())
+    {
+        m_within_braces = true;
+        m_code += "\n{";
+        Eol();
+    }
+    return *this;
+}
+
+Code& Code::CloseBrace()
+{
+    if (is_cpp())
+    {
+        m_within_braces = false;
+        while (ttlib::is_whitespace(m_code.back()))
+            m_code.pop_back();
+        Eol().Str("}").Eol();
     }
     return *this;
 }
@@ -812,7 +837,6 @@ int Code::WhatParamsNeeded(ttlib::sview default_style) const
     }
 
     // This could be done as a single if statement, but it is easier to read this way.
-    bool result = nothing_needed;
     if ((m_node->HasValue(prop_style) && m_node->as_string(prop_style) != default_style))
         return (pos_needed | size_needed | style_needed);
     else if (m_node->HasValue(prop_window_style))

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -85,9 +85,19 @@ public:
     // Pass true to only add EOL if there is already code in the string
     Code& Eol(bool check_size = false);
 
+    // Pass true to only add EOL if there is already code in the string
+    Code& NewLine(bool check_size = false) { return Eol(check_size); }
+
     // Adds as many '\t' characters as specified by nTabs. Note that tabs are converted to
     // spaces when the line is written.
     Code& Tab(int nTabs = 1);
+
+    // In C++, this adds "{\n" and indents all lines until CloseBrace() is called.
+    //
+    // Ignored by Python.
+    Code& OpenBrace();
+
+    Code& CloseBrace();
 
     void EnableAutoLineBreak(bool auto_break = true) { m_auto_break = auto_break; }
 
@@ -231,8 +241,10 @@ protected:
     void InsertLineBreak(size_t cur_pos);
 
 private:
-    bool m_auto_break { true };
     size_t m_break_length { 80 };
     size_t m_break_at { 80 };       // this should be the same as m_break_length
     size_t m_minium_length { 10 };  // if the line is shorter than this, don't break it
+
+    bool m_auto_break { true };
+    bool m_within_braces { false };
 };

--- a/src/generate/gen_flexgrid_sizer.h
+++ b/src/generate/gen_flexgrid_sizer.h
@@ -13,11 +13,12 @@ class FlexGridSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
+
+    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
+    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
-    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/gen_grid_sizer.h
+++ b/src/generate/gen_grid_sizer.h
@@ -13,8 +13,9 @@ class GridSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
+    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
+    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;

--- a/src/generate/gen_gridbag_sizer.h
+++ b/src/generate/gen_gridbag_sizer.h
@@ -19,8 +19,8 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
     void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
+    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -9,8 +9,9 @@
 #include <wx/sizer.h>
 #include <wx/statbox.h>
 
-#include "gen_common.h"  // GeneratorLibrary -- Generator classes
-#include "node.h"        // Node class
+#include "gen_common.h"     // GeneratorLibrary -- Generator classes
+#include "node.h"           // Node class
+#include "project_class.h"  // Project class
 
 #include "pugixml.hpp"  // xml read/write/create/process
 
@@ -18,30 +19,40 @@
 
 wxObject* StaticCheckboxBoxSizerGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    long style_value = 0;
-    if (node->prop_as_string(prop_style).contains("wxALIGN_RIGHT"))
-        style_value |= wxALIGN_RIGHT;
+    wxStaticBoxSizer* sizer;
 
-    m_checkbox = new wxCheckBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
-                                wxDefaultPosition, wxDefaultSize, style_value);
-    if (node->prop_as_bool(prop_checked))
-        m_checkbox->SetValue(true);
+    if (GetProject()->as_string(prop_code_preference) != "Python")
+    {
+        long style_value = 0;
+        if (node->prop_as_string(prop_style).contains("wxALIGN_RIGHT"))
+            style_value |= wxALIGN_RIGHT;
 
-    auto staticbox = new wxStaticBox(wxStaticCast(parent, wxWindow), wxID_ANY, m_checkbox);
+        m_checkbox = new wxCheckBox(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_wxString(prop_label),
+                                    wxDefaultPosition, wxDefaultSize, style_value);
+        if (node->prop_as_bool(prop_checked))
+            m_checkbox->SetValue(true);
 
-    auto sizer = new wxStaticBoxSizer(staticbox, node->prop_as_int(prop_orientation));
+        if (node->HasValue(prop_tooltip))
+            m_checkbox->SetToolTip(node->prop_as_wxString(prop_tooltip));
+
+        auto staticbox = new wxStaticBox(wxStaticCast(parent, wxWindow), wxID_ANY, m_checkbox);
+
+        sizer = new wxStaticBoxSizer(staticbox, node->prop_as_int(prop_orientation));
+    }
+    else
+    {
+        sizer = new wxStaticBoxSizer(node->prop_as_int(prop_orientation), wxStaticCast(parent, wxWindow),
+                                     node->prop_as_wxString(prop_label));
+    }
+
     if (auto dlg = wxDynamicCast(parent, wxDialog); dlg)
     {
         if (!dlg->GetSizer())
             dlg->SetSizer(sizer);
     }
 
-    auto min_size = node->prop_as_wxSize(prop_minimum_size);
-    if (min_size.x != -1 || min_size.y != -1)
-        sizer->SetMinSize(min_size);
-
-    if (node->HasValue(prop_tooltip))
-        m_checkbox->SetToolTip(node->prop_as_wxString(prop_tooltip));
+    if (node->HasValue(prop_minimum_size))
+        sizer->SetMinSize(node->as_wxSize(prop_minimum_size));
 
     return sizer;
 }
@@ -66,32 +77,29 @@ bool StaticCheckboxBoxSizerGenerator::OnPropertyChange(wxObject* /* widget */, N
     return false;
 }
 
-std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenConstruction(Node* node)
+std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonConstruction(Code& code)
 {
-    ttlib::cstr code;
-    code << node->prop_as_string(prop_checkbox_var_name) << " = new wxCheckBox(";
-    code << GetParentName(node) << ", " << node->prop_as_string(prop_id) << ", ";
-
-    if (node->prop_as_string(prop_label).size())
+    Node* node = code.node();
+    if (code.is_cpp())
     {
-        code << GenerateQuotedString(node->prop_as_string(prop_label));
+        code.as_string(prop_checkbox_var_name) << " = new wxCheckBox(";
+        code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label).EndFunction();
+
+        if (auto result = GenValidatorSettings(node); result)
+        {
+            code.Str(result.value());
+        }
+        code.Eol();
     }
     else
     {
-        code << "wxEmptyString";
+        code.Str("# wxPython currently does not support a checkbox as a static box label").Eol();
     }
 
-    code << ");\n";
-
-    if (auto result = GenValidatorSettings(node); result)
-    {
-        code << result.value() << '\n';
-    }
-
-    if (node->IsLocal())
+    if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
 
-    ttlib::cstr parent_name("this");
+    ttlib::cstr parent_name(code.is_cpp() ? "this" : "self");
     if (!node->GetParent()->IsForm())
     {
         auto parent = node->GetParent();
@@ -105,94 +113,101 @@ std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenConstruction(Node
             else if (parent->isGen(gen_wxStaticBoxSizer) || parent->isGen(gen_StaticCheckboxBoxSizer) ||
                      parent->isGen(gen_StaticRadioBtnBoxSizer))
             {
-                parent_name.clear();
-                parent_name << parent->get_node_name() << "->GetStaticBox()";
+                parent_name = parent->get_node_name();
+                if (code.is_cpp())
+                    parent_name << "->GetStaticBox()";
+                else
+                    parent_name << ".GetStaticBox()";
                 break;
             }
             parent = parent->GetParent();
         }
     }
-
-    code << node->get_node_name() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY,";
-    if (wxGetProject().value(prop_wxWidgets_version) == "3.1")
+    if (code.is_cpp())
     {
-        code << "\n#if wxCHECK_VERSION(3, 1, 1)\n\t";
-        code << node->prop_as_string(prop_checkbox_var_name) << "),";
-        code << "\n#else\n\t";
-        code << "wxEmptyString),";
-        code << "\n#endif\n";
-        code << node->prop_as_string(prop_orientation) << ");";
-    }
-    else
-    {
-        code << node->prop_as_string(prop_checkbox_var_name) << "), " << node->prop_as_string(prop_orientation) << ");";
-    }
-
-    auto min_size = node->prop_as_wxSize(prop_minimum_size);
-    if (min_size.GetX() != -1 || min_size.GetY() != -1)
-    {
-        code << "\n" << node->get_node_name() << "->SetMinSize(" << min_size.GetX() << ", " << min_size.GetY() << ");";
-    }
-
-    return code;
-}
-
-std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenSettings(Node* node, size_t& /* auto_indent */)
-{
-    ttlib::cstr code;
-    if (node->prop_as_bool(prop_disabled))
-    {
-        code << node->get_node_name() << "->GetStaticBox()->Enable(false);";
-    }
-
-    if (node->HasValue(prop_tooltip))
-    {
-        if (code.size())
-            code << "\n";
-        code << node->prop_as_string(prop_checkbox_var_name) << "->SetToolTip("
-             << GenerateQuotedString(node->prop_as_string(prop_tooltip)) << ");";
-    }
-
-    if (code.size())
-        return code;
-    else
-        return {};
-}
-
-std::optional<ttlib::cstr> StaticCheckboxBoxSizerGenerator::GenAfterChildren(Node* node)
-{
-    ttlib::cstr code;
-    if (node->as_bool(prop_hidden))
-    {
-        code << "\t" << node->get_node_name() << "->ShowItems(false);";
-    }
-
-    auto parent = node->GetParent();
-    if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
-    {
-        if (code.size())
-            code << '\n';
-        code << "\n";
-
-        // The parent node is not a sizer -- which is expected if this is the parent sizer underneath a form or
-        // wxPanel.
-
-        if (parent->isGen(gen_wxRibbonPanel))
+        code.NodeName() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY";
+        code.Comma();
+        if (wxGetProject().value(prop_wxWidgets_version) == "3.1")
         {
-            code << parent->get_node_name() << "->SetSizerAndFit(" << node->get_node_name() << ");";
+            code.Eol().Str("#if wxCHECK_VERSION(3, 1, 1)").Eol().Tab();
+            code.as_string(prop_checkbox_var_name) << "),";
+            code.Eol().Str("#else").Eol().Tab().Str("wxEmptyString),");
+            code.Eol().Str("#endif").Eol();
+            code.as_string(prop_orientation).EndFunction();
         }
         else
         {
-            if (GetParentName(node) != "this")
-                code << GetParentName(node) << "->";
-            code << "SetSizerAndFit(" << node->get_node_name() << ");";
+            code.as_string(prop_checkbox_var_name).Str("), ").as_string(prop_orientation).EndFunction();
+        }
+    }
+    else
+    {
+        code.NodeName().CreateClass(false, "wxStaticBoxSizer").as_string(prop_orientation).Comma().Str(parent_name);
+        auto& label = node->prop_as_string(prop_label);
+        if (label.size())
+        {
+            code.Comma().QuotedString(label);
+        }
+        code.EndFunction();
+    }
+
+    if (code.HasValue(prop_minimum_size))
+    {
+        code.Eol().NodeName().Function("SetMinSize(").WxSize(prop_minimum_size).EndFunction();
+    }
+
+    return code.m_code;
+}
+
+std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonSettings(Code& code)
+{
+    if (code.IsTrue(prop_disabled))
+    {
+        if (code.is_cpp())
+            code.NodeName().Function("GetStaticBox()->Enable(false);");
+        else
+            code.NodeName().Function("GetStaticBox().Enable(False)");
+    }
+
+    if (code.HasValue(prop_tooltip) && code.is_cpp())
+    {
+        code.NewLine(true).as_string(prop_checkbox_var_name).Function("SetToolTip(");
+        code.QuotedString(prop_tooltip).EndFunction();
+    }
+
+    return code.m_code;
+}
+
+std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonAfterChildren(Code& code)
+{
+    if (code.IsTrue(prop_hide_children))
+    {
+        code.NodeName().Function("ShowItems(").Str(code.is_cpp() ? "false" : "False").EndFunction();
+    }
+
+    auto parent = code.node()->GetParent();
+    if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
+    {
+        code.NewLine(true);
+        if (parent->isGen(gen_wxRibbonPanel))
+        {
+            code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
+        }
+        else
+        {
+            if (GetParentName(code.node()) != "this")
+            {
+                code.ParentName().Add(".");
+                code.Function("SetSizerAndFit(").NodeName().EndFunction();
+            }
+            else
+            {
+                code.FormFunction("SetSizerAndFit(").NodeName().EndFunction();
+            }
         }
     }
 
-    if (code.size())
-        return code;
-    else
-        return {};
+    return code.m_code;
 }
 
 bool StaticCheckboxBoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)

--- a/src/generate/gen_statchkbox_sizer.h
+++ b/src/generate/gen_statchkbox_sizer.h
@@ -17,9 +17,9 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
-    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
+    std::optional<ttlib::sview> CommonSettings(Code&) override;
+    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_staticbox_sizer.h
+++ b/src/generate/gen_staticbox_sizer.h
@@ -15,9 +15,9 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
-    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
+    std::optional<ttlib::sview> CommonSettings(Code&) override;
+    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_statradiobox_sizer.h
+++ b/src/generate/gen_statradiobox_sizer.h
@@ -17,9 +17,9 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
-    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
+    std::optional<ttlib::sview> CommonSettings(Code&) override;
+    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_std_dlgbtn_sizer.cpp
+++ b/src/generate/gen_std_dlgbtn_sizer.cpp
@@ -152,53 +152,53 @@ std::optional<ttlib::sview> StdDialogButtonSizerGenerator::CommonConstruction(Co
     if (node->prop_as_bool(prop_OK))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_OK));";
+        code += "new wxButton(this, wxID_OK));";
     }
     else if (node->prop_as_bool(prop_Yes))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_YES));";
+        code += "new wxButton(this, wxID_YES));";
     }
     else if (node->prop_as_bool(prop_Save))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_SAVE));";
+        code += "new wxButton(this, wxID_SAVE));";
     }
 
     if (node->prop_as_bool(prop_No))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_NO));";
+        code += "new wxButton(this, wxID_NO));";
     }
 
     // You can only have one of: Cancel, Close
     if (node->prop_as_bool(prop_Cancel))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_CANCEL));";
+        code += "new wxButton(this, wxID_CANCEL));";
     }
     else if (node->prop_as_bool(prop_Close))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_CLOSE));";
+        code += "new wxButton(this, wxID_CLOSE));";
     }
 
     if (node->prop_as_bool(prop_Apply))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_APPLY));";
+        code += "new wxButton(this, wxID_APPLY));";
     }
 
     // You can only have one of: Help, ContextHelp
     if (node->prop_as_bool(prop_Help))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_HELP));";
+        code += "new wxButton(this, wxID_HELP));";
     }
     else if (node->prop_as_bool(prop_ContextHelp))
     {
         code.Eol().NodeName().Function("AddButton(");
-            code += "new wxButton(this, wxID_CONTEXT_HELP));";
+        code += "new wxButton(this, wxID_CONTEXT_HELP));";
     }
 
     if (def_btn_name == "OK" || def_btn_name == "Yes" || def_btn_name == "Save")

--- a/src/generate/gen_submenu.cpp
+++ b/src/generate/gen_submenu.cpp
@@ -46,7 +46,6 @@ std::optional<ttlib::cstr> SubMenuGenerator::GenSettings(Node* node, size_t& /* 
 
     // BUGBUG: [Randalphwa - 12-16-2022] See issue #865 -- this should be in AdditionalCode, not here
 
-
     if (node->HasValue(prop_bitmap))
     {
         ttlib::cstr bundle_code;

--- a/src/generate/gen_wrap_sizer.h
+++ b/src/generate/gen_wrap_sizer.h
@@ -13,8 +13,9 @@ class WrapSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
-    std::optional<ttlib::cstr> GenAfterChildren(Node* node) override;
+
+    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
+    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -66,18 +66,17 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 		<inherits class="C++" />
 		<inherits class="wxPython" />
 		<inherits class="XRC" />
-		<property name="art_directory" type="path"
-			help="The directory containing your images (png, ico, xpm, etc.)." />
-		<property name="internationalize" type="bool"
-			help="Wrap strings in a _() macro which expands into a call to wxGetTranslation().">0</property>
 		<property name="code_preference" type="option"
-			help="Specify the code you prefer to generate to minimize other coding categories and properties in the wxUiEditor UI.">
-			<option name="any" />
+			help="Specify the code you prefer to generate. This can affect the UI display in the Mockup panel, and affects the initial expansion/contraction of language properties in wxUiEditor.">
 			<option name="C++" />
 			<option name="Python" />
 			<option name="XRC" />
 			C++
 		</property>
+		<property name="art_directory" type="path"
+			help="The directory containing your images (png, ico, xpm, etc.)." />
+		<property name="internationalize" type="bool"
+			help="Wrap strings in a _() macro which expands into a call to wxGetTranslation().">0</property>
 		<property name="help_provider" type="option"
 			help="The class of help provider to use for context-sensitive help.">
 			<option name="none"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR completes adding  wxPython code generation to all sizers. It removes the `any` option for `code_preference` and both the checkbox and radio button variants of `wxStaticBoxSizer` will change the Mockup display based on the `code_preference` setting. In addition, those two sizer variants will generate a comment in the Python code about their not being supported, and instead a regular `wxStaticBoxSizer` will be created using the label from the checkbox or radio button as the wxStaticBox label.

Both the Mockup and C++ code generation have changed when `wxGridBagSizer::AddGrowableRow()` is called. Previously, this was called before any children were added, which resulted in an assertion error in wxWidgets Debug builds. This was because the sizer still had the maximum row and column set to zero. Now both the Mockup and C++/Python code generation makes the call(s) _after_ all children have been added.
