### PR TITLE
Change how variable prefixes are added/removed

### DIFF
--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1076,13 +1076,49 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                     }
                     else if (prop->isProp(prop_class_access) && wxGetApp().IsPjtMemberPrefix())
                     {
-                        // TODO: [KeyWorks - 08-23-2020] This needs to be a preference
-
-                        // If access is changed to local and the name starts with "m_", then the "m_" will be stripped
-                        // off. Conversely, if the name is changed from local to a class member, a "m_" is added as a
-                        // prefix (if it doesn't already have one).
                         tt_string name = node->prop_as_string(prop_var_name);
-                        if (value == "none" && name.starts_with("m_"))
+                        if (Project.get_PreferredLanguage() == GEN_LANG_PYTHON)
+                        {
+                            // The convention in python is to use a leading underscore for
+                            // local members.
+
+                            if (value == "none" && !name.starts_with("_"))
+                            {
+                                if (name.starts_with("_"))
+                                {
+                                    name.erase(0, 1);
+                                }
+                                else
+                                {
+                                    name.insert(0, "_");
+                                }
+                                auto final_name = node->GetUniqueName(name);
+                                if (final_name.size())
+                                    name = final_name;
+                                auto propChange = selected_node->get_prop_ptr(prop_var_name);
+                                auto grid_property = m_prop_grid->GetPropertyByLabel("var_name");
+                                grid_property->SetValueFromString(name, 0);
+                                modifyProperty(propChange, name);
+                            }
+                            else if (value != "none" && name.starts_with("_"))
+                            {
+                                name.erase(0, 1);
+                                auto final_name = node->GetUniqueName(name);
+                                if (final_name.size())
+                                    name = final_name;
+                                auto propChange = selected_node->get_prop_ptr(prop_var_name);
+                                auto grid_property = m_prop_grid->GetPropertyByLabel("var_name");
+                                grid_property->SetValueFromString(name, 0);
+                                modifyProperty(propChange, name);
+                            }
+                        }
+
+                        // If access is changed to local and the name starts with "m_", then
+                        // the "m_" will be stripped off. Conversely, if the name is changed
+                        // from local to a class member, a "m_" is added as a prefix if
+                        // preferred language isw C++.
+
+                        else if (value == "none" && name.starts_with("m_"))
                         {
                             name.erase(0, 2);
                             auto final_name = node->GetUniqueName(name);

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1093,7 +1093,8 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                             grid_property->SetValueFromString(name, 0);
                             modifyProperty(propChange, name);
                         }
-                        else if (value != "none" && !name.starts_with("m_") && Preferences().is_VarPrefix())
+                        else if (value != "none" && !name.starts_with("m_") &&
+                                 Project.get_PreferredLanguage() == GEN_LANG_CPLUSPLUS)
                         {
                             name.insert(0, "m_");
                             auto final_name = node->GetUniqueName(name);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -25,9 +25,6 @@ struct PREFS
     // Add expand flag to all new sizers
     bool is_SizersExpand() const { return m_sizers_always_expand; }
 
-    // Add "m_" prefix to all new non-local member variables
-    bool is_VarPrefix() const { return m_var_prefix; }
-
     // Enable WakaTime support
     bool is_WakaTimeEnabled() const { return m_enable_wakatime; }
 

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -206,3 +206,16 @@ Node* ProjectHandler::GetFirstFormChild(Node* node) const
 
     return nullptr;
 }
+
+int ProjectHandler::get_PreferredLanguage()
+{
+    auto& value = Project.value(prop_code_preference);
+    if (value == "C++")
+        return GEN_LANG_CPLUSPLUS;
+    else if (value == "Python")
+        return GEN_LANG_PYTHON;
+    else if (value == "XRC")
+        return GEN_LANG_XRC;
+    else
+        return GEN_LANG_CPLUSPLUS;
+}

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -5,7 +5,7 @@
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#pragma once  // NOLINT(#pragma once in main file)
 
 #include <map>
 #include <mutex>
@@ -28,6 +28,7 @@ private:
 
 public:
     ProjectHandler(ProjectHandler const&) = delete;
+
     void operator=(ProjectHandler const&) = delete;
 
     static ProjectHandler& getInstance()
@@ -71,6 +72,9 @@ public:
     bool is_UiAllowed() const { return m_allow_ui; }
 
     size_t ChildCount() const { return m_project_node->GetChildCount(); }
+
+    // Returns a GEN_LANG_... enum value
+    int get_PreferredLanguage();
 
     const tt_string& value(GenEnum::PropName name) const { return m_project_node->prop_as_string(name); }
     const tt_string_view view(PropName name) const { return m_project_node->prop_as_string(name); }

--- a/src/wxui/optionsdlg.cpp
+++ b/src/wxui/optionsdlg.cpp
@@ -38,14 +38,6 @@ bool OptionsDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     box_sizer->AddSpacer(16);
 
-    auto* checkBox_var_prefix = new wxCheckBox(this, wxID_ANY, "Add \"m_\" prefix to class members");
-    checkBox_var_prefix->SetValue(true);
-    checkBox_var_prefix->SetValidator(wxGenericValidator(&m_var_prefix));
-    checkBox_var_prefix->SetToolTip("If checked, new sizers will be created with the wxEXPAND flag.");
-    box_sizer->Add(checkBox_var_prefix, wxSizerFlags().Border(wxALL));
-
-    box_sizer->AddSpacer(16);
-
     auto* checkBox_wakatime = new wxCheckBox(this, wxID_ANY, "Enable WakaTime");
     checkBox_wakatime->SetValue(true);
     checkBox_wakatime->SetValidator(wxGenericValidator(&m_isWakaTimeEnabled));
@@ -97,7 +89,6 @@ void OptionsDlg::OnInit(wxInitDialogEvent& event)
     m_sizers_all_borders = Preferences().is_SizersAllBorders();
     m_sizers_always_expand = Preferences().is_SizersExpand();
     m_isWakaTimeEnabled = Preferences().is_WakaTimeEnabled();
-    m_var_prefix = Preferences().is_VarPrefix();
 
     event.Skip();  // transfer all validator data to their windows and update UI
 }
