### PR TITLE
Add Python embedded image support

### DIFF
--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -56,6 +56,7 @@ set (file_list
     generate/gen_construction.cpp  # Top level Object construction code
     generate/gen_cmake.cpp         # Auto-generate a .cmake file
     generate/write_code.cpp        # Write code to Scintilla or file
+    generate/image_gen.cpp         # Functions for generating embedded images
 
     generate/base_generator.cpp    # Base widget generator class
     generate/gen_initialize.cpp    # Initialize all widget generate classes

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -261,13 +261,13 @@ public:
 
     Code& itoa(int val)
     {
-        m_code << val;
+        m_code += std::to_string(val);
         return *this;
     }
 
-    Code& to_a(size_t val)
+    Code& itoa(size_t val)
     {
-        m_code << val;
+        m_code += std::to_string(val);
         return *this;
     }
 
@@ -344,15 +344,15 @@ public:
         return *this;
     }
 
-    Code& operator<<(int i)
+    Code& operator<<(int val)
     {
-        m_code << i;
+        m_code += std::to_string(val);
         return *this;
     }
 
-    Code& operator<<(size_t i)
+    Code& operator<<(size_t val)
     {
-        m_code << i;
+        m_code += std::to_string(val);
         return *this;
     }
 

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -9,12 +9,13 @@
 
 #include <set>
 
-#include "node_classes.h"  // Forward defintions of Node classes
-
 #include "../panels/base_panel.h"  // BasePanel -- Base class for all code generation panels
 #include "gen_enums.h"             // Enumerations for generators
 #include "gen_xrc.h"               // BaseXrcGenerator -- Generate XRC file
 
+#include "node_classes.h"  // Forward defintions of Node classes
+
+class Code;
 class ProjectSettings;
 class NodeCreator;
 class WriteCode;
@@ -22,12 +23,12 @@ class wxWindow;
 
 struct EmbeddedImage;
 
-using EventVector = std::vector<NodeEvent*>;
-
 namespace pugi
 {
     class xml_node;
 }
