### PR TITLE
Improve importing of wxGlade projects

### DIFF
--- a/python_tests/python/main_test_dlg.py
+++ b/python_tests/python/main_test_dlg.py
@@ -45,52 +45,6 @@ no_hour_png = PyEmbeddedImage(
     b"/b8FIjK58Qk3QSMijz4gIioiKYn7iQPP8TTL89fu4f18JrXFrUSJTUGJqtR13f8gxfBvSVTCMOiD/Z6H"
     b"4xGAt8slKcm9+hXUBO08n//djVUFux3aVvoF3WivIiuis94AAAAASUVORK5CYII=")
 
-clr_hourglass_gif = PyEmbeddedImage(
-    b"R0lGODlhIAAgAPIAAP///8zMzAD//wCZmQAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQJ"
-    b"CgAFACwAAAAAIAAgAAADZli63P4wykmrvTjnwbvnhFZwQil8QygSbOuqYiDPNKzJAEDLdobrux6GByAE"
-    b"jEjRAnlsCjXMpLIRnT6k1gYvq509YwHgkfurWcvBKdqsXHvVYfFbifJ8KSQT6i55+VlcgYKDhIUSCQAh"
-    b"+QQJCgAFACwAAAAAIAAgAAADZ1i63P4wykmrvTjnwbvnhFZwQil8QygSbOuqYiDPNKzJAEDLdobrux6G"
-    b"ByDMjEIMMrBMZppM0aMphSCrEB7WUdsucMbo9tetkoPmQG4njqmBZfcaLUV5nBSSCYWXvP4sXoKDhIWG"
-    b"EgkAIfkECQoABQAsAAAAACAAIAAAA2pYutz+MMpJq70458G754RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG"
-    b"67sehgfkBYQYwnGpRGaaTNED6pQ2pREe9lHbMnDKo7fw62LLYa20HDwHcjvx+l2cVSkoz11CMqH2EC+C"
-    b"LGOFhoeIiRIJACH5BAkKAAUALAAAAAAgACAAAANpWLrc/jDKSau9OOfBu+eEVnBCKXxDKBJs66piIM80"
-    b"rMkAQMt2huu7HoYHrIkWhEByqTwymEtnAyp1RKsNHpZh3OKSzeqvexyDteVAbheOqXXn9u3NFl5QHnuF"
-    b"ZELpJy+BLFuEhYaHiAwJACH5BAkKAAUALAAAAAAgACAAAANpWLrc/jDKSau9OOfBu+eEVnBCKXxDKBJs"
-    b"66piIM80rMkAQMt2huu7Hua3CwgxBKMyecwwl6LHsxllRiO866OmZeCSxm6BOKNWiOBslMxdB3LK8vWX"
-    b"VotQHrOEZELpIS+BLGKEhYaHiBIJACH5BAkKAAUALAAAAAAgACAAAANoWLrc/jDKSau9OOfBu+eEVnBC"
-    b"KXxDKBJs66piIM80rMkAQMt2huu7Hua3CwgxBOMsecwwlU3NM7oyiiS8K6SmbeCS1m6BuOwSwdkrmasO"
-    b"5JTldu6ZFqE8VAnJhMpDXoAsYoOEhYaHGAkAIfkECQoABQAsAAAAACAAIAAAA2lYutz+MMpJq70458G7"
-    b"54RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG67se5rcLCDEEY1DUSDqNTMfzGHVGIbyro6Zd4JJQLXFGtRDB"
-    b"WeaYqw7klOQoD/BMi1Ce8oRkQukjL4EsXYSFhoeIEgkAIfkECQoABQAsAAAAACAAIAAAA2lYutz+MMpJ"
-    b"q70458G754RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG67se5rcLCDGEolHUSDqXzKYRGpUeq7yqo6Zd4JLU"
-    b"KHF2tRDBWeaYqw7kpmSxEfB0RlGe8oRkQukjL4EsXYSFhoeIEgkAIfkECQoABQAsAAAAACAAIAAAA2xY"
-    b"utz+MMpJq70458G754RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG67se5rcLCDGEolHUSCZ5TIdzGZVSqw0o"
-    b"llHbKnDPoy+Q60aJT22MDDSvAdOZuMKDG+9zCsqTl5BMKH0QL4QsXoeIiYqLDAkAIfkECQoABQAsAAAA"
-    b"ACAAIAAAA2pYutz+MMpJq70458G754RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG67se5rcLCDGEolHUSNaY"
-    b"jqQU+phSHbxr46kt4JxHXyDHZRKdWfMYWL6NpcZ0zAiAW0UoT5hCMqH2Ei+CLF2FhoeIiQwJACH5BAkK"
-    b"AAUALAAAAAAgACAAAANsWLrc/jDKSau9OOfBu+eEVnBCKXxDKBJs66piIM80rMkAQMt2huu7Hua3Cwgx"
-    b"hKJR1EjWmA7nEhqdUhu8K3Z2jAUAzu7wC8xCiVLrjZxW+77JuNlLABvvYgrKk5eQTCh9EC+ELFqHiImK"
-    b"ixIJACH5BAkKAAUALAAAAAAgACAAAANrWLrc/jDKSau9OOfBu+eEVnBCKXxDKBJs66piIM80rMkAQMt2"
-    b"huu7Hua3CwgxhKJR1EjWmA7nEhqdUhu8K3Z2jAWAViiRSyVKw74vICntVnBsY5bJW8vZUJTHPSGZUHwR"
-    b"L4MsWoaHiImKEgkAIfkECQoABQAsAAAAACAAIAAAA2dYutz+MMpJq7046zfInkP3RYMgjk0QlCdaqADA"
-    b"eigMqGG7BbGKh7TdzffTYXhEH2H5QSaDl+SQCLXYeoGlVmOjfoBZAMG7mYmzytEMPWaqTW22KxevfsF2"
-    b"NdDl2PMbbn+Cg4SFhhMJACH5BAkKAAUALAAAAAAgACAAAANzWLrc/jDKSau9OOvNu//ZMGgDIYlEoAbQ"
-    b"GqCnkK5m475ynAJ8UCsqHm+QixB3PR8wIBwWIUdm0hcEuI6n0m17gxm1qbBv1i1lCeKwgrzyQsHUX4H9"
-    b"Mn/RcQfb/UCh0RB/aHaBchaAIImKi4yNjo+QkZINCQAh+QQJCgAFACwAAAAAIAAgAAADbVi63P4wykmr"
-    b"vTjrQsiWxOB9TyiSjjkEI8oNcCC3Xyis8kzaeM7Wg5uP9dvAVgAAgdhxzZRMV+FJgPpomI4WMCyiAtwh"
-    b"VgPuspqbshg2toDDsyNJlozDnG+VdMoKDvYKPIAKfoOEf4aJiouMJAkAIf4yUmVkdWNlZCA1NiUgQCB3"
-    b"d3cucmFzcGJlcnJ5aGlsbC5jb20vZ2lmd2l6YXJkLmh0bWwAOw==")
-
-disabled_png = PyEmbeddedImage(
-    b"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAABZ0lE"
-    b"QVQ4y5VTMW7CQBCctY1EmnBKRBEocMEPgtLxATr3lFS01BQUKWnyBOSCgjovoIpOPCBSRBMZKSBkU2An"
-    b"2N4UwScbbCKmujvNzO3O3RKOeOr1mDQNN0IkRzj4Pg6+j1MsbBthEBAAGMkhaRo+pcRtraaIgech8Dww"
-    b"8x+HSK2VLllMp9N7Zt4QEQzDQBzHiKLo7PbBYADHcZROVdBsNgEA7+MxflCMUqmU2Wu4Eu12u9Bg22q1"
-    b"6GW5/CgSv+o6bNumdOuUR+x2u9w56T8lzg/xkkmROBNiGlLKqhACb8Phv5loOWJTCPGVFneiCEa5zBcN"
-    b"pJQkpXwUQizziBPLSptQXgV3AGQYhoWlTywLjUaDAXBhC4vR6Kp/oUJ0tlswM6r9PkzThOu6cBznTBDN"
-    b"5/kGz7PZhjQtM0zfux18182++8MDjPWak2lUYVTqdSZdR7lSUeQwCHDY749KAo6TuFutwHFMAPALdYaS"
-    b"dnNwM6gAAAAASUVORK5CYII=")
-
 left_png = PyEmbeddedImage(
     b"iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAUElE"
     b"QVRIx+3QwQ2AMAwEwU1ESanJRaUm93Q8EDSAEwl099qXJQ/8Z5EiUqUN9G0PCCRQ9d2+lNpEJjKRiUxU"
@@ -253,11 +207,6 @@ class MainTestDialog(wx.Dialog):
         self.m_toggleBtn_2 = wx.ToggleButton(static_box_3.GetStaticBox(), wx.ID_ANY,
             "Play Animation", wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT)
         static_box_3.Add(self.m_toggleBtn_2, wx.SizerFlags().Border(wx.ALL))
-
-        self.m_animation_ctrl = wx.adv.AnimationCtrl(static_box_3.GetStaticBox(), wx.ID_ANY,
-            , wx.DefaultPosition, wx.DefaultSize, wx.adv.AC_DEFAULT_STYLE)
-        self.m_animation_ctrl.SetInactiveBitmap(wx.NullBitmap)
-        static_box_3.Add(self.m_animation_ctrl, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_19.Add(static_box_3, wx.SizerFlags().Border(wx.ALL))
 

--- a/python_tests/python_tests.wxui
+++ b/python_tests/python_tests.wxui
@@ -381,10 +381,6 @@
                     style="wxBU_EXACTFIT"
                     var_name="m_toggleBtn_2"
                     wxEVT_TOGGLEBUTTON="[this](wxCommandEvent&amp;)@@{@@if (m_toggleBtn->GetValue()) @@{@@    m_animation_ctrl->Play();@@    m_checkPlayAnimation->SetValue(true);@@}@@else @@{  @@    m_animation_ctrl->Stop();@@    m_checkPlayAnimation->SetValue(false);@@}@@@@}[python:OnToggleButton]" />
-                  <node
-                    class="wxAnimationCtrl"
-                    animation="Embed;art/clr_hourglass.gif"
-                    inactive_bitmap="Embed;art/disabled.png" />
                 </node>
               </node>
             </node>

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -232,6 +232,15 @@ void FormBuilder::CreateProjectNode(pugi::xml_node& xml_obj, Node* new_node)
                 {
                     ConvertNameSpaceProp(new_node->get_prop_ptr(prop_name_space), xml_prop.text().as_string());
                 }
+                else if (prop_name.as_string() == "code_generation")
+                {
+                    if (tt::contains(xml_prop.text().as_string(), "Python"))
+                        m_language = GEN_LANG_PYTHON;
+                    else if (tt::contains(xml_prop.text().as_string(), "C++"))
+                        m_language = GEN_LANG_CPLUSPLUS;
+                    else if (tt::contains(xml_prop.text().as_string(), "XRC"))
+                        m_language = GEN_LANG_XRC;
+                }
             }
         }
     }

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -366,3 +366,18 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
 
     return new_node;
 }
