### PR TITLE
Refactor BaseGenerator and WriteCode class methods

### DIFF
--- a/src/generate/CONTENTS.md
+++ b/src/generate/CONTENTS.md
@@ -23,7 +23,7 @@ The following tables list classes, objects and functions that wxUiEditor can gen
 | wxDialog | yes| yes | yes | gen_dialog.cpp |
 | wxFrame | yes| yes | yes | gen_frame.cpp |
 | wxMenuBar | yes| ?? | yes | menu_widgets.cpp |
-| wxPanel | yes| ?? | yes | gen_panel_form.cpp |
+| wxPanel | yes| yes | yes | gen_panel_form.cpp |
 | wxPopupTransientWindow | yes| ?? | no | gen_popup_trans_win.cpp |
 | wxRibbonBar | yes| ?? | yes | ribbon_widgets.cpp |
 | wxToolBar | yes| ?? | yes | gen_toolbar.cpp |
@@ -144,7 +144,7 @@ The following tables list classes, objects and functions that wxUiEditor can gen
 | RibbonGalleryItem | yes | ?? | yes | ribbon_widgets.cpp |
 | RibbonTool | yes | ?? | yes | ribbon_widgets.cpp |
 | Separator | yes | ?? | yes | menu_widgets.cpp |
-| Spacer | yes | ?? | yes | gen_spacer_sizer.cpp |
+| Spacer | yes | yes | yes | gen_spacer_sizer.cpp |
 | SubMenu | yes | yes | yes | gen_submenu.cpp |
 | ToolDropDown | yes | yes | yes | gen_toolbar.cpp |
 | ToolGenerator | yes | yes | yes | gen_toolbar.cpp |

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -138,7 +138,6 @@ public:
     //
     // Code will be written with indent::none set
     virtual std::optional<ttlib::cstr> GenAfterChildren(Node* /* node */) { return {}; }
-    virtual std::optional<ttlib::cstr> GenPythonAfterChildren(Node* /* node */) { return {}; }
 
     // Generate code to bind the event to a handler -- only override if you need to do
     // something special

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -77,6 +77,16 @@ public:
     MockupParent* GetMockup();
 
     // Generate the code used to construct the object using either C++ or Python
+    virtual bool CodeConstruction(Code&) { return false; }
+
+    // Generate any settings the object needs using either C++ or Python
+    virtual bool CodeSettings(Code&) { return false; }
+
+    // Generate either C++ or Python code for any additiional code the object needs.
+    // The GenCodeType parameter indicates what type of code is needed.
+    virtual bool CodeAdditionalCode(Code&, GenEnum::GenCodeType /* command */) { return false; }
+
+    // Generate the code used to construct the object using either C++ or Python
     virtual std::optional<ttlib::sview> CommonConstruction(Code&) { return {}; }
 
     // Generate code after any children have been constructed

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -77,14 +77,27 @@ public:
     MockupParent* GetMockup();
 
     // Generate the code used to construct the object using either C++ or Python
-    virtual bool CodeConstruction(Code&) { return false; }
+    virtual bool ConstructionCode(Code&) { return false; }
 
     // Generate any settings the object needs using either C++ or Python
-    virtual bool CodeSettings(Code&) { return false; }
+    virtual bool SettingsCode(Code&) { return false; }
+
+    // Generate code after any children have been constructed
+    //
+    // Code will be written with indent::auto_keep_whitespace set
+    virtual bool AfterChildrenCode(Code&) { return false; }
+
+    // Generate code to add to a C++ header file -- this is normally the class header
+    // definition
+    virtual bool HeaderCode(Code&) { return false; }
+
+    // Called when generating a C++ header -- this should return the actual name of the class
+    // or it's derived class name. I.e., PanelForm adds wxPanel.
+    virtual bool BaseClassNameCode(Code&) { return false; }
 
     // Generate either C++ or Python code for any additiional code the object needs.
     // The GenCodeType parameter indicates what type of code is needed.
-    virtual bool CodeAdditionalCode(Code&, GenEnum::GenCodeType /* command */) { return false; }
+    virtual bool AdditionalCode(Code&, GenEnum::GenCodeType /* command */) { return false; }
 
     // Generate the code used to construct the object using either C++ or Python
     virtual std::optional<ttlib::sview> CommonConstruction(Code&) { return {}; }

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -265,7 +265,7 @@ Code& Code::AddAuto()
 {
     if (is_cpp() && is_local_var())
     {
-        m_code += "auto ";
+        m_code += "auto* ";
     }
     return *this;
 }

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -618,7 +618,7 @@ static constexpr GenType s_GenParentTypes[] = {
 
 // clang-format on
 
-Code& Code::GetParentName()
+Code& Code::ValidParentName()
 {
     auto parent = m_node->GetParent();
     while (parent)

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -261,6 +261,15 @@ Code& Code::CloseBrace()
     return *this;
 }
 
+Code& Code::AddAuto()
+{
+    if (is_cpp() && is_local_var())
+    {
+        m_code += "auto ";
+    }
+    return *this;
+}
+
 void Code::InsertLineBreak(size_t cur_pos)
 {
     ASSERT(cur_pos > 1 && cur_pos <= m_code.size());

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -66,7 +66,7 @@ public:
             m_break_at = 100000;  // initialize this high enough that no line will break unless SetBreakAt() is called
         }
     }
-    auto size() { return m_code.size(); }
+    auto size() const { return m_code.size(); }
 
     bool is_cpp() const { return m_language == GEN_LANG_CPLUSPLUS; }
     bool is_python() const { return m_language == GEN_LANG_PYTHON; }

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -51,6 +51,7 @@ public:
     int m_language;
 
     Code(Node* node, int language = GEN_LANG_CPLUSPLUS);
+    ttlib::sview GetCode() const { return m_code; }
 
     void clear()
     {
@@ -236,8 +237,8 @@ public:
 
     // For Python code, a non-local, non-form name will be prefixed with "self."
     //
-    // m_code += m_node->get_node_name();
-    Code& NodeName();
+    // m_code += node->get_node_name();
+    Code& NodeName(Node* node = nullptr);
 
     // For Python code, a non-local, non-form name will be prefixed with "self."
     //
@@ -320,6 +321,7 @@ public:
         }
     }
     void ResetIndent() { m_indent = 0; }
