### PR TITLE
Add and support generate_const_values C++ property

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -132,6 +132,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_combine_all_forms, "combine_all_forms" },
     { prop_combined_xrc_file, "combined_xrc_file" },
     { prop_compiler_standard, "compiler_standard" },
+    { prop_const_values, "generate_const_values" },
     { prop_contents, "contents" },
     { prop_context_help, "context_help" },
     { prop_context_menu, "context_menu" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -138,6 +138,7 @@ namespace GenEnum
         prop_combine_all_forms,
         prop_combined_xrc_file,
         prop_compiler_standard,
+        prop_const_values,
         prop_contents,
         prop_context_help,
         prop_context_menu,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Generate Src and Hdr files for the Base Class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -1367,6 +1367,34 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     {
         WriteSetLines(m_header, code_lines);
         m_header->writeLine();
+    }
+
+    if (form_node->as_bool(prop_const_values))
+    {
+        code.clear();
+        if (form_node->HasProp(prop_id))
+            code.Eol(eol_if_needed).Str("const int form_id = ").Str(prop_id) += ";";
+        if (form_node->HasProp(prop_style))
+            code.Eol(eol_if_needed).Str("const int form_style = ").Str(prop_style) += ";";
+        if (form_node->HasProp(prop_pos))
+            code.Eol(eol_if_needed).Str("const wxPoint form_pos = ").Pos(prop_pos, no_dlg_units) += ";";
+        if (form_node->HasProp(prop_size))
+            code.Eol(eol_if_needed).Str("const wxSize form_size = ").WxSize(prop_size, no_dlg_units) += ";";
+        if (form_node->HasProp(prop_title))
+        {
+            code.Eol(eol_if_needed).Str("static const wxString form_title() { return ");
+            if (form_node->HasValue(prop_title))
+                code.Str("wxString::FromUTF8(\"").Str(prop_title) += "\"); }";
+            else
+                code.Str("wxEmptyString; }");
+        }
+
+        if (code.size())
+        {
+            m_header->writeLine(code);
+            m_header->writeLine();
+            m_header->writeLine();
+        }
     }
 
     code.clear();

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -11,7 +11,8 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 		<property name="inserted_hdr_code" type="code_edit"
 			help="Specify code to insert into the header file at the end of the public: section. You may add protected: and private: sections as needed for additional methods and member variables." />
 		<property name="use_derived_class" type="bool"
-			help="Check this if you will be creating a derived class. If not checked, you will need to create a source file implementing any event handlers.">1</property>
+			help="Check this if you will be creating a derived class. If not checked, you will need to create a source file implementing any event handlers.">
+			1</property>
 		<property name="derived_class_name" type="string"
 			help="The name of the derived class. Ignored if use_derived_class is unchecked." />
 		<property name="derived_file" type="file"
@@ -21,7 +22,11 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 		<property name="class_decoration" type="string"
 			help="This specifies the keyword or macro to add to the class declaration (such as __declspec(dllexport) )." />
 		<property name="generate_ids" type="bool"
-			help="If checked, any non-wxWidgets ids will be created as an enumerated list. If you want to use your own id values, uncheck this and add the header file containing the ids to either base_src_includes or base_hdr_includes.">1</property>
+			help="If checked, any non-wxWidgets ids will be created as an enumerated list. If you want to use your own id values, uncheck this and add the header file containing the ids to either base_src_includes or base_hdr_includes.">
+			1</property>
+		<property name="generate_const_values" type="bool"
+			help="If checked, each form's header file will have const values declared for some of the possible parameters. E.g., const int form_id = your_id. You can use this when creating multiple instances of a form with different construction parameters.">
+			0</property>
 	</gen>
 
 	<gen class="wxPython Settings" type="interface">
@@ -30,19 +35,26 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 		<property name="insert_python_code" type="code_edit"
 			help="Specify the code to insert into the python file after the generated import statements. This is usually used to import addtional modules, but can be any valid python code for use before the class definition." />
 		<!-- <property name="python_variable_args" type="bool"
-			help="If checked, the form parameters will be set to (*args, **kwargs) instead of listing all the parameters and their default values.">1</property> -->
+			help="If checked, the form
+		parameters will be set to (*args, **kwargs) instead of listing all the parameters and their
+		default values.">1</property> -->
 		<property name="python_inherit_name" type="string"
 			help="The name to use for an inherited class. If specified, the Inherit tab in the Python panel will include a sample for creating an inherited class." />
 		<!-- <property name="python_use_xrc" type="bool"
-			help="If checked, the form will load the file specified in python_xrc_file and use that for the UI instead of using Python to create the wxWidgets controls.">0</property>
+			help="If checked, the form will load the
+		file specified in python_xrc_file and use that for the UI instead of using Python to create
+		the wxWidgets controls.">0</property>
 		<property name="python_xrc_file" type="file"
-			help="If specified and python_use_xrc is checked, then this XRC file will be generated when Python code is generated, and the form will be initialized to use the generated XRC file." /> -->
+		help="If specified and python_use_xrc is checked, then this XRC file will be generated when
+		Python code is generated, and the form will be initialized to use the generated XRC file."
+		/> -->
 	</gen>
 
 	<gen class="XRC Settings" type="interface">
 		<property name="xrc_file" type="file"
 			help="The filename to use if generating XRC (wxPython can override this with its own file name)." />
 		<property name="xrc_no_whitespace" type="bool"
-			help="If checked, no leading whitespace will be used. This makes the file smaller, but less readable.">0</property>
+			help="If checked, no leading whitespace will be used. This makes the file smaller, but less readable.">
+			0</property>
 	</gen>
 </GeneratorDefinitions>)===";


### PR DESCRIPTION
This implements #844, but not #884.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `generate_const_values` property in the C++ Settings category. When checked it generates `const` values for most of the form's parameters. Currently, all it does is generate the const definitions, neither the remainder of the header file or any of the code generators use this value.

In the original discussion, I suggested using the form type prefix, i.e. `dlg_` for wxDialog, `frame_` for wxFrame, etc. However, that means every time a form is added to wxUiEditor, the code for this will not work unless someone remembers to update it. Instead, I went with a `form_` prefix for all forms -- that completely removes any maintenance issues for adding new forms.

The code also tracks whether the form actually has each parameter property. So for wxFrame, you get:

```c++
    const int form_id = wxID_ANY;
    const int form_style = wxDEFAULT_FRAME_STYLE;
    const wxPoint form_pos = wxDefaultPosition;
    const wxSize form_size = wxDefaultSize;
    static const wxString form_title_title() { return wxEmptyString; }
```

whereas for a wxPanel form, you would only get:

```c++
    const int form_id = wxID_ANY;
    const wxPoint form_pos = wxDefaultPosition;
    const wxSize form_size = wxDefaultSize;
```

All of those default values show up, but are replaced with a non-default value if a non-default property is used. I.e., you might see something like:

```c++
    const wxPoint form_pos = wxDefaultPosition;
    const wxSize form_size = wxSize(400, 300);
    static const wxString form_title() { return wxString::FromUTF8("Hello World!"); }
```