+
+bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, Node* /* parent */)
+{
+    auto node_name = xml_obj.name();
+    if (node_name == "attribute")
+    {
+        // Technically, this is a bool value, but currently wxGlade only outputs it if the
+        // value is 1. It is used to indicate that the variable name should be prefixed with
+        // "self." to make it a class member variable.
+        node->set_value(prop_class_access, "protected:");
+        return true;
+    }
+
+    return false;
+}

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -378,6 +378,20 @@ bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
         node->set_value(prop_class_access, "protected:");
         return true;
     }
+    if (node_name == "events")
+    {
+        for (auto& handler: xml_obj.children())
+        {
+            tt_string event_name("wx");
+            event_name += handler.attribute("event").as_string();
+            if (auto* event = node->GetEvent(event_name); event)
+            {
+                event->set_value(handler.text().as_string());
+            }
+        }
+
+        return true;
+    }
 
     return false;
 }

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -51,6 +51,25 @@ bool WxGlade::Import(const tt_wxString& filename, bool write_doc)
     try
     {
         m_project = NodeCreation.CreateNode(gen_Project, nullptr);
+        if (auto src_ext = root.attribute("source_extension").as_string(); src_ext.size())
+        {
+            if (src_ext == ".cpp" || src_ext == ".cc" || src_ext == ".cxx")
+            {
+                m_project->prop_set_value(prop_source_ext, src_ext);
+            }
+        }
+        if (auto hdr_ext = root.attribute("header_extension").as_string(); hdr_ext.size())
+        {
+            if (hdr_ext == ".h" || hdr_ext == ".hh" || hdr_ext == ".hpp" || hdr_ext == ".hxx")
+            {
+                m_project->prop_set_value(prop_header_ext, hdr_ext);
+            }
+        }
+        if (root.attribute("use_gettext").as_bool())
+        {
+            m_project->prop_set_value(prop_internationalize, true);
+        }
+
         for (auto& iter: root.children())
         {
             auto new_node = CreateGladeNode(iter, m_project.get());

--- a/src/import/import_wxglade.h
+++ b/src/import/import_wxglade.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Import a wxGlade file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -17,6 +17,7 @@ public:
     WxGlade();
 
     bool Import(const tt_wxString& filename, bool write_doc = true) override;
+    bool HandleUnknownProperty(const pugi::xml_node& /* xml_obj */, Node* /* node */, Node* /* parent */) override;
 
 protected:
     NodeSharedPtr CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, Node* sizeritem = nullptr);

--- a/src/import/import_wxglade.h
+++ b/src/import/import_wxglade.h
@@ -17,7 +17,11 @@ public:
     WxGlade();
 
     bool Import(const tt_wxString& filename, bool write_doc = true) override;
+
     bool HandleUnknownProperty(const pugi::xml_node& /* xml_obj */, Node* /* node */, Node* /* parent */) override;
+
+    bool HandleNormalProperty(const pugi::xml_node& /* xml_obj */, Node* /* node */, Node* /* parent */,
+                              GenEnum::PropName /* wxue_prop */) override;
 
 protected:
     NodeSharedPtr CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, Node* sizeritem = nullptr);

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -623,7 +623,11 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
 
         if (wxue_prop == prop_unknown)
         {
-            ProcessUnknownProperty(iter, node, parent);
+            // Give inherited classes a chance to process unknown properties.
+            if (!HandleUnknownProperty(iter, node, parent))
+            {
+                ProcessUnknownProperty(iter, node, parent);
+            }
             continue;
         }
 

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -631,6 +631,11 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
             continue;
         }
 
