### PR TITLE
Add additional methods to Node and Code classes

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -175,14 +175,20 @@ Code& Code::Eol(int flag)
     if (flag == eol_if_empty)
     {
         if (m_code.size())
+        {
             m_code += '\n';
+        }
     }
     else if (flag == eol_if_needed)
     {
-        if (m_code.size() && m_code.back() != '\n' ||
-            /* If we're in a brace section, the last line will end with \n\t */
-            (m_code.size() > 2 && m_code.back() == '\t' && m_code[m_code.size() - 2] == '\n'))
-            m_code += '\n';
+        if (m_code.size() && m_code.back() != '\n')
+        {
+            // If we're in a brace section, the last line will end with \n\t
+            if (m_code.size() < 3 || m_code.back() != '\t' || m_code[m_code.size() - 2] != '\n')
+            {
+                m_code += '\n';
+            }
+        }
     }
     else
     {
@@ -190,8 +196,11 @@ Code& Code::Eol(int flag)
             m_code.pop_back();
         m_code += '\n';
     }
-    if (m_within_braces && is_cpp())
+
+    if (m_within_braces && is_cpp() && m_code.back() != '\t')
+    {
         m_code += '\t';
+    }
 
     if (m_auto_break)
     {
@@ -207,7 +216,9 @@ Code& Code::OpenBrace()
     {
         m_within_braces = true;
         if (m_code.size() && m_code.back() != '\n')
+        {
             m_code += '\n';
+        }
         m_code += '{';
         Eol();
     }
@@ -549,36 +560,6 @@ bool Code::HasValue(GenEnum::PropName prop_name) const
 int Code::IntValue(GenEnum::PropName prop_name) const
 {
     return m_node->as_int(prop_name);
-}
-
-bool Code::IsTrue(GenEnum::PropName prop_name) const
-{
-    return m_node->as_bool(prop_name);
-}
-
-bool Code::IsFalse(GenEnum::PropName prop_name) const
-{
-    return m_node->as_bool(prop_name);
-}
-
-bool Code::IsEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const
-{
-    return (m_node->as_string(prop_name) == text);
-}
-
-bool Code::IsNotEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const
-{
-    return (m_node->as_string(prop_name) != text);
-}
-
-bool Code::IsEqualTo(GenEnum::PropName prop_name, int val) const
-{
-    return (m_node->as_int(prop_name) == val);
-}
-
-bool Code::IsNotEqualTo(GenEnum::PropName prop_name, int val) const
-{
-    return (m_node->as_int(prop_name) == val);
 }
 
 bool Code::PropContains(GenEnum::PropName prop_name, ttlib::sview text) const

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -15,7 +15,7 @@
 
 #include "gen_enums.h"  // Enumerations for generators
 
-class Node;
+#include "node.h"  // Node class
 
 namespace code
 {

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -100,7 +100,10 @@ public:
     bool IsEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const { return (m_node->as_string(prop_name) == text); }
 
     // Equivalent to calling (node->as_string(prop_name) != text)
-    bool IsNotEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const { return (m_node->as_string(prop_name) != text); }
+    bool IsNotEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const
+    {
+        return (m_node->as_string(prop_name) != text);
+    }
 
     // Equivalent to calling (node->as_int(prop_name) == val)
     bool IsEqualTo(GenEnum::PropName prop_name, int val) const { return (m_node->as_int(prop_name) == val); }

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -78,23 +78,35 @@ public:
 
     bool HasValue(GenEnum::PropName prop_name) const;
 
-    // Equivalent to calling m_node->prop_as_bool(prop_name)
-    bool IsTrue(GenEnum::PropName prop_name) const;
+    // Avoid the temptation to use ttlib::sview instead of const char* -- the MSVC compiler will assume value is a bool if
+    // you call  is_value(propm, "string")
+
+    bool is_value(PropName name, const char* value) const noexcept { return m_node->is_value(name, value); }
+    bool is_value(PropName name, bool value) const noexcept { return m_node->is_value(name, value); }
+    bool is_value(PropName name, int value) const noexcept { return m_node->is_value(name, value); }
+
+    // Can return nullptr
+    NodeProperty* prop(PropName name) const { return m_node->prop(name); }
+
+    ttlib::sview view(PropName name) const { return m_node->view(name); }
+
+    // Returns m_node->as_bool(prop_name);
+    bool IsTrue(GenEnum::PropName prop_name) const { return m_node->as_bool(prop_name); }
 
     // Equivalent to calling m_node->prop_as_bool(prop_name)
-    bool IsFalse(GenEnum::PropName prop_name) const;
+    bool IsFalse(GenEnum::PropName prop_name) const { return !m_node->as_bool(prop_name); }
 
     // Equivalent to calling (node->as_string(prop_name) == text)
-    bool IsEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const;
+    bool IsEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const { return (m_node->as_string(prop_name) == text); }
 
     // Equivalent to calling (node->as_string(prop_name) != text)
-    bool IsNotEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const;
+    bool IsNotEqualTo(GenEnum::PropName prop_name, ttlib::sview text) const { return (m_node->as_string(prop_name) != text); }
 
     // Equivalent to calling (node->as_int(prop_name) == val)
-    bool IsEqualTo(GenEnum::PropName prop_name, int val) const;
+    bool IsEqualTo(GenEnum::PropName prop_name, int val) const { return (m_node->as_int(prop_name) == val); }
 
     // Equivalent to calling (node->as_int(prop_name) != val)
-    bool IsNotEqualTo(GenEnum::PropName prop_name, int val) const;
+    bool IsNotEqualTo(GenEnum::PropName prop_name, int val) const { return (m_node->as_int(prop_name) != val); }
 
     // Equivalent to calling node->as_string(prop_name).contains(text)
     bool PropContains(GenEnum::PropName prop_name, ttlib::sview text) const;

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -112,7 +112,12 @@ std::optional<ttlib::sview> RearrangeCtrlGenerator::CommonSettings(Code& code)
         {
             for (auto& iter: contents)
             {
-                code.Eol(eol_if_empty).NodeName().Function("GetList()").Function("Append(").QuotedString(iter.label).EndFunction();
+                code.Eol(eol_if_empty)
+                    .NodeName()
+                    .Function("GetList()")
+                    .Function("Append(")
+                    .QuotedString(iter.label)
+                    .EndFunction();
             }
         }
         else

--- a/src/generate/styled_text.h
+++ b/src/generate/styled_text.h
@@ -17,7 +17,6 @@ public:
     std::optional<ttlib::sview> CommonConstruction(Code& code) override;
     std::optional<ttlib::sview> CommonSettings(Code&) override;
 
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
     std::optional<ttlib::cstr> GenSettings(Node* node, size_t& auto_indent) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -340,6 +340,16 @@ bool Node::isPropValue(PropName name, bool value) const noexcept
     return false;
 }
 
+bool Node::is_value(PropName name, int value) const noexcept
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+    {
+        return (m_properties[result->second].as_int() == value);
+    }
+
+    return false;
+}
+
 bool Node::prop_as_bool(PropName name) const
 {
     if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -50,6 +50,8 @@ public:
 
     NodeProperty* get_prop_ptr(PropName name);
 
+    NodeProperty* prop(PropName name) { return get_prop_ptr(name); }
+
     NodeEvent* GetEvent(ttlib::sview name);
     NodeMapEvents& GetMapEvents() { return m_map_events; }
 
@@ -157,6 +159,13 @@ public:
     // value.
     bool isPropValue(PropName name, bool value) const noexcept;
 
+    // Avoid the temptation to use ttlib::sview instead of const char* -- the MSVC compiler will assume value is a bool if
+    // you call  is_value(propm, "string")
+
+    bool is_value(PropName name, const char* value) const noexcept { return isPropValue(name, value); }
+    bool is_value(PropName name, bool value) const noexcept { return isPropValue(name, value); }
+    bool is_value(PropName name, int value) const noexcept;
+
     // Sets value only if the property exists, returns false if it doesn't exist.
     template <typename T>
     bool prop_set_value(PropName name, T value)
@@ -228,7 +237,10 @@ public:
             return false;
         }
     }
+
     const ttlib::cstr& value(PropName name) const { return prop_as_string(name); }
+
+    const ttlib::sview view(PropName name) const { return prop_as_string(name); }
 
     bool as_bool(PropName name) const { return prop_as_bool(name); }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes adds is_value(), prop(), and view() to the `Node` class. I also added the same functions to the `Code` class which use `m_node` to make the call into `Node`. The reason for all of these is to reduce some of the complexity of both the `Code` class and all the functions that call into it.

I used the `StyledTextGenerator` as the test case since this is by far the most complicated generator we have with it's 40+ possible settings.