+    void ResetBraces() { m_within_braces = false; }
 
     Code& operator<<(std::string_view str)
     {

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -147,6 +147,9 @@ public:
 
     Code& CloseBrace();
 
+    // If C++ and node is a local variable, will add "auto* " -- otherwise, it does nothing.
+    Code& AddAuto();
+
     void EnableAutoLineBreak(bool auto_break = true) { m_auto_break = auto_break; }
 
     // Only call the following two functions if you called DisableAutoLineBreak() first.

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -245,9 +245,10 @@ public:
     // m_code += m_node->GetParent()->get_node_name();
     Code& ParentName();
 
-    // This is *NOT* the same as ParentName() -- this will handle wxStaticBox and
-    // wxCollapsiblePane parents as well as non-sizer parents
-    Code& GetParentName();
+    // Find a valid parent for the current node and add it's name. This is *not* the same as
+    // ParentName() -- this will handle wxStaticBox and wxCollapsiblePane parents as well as
+    // non-sizer parents.
+    Code& ValidParentName();
 
     // Handles regular or or'd styles for C++ or Python
     Code& as_string(GenEnum::PropName prop_name);

--- a/src/generate/gen_activity.cpp
+++ b/src/generate/gen_activity.cpp
@@ -35,7 +35,7 @@ std::optional<ttlib::sview> ActivityIndicatorGenerator::CommonConstruction(Code&
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -52,7 +52,7 @@ std::optional<ttlib::sview> AnimationGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().CheckLineLength();
+    code.ValidParentName().Comma().as_string(prop_id).Comma().CheckLineLength();
     // TODO: [Randalphwa - 12-08-2022] Enable Python support once image handling is worked out
     if (code.HasValue(prop_animation) && code.is_cpp())
     {

--- a/src/generate/gen_aui_notebook.cpp
+++ b/src/generate/gen_aui_notebook.cpp
@@ -51,7 +51,7 @@ std::optional<ttlib::sview> AuiNotebookGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
 
     // TODO: [Randalphwa - 12-21-2022] Add Python support
     if (code.is_cpp())

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -104,7 +104,7 @@ std::optional<ttlib::sview> AuiToolBarGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().Add(prop_id);
+    code.ValidParentName().Comma().Add(prop_id);
     code.PosSizeFlags(false, "wxAUI_TB_DEFAULT_STYLE");
 
     return code.m_code;

--- a/src/generate/gen_banner_window.cpp
+++ b/src/generate/gen_banner_window.cpp
@@ -48,12 +48,12 @@ std::optional<ttlib::sview> BannerWindowGenerator::CommonConstruction(Code& code
         code << "auto* ";
     code.NodeName().CreateClass();
     if (code.is_cpp())
-        code.GetParentName().Comma().as_string(prop_direction);
+        code.ValidParentName().Comma().as_string(prop_direction);
     else
     {
         // wxPython docs state that you only need the direction, but in 4.2, there's an error
         // if you don't inlude the id.
-        code.GetParentName().Comma().as_string(prop_id).Comma().as_string(prop_direction);
+        code.ValidParentName().Comma().as_string(prop_id).Comma().as_string(prop_direction);
     }
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1339,7 +1339,7 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     code.Str(prop_class_name) += " : public ";
     if (generator->BaseClassNameCode(code))
     {
-        m_header->writeLine(code.GetCode(), indent::auto_keep_whitespace);
+        m_header->writeLine(code);
     }
     else if (auto result = generator->GenAdditionalCode(code_base_class, form_node); result)
     {
@@ -1372,11 +1372,11 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     code.clear();
     if (generator->HeaderCode(code))
     {
-        m_header->writeLine(code.GetCode(), indent::auto_keep_whitespace);
+        m_header->writeLine(code);
     }
     else if (generator->AdditionalCode(code, code_header))
     {
-        m_header->writeLine(code.GetCode(), indent::auto_keep_whitespace);
+        m_header->writeLine(code);
     }
     else if (auto result = generator->GenAdditionalCode(code_header, form_node); result)
     {
@@ -1478,7 +1478,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
     Code code(form_node, GEN_LANG_CPLUSPLUS);
     if (generator->ConstructionCode(code))
     {
-        m_source->writeLine(code.GetCode(), indent::auto_keep_whitespace);
+        m_source->writeLine(code);
         m_source->Indent();
 
         if (form_node->isGen(gen_wxFrame))
@@ -1489,7 +1489,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
         code.clear();
         if (generator->SettingsCode(code))
         {
-            m_source->writeLine(code.GetCode());
+            m_source->writeLine(code);
             m_source->writeLine();
         }
         else
@@ -1563,7 +1563,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
         if (code.size())
         {
             m_source->writeLine();
-            m_source->writeLine(code.GetCode(), indent::auto_keep_whitespace);
+            m_source->writeLine(code);
         }
     }
     else if (auto result = generator->GenAdditionalCode(code_after_children, form_node); result)
@@ -1973,17 +1973,30 @@ void BaseCodeGenerator::GenCtxConstruction(Node* node)
         if (node->isGen(gen_submenu))
         {
             gen_code.clear();
-            scode = generator->CommonAdditionalCode(gen_code, code_after_children);
-            if (!scode && is_cpp())
+            if (generator->AfterChildrenCode(gen_code))
             {
-                if (result = generator->GenAdditionalCode(code_after_children, node); result)
-                    scode = *result;
+                ASSERT_MSG(gen_code.size(), "AfterChildrenCode() returned true, but no code was generated");
+                if (gen_code.size())
+                {
+                    if (!node->isGen(gen_wxMenuItem))
+                        m_source->writeLine();
+                    m_source->writeLine(gen_code);
+                }
             }
-            if (scode && scode->size())
+            else
             {
-                if (!node->isGen(gen_wxMenuItem))
-                    m_source->writeLine();
-                m_source->writeLine(scode.value(), indent::auto_keep_whitespace);
+                scode = generator->CommonAdditionalCode(gen_code, code_after_children);
+                if (!scode && is_cpp())
+                {
+                    if (result = generator->GenAdditionalCode(code_after_children, node); result)
+                        scode = *result;
+                }
+                if (scode && scode->size())
+                {
+                    if (!node->isGen(gen_wxMenuItem))
+                        m_source->writeLine();
+                    m_source->writeLine(scode.value(), indent::auto_keep_whitespace);
+                }
             }
         }
         m_source->writeLine();

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1337,7 +1337,7 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     if (form_node->HasValue(prop_class_decoration))
         code.Str(prop_class_decoration) += " ";
     code.Str(prop_class_name) += " : public ";
-    if (generator->CodeAdditionalCode(code, code_base_class))
+    if (generator->BaseClassNameCode(code))
     {
         m_header->writeLine(code.GetCode(), indent::auto_keep_whitespace);
     }
@@ -1370,11 +1370,14 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     }
 
     code.clear();
-    if (generator->CodeAdditionalCode(code, code_header))
+    if (generator->HeaderCode(code))
     {
         m_header->writeLine(code.GetCode(), indent::auto_keep_whitespace);
     }
-
+    else if (generator->AdditionalCode(code, code_header))
+    {
+        m_header->writeLine(code.GetCode(), indent::auto_keep_whitespace);
+    }
     else if (auto result = generator->GenAdditionalCode(code_header, form_node); result)
     {
         m_header->writeLine(result.value(), indent::auto_keep_whitespace);
@@ -1473,7 +1476,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
 
     auto* generator = form_node->GetGenerator();
     Code code(form_node, GEN_LANG_CPLUSPLUS);
-    if (generator->CodeConstruction(code))
+    if (generator->ConstructionCode(code))
     {
         m_source->writeLine(code.GetCode(), indent::auto_keep_whitespace);
         m_source->Indent();
@@ -1484,7 +1487,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
         }
 
         code.clear();
-        if (generator->CodeSettings(code))
+        if (generator->SettingsCode(code))
         {
             m_source->writeLine(code.GetCode());
             m_source->writeLine();
@@ -1555,7 +1558,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, const EventVec
     }
 
     code.clear();
-    if (generator->CodeAdditionalCode(code, code_after_children))
+    if (generator->AfterChildrenCode(code))
     {
         if (code.size())
         {

--- a/src/generate/gen_book_page.cpp
+++ b/src/generate/gen_book_page.cpp
@@ -234,7 +234,7 @@ std::optional<ttlib::sview> BookPageGenerator::CommonConstruction(Code& code)
     }
     else
     {
-        code.GetParentName().Comma().as_string(prop_id);
+        code.ValidParentName().Comma().as_string(prop_id);
         code.PosSizeFlags(false);
         code.Eol().ParentName().Function("AddPage(").NodeName().Comma().QuotedString(prop_label);
 

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -26,23 +26,6 @@ wxObject* BoxSizerGenerator::CreateMockup(Node* node, wxObject* parent)
     return sizer;
 }
 
-std::optional<ttlib::sview> BoxSizerGenerator::CommonConstruction(Code& code)
-{
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-
-    code.NodeName().CreateClass().Add(prop_orientation).EndFunction();
-
-    auto min_size = code.m_node->prop_as_wxSize(prop_minimum_size);
-    if (min_size.GetX() != -1 || min_size.GetY() != -1)
-    {
-        code.Eol().Tab().NodeName().Function("SetMinSize(") << min_size.GetX() << ", " << min_size.GetY();
-        code.EndFunction();
-    }
-
-    return code.m_code;
-}
-
 void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
 {
     if (node->as_bool(prop_hide_children))
@@ -52,7 +35,21 @@ void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/
     }
 }
 
-std::optional<ttlib::sview> BoxSizerGenerator::CommonAfterChildren(Code& code)
+bool BoxSizerGenerator::ConstructionCode(Code& code)
+{
+    code.AddAuto().NodeName().CreateClass().Add(prop_orientation).EndFunction();
+
+    auto min_size = code.m_node->prop_as_wxSize(prop_minimum_size);
+    if (min_size.GetX() != -1 || min_size.GetY() != -1)
+    {
+        code.Eol().Tab().NodeName().Function("SetMinSize(") << min_size.GetX() << ", " << min_size.GetY();
+        code.EndFunction();
+    }
+
+    return true;
+}
+
+bool BoxSizerGenerator::AfterChildrenCode(Code& code)
 {
     if (code.IsTrue(prop_hide_children))
     {
@@ -85,7 +82,7 @@ std::optional<ttlib::sview> BoxSizerGenerator::CommonAfterChildren(Code& code)
         }
     }
 
-    return code.m_code;
+    return true;
 }
 
 bool BoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -75,7 +75,7 @@ std::optional<ttlib::sview> BoxSizerGenerator::CommonAfterChildren(Code& code)
         {
             if (GetParentName(code.node()) != "this")
             {
-                code.GetParentName().Function("SetSizerAndFit(");
+                code.ValidParentName().Function("SetSizerAndFit(");
             }
             else
             {

--- a/src/generate/gen_box_sizer.h
+++ b/src/generate/gen_box_sizer.h
@@ -14,12 +14,12 @@ class BoxSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
-    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
+    bool ConstructionCode(Code& code) override;
+    bool AfterChildrenCode(Code& code) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
-    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/gen_button.cpp
+++ b/src/generate/gen_button.cpp
@@ -147,7 +147,7 @@ std::optional<ttlib::sview> ButtonGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma();
+    code.ValidParentName().Comma().as_string(prop_id).Comma();
 
     // If prop_markup is set, then the label will be set in GenSettings()
     if (code.HasValue(prop_label) && !code.IsTrue(prop_markup))

--- a/src/generate/gen_calendar_ctrl.cpp
+++ b/src/generate/gen_calendar_ctrl.cpp
@@ -34,7 +34,7 @@ std::optional<ttlib::sview> CalendarCtrlGenerator::CommonConstruction(Code& code
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().Add("wxDefaultDateTime");
+    code.ValidParentName().Comma().as_string(prop_id).Comma().Add("wxDefaultDateTime");
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_check_listbox.cpp
+++ b/src/generate/gen_check_listbox.cpp
@@ -56,7 +56,7 @@ std::optional<ttlib::sview> CheckListBoxGenerator::CommonConstruction(Code& code
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     auto params_needed = code.WhatParamsNeeded();
     if (params_needed != nothing_needed || !code.IsEqualTo(prop_type, "wxLB_SINGLE"))
     {

--- a/src/generate/gen_checkbox.cpp
+++ b/src/generate/gen_checkbox.cpp
@@ -53,7 +53,7 @@ std::optional<ttlib::sview> CheckBoxGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true);
 
     return code.m_code;
@@ -151,7 +151,7 @@ std::optional<ttlib::sview> Check3StateGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass(false, "wxCheckBox");
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeForceStyle("wxCHK_3STATE");
 
     return code.m_code;

--- a/src/generate/gen_choice.cpp
+++ b/src/generate/gen_choice.cpp
@@ -67,7 +67,7 @@ std::optional<ttlib::sview> ChoiceGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     if (code.HasValue(prop_style))
     {
         code.Comma().Pos().Comma().CheckLineLength().WxSize();

--- a/src/generate/gen_choicebook.cpp
+++ b/src/generate/gen_choicebook.cpp
@@ -38,7 +38,7 @@ std::optional<ttlib::sview> ChoicebookGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).PosSizeFlags(false, "wxCHB_DEFAULT");
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false, "wxCHB_DEFAULT");
 
     return code.m_code;
 }

--- a/src/generate/gen_close_btn.cpp
+++ b/src/generate/gen_close_btn.cpp
@@ -31,7 +31,7 @@ std::optional<ttlib::sview> CloseButtonGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().Add(" = ").Add("wxBitmapButton") << (code.is_cpp() ? "::" : ".");
-    code.Add("NewCloseButton(").GetParentName().Comma().as_string(prop_id);
+    code.Add("NewCloseButton(").ValidParentName().Comma().as_string(prop_id);
     if (code.HasValue(prop_window_name))
         code.Comma().QuotedString(prop_window_name);
     code.EndFunction();

--- a/src/generate/gen_clr_picker.cpp
+++ b/src/generate/gen_clr_picker.cpp
@@ -31,7 +31,7 @@ std::optional<ttlib::sview> ColourPickerGenerator::CommonConstruction(Code& code
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma();
+    code.ValidParentName().Comma().as_string(prop_id).Comma();
     if (code.node()->prop_as_string(prop_colour).size())
         ColourCode(code, prop_colour);
     else

--- a/src/generate/gen_cmd_link_btn.cpp
+++ b/src/generate/gen_cmd_link_btn.cpp
@@ -65,7 +65,7 @@ std::optional<ttlib::sview> CommandLinkBtnGenerator::CommonConstruction(Code& co
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_main_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_main_label);
     code.Comma().QuotedString(prop_note).PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_collapsible.cpp
+++ b/src/generate/gen_collapsible.cpp
@@ -56,7 +56,7 @@ std::optional<ttlib::sview> CollapsiblePaneGenerator::CommonConstruction(Code& c
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true, "wxCP_DEFAULT_STYLE");
 
     return code.m_code;

--- a/src/generate/gen_combobox.cpp
+++ b/src/generate/gen_combobox.cpp
@@ -55,7 +55,7 @@ std::optional<ttlib::sview> ComboBoxGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     if (code.HasValue(prop_style))
     {
         code.Comma().Add("wxEmptyString");

--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -50,7 +50,14 @@ void BaseCodeGenerator::GenConstruction(Node* node)
 
     if (generator->ConstructionCode(gen_code))
     {
+        // Don't add blank lines when adding tools to a toolbar, or creating menu items
+        if (gen_code.GetCode()[0] != '{' && type != type_aui_tool && type != type_tool && type != type_menuitem)
+        {
+            m_source->writeLine();
+        }
+
         m_source->writeLine(gen_code);
+
         if (gen_code.GetCode().starts_with("{") && !gen_code.GetCode().ends_with("}\n"))
         {
             need_closing_brace = true;

--- a/src/generate/gen_date_picker.cpp
+++ b/src/generate/gen_date_picker.cpp
@@ -46,7 +46,7 @@ std::optional<ttlib::sview> DatePickerCtrlGenerator::CommonConstruction(Code& co
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().Add("wxDefaultDateTime");
+    code.ValidParentName().Comma().as_string(prop_id).Comma().Add("wxDefaultDateTime");
     code.PosSizeFlags(true, "wxDP_DEFAULT|wxDP_SHOWCENTURY");
 
     return code.m_code;

--- a/src/generate/gen_dir_picker.cpp
+++ b/src/generate/gen_dir_picker.cpp
@@ -41,7 +41,7 @@ std::optional<ttlib::sview> DirPickerGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma();
+    code.ValidParentName().Comma().as_string(prop_id).Comma();
 
     if (auto& path = code.node()->prop_as_string(prop_initial_path); path.size())
     {

--- a/src/generate/gen_edit_listbox.cpp
+++ b/src/generate/gen_edit_listbox.cpp
@@ -37,7 +37,7 @@ std::optional<ttlib::sview> EditListBoxGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_file_ctrl.cpp
+++ b/src/generate/gen_file_ctrl.cpp
@@ -45,7 +45,7 @@ std::optional<ttlib::sview> FileCtrlGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     code.Comma().QuotedString(prop_initial_folder).Comma().QuotedString(prop_initial_filename);
     code.Comma();
     if (code.HasValue(prop_wildcard))

--- a/src/generate/gen_file_picker.cpp
+++ b/src/generate/gen_file_picker.cpp
@@ -50,7 +50,7 @@ std::optional<ttlib::sview> FilePickerGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma();
+    code.ValidParentName().Comma().as_string(prop_id).Comma();
 
     if (auto& path = code.node()->prop_as_string(prop_initial_path); path.size())
     {

--- a/src/generate/gen_flexgrid_sizer.cpp
+++ b/src/generate/gen_flexgrid_sizer.cpp
@@ -60,7 +60,7 @@ wxObject* FlexGridSizerGenerator::CreateMockup(Node* node, wxObject* parent)
     return sizer;
 }
 
-std::optional<ttlib::sview> FlexGridSizerGenerator::CommonConstruction(Code& code)
+bool FlexGridSizerGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
@@ -127,7 +127,7 @@ std::optional<ttlib::sview> FlexGridSizerGenerator::CommonConstruction(Code& cod
     {
         if (is_within_braces)
             code.CloseBrace();
-        return code.m_code;
+        return true;
     }
 
     code.Eol(eol_if_empty).NodeName().Function("SetFlexibleDirection(").Add(direction).EndFunction();
@@ -137,26 +137,26 @@ std::optional<ttlib::sview> FlexGridSizerGenerator::CommonConstruction(Code& cod
     {
         if (is_within_braces)
             code.CloseBrace();
-        return code.m_code;
+        return true;
     }
     code.NodeName().Function("SetNonFlexibleGrowMode").Add(non_flex_growth).EndFunction();
     if (is_within_braces)
         code.CloseBrace();
 
-    return code.m_code;
+    return true;
 }
 
-std::optional<ttlib::sview> FlexGridSizerGenerator::CommonAfterChildren(Code& code)
+bool FlexGridSizerGenerator::AfterChildrenCode(Code& code)
 {
     if (code.IsTrue(prop_hide_children))
     {
-        code.NodeName().Function("ShowItems(").Str(code.is_cpp() ? "false" : "False").EndFunction();
+        code.NodeName().Function("ShowItems(").AddFalse().EndFunction();
     }
 
     auto parent = code.node()->GetParent();
     if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
     {
-        code.NewLine(true);
+        code.Eol(eol_if_needed);
         if (parent->isGen(gen_wxRibbonPanel))
         {
             code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
@@ -174,7 +174,7 @@ std::optional<ttlib::sview> FlexGridSizerGenerator::CommonAfterChildren(Code& co
         }
     }
 
-    return code.m_code;
+    return true;
 }
 
 void FlexGridSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)

--- a/src/generate/gen_flexgrid_sizer.h
+++ b/src/generate/gen_flexgrid_sizer.h
@@ -15,8 +15,8 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
-    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
+    bool ConstructionCode(Code&) override;
+    bool AfterChildrenCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_font_picker.cpp
+++ b/src/generate/gen_font_picker.cpp
@@ -36,7 +36,7 @@ std::optional<ttlib::sview> FontPickerGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma();
+    code.ValidParentName().Comma().as_string(prop_id).Comma();
     if (code.HasValue(prop_initial_font))
     {
         auto fontprop = code.node()->prop_as_font_prop(prop_initial_font);

--- a/src/generate/gen_gauge.cpp
+++ b/src/generate/gen_gauge.cpp
@@ -43,7 +43,7 @@ std::optional<ttlib::sview> GaugeGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().as_string(prop_range);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().as_string(prop_range);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_grid_sizer.h
+++ b/src/generate/gen_grid_sizer.h
@@ -13,12 +13,12 @@ class GridSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
+    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
-    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
+    bool ConstructionCode(Code&) override;
+    bool AfterChildrenCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
-    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/gen_gridbag_sizer.h
+++ b/src/generate/gen_gridbag_sizer.h
@@ -19,8 +19,8 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
     void AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
-    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
+    bool ConstructionCode(Code&) override;
+    bool AfterChildrenCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_html_window.cpp
+++ b/src/generate/gen_html_window.cpp
@@ -60,7 +60,7 @@ std::optional<ttlib::sview> HtmlWindowGenerator::CommonConstruction(Code& code)
 {
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
-    code.NodeName().CreateClass().GetParentName().Comma().Add(prop_id);
+    code.NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
     code.PosSizeFlags(true, "wxHW_SCROLLBAR_AUTO");
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/generate/gen_hyperlink.cpp
+++ b/src/generate/gen_hyperlink.cpp
@@ -67,7 +67,7 @@ std::optional<ttlib::sview> HyperlinkGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && !code.IsTrue(prop_underlined))
         code.m_code.Replace("wxHyperlinkCtrl", "wxGenericHyperlinkCtrl");
 
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.Comma().QuotedString(prop_url);
     code.PosSizeFlags(false, "wxHL_DEFAULT_STYLE");
 

--- a/src/generate/gen_infobar.cpp
+++ b/src/generate/gen_infobar.cpp
@@ -41,7 +41,7 @@ std::optional<ttlib::sview> InfoBarGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName();
+    code.ValidParentName();
     if (code.node()->as_string(prop_id) != "wxID_ANY")
         code.Comma().as_string(prop_id);
     code.EndFunction();

--- a/src/generate/gen_listbook.cpp
+++ b/src/generate/gen_listbook.cpp
@@ -44,7 +44,7 @@ std::optional<ttlib::sview> ListbookGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).PosSizeFlags(false, "wxBK_DEFAULT");
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false, "wxBK_DEFAULT");
 
     // TODO: [Randalphwa - 12-21-2022] Add Python support
     if (code.is_cpp())

--- a/src/generate/gen_listbox.cpp
+++ b/src/generate/gen_listbox.cpp
@@ -50,7 +50,7 @@ std::optional<ttlib::sview> ListBoxGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     auto params_needed = code.WhatParamsNeeded();
     if (params_needed != nothing_needed || !code.IsEqualTo(prop_type, "wxLB_SINGLE"))
     {

--- a/src/generate/gen_menu.cpp
+++ b/src/generate/gen_menu.cpp
@@ -52,7 +52,7 @@ std::optional<ttlib::sview> MenuGenerator::CommonAdditionalCode(Code& code, GenE
             }
             else
             {
-                code.GetParentName().Function("Bind(wxEVT_RIGHT_DOWN, &")
+                code.ValidParentName().Function("Bind(wxEVT_RIGHT_DOWN, &")
                     << node->get_form_name() << "::" << node->get_parent_name() << "OnContextMenu, this);";
             }
         }

--- a/src/generate/gen_menuitem.cpp
+++ b/src/generate/gen_menuitem.cpp
@@ -107,6 +107,7 @@ std::optional<ttlib::sview> MenuItemGenerator::CommonSettings(Code& code)
                 if (wxGetProject().value(prop_wxWidgets_version) != "3.1")
                 {
                     GenerateBundleCode(description, code.m_code);
+                    code.EndFunction();
                 }
                 else
                 {
@@ -115,9 +116,9 @@ std::optional<ttlib::sview> MenuItemGenerator::CommonSettings(Code& code)
                     code.Eol() += "#else";
                     code.Eol().Tab() << "wxBitmap(" << GenerateBitmapCode(description) << ")";
                     code.Eol() += "#endif";
+                    code.Eol().EndFunction();
                 }
-                code.Eol(eol_if_needed).UpdateBreakAt();
-                code.EndFunction();
+                code.Eol();
             }
             else
             {

--- a/src/generate/gen_notebook.cpp
+++ b/src/generate/gen_notebook.cpp
@@ -43,7 +43,7 @@ std::optional<ttlib::sview> NotebookGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
 
     // TODO: [Randalphwa - 12-21-2022] Add Python support
     if (code.is_cpp())

--- a/src/generate/gen_page_ctrl.cpp
+++ b/src/generate/gen_page_ctrl.cpp
@@ -161,7 +161,7 @@ std::optional<ttlib::sview> PageCtrlGenerator::CommonConstruction(Code& code)
             {
                 code += gen_code.m_code;
                 code.Eol(eol_if_needed)
-                    .GetParentName()
+                    .ValidParentName()
                     .Function("AddPage(")
                     .Str(child_node->get_node_name())
                     .Comma()

--- a/src/generate/gen_panel.cpp
+++ b/src/generate/gen_panel.cpp
@@ -30,7 +30,7 @@ std::optional<ttlib::sview> PanelGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_panel_form.cpp
+++ b/src/generate/gen_panel_form.cpp
@@ -39,48 +39,13 @@ wxObject* PanelFormGenerator::CreateMockup(Node* node, wxObject* parent)
     return widget;
 }
 
-bool PanelFormGenerator::GenConstruction(Node* node, BaseCodeGenerator* code_gen)
-{
-    auto src_code = code_gen->GetSrcWriter();
-
-    ttlib::cstr code;
-    code << "bool " << node->prop_as_string(prop_class_name) << "::Create";
-
-    code << "(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style, const wxString "
-            "&name)\n{";
-    code << "\n\tif (!wxPanel::Create(parent, id, pos, size, style, name))\n\t\treturn false;\n\n";
-
-    src_code->writeLine(code, indent::none);
-    code.clear();
-    src_code->Indent();
-
-    if (node->HasValue(prop_extra_style))
-    {
-        code << "SetExtraStyle(GetExtraStyle() | " << node->prop_as_string(prop_extra_style) << ");";
-        src_code->writeLine(code);
-        code.clear();
-    }
-
-    code << GenFontColourSettings(node);
-    if (code.size())
-    {
-        src_code->writeLine(code);
-        code.clear();
-    }
-
-    src_code->Unindent();
-    src_code->writeLine();
-
-    return true;
-}
-
-bool PanelFormGenerator::GenPythonForm(Code& code)
+bool PanelFormGenerator::CodeConstruction(Code& code)
 {
     if (code.is_cpp())
     {
         code.Str("bool ").Str((prop_class_name)) += "::Create";
         code += "(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style, const wxString "
-            "&name)";
+                "&name)";
         code.OpenBrace();
         code += "if (!wxPanel::Create(parent, id, pos, size, style, name))";
         code.Eol().Tab() += "return false;\n";
@@ -112,94 +77,65 @@ bool PanelFormGenerator::GenPythonForm(Code& code)
         code.FormFunction("SetExtraStyle(GetExtraStyle() | ").Add(prop_extra_style).Str(")").EndFunction();
     }
 
-    code.GenFontColourSettings();
     code.ResetIndent();
+    code.ResetBraces();  // In C++, caller must close the final brace after all construction
 
     return true;
 }
 
-std::optional<ttlib::cstr> PanelFormGenerator::GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node)
+std::optional<ttlib::cstr> PanelFormGenerator::GenAdditionalCode(GenEnum::GenCodeType /* cmd */, Node* /* node */)
 {
-    if (cmd == code_header)
+    FAIL_MSG("This function should NOT be called any more -- see CodeAdditionalCode() below")
+
+    return {};
+}
+
+bool PanelFormGenerator::CodeAdditionalCode(Code& code, GenEnum::GenCodeType cmd)
+{
+    if (cmd == code_header && code.is_cpp())
     {
-        ttlib::cstr code;
-
-        code << node->get_node_name() << "() {}\n";
-
-        code << node->get_node_name() << "(wxWindow* parent, wxWindowID id = " << node->prop_as_string(prop_id) << ", ";
-        code << "const wxPoint& pos = ";
-
-        auto position = node->prop_as_wxPoint(prop_pos);
-        if (position == wxDefaultPosition)
-            code << "wxDefaultPosition, ";
+        code.NodeName() += "() {}";
+        code.Eol().Str("const wxPoint& pos = ").Pos(prop_pos).Comma();
+        code.Str("const wxSize& size = ").WxSize(prop_size).Comma();
+        code.Str("long style = ");
+        if (code.HasValue(prop_style))
+            code.Str(prop_style);
         else
-            code << "wxPoint(" << position.x << ", " << position.y << "), ";
-
-        code << "const wxSize& size = ";
-
-        auto size = node->prop_as_wxSize(prop_size);
-        if (size == wxDefaultSize)
-            code << "wxDefaultSize";
+            code += "wxTAB_TRAVERSAL";
+        code.Comma().Str("const wxString &name = ");
+        if (code.HasValue(prop_window_name))
+            code.QuotedString(prop_window_name);
         else
-            code << "wxSize(" << size.x << ", " << size.y << ")";
-
-        code << ",\n\tlong style = ";
-        if (node->HasValue(prop_style))
-            code << node->prop_as_string(prop_style);
+            code.Str("wxPanelNameStr");
+        code += ")";
+        code.OpenBrace().Str("Create(parent, id, pos, size, style, name);").CloseBrace();
+        code.Eol() += "bool Create(wxWindow *parent, ";
+        code.Str("wxWindowID id = ").Str(prop_id).Comma();
+        code.Str("const wxPoint& pos = ").Pos(prop_pos).Comma();
+        code.Str("const wxSize& size = ").WxSize(prop_size).Comma();
+        code.Str("long style = ");
+        if (code.HasValue(prop_style))
+            code.Str(prop_style);
         else
-            code << "wxTAB_TRAVERSAL";
-
-        code << ", const wxString &name = ";
-        if (node->HasValue(prop_window_name))
-            code << GenerateQuotedString(node, prop_window_name);
+            code.Str("wxTAB_TRAVERSAL");
+        code.Comma().Str("const wxString &name = ");
+        if (code.HasValue(prop_window_name))
+            code.QuotedString(prop_window_name);
         else
-            code << "wxPanelNameStr";
-
-        code << ")\n{\n\tCreate(parent, id, pos, size, style, name);\n}\n";
-
-        code << "\nbool Create(wxWindow *parent, ";
-        code << "wxWindowID id = " << node->prop_as_string(prop_id) << ", ";
-        code << "const wxPoint& pos = ";
-
-        if (position == wxDefaultPosition)
-            code << "wxDefaultPosition, ";
-        else
-            code << "wxPoint(" << position.x << ", " << position.y << "), ";
-
-        code << "const wxSize& size = ";
-
-        if (size == wxDefaultSize)
-            code << "wxDefaultSize";
-        else
-            code << "wxSize(" << size.x << ", " << size.y << ")";
-
-        code << ",\n\tlong style = ";
-        if (node->HasValue(prop_style))
-            code << node->prop_as_string(prop_style);
-        else
-            code << "wxTAB_TRAVERSAL";
-
-        code << ", const wxString &name = ";
-        if (node->HasValue(prop_window_name))
-            code << GenerateQuotedString(node, prop_window_name);
-        else
-            code << "wxPanelNameStr";
-
-        code << ");\n\n";
-
-        return code;
+            code.Str("wxPanelNameStr");
+        code += ");\n\n";
+        return true;
     }
     else if (cmd == code_after_children)
     {
-        ttlib::cstr code;
-
         Node* panel;
+        auto* node = code.node();
         if (node->IsForm())
         {
             panel = node;
             ASSERT_MSG(panel->GetChildCount(), "Trying to generate code for a wxPanel with no children.")
             if (!panel->GetChildCount())
-                return {};  // empty dialog, so nothing to do
+                return true;  // empty dialog, so nothing to do
             ASSERT_MSG(panel->GetChild(0)->IsSizer(), "Expected first child of a wxPanel to be a sizer.");
             if (panel->GetChild(0)->IsSizer())
                 node = panel->GetChild(0);
@@ -209,43 +145,42 @@ std::optional<ttlib::cstr> PanelFormGenerator::GenAdditionalCode(GenEnum::GenCod
             panel = node->get_form();
         }
 
-        auto min_size = panel->prop_as_wxSize(prop_minimum_size);
-        auto max_size = panel->prop_as_wxSize(prop_maximum_size);
-        auto size = panel->prop_as_wxSize(prop_size);
+        const auto min_size = panel->prop_as_wxSize(prop_minimum_size);
+        const auto max_size = panel->prop_as_wxSize(prop_maximum_size);
+        const auto size = panel->prop_as_wxSize(prop_size);
 
         if (min_size == wxDefaultSize && max_size == wxDefaultSize)
         {
-            code << "\tSetSizerAndFit(" << node->get_node_name() << ");";
+            code.FormFunction("SetSizerAndFit(").NodeName(node).EndFunction();
         }
         else
         {
-            code << "\tSetSizer(" << node->get_node_name() << ");";
+            code.FormFunction("SetSizer(").NodeName(node).EndFunction();
             if (min_size != wxDefaultSize)
             {
-                code << "\n\tSetMinSize(wxSize(" << min_size.GetWidth() << ", " << min_size.GetHeight() << "));";
+                code.Eol().FormFunction("SetMinSize(").WxSize(prop_minimum_size).EndFunction();
             }
             if (max_size != wxDefaultSize)
             {
-                code << "\n\tSetMaxSize(wxSize(" << max_size.GetWidth() << ", " << max_size.GetHeight() << "));";
+                code.Eol().FormFunction("SetMaxSize(").WxSize(prop_maximum_size).EndFunction();
             }
-            code << "\n\tFit();";
+            code.Eol().FormFunction("Fit(").EndFunction();
         }
 
         if (size != wxDefaultSize)
         {
-            code << "\n\tSetSize(wxSize(" << size.GetWidth() << ", " << size.GetHeight() << "));";
+            code.Eol().FormFunction("SetSize(").WxSize(prop_size).EndFunction();
         }
 
-        return code;
+        return true;
     }
     else if (cmd == code_base_class)
     {
-        ttlib::cstr code;
-        code << "wxPanel";
-        return code;
+        code += "wxPanel";
+        return true;
     }
 
-    return {};
+    return false;
 }
 
 int PanelFormGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)

--- a/src/generate/gen_panel_form.h
+++ b/src/generate/gen_panel_form.h
@@ -14,10 +14,8 @@ class PanelFormGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
 
-    // Return true if all construction and settings code was written to src_code
-    bool GenConstruction(Node*, BaseCodeGenerator* code_gen) override;
-
-    bool GenPythonForm(Code&) override;
+    bool CodeConstruction(Code&) override;
+    bool CodeAdditionalCode(Code&, GenEnum::GenCodeType cmd) override;
 
     std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
 

--- a/src/generate/gen_panel_form.h
+++ b/src/generate/gen_panel_form.h
@@ -14,13 +14,13 @@ class PanelFormGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
 
-    bool CodeConstruction(Code&) override;
-    bool CodeAdditionalCode(Code&, GenEnum::GenCodeType cmd) override;
-
-    std::optional<ttlib::cstr> GenAdditionalCode(GenEnum::GenCodeType cmd, Node* node) override;
-
-    bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+    bool ConstructionCode(Code&) override;
+    bool AfterChildrenCode(Code&) override;
+    bool HeaderCode(Code&) override;
+    bool BaseClassNameCode(Code&) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
+
+    bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 };

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -305,7 +305,7 @@ void BaseCodeGenerator::GeneratePythonClass(Node* form_node, PANEL_PAGE panel_ty
     auto generator = form_node->GetNodeDeclaration()->GetGenerator();
     Code code(form_node, GEN_LANG_PYTHON);
 
-    if (generator->GenPythonForm(code))
+    if (generator->CodeConstruction(code) || generator->GenPythonForm(code))
     {
         m_source->writeLine(code.m_code, indent::auto_keep_whitespace);
         m_source->writeLine();

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -305,7 +305,7 @@ void BaseCodeGenerator::GeneratePythonClass(Node* form_node, PANEL_PAGE panel_ty
     auto generator = form_node->GetNodeDeclaration()->GetGenerator();
     Code code(form_node, GEN_LANG_PYTHON);
 
-    if (generator->CodeConstruction(code) || generator->GenPythonForm(code))
+    if (generator->ConstructionCode(code) || generator->GenPythonForm(code))
     {
         m_source->writeLine(code.m_code, indent::auto_keep_whitespace);
         m_source->writeLine();

--- a/src/generate/gen_radio_box.cpp
+++ b/src/generate/gen_radio_box.cpp
@@ -84,7 +84,7 @@ std::optional<ttlib::sview> RadioBoxGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.Comma().Pos().Comma().WxSize().Comma();
     if (code.is_cpp())
     {

--- a/src/generate/gen_radio_btn.cpp
+++ b/src/generate/gen_radio_btn.cpp
@@ -51,7 +51,7 @@ std::optional<ttlib::sview> RadioButtonGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -54,7 +54,7 @@ std::optional<ttlib::sview> RearrangeCtrlGenerator::CommonConstruction(Code& cod
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     code.Comma().Pos().Comma().WxSize();
     code.Comma();
     if (code.is_cpp())

--- a/src/generate/gen_rich_text.cpp
+++ b/src/generate/gen_rich_text.cpp
@@ -34,7 +34,7 @@ std::optional<ttlib::sview> RichTextCtrlGenerator::CommonConstruction(Code& code
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_value);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_value);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_search_ctrl.cpp
+++ b/src/generate/gen_search_ctrl.cpp
@@ -43,7 +43,7 @@ std::optional<ttlib::sview> SearchCtrlGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_value);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_value);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_simplebook.cpp
+++ b/src/generate/gen_simplebook.cpp
@@ -47,7 +47,7 @@ std::optional<ttlib::sview> SimplebookGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
 
     return code.m_code;
 }

--- a/src/generate/gen_slider.cpp
+++ b/src/generate/gen_slider.cpp
@@ -60,7 +60,7 @@ std::optional<ttlib::sview> SliderGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName()
+    code.ValidParentName()
         .Comma()
         .as_string(prop_id)
         .Comma()

--- a/src/generate/gen_spacer_sizer.cpp
+++ b/src/generate/gen_spacer_sizer.cpp
@@ -14,64 +14,70 @@
 
 #include "gen_spacer_sizer.h"
 
-std::optional<ttlib::cstr> SpacerGenerator::GenConstruction(Node* node)
+bool SpacerGenerator::ConstructionCode(Code& code)
 {
-    ttlib::cstr code;
-    code << node->GetParent()->get_node_name();
+    auto* node = code.node();
+    code.ParentName();
+    ;
 
     if (node->GetParent()->isGen(gen_wxGridBagSizer))
     {
         auto flags = node->GetSizerFlags();
 
-        code << "->Add(" << node->prop_as_int(prop_width) << ", " << node->prop_as_int(prop_height);
-        code << ", wxGBPosition(" << node->prop_as_int(prop_row) << ", " << node->prop_as_int(prop_column);
-        code << "), wxGBSpan(" << node->prop_as_int(prop_rowspan) << ", " << node->prop_as_int(prop_colspan);
-        code << "), " << flags.GetFlags() << ", " << node->prop_as_int(prop_border_size);
+        code.Function("Add(").Str(prop_width).Comma().Str(prop_height);
+        code.Comma().Add("wxGBPosition(").Str(prop_row).Comma().Str(prop_column) += ")";
+        code.Comma().Add("wxGBSpan(").Str(prop_rowspan).Comma().Str(prop_colspan) += ")";
+        code.Comma().itoa(flags.GetFlags()).Comma().Str(prop_border_size);
         if (node->prop_as_bool(prop_add_default_border))
-            code << " + wxSizerFlags::GetDefaultBorder()";
-        code << ");";
+        {
+            code.Str(" + ").Add("wxSizerFlags").ClassMethod("GetDefaultBorder()");
+        }
+        code.EndFunction();
     }
     else
     {
-        if (node->prop_as_int(prop_proportion) != 0)
+        if (node->as_int(prop_proportion) != 0)
         {
-            code << "->AddStretchSpacer(" << node->prop_as_string(prop_proportion) << ");";
+            code.Function("AddStretchSpacer(").Add(prop_proportion).EndFunction();
         }
         else
         {
             if (node->prop_as_int(prop_width) == node->prop_as_int(prop_height))
             {
-                code << "->AddSpacer(" << node->prop_as_string(prop_width);
+                code.Function("AddSpacer(").Str(prop_width);
             }
             else if (node->GetParent()->HasValue(prop_orientation))
             {
-                code << "->AddSpacer(";
-                if (node->GetParent()->prop_as_string(prop_orientation) == "wxVERTICAL")
+                code.Function("AddSpacer(");
+                if (node->GetParent()->as_string(prop_orientation) == "wxVERTICAL")
                 {
-                    code << node->prop_as_string(prop_height);
+                    code.Str(prop_height);
                 }
                 else
                 {
-                    code << node->prop_as_string(prop_width);
+                    code.Str(prop_width);
                 }
             }
 
             else
             {
-                code << "->Add(" << node->prop_as_string(prop_width);
-                if (node->prop_as_bool(prop_add_default_border))
-                    code << " + wxSizerFlags::GetDefaultBorder()";
-                code << ", " << node->prop_as_string(prop_height);
+                code.Function("Add(").Str(prop_width);
+                if (node->as_bool(prop_add_default_border))
+                {
+                    code.Str(" + ").Add("wxSizerFlags").ClassMethod("GetDefaultBorder()");
+                }
+                code.Comma().Str(prop_height);
             }
 
             if (node->prop_as_bool(prop_add_default_border))
-                code << " + wxSizerFlags::GetDefaultBorder()";
-
-            code << ");";
+            {
+                code.Str(" + ").Add("wxSizerFlags").ClassMethod("GetDefaultBorder()");
+            }
+            code.EndFunction();
         }
     }
 
-    return code;
+    return true;
 }
 
 // ../../wxSnapShot/src/xrc/xh_sizer.cpp

--- a/src/generate/gen_spacer_sizer.h
+++ b/src/generate/gen_spacer_sizer.h
@@ -13,7 +13,7 @@
 class SpacerGenerator : public BaseGenerator
 {
 public:
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+    bool ConstructionCode(Code&) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/gen_spin_btn.cpp
+++ b/src/generate/gen_spin_btn.cpp
@@ -37,7 +37,7 @@ std::optional<ttlib::sview> SpinButtonGenerator::CommonConstruction(Code& code)
 {
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
-    code.NodeName().CreateClass().GetParentName().Comma().Add(prop_id);
+    code.NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
     code.PosSizeFlags(false, "wxSP_VERTICAL");
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/generate/gen_spin_ctrl.cpp
+++ b/src/generate/gen_spin_ctrl.cpp
@@ -55,7 +55,7 @@ std::optional<ttlib::sview> SpinCtrlGenerator::CommonConstruction(Code& code)
 {
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
-    code.NodeName().CreateClass().GetParentName();
+    code.NodeName().CreateClass().ValidParentName();
     auto needed_parms = code.WhatParamsNeeded("wxSP_ARROW_KEYS");
     Node* node = code.node();
     if (needed_parms == nothing_needed && node->as_int(prop_min) == 0 && node->as_int(prop_max) == 100 &&

--- a/src/generate/gen_split_win.cpp
+++ b/src/generate/gen_split_win.cpp
@@ -165,7 +165,7 @@ std::optional<ttlib::sview> SplitterWindowGenerator::CommonConstruction(Code& co
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -77,7 +77,7 @@ bool StaticCheckboxBoxSizerGenerator::OnPropertyChange(wxObject* /* widget */, N
     return false;
 }
 
-std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonConstruction(Code& code)
+bool StaticCheckboxBoxSizerGenerator::ConstructionCode(Code& code)
 {
     Node* node = code.node();
     if (code.is_cpp())
@@ -96,8 +96,7 @@ std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonConstruction(
         code.Str("# wxPython currently does not support a checkbox as a static box label").Eol();
     }
 
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
+    code.AddAuto();
 
     ttlib::cstr parent_name(code.is_cpp() ? "this" : "self");
     if (!node->GetParent()->IsForm())
@@ -142,11 +141,10 @@ std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonConstruction(
     }
     else
     {
-        code.NodeName().CreateClass(false, "wxStaticBoxSizer").as_string(prop_orientation).Comma().Str(parent_name);
-        auto& label = node->prop_as_string(prop_label);
-        if (label.size())
+        code.NodeName().CreateClass(false, "wxStaticBoxSizer").Str(prop_orientation).Comma().Str(parent_name);
+        if (code.HasValue(prop_label))
         {
-            code.Comma().QuotedString(label);
+            code.Comma().QuotedString(prop_label);
         }
         code.EndFunction();
     }
@@ -156,39 +154,36 @@ std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonConstruction(
         code.Eol().NodeName().Function("SetMinSize(").WxSize(prop_minimum_size).EndFunction();
     }
 
-    return code.m_code;
+    return true;
 }
 
-std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonSettings(Code& code)
+bool StaticCheckboxBoxSizerGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_disabled))
     {
-        if (code.is_cpp())
-            code.NodeName().Function("GetStaticBox()->Enable(false);");
-        else
-            code.NodeName().Function("GetStaticBox().Enable(False)");
+        code.Eol(eol_if_needed).NodeName().Function("GetStaticBox()->Enable(").AddFalse().EndFunction();
     }
 
     if (code.HasValue(prop_tooltip) && code.is_cpp())
     {
-        code.NewLine(true).as_string(prop_checkbox_var_name).Function("SetToolTip(");
+        code.Eol(eol_if_needed).Str(prop_checkbox_var_name).Function("SetToolTip(");
         code.QuotedString(prop_tooltip).EndFunction();
     }
 
-    return code.m_code;
+    return true;
 }
 
-std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonAfterChildren(Code& code)
+bool StaticCheckboxBoxSizerGenerator::AfterChildrenCode(Code& code)
 {
     if (code.IsTrue(prop_hide_children))
     {
-        code.NodeName().Function("ShowItems(").Str(code.is_cpp() ? "false" : "False").EndFunction();
+        code.NodeName().Function("ShowItems(").AddFalse().EndFunction();
     }
 
     auto parent = code.node()->GetParent();
     if (!parent->IsSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
     {
-        code.NewLine(true);
+        code.Eol(eol_if_needed);
         if (parent->isGen(gen_wxRibbonPanel))
         {
             code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
@@ -207,7 +202,7 @@ std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonAfterChildren
         }
     }
 
-    return code.m_code;
+    return true;
 }
 
 bool StaticCheckboxBoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -83,7 +83,7 @@ std::optional<ttlib::sview> StaticCheckboxBoxSizerGenerator::CommonConstruction(
     if (code.is_cpp())
     {
         code.as_string(prop_checkbox_var_name) << " = new wxCheckBox(";
-        code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label).EndFunction();
+        code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label).EndFunction();
 
         if (auto result = GenValidatorSettings(node); result)
         {

--- a/src/generate/gen_statchkbox_sizer.h
+++ b/src/generate/gen_statchkbox_sizer.h
@@ -17,9 +17,9 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
-    std::optional<ttlib::sview> CommonSettings(Code&) override;
-    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
+    bool ConstructionCode(Code&) override;
+    bool SettingsCode(Code&) override;
+    bool AfterChildrenCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_static_bmp.cpp
+++ b/src/generate/gen_static_bmp.cpp
@@ -52,7 +52,7 @@ std::optional<ttlib::sview> StaticBitmapGenerator::CommonConstruction(Code& code
         if (code.HasValue(prop_bitmap))
         {
             bool is_list_created = PythonBitmapList(code, prop_bitmap);
-            code.NodeName().CreateClass().GetParentName().Comma().as_string(prop_id).Comma();
+            code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
 
             if (is_list_created)
             {
@@ -66,7 +66,7 @@ std::optional<ttlib::sview> StaticBitmapGenerator::CommonConstruction(Code& code
         }
         else
         {
-            code.NodeName().CreateClass().GetParentName().Comma().as_string(prop_id).Comma();
+            code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
             code.Add("wxNullBitmap");
             code.PosSizeFlags();
         }
@@ -99,7 +99,7 @@ void StaticBitmapGenerator::GenCppConstruction(Code& gen_code)
         else
             gen_code.NodeName() << " = new wxStaticBitmap(";
 
-        gen_code.GetParentName().Comma().as_string(prop_id).Comma();
+        gen_code.ValidParentName().Comma().as_string(prop_id).Comma();
 
         if (!is_vector_code)
         {
@@ -179,7 +179,7 @@ void StaticBitmapGenerator::GenCppConstruction(Code& gen_code)
         else
             gen_code.NodeName() << " = new wxStaticBitmap(";
 
-        gen_code.GetParentName().Comma().as_string(prop_id).Comma();
+        gen_code.ValidParentName().Comma().as_string(prop_id).Comma();
 
         code << "wxNullBitmap";
     }

--- a/src/generate/gen_static_box.cpp
+++ b/src/generate/gen_static_box.cpp
@@ -31,7 +31,7 @@ std::optional<ttlib::sview> StaticBoxGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().Add(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().Add(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true);
 
     return code.m_code;

--- a/src/generate/gen_static_line.cpp
+++ b/src/generate/gen_static_line.cpp
@@ -31,7 +31,7 @@ std::optional<ttlib::sview> StaticLineGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName();
+    code.ValidParentName();
     if (!code.IsEqualTo(prop_id, "wxID_ANY") || code.HasValue(prop_pos) || code.HasValue(prop_size) ||
         code.HasValue(prop_window_name) || code.PropContains(prop_style, "wxLI_VERTICAL"))
     {

--- a/src/generate/gen_static_text.cpp
+++ b/src/generate/gen_static_text.cpp
@@ -76,7 +76,7 @@ std::optional<ttlib::sview> StaticTextGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass((code.m_node->prop_as_bool(prop_markup) && code.m_node->prop_as_int(prop_wrap) <= 0));
-    code.GetParentName().Comma().as_string(prop_id).Comma();
+    code.ValidParentName().Comma().as_string(prop_id).Comma();
     if (code.m_node->prop_as_bool(prop_markup))
     {
         code.EmptyString();

--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -44,11 +44,8 @@ void StaticBoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
     }
 }
 
-std::optional<ttlib::sview> StaticBoxSizerGenerator::CommonConstruction(Code& code)
+bool StaticBoxSizerGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-
     Node* node = code.node();
 
     ttlib::cstr parent_name(code.is_cpp() ? "this" : "self");
@@ -75,7 +72,7 @@ std::optional<ttlib::sview> StaticBoxSizerGenerator::CommonConstruction(Code& co
             parent = parent->GetParent();
         }
     }
-    code.NodeName().CreateClass().as_string(prop_orientation).Comma().Str(parent_name);
+    code.AddAuto().NodeName().CreateClass().Str(prop_orientation).Comma().Str(parent_name);
 
     if (auto& label = node->prop_as_string(prop_label); label.size())
     {
@@ -88,27 +85,24 @@ std::optional<ttlib::sview> StaticBoxSizerGenerator::CommonConstruction(Code& co
         code.Eol().NodeName().Function("SetMinSize(").WxSize(prop_minimum_size).EndFunction();
     }
 
-    return code.m_code;
+    return true;
 }
 
-std::optional<ttlib::sview> StaticBoxSizerGenerator::CommonSettings(Code& code)
+bool StaticBoxSizerGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_disabled))
     {
-        if (code.is_cpp())
-            code.NodeName().Function("GetStaticBox()->Enable(false);");
-        else
-            code.NodeName().Function("GetStaticBox().Enable(False)");
+        code.NodeName().Function("GetStaticBox()->Enable(").AddFalse().EndFunction();
     }
 
-    return code.m_code;
+    return true;
 }
 
-std::optional<ttlib::sview> StaticBoxSizerGenerator::CommonAfterChildren(Code& code)
+bool StaticBoxSizerGenerator::AfterChildrenCode(Code& code)
 {
     if (code.IsTrue(prop_hide_children))
     {
-        code.NodeName().Function("ShowItems(").Str(code.is_cpp() ? "false" : "False").EndFunction();
+        code.NodeName().Function("ShowItems(").AddFalse().EndFunction();
     }
 
     auto parent = code.node()->GetParent();
@@ -132,7 +126,7 @@ std::optional<ttlib::sview> StaticBoxSizerGenerator::CommonAfterChildren(Code& c
         }
     }
 
-    return code.m_code;
+    return true;
 }
 
 bool StaticBoxSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)

--- a/src/generate/gen_staticbox_sizer.h
+++ b/src/generate/gen_staticbox_sizer.h
@@ -15,9 +15,9 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
-    std::optional<ttlib::sview> CommonSettings(Code&) override;
-    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
+    bool ConstructionCode(Code&) override;
+    bool SettingsCode(Code&) override;
+    bool AfterChildrenCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -77,7 +77,7 @@ std::optional<ttlib::sview> StaticRadioBtnBoxSizerGenerator::CommonConstruction(
     if (code.is_cpp())
     {
         code.as_string(prop_radiobtn_var_name) << " = new wxRadioButton(";
-        code.GetParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label).EndFunction();
+        code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label).EndFunction();
 
         if (auto result = GenValidatorSettings(node); result)
         {

--- a/src/generate/gen_statradiobox_sizer.h
+++ b/src/generate/gen_statradiobox_sizer.h
@@ -17,9 +17,9 @@ public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
-    std::optional<ttlib::sview> CommonSettings(Code&) override;
-    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
+    bool ConstructionCode(Code&) override;
+    bool SettingsCode(Code&) override;
+    bool AfterChildrenCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 

--- a/src/generate/gen_std_dlgbtn_sizer.cpp
+++ b/src/generate/gen_std_dlgbtn_sizer.cpp
@@ -76,7 +76,7 @@ wxObject* StdDialogButtonSizerGenerator::CreateMockup(Node* node, wxObject* pare
     return sizer;
 }
 
-std::optional<ttlib::sview> StdDialogButtonSizerGenerator::CommonConstruction(Code& code)
+bool StdDialogButtonSizerGenerator::ConstructionCode(Code& code)
 {
     // The Python code for StdDialogButtonSizer cannot be implemented the same way as the C++
     // code, so it needs it's own function. Specifically, wx/sizer.h has several public Get
@@ -86,11 +86,10 @@ std::optional<ttlib::sview> StdDialogButtonSizerGenerator::CommonConstruction(Co
     if (code.is_python())
     {
         GenPythonConstruction(code);
-        return code.m_code;
+        return true;
     }
 
-    if (code.is_local_var())
-        code << "auto* ";
+    code.AddAuto();
 
     Node* node = code.node();  // purely for convenience
 
@@ -136,7 +135,7 @@ std::optional<ttlib::sview> StdDialogButtonSizerGenerator::CommonConstruction(Co
         else if (def_btn_name == "Apply")
             code.Eol().NodeName().Function("GetApplyButton()").Function("SetDefault(").EndFunction();
 
-        return code.m_code;
+        return true;
     }
 
     code.NodeName().CreateClass(false, "wxStdDialogButtonSizer").EndFunction();
@@ -237,7 +236,7 @@ std::optional<ttlib::sview> StdDialogButtonSizerGenerator::CommonConstruction(Co
             code.NodeName() << "ContextHelp = wxStaticCast(FindWindowById(wxID_CONTEXT_HELP), wxButton);\n";
     }
 
-    return code.m_code;
+    return true;
 }
 
 void StdDialogButtonSizerGenerator::GenPythonConstruction(Code& code)

--- a/src/generate/gen_std_dlgbtn_sizer.h
+++ b/src/generate/gen_std_dlgbtn_sizer.h
@@ -14,7 +14,7 @@ class StdDialogButtonSizerGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
+    bool ConstructionCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     std::optional<ttlib::sview> GenEvents(Code&, NodeEvent*, const std::string&) override;

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -103,7 +103,7 @@ std::optional<ttlib::sview> TextCtrlGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().CheckLineLength();
+    code.ValidParentName().Comma().as_string(prop_id).Comma().CheckLineLength();
     code.QuotedString(prop_value);
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_text_sizer.cpp
+++ b/src/generate/gen_text_sizer.cpp
@@ -22,13 +22,10 @@ wxObject* TextSizerGenerator::CreateMockup(Node* node, wxObject* parent)
     return wrapper.CreateSizer(node->prop_as_wxString(prop_text), node->prop_as_int(prop_wrap));
 }
 
-std::optional<ttlib::cstr> TextSizerGenerator::GenConstruction(Node* node)
+bool TextSizerGenerator::ConstructionCode(Code& code)
 {
-    ttlib::cstr code;
-    if (node->IsLocal())
-        code << "auto* ";
-
-    code << node->get_node_name();
+    auto* node = code.node();
+    code.AddAuto().NodeName();
     auto parent = node->GetParent();
     while (parent->IsSizer())
         parent = parent->GetParent();
@@ -42,9 +39,9 @@ std::optional<ttlib::cstr> TextSizerGenerator::GenConstruction(Node* node)
         code << " = wxTextSizerWrapper(" << parent->get_node_name() << ").CreateSizer(";
     }
 
-    code << GenerateQuotedString(node->prop_as_string(prop_text)) << ", " << node->prop_as_string(prop_width) << ");";
+    code.QuotedString(prop_text).Comma().Str(prop_width).EndFunction();
 
-    return code;
+    return true;
 }
 
 bool TextSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)

--- a/src/generate/gen_text_sizer.h
+++ b/src/generate/gen_text_sizer.h
@@ -13,7 +13,8 @@ class TextSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    std::optional<ttlib::cstr> GenConstruction(Node* node) override;
+
+    bool ConstructionCode(Code&) override;
     // std::optional<ttlib::cstr> GenEvents(NodeEvent* event, const std::string& class_name) override;
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };

--- a/src/generate/gen_time_picker.cpp
+++ b/src/generate/gen_time_picker.cpp
@@ -31,7 +31,7 @@ std::optional<ttlib::sview> TimePickerCtrlGenerator::CommonConstruction(Code& co
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma().Add("wxDefaultDateTime");
+    code.ValidParentName().Comma().as_string(prop_id).Comma().Add("wxDefaultDateTime");
     code.PosSizeFlags(true, "wxTP_DEFAULT");
 
     return code.m_code;

--- a/src/generate/gen_toggle_btn.cpp
+++ b/src/generate/gen_toggle_btn.cpp
@@ -95,7 +95,7 @@ std::optional<ttlib::sview> ToggleButtonGenerator::CommonConstruction(Code& code
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).Comma();
+    code.ValidParentName().Comma().as_string(prop_id).Comma();
 
     // If prop_markup is set, then the label will be set in GenSettings()
     if (code.HasValue(prop_label) && !code.IsTrue(prop_markup))

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -330,7 +330,7 @@ std::optional<ttlib::sview> ToolBarGenerator::CommonConstruction(Code& code)
     }
     else
     {
-        code.CreateClass().GetParentName().Comma().as_string(prop_id);
+        code.CreateClass().ValidParentName().Comma().as_string(prop_id);
         code.PosSizeFlags();
     }
 
@@ -590,7 +590,7 @@ std::optional<ttlib::sview> ToolSeparatorGenerator::CommonConstruction(Code& cod
     auto* node = code.node();
     if (node->isParent(gen_wxToolBar) || node->isParent(gen_wxRibbonToolBar) || node->isParent(gen_wxAuiToolBar))
     {
-        code.GetParentName().Function("AddSeparator(").EndFunction();
+        code.ValidParentName().Function("AddSeparator(").EndFunction();
     }
     else
     {

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -590,7 +590,7 @@ std::optional<ttlib::sview> ToolSeparatorGenerator::CommonConstruction(Code& cod
     auto* node = code.node();
     if (node->isParent(gen_wxToolBar) || node->isParent(gen_wxRibbonToolBar) || node->isParent(gen_wxAuiToolBar))
     {
-        code.ParentName().Function("AddSeparator(").EndFunction();
+        code.GetParentName().Function("AddSeparator(").EndFunction();
     }
     else
     {

--- a/src/generate/gen_toolbook.cpp
+++ b/src/generate/gen_toolbook.cpp
@@ -51,7 +51,7 @@ std::optional<ttlib::sview> ToolbookGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
 
     // TODO: [Randalphwa - 12-21-2022] Add Python support
     if (code.is_cpp())

--- a/src/generate/gen_treebook.cpp
+++ b/src/generate/gen_treebook.cpp
@@ -42,7 +42,7 @@ std::optional<ttlib::sview> TreebookGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
 
     // TODO: [Randalphwa - 12-21-2022] Add Python support
     if (code.is_cpp())

--- a/src/generate/gen_web_view.cpp
+++ b/src/generate/gen_web_view.cpp
@@ -34,7 +34,7 @@ std::optional<ttlib::sview> WebViewGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().Str(" = ").Add("wxWebView").ClassMethod("New(");
-    code.GetParentName().Comma().Add(prop_id).Comma().QuotedString(prop_url);
+    code.ValidParentName().Comma().Add(prop_id).Comma().QuotedString(prop_url);
 
     auto params_needed = code.WhatParamsNeeded();
     if (params_needed == nothing_needed)

--- a/src/generate/gen_wrap_sizer.h
+++ b/src/generate/gen_wrap_sizer.h
@@ -14,8 +14,8 @@ class WrapSizerGenerator : public BaseGenerator
 public:
     wxObject* CreateMockup(Node* node, wxObject* /*parent*/) override;
 
-    std::optional<ttlib::sview> CommonConstruction(Code& code) override;
-    std::optional<ttlib::sview> CommonAfterChildren(Code& code) override;
+    bool ConstructionCode(Code&) override;
+    bool AfterChildrenCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
     void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -480,7 +480,7 @@ std::optional<ttlib::sview> StyledTextGenerator::CommonConstruction(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.GetParentName().Comma().Add(prop_id);
+    code.ValidParentName().Comma().Add(prop_id);
     code.PosSizeFlags(true);
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/generate/write_code.h
+++ b/src/generate/write_code.h
@@ -17,6 +17,8 @@ namespace indent
     };
 };
 
+class Code;
+
 class WriteCode
 {
 public:
@@ -30,6 +32,10 @@ public:
             --m_indent;
     }
     void ResetIndent() { m_indent = 0; }
+
+    // Write one or more lines, adding a trailing \n to the final line. Multiple lines
+    // are indicated if the supplied string contains one or more \n characters.
+    void writeLine(const Code& code);
 
     // Write one or more lines, adding a trailing \n to the final line. Multiple lines
     // are indicated if the supplied string contains one or more \n characters.


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds new virtual functions to the `BaseGenerator` class. All of the new functions take a single `Code&` parameter and return a bool if the generator function has been implemented (the Code parameter may not have been modified if nothing needed to be added). These functions are designed to replace the generator functions which return `std::optional<ttlib::sview>`.

The second part of this PR is creating a new version of `WriteCode::writeLine()`. This new version takes a single `Code&` parameter, which allows the function to be more highly optimized than the older variants.

The `std::optional<ttlib::sview>` return was only useful when the generator created a string on the stack and returned it. Once all generators have been updated, all of those functions will removed.