@@ -117,7 +108,6 @@ void OptionsDlg::OnAffirmative(wxCommandEvent& WXUNUSED(event))
         }
     };
 
-    lambda(m_var_prefix, Preferences().RefVarPrefix());
     lambda(m_sizers_all_borders, Preferences().RefSizersAllBorders());
     lambda(m_sizers_always_expand, Preferences().RefSizersExpand());
     lambda(m_isWakaTimeEnabled, Preferences().RefWakaTimeEnabled());

--- a/src/wxui/optionsdlg.h
+++ b/src/wxui/optionsdlg.h
@@ -40,7 +40,6 @@ protected:
     bool m_isWakaTimeEnabled { true };
     bool m_sizers_all_borders { true };
     bool m_sizers_always_expand { true };
-    bool m_var_prefix { true };
 };
 
 // ************* End of generated code ***********

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -3894,18 +3894,6 @@
             class="wxCheckBox"
             checked="1"
             class_access="none"
-            label="Add &quot;m_&quot; prefix to class members"
-            var_comment="// controls whether m_ is automatically added to non-local var_name"
-            var_name="checkBox_var_prefix"
-            validator_variable="m_var_prefix"
-            tooltip="If checked, new sizers will be created with the wxEXPAND flag." />
-          <node
-            class="spacer"
-            height="16" />
-          <node
-            class="wxCheckBox"
-            checked="1"
-            class_access="none"
             label="Enable WakaTime"
             var_name="checkBox_wakatime"
             validator_variable="m_isWakaTimeEnabled"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the default prop_var_name used so that the `m_` prefix is only used if the preferred code generation is C++. This affects both new node creation, and changing node access from local to protected/public.

If the preferred language is Python and the access of a variable is changed in the property grid, then local names will have a leading underscore, and non-local names will remove the underscore.

The Preferences function for controlling whether or not `m_` is added has been removed, as it is now controlled by `prop_code_preference`.

Closes #867