+        if (HandleNormalProperty(iter, node, parent, wxue_prop))
+        {
+            continue;
+        }
+
         // Start by processing names that wxUiEditor might use but that need special processing when importing.
 
         if (wxue_prop == prop_bitmap)

--- a/src/import/import_xml.h
+++ b/src/import/import_xml.h
@@ -38,17 +38,28 @@ public:
     // Only call this from an XRC importer (e.g., wxSMITH)
     NodeSharedPtr CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, Node* sizeritem = nullptr);
 
+    // Caller should return true if it is able to handle this unknown property
     virtual bool HandleUnknownProperty(const pugi::xml_node& /* xml_obj */, Node* /* node */, Node* /* parent */)
     {
         return false;
     }
+
+    // Caller should return true if it is able to handle this known property. This is used
+    // when the property name is knonwn, but it's actually the wrong property for the node
+    // type. E.g., prop_border for a sizer really should be prop_border_size.
+    virtual bool HandleNormalProperty(const pugi::xml_node& /* xml_obj */, Node* /* node */, Node* /* parent */,
+                                      GenEnum::PropName /* wxue_prop */)
+    {
+        return false;
+    }
+
+    void HandleSizerItemProperty(const pugi::xml_node& xml_prop, Node* node, Node* parent = nullptr);
 
 protected:
     void ProcessUnknownProperty(const pugi::xml_node& xml_obj, Node* node, Node* parent);
     std::optional<pugi::xml_document> LoadDocFile(const tt_wxString& file);
     GenEnum::GenName ConvertToGenName(const tt_string& object_name, Node* parent);
 