+
+using EventVector = std::vector<NodeEvent*>;
 
 enum PANEL_PAGE : size_t
 {
@@ -60,7 +61,7 @@ public:
     void SetHdrWriteCode(WriteCode* cw) { m_header = cw; }
     void SetSrcWriteCode(WriteCode* cw) { m_source = cw; }
 
-    void GenerateBaseClass(Node* form_node, PANEL_PAGE panel_type = NOT_PANEL);
+    void GenerateCppClass(Node* form_node, PANEL_PAGE panel_type = NOT_PANEL);
     void GeneratePythonClass(Node* form_node, PANEL_PAGE panel_type = NOT_PANEL);
 
     // GenerateDerivedClass() is in gen_derived.cpp
@@ -84,6 +85,22 @@ public:
     bool is_cpp() const { return m_language == GEN_LANG_CPLUSPLUS; }
 
 protected:
+    // Generate extern references to images used in the current form that are defined in the
+    // gen_Images node.
+    //
+    // This will call code.clear() before writing any code.
+    void WriteImagePreConstruction(Code& code);
+
+    // Generate code after the construcor for embedded images not defined in the gen_Images
+    // node.
+    //
+    // This will call code.clear() before writing any code.
+    void WriteImagePostConstruction(Code& code);
+
+    // Generate extern statements after the header definition for embedded images not defined
+    // in the gen_Images node.
+    void WriteImagePostHeader();
+
     void WritePropSourceCode(Node* node, GenEnum::PropName prop);
     void WritePropHdrCode(Node* node, GenEnum::PropName prop);
     void AddPersistCode(Node* node);

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -149,7 +149,7 @@ void GenThreadCpp(GenData& gen_data, Node* form)
     auto cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
     codegen.SetSrcWriteCode(cpp_cw.get());
 
-    codegen.GenerateBaseClass(form);
+    codegen.GenerateCppClass(form);
 
     path.replace_extension(header_ext);
 
@@ -605,7 +605,7 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
 
                 if (language == GEN_LANG_CPLUSPLUS)
                 {
-                    codegen.GenerateBaseClass(form);
+                    codegen.GenerateCppClass(form);
                 }
                 else if (language == GEN_LANG_PYTHON)
                 {
@@ -644,7 +644,7 @@ void GenerateTmpFiles(const std::vector<ttlib::cstr>& ClassList, pugi::xml_node 
 
                     if (language == GEN_LANG_CPLUSPLUS)
                     {
-                        codegen.GenerateBaseClass(form);
+                        codegen.GenerateCppClass(form);
                     }
                     else if (language == GEN_LANG_PYTHON)
                     {

--- a/src/generate/gen_radio_box.cpp
+++ b/src/generate/gen_radio_box.cpp
@@ -88,7 +88,7 @@ std::optional<ttlib::sview> RadioBoxGenerator::CommonConstruction(Code& code)
     code.Comma().Pos().Comma().WxSize().Comma();
     if (code.is_cpp())
     {
-        code.to_a(array.size()).Comma();
+        code.itoa(array.size()).Comma();
         if (array.size())
             code.Str(choice_name);
         else

--- a/src/generate/gen_status_bar.cpp
+++ b/src/generate/gen_status_bar.cpp
@@ -135,9 +135,9 @@ std::optional<ttlib::sview> StatusBarGenerator::CommonSettings(Code& code)
     {
         code.OpenBrace();
         code.m_code << "const int sb_field_widths[" << fields.size() << "] = {" << widths << "};";
-        code.Eol().NodeName().Function("SetStatusWidths(").to_a(fields.size()).Comma().Str("sb_field_widths);");
-        code.Eol().Str("const int sb_field_styles[").to_a(fields.size()).Str("] = {").Str(widths).Str("};");
-        code.Eol().NodeName().Function("SetStatusStyles(").to_a(fields.size()).Comma().Str("sb_field_styles);");
+        code.Eol().NodeName().Function("SetStatusWidths(").itoa(fields.size()).Comma().Str("sb_field_widths);");
+        code.Eol().Str("const int sb_field_styles[").itoa(fields.size()).Str("] = {").Str(widths).Str("};");
+        code.Eol().NodeName().Function("SetStatusStyles(").itoa(fields.size()).Comma().Str("sb_field_styles);");
         code.CloseBrace();
     }
     else

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -1,0 +1,176 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Functions for generating embedded images
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
+
+#include "gen_base.h"
+
+#include "code.h"           // Code -- Helper class for generating code
+#include "project_class.h"  // Project class
+#include "write_code.h"     // Write code to Scintilla or file
+
+// Generate extern references to images used in the current form that are defined in the
+// gen_Images node. These are written before the class constructor.
+void BaseCodeGenerator::WriteImagePreConstruction(Code& code)
+{
+    code.clear();
+
+    bool is_namespace_written = false;
+    for (auto iter_array: m_embedded_images)
+    {
+        // If the image is defined in this form, then it will already have been declared in the class's header file.
+        // For the source code, we only care about images defined in another source module.
+
+        if (iter_array->form == m_form_node)
+            continue;
+
+        if (code.is_cpp())
+        {
+            if (!is_namespace_written)
+            {
+                is_namespace_written = true;
+                code.Str("namespace wxue_img").OpenBrace();
+            }
+            code.Eol(eol_if_needed).Str("extern const unsigned char ").Str(iter_array->array_name);
+            code.Str("[").itoa(iter_array->array_size & 0xFFFFFFFF).Str("];");
+        }
+    }
+
+    if (code.is_cpp() && is_namespace_written)
+    {
+        code.CloseBrace();
+    }
+    // m_source->writeLine(code);
+}
+
+// Generate code after the construcor for embedded images not defined in the gen_Images node.
+void BaseCodeGenerator::WriteImagePostConstruction(Code& code)
+{
+    code.clear();
+
+    bool is_namespace_written = false;
+    // -12 to account for 8 indent + max 3 chars for number + comma
+    size_t cpp_line_length = (to_size_t) GetProject()->as_int(prop_cpp_line_length) - 12;
+
+    for (auto iter_array: m_embedded_images)
+    {
+        if (iter_array->form != m_form_node)
+            continue;
+
+        if (code.is_cpp())
+        {
+            if (!is_namespace_written)
+            {
+                is_namespace_written = true;
+                code.Eol().Str("namespace wxue_img").OpenBrace();
+            }
+
+            // SVG images store the original size in the high 32 bits
+            size_t max_pos = (iter_array->array_size & 0xFFFFFFFF);
+
+            code.Eol().Str("const unsigned char ").Str(iter_array->array_name);
+            code.Str("[").itoa(max_pos).Str("] {");
+            m_source->writeLine(code);
+            code.clear();
+            // Since we don't call Eol() in the following loop, the indentation is not processed.
+            code.Tab(2);
+
+            size_t pos = 0;
+            while (pos < max_pos)
+            {
+                for (; pos < max_pos && code.size() < cpp_line_length; ++pos)
+                {
+                    code.itoa(iter_array->array_data[pos]) += ",";
+                }
+                if (pos >= max_pos && code.m_code.back() == ',')
+                {
+                    code.m_code.pop_back();
+                }
+                m_source->writeLine(code);
+                code.clear();
+                // Since we don't call Eol() in this loop, the indentation is not processed.
+                code.Tab(2);
+            }
+            if (code.m_code.back() == '\t')
+            {
+                code.m_code.pop_back();
+            }
+            code += "};\n";
+        }
+    }
+
+    if (code.is_cpp() && is_namespace_written)
+    {
+        code.ResetBraces();
+        code.Eol() += "}";
+    }
+
+    if (code.size())
+    {
+        m_source->writeLine(code);
+    }
+}
+
+// clang-format off
+
+inline constexpr const auto txt_wxueImageFunction = R"===(
+// Convert a data array into a wxImage
+inline wxImage wxueImage(const unsigned char* data, size_t size_data)
+{
+    wxMemoryInputStream strm(data, size_data);
+    wxImage image;
+    image.LoadFile(strm);
+    return image;
+};
+)===";
+
+// clang-format on
+
+void BaseCodeGenerator::WriteImagePostHeader()
+{
+    bool is_namespace_written = false;
+    for (auto iter_array: m_embedded_images)
+    {
+        if (iter_array->form != m_form_node)
+            continue;
+
+        if (!is_namespace_written)
+        {
+            m_header->writeLine();
+            m_header->writeLine("namespace wxue_img\n{");
+
+            if (m_form_node->isType(type_images))
+            {
+                ttlib::viewfile function;
+                function.ReadString(txt_wxueImageFunction);
+                for (auto& iter: function)
+                {
+                    m_header->write("\t");
+                    if (iter.size() && iter.at(0) == ' ')
+                        m_header->write("\t");
+                    m_header->writeLine(iter);
+                }
+                m_header->writeLine();
+            }
+
+            m_header->Indent();
+            if (!m_form_node->isType(type_images))
+            {
+                m_header->writeLine("// Images declared in this class module:");
+                m_header->writeLine();
+            }
+            is_namespace_written = true;
+        }
+        m_header->writeLine(ttlib::cstr("extern const unsigned char ")
+                            << iter_array->array_name << '[' << (iter_array->array_size & 0xFFFFFFFF) << "];");
+    }
+    if (is_namespace_written)
+    {
+        m_header->Unindent();
+        m_header->writeLine("}\n");
+    }
+}

--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   Write code to Scintilla
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -57,6 +57,56 @@ void WriteCode::writeLine(const Code& code)
             }
 
             doWrite(line);
+        }
+        doWrite("\n");
+    }
+
+    m_IsLastLineBlank = (lines.back().empty() ? true : false);
+}
+
+void WriteCode::writeLine(std::vector<std::string>& lines)
+{
+    for (auto& line: lines)
+    {
+        // Remove any trailing tabs -- this occurs when Code::Eol() is called when an indent
+        // is active.
+        while (line.size() && line.back() == '\t')
+        {
+            line.pop_back();
+        }
+
+        if (line.size())
+        {
+            // Don't indent #if, #else or #endif
+            if (line[0] != '#' || !(line.starts_with("#if") || line.starts_with("#else") || line.starts_with("#endif")))
+            {
+                for (int i = 0; i < m_indent; ++i)
+                {
+                    doWrite(TabSpaces);
+                }
+            }
+
+            if (line[0] == '\t')
+            {
+                size_t idx = 0;
+                for (; idx < line.size(); ++idx)
+                {
+                    if (line[idx] == '\t')
+                    {
+                        doWrite(TabSpaces);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                doWrite(line.substr(idx));
+            }
+            else
+            {
+                doWrite(line);
+            }
         }
         doWrite("\n");
     }

--- a/src/generate/write_code.h
+++ b/src/generate/write_code.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   Write code to Scintilla
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -36,6 +36,11 @@ public:
     // Write one or more lines, adding a trailing \n to the final line. Multiple lines
     // are indicated if the supplied string contains one or more \n characters.
     void writeLine(const Code& code);
+
+    // Will convert tabs to spaces, and adds a \n after each line.
+    //
+    // This WILL modify the strings in the vector
+    void writeLine(std::vector<std::string>& lines);
 
     // Write one or more lines, adding a trailing \n to the final line. Multiple lines
     // are indicated if the supplied string contains one or more \n characters.

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -227,7 +227,7 @@ void BasePanel::GenerateBaseClass()
     switch (m_panel_type)
     {
         case GEN_LANG_CPLUSPLUS:
-            codegen.GenerateBaseClass(m_cur_form, panel_page);
+            codegen.GenerateCppClass(m_cur_form, panel_page);
 
             m_inherit_src_panel->Clear();
             codegen.SetSrcWriteCode(m_inherit_src_panel);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds initial support for embedded Python images, utilizing the wxPython `PyEmbeddedImage` library. Images are converted into Base64 and written as a PyEmbeddedImage object and loaded using the object's `.Bitmap` property.

There is still no support for the `Images` node -- that will need a change to add the Python filename to use, and then all forms will need to add it to their `import` list if it is used.

SVG files are still external.