-    void HandleSizerItemProperty(const pugi::xml_node& xml_prop, Node* node, Node* parent = nullptr);
     void ProcessStyle(pugi::xml_node& xml_prop, Node* node, NodeProperty* prop);
     void ProcessAttributes(const pugi::xml_node& xml_obj, Node* node);
     void ProcessContent(const pugi::xml_node& xml_obj, Node* node);
@@ -57,7 +68,7 @@ protected:
     void ProcessHandler(const pugi::xml_node& xml_obj, Node* node);
     void ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Node* parent = nullptr);
 
-    // Returns prop_unknown if the property name has not equivalent in wxUiEditor
+    // Returns prop_unknown if the property name has no equivalent in wxUiEditor
     GenEnum::PropName MapPropName(std::string_view name) const;
 
     // Returns gen_unknown if the property name has not equivalent in wxUiEditor

--- a/src/import/import_xml.h
+++ b/src/import/import_xml.h
@@ -38,6 +38,11 @@ public:
     // Only call this from an XRC importer (e.g., wxSMITH)
     NodeSharedPtr CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, Node* sizeritem = nullptr);
 
+    virtual bool HandleUnknownProperty(const pugi::xml_node& /* xml_obj */, Node* /* node */, Node* /* parent */)
+    {
+        return false;
+    }
+
 protected:
     void ProcessUnknownProperty(const pugi::xml_node& xml_obj, Node* node, Node* parent);
     std::optional<pugi::xml_document> LoadDocFile(const tt_wxString& file);

--- a/src/import/import_xml.h
+++ b/src/import/import_xml.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Base class for XML importing
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -27,6 +27,9 @@ public:
     NodeSharedPtr GetProjectPtr() { return m_project; }
 
     auto GetErrors() { return m_errors; }
+
+    // Returns a GEN_LANG_* value -- default is GEN_LANG_NONE
+    auto GetLanguage() const { return m_language; }
 
     // This will check for an obsolete event name, and if found, it will return the 3.x
     // version of the name. Otherwise, it returns name unmodified.
@@ -61,4 +64,6 @@ protected:
     std::map<std::string, std::string, std::less<>> m_notebook_tabs;
 
     std::set<tt_string> m_errors;
+
+    int m_language = GEN_LANG_NONE;
 };

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -626,7 +626,54 @@ bool ProjectHandler::Import(ImportXML& import, tt_wxString& file, bool append, b
         }
 
         auto project_node = NodeCreation.CreateProjectNode(&project);
-        if (allow_ui)
+
+        auto SetLangFilenames = [&]()
+        {
+            for (const auto& iter: project_node->GetChildNodePtrs())
+            {
+                if (iter->HasValue(prop_base_file) && project_node->value(prop_code_preference) != "C++")
+                {
+                    if (project_node->value(prop_code_preference) == "Python")
+                    {
+                        iter->prop_set_value(prop_python_file, iter->value(prop_base_file));
+                    }
+                    else if (project_node->value(prop_code_preference) == "XRC")
+                    {
+                        iter->prop_set_value(prop_xrc_file, iter->value(prop_base_file));
+                        // XRC files can be combined into a single file so we
+                        if (!project_node->HasValue(prop_combined_xrc_file))
+                            project_node->prop_set_value(prop_combined_xrc_file, iter->value(prop_base_file));
+                    }
+                }
+            }
+
+            if (project_node->GetChildCount() > 1 && project_node->value(prop_code_preference) != "XRC")
+            {
+                wxMessageBox("Each form must have a unique base filename when generating Python or C++ code.\nCurrently, "
+                             "only one form has a unique filename. You will need to add names to the other forms before "
+                             "generating code for them.",
+                             "Code Import Change", wxOK | wxICON_WARNING);
+            }
+        };
+
+        if (auto language = import.GetLanguage(); language != GEN_LANG_NONE)
+        {
+            switch (language)
+            {
+                case GEN_LANG_CPLUSPLUS:
+                    project_node->prop_set_value(prop_code_preference, "C++");
+                    break;
+                case GEN_LANG_PYTHON:
+                    project_node->prop_set_value(prop_code_preference, "Python");
+                    break;
+                case GEN_LANG_XRC:
+                    project_node->prop_set_value(prop_code_preference, "XRC");
+                    break;
+            }
+            SetLangFilenames();
+        }
+
+        if (allow_ui && import.GetLanguage() == GEN_LANG_NONE)
         {
             CodePreferenceDlg dlg(GetMainFrame());
             if (dlg.ShowModal() == wxID_OK)
@@ -643,30 +690,7 @@ bool ProjectHandler::Import(ImportXML& import, tt_wxString& file, bool append, b
                 {
                     project_node->prop_set_value(prop_code_preference, "C++");
                 }
-
-                for (const auto& iter: project_node->GetChildNodePtrs())
-                {
-                    if (iter->HasValue(prop_base_file) && project_node->value(prop_code_preference) != "C++")
-                    {
-                        if (project_node->value(prop_code_preference) == "Python")
-                        {
-                            iter->prop_set_value(prop_python_file, iter->value(prop_base_file));
-                        }
-                        else if (project_node->value(prop_code_preference) == "XRC")
-                        {
-                            iter->prop_set_value(prop_xrc_file, iter->value(prop_base_file));
-                            // XRC files can be combined into a single file so we
-                            if (!project_node->HasValue(prop_combined_xrc_file))
-                                project_node->prop_set_value(prop_combined_xrc_file, iter->value(prop_base_file));
-                        }
-                    }
-                }
-
-                if (project_node->GetChildCount() > 1 && project_node->value(prop_code_preference) != "XRC")
-                {
-                    wxMessageBox("Each form must have a unique base filename when generating Python or C++ code.\nCurrently, only one form has a unique filename. You will need to add names to the other forms before generating code for them.",
-                                 "Code Import Change", wxOK | wxICON_WARNING);
-                }
+                SetLangFilenames();
             }
         }
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -661,6 +661,12 @@ bool ProjectHandler::Import(ImportXML& import, tt_wxString& file, bool append, b
                         }
                     }
                 }
+
+                if (project_node->GetChildCount() > 1 && project_node->value(prop_code_preference) != "XRC")
+                {
+                    wxMessageBox("Each form must have a unique base filename when generating Python or C++ code.\nCurrently, only one form has a unique filename. You will need to add names to the other forms before generating code for them.",
+                                 "Code Import Change", wxOK | wxICON_WARNING);
+                }
             }
         }
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -643,6 +643,24 @@ bool ProjectHandler::Import(ImportXML& import, tt_wxString& file, bool append, b
                 {
                     project_node->prop_set_value(prop_code_preference, "C++");
                 }
+
+                for (const auto& iter: project_node->GetChildNodePtrs())
+                {
+                    if (iter->HasValue(prop_base_file) && project_node->value(prop_code_preference) != "C++")
+                    {
+                        if (project_node->value(prop_code_preference) == "Python")
+                        {
+                            iter->prop_set_value(prop_python_file, iter->value(prop_base_file));
+                        }
+                        else if (project_node->value(prop_code_preference) == "XRC")
+                        {
+                            iter->prop_set_value(prop_xrc_file, iter->value(prop_base_file));
+                            // XRC files can be combined into a single file so we
+                            if (!project_node->HasValue(prop_combined_xrc_file))
+                                project_node->prop_set_value(prop_combined_xrc_file, iter->value(prop_base_file));
+                        }
+                    }
+                }
             }
         }
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -631,16 +631,18 @@ bool ProjectHandler::Import(ImportXML& import, tt_wxString& file, bool append, b
         {
             for (const auto& iter: project_node->GetChildNodePtrs())
             {
+                // If importing from wxGlade, then either a combined file will be set, or the individual file for
+                // the language will be already set.
                 if (iter->HasValue(prop_base_file) && project_node->value(prop_code_preference) != "C++")
                 {
-                    if (project_node->value(prop_code_preference) == "Python")
+                    if (project_node->value(prop_code_preference) == "Python" && !iter->HasValue(prop_python_file))
                     {
                         iter->prop_set_value(prop_python_file, iter->value(prop_base_file));
                     }
-                    else if (project_node->value(prop_code_preference) == "XRC")
+                    else if (project_node->value(prop_code_preference) == "XRC" && !iter->HasValue(prop_xrc_file))
                     {
                         iter->prop_set_value(prop_xrc_file, iter->value(prop_base_file));
-                        // XRC files can be combined into a single file so we
+                        // XRC files can be combined into a single file
                         if (!project_node->HasValue(prop_combined_xrc_file))
                             project_node->prop_set_value(prop_combined_xrc_file, iter->value(prop_base_file));
                     }

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -60,6 +60,10 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 		</property>
 		<property name="python_output_folder" type="path"
 			help="If a folder name is specified, it will be used for all python code. It will also be used for generated xrc and art files if the matching options below are checked." />
+		<property name="python_combine_forms" type="bool"
+			help="If checked, all code will be generated to a single file.\n\nThe code preview will only display code for the currently selected form, even if this is checked.">0</property>
+		<property name="python_combined_file" type="file"
+			help="This filename will be used to write all Python content to unless you unchecked the python_combine_forms property above." />
 		<property name="python_line_length" type="uint"
 			help="Specifies a guideline for generated code line length. Most lines will be wrapped so that they do not exceed this length.">90</property>
 	</gen>
@@ -107,8 +111,10 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 	<gen class="Folder wxPython Overrides" type="interface">
 		<property name="folder_python_output_folder" type="path"
 			help="Overrides any project setting of the output folder used for all generated python code. Only affects the forms within this folder." />
+		<property name="folder_python_combine_forms" type="bool"
+			help="If checked, the code for all forms in this folder will be generated to a single file.\n\nThe code preview will only display code for the currently selected form, even if this is checked.">0</property>
 		<property name="folder_python_combined_file" type="file"
-			help="Overrides any project setting of the combined filename. Only affects the forms within this folder." />
+			help="Overrides any project setting of the combined filename. Only affects the forms within this folder, and is only used if the folder_python_combine_forms above is checked." />
 	</gen>
 
 	<gen class="Folder XRC Overrides" type="interface">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes an initial pass through the wxGlade import functionality, fixing and improving general problems as well as adding more conversion support specific to wxPython code generation.

Related to #929 and #928

The properties and importing of a single project that has multiple passes is in place, but code generation has not been changed.