### PR TITLE
Resolve problems with wxPython wx.AnimationCtrl

### DIFF
--- a/python_tests/cpp/maintestdialog.cpp
+++ b/python_tests/cpp/maintestdialog.cpp
@@ -668,7 +668,6 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
             {  
                 m_animation_ctrl->Stop();
             }
-
         });
     m_checkBox2->Bind(wxEVT_CHECKBOX,
         [this](wxCommandEvent&)

--- a/python_tests/python/main_test_dlg.py
+++ b/python_tests/python/main_test_dlg.py
@@ -45,6 +45,52 @@ no_hour_png = PyEmbeddedImage(
     b"/b8FIjK58Qk3QSMijz4gIioiKYn7iQPP8TTL89fu4f18JrXFrUSJTUGJqtR13f8gxfBvSVTCMOiD/Z6H"
     b"4xGAt8slKcm9+hXUBO08n//djVUFux3aVvoF3WivIiuis94AAAAASUVORK5CYII=")
 
+clr_hourglass_gif = PyEmbeddedImage(
+    b"R0lGODlhIAAgAPIAAP///8zMzAD//wCZmQAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQJ"
+    b"CgAFACwAAAAAIAAgAAADZli63P4wykmrvTjnwbvnhFZwQil8QygSbOuqYiDPNKzJAEDLdobrux6GByAE"
+    b"jEjRAnlsCjXMpLIRnT6k1gYvq509YwHgkfurWcvBKdqsXHvVYfFbifJ8KSQT6i55+VlcgYKDhIUSCQAh"
+    b"+QQJCgAFACwAAAAAIAAgAAADZ1i63P4wykmrvTjnwbvnhFZwQil8QygSbOuqYiDPNKzJAEDLdobrux6G"
+    b"ByDMjEIMMrBMZppM0aMphSCrEB7WUdsucMbo9tetkoPmQG4njqmBZfcaLUV5nBSSCYWXvP4sXoKDhIWG"
+    b"EgkAIfkECQoABQAsAAAAACAAIAAAA2pYutz+MMpJq70458G754RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG"
+    b"67sehgfkBYQYwnGpRGaaTNED6pQ2pREe9lHbMnDKo7fw62LLYa20HDwHcjvx+l2cVSkoz11CMqH2EC+C"
+    b"LGOFhoeIiRIJACH5BAkKAAUALAAAAAAgACAAAANpWLrc/jDKSau9OOfBu+eEVnBCKXxDKBJs66piIM80"
+    b"rMkAQMt2huu7HoYHrIkWhEByqTwymEtnAyp1RKsNHpZh3OKSzeqvexyDteVAbheOqXXn9u3NFl5QHnuF"
+    b"ZELpJy+BLFuEhYaHiAwJACH5BAkKAAUALAAAAAAgACAAAANpWLrc/jDKSau9OOfBu+eEVnBCKXxDKBJs"
+    b"66piIM80rMkAQMt2huu7Hua3CwgxBKMyecwwl6LHsxllRiO866OmZeCSxm6BOKNWiOBslMxdB3LK8vWX"
+    b"VotQHrOEZELpIS+BLGKEhYaHiBIJACH5BAkKAAUALAAAAAAgACAAAANoWLrc/jDKSau9OOfBu+eEVnBC"
+    b"KXxDKBJs66piIM80rMkAQMt2huu7Hua3CwgxBOMsecwwlU3NM7oyiiS8K6SmbeCS1m6BuOwSwdkrmasO"
+    b"5JTldu6ZFqE8VAnJhMpDXoAsYoOEhYaHGAkAIfkECQoABQAsAAAAACAAIAAAA2lYutz+MMpJq70458G7"
+    b"54RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG67se5rcLCDEEY1DUSDqNTMfzGHVGIbyro6Zd4JJQLXFGtRDB"
+    b"WeaYqw7klOQoD/BMi1Ce8oRkQukjL4EsXYSFhoeIEgkAIfkECQoABQAsAAAAACAAIAAAA2lYutz+MMpJ"
+    b"q70458G754RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG67se5rcLCDGEolHUSDqXzKYRGpUeq7yqo6Zd4JLU"
+    b"KHF2tRDBWeaYqw7kpmSxEfB0RlGe8oRkQukjL4EsXYSFhoeIEgkAIfkECQoABQAsAAAAACAAIAAAA2xY"
+    b"utz+MMpJq70458G754RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG67se5rcLCDGEolHUSCZ5TIdzGZVSqw0o"
+    b"llHbKnDPoy+Q60aJT22MDDSvAdOZuMKDG+9zCsqTl5BMKH0QL4QsXoeIiYqLDAkAIfkECQoABQAsAAAA"
+    b"ACAAIAAAA2pYutz+MMpJq70458G754RWcEIpfEMoEmzrqmIgzzSsyQBAy3aG67se5rcLCDGEolHUSNaY"
+    b"jqQU+phSHbxr46kt4JxHXyDHZRKdWfMYWL6NpcZ0zAiAW0UoT5hCMqH2Ei+CLF2FhoeIiQwJACH5BAkK"
+    b"AAUALAAAAAAgACAAAANsWLrc/jDKSau9OOfBu+eEVnBCKXxDKBJs66piIM80rMkAQMt2huu7Hua3Cwgx"
+    b"hKJR1EjWmA7nEhqdUhu8K3Z2jAUAzu7wC8xCiVLrjZxW+77JuNlLABvvYgrKk5eQTCh9EC+ELFqHiImK"
+    b"ixIJACH5BAkKAAUALAAAAAAgACAAAANrWLrc/jDKSau9OOfBu+eEVnBCKXxDKBJs66piIM80rMkAQMt2"
+    b"huu7Hua3CwgxhKJR1EjWmA7nEhqdUhu8K3Z2jAWAViiRSyVKw74vICntVnBsY5bJW8vZUJTHPSGZUHwR"
+    b"L4MsWoaHiImKEgkAIfkECQoABQAsAAAAACAAIAAAA2dYutz+MMpJq7046zfInkP3RYMgjk0QlCdaqADA"
+    b"eigMqGG7BbGKh7TdzffTYXhEH2H5QSaDl+SQCLXYeoGlVmOjfoBZAMG7mYmzytEMPWaqTW22KxevfsF2"
+    b"NdDl2PMbbn+Cg4SFhhMJACH5BAkKAAUALAAAAAAgACAAAANzWLrc/jDKSau9OOvNu//ZMGgDIYlEoAbQ"
+    b"GqCnkK5m475ynAJ8UCsqHm+QixB3PR8wIBwWIUdm0hcEuI6n0m17gxm1qbBv1i1lCeKwgrzyQsHUX4H9"
+    b"Mn/RcQfb/UCh0RB/aHaBchaAIImKi4yNjo+QkZINCQAh+QQJCgAFACwAAAAAIAAgAAADbVi63P4wykmr"
+    b"vTjrQsiWxOB9TyiSjjkEI8oNcCC3Xyis8kzaeM7Wg5uP9dvAVgAAgdhxzZRMV+FJgPpomI4WMCyiAtwh"
+    b"VgPuspqbshg2toDDsyNJlozDnG+VdMoKDvYKPIAKfoOEf4aJiouMJAkAIf4yUmVkdWNlZCA1NiUgQCB3"
+    b"d3cucmFzcGJlcnJ5aGlsbC5jb20vZ2lmd2l6YXJkLmh0bWwAOw==")
+
+disabled_png = PyEmbeddedImage(
+    b"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAABZ0lE"
+    b"QVQ4y5VTMW7CQBCctY1EmnBKRBEocMEPgtLxATr3lFS01BQUKWnyBOSCgjovoIpOPCBSRBMZKSBkU2An"
+    b"2N4UwScbbCKmujvNzO3O3RKOeOr1mDQNN0IkRzj4Pg6+j1MsbBthEBAAGMkhaRo+pcRtraaIgech8Dww"
+    b"8x+HSK2VLllMp9N7Zt4QEQzDQBzHiKLo7PbBYADHcZROVdBsNgEA7+MxflCMUqmU2Wu4Eu12u9Bg22q1"
+    b"6GW5/CgSv+o6bNumdOuUR+x2u9w56T8lzg/xkkmROBNiGlLKqhACb8Phv5loOWJTCPGVFneiCEa5zBcN"
+    b"pJQkpXwUQizziBPLSptQXgV3AGQYhoWlTywLjUaDAXBhC4vR6Kp/oUJ0tlswM6r9PkzThOu6cBznTBDN"
+    b"5/kGz7PZhjQtM0zfux18182++8MDjPWak2lUYVTqdSZdR7lSUeQwCHDY749KAo6TuFutwHFMAPALdYaS"
+    b"dnNwM6gAAAAASUVORK5CYII=")
+
 left_png = PyEmbeddedImage(
     b"iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAUElE"
     b"QVRIx+3QwQ2AMAwEwU1ESanJRaUm93Q8EDSAEwl099qXJQ/8Z5EiUqUN9G0PCCRQ9d2+lNpEJjKRiUxU"
@@ -207,6 +253,12 @@ class MainTestDialog(wx.Dialog):
         self.m_toggleBtn_2 = wx.ToggleButton(static_box_3.GetStaticBox(), wx.ID_ANY,
             "Play Animation", wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT)
         static_box_3.Add(self.m_toggleBtn_2, wx.SizerFlags().Border(wx.ALL))
+
+        self.m_animation_ctrl = wx.adv.AnimationCtrl(static_box_3.GetStaticBox(), wx.ID_ANY,
+            wx.adv.Animation("../art/clr_hourglass.gif"), wx.DefaultPosition, wx.DefaultSize,
+            wx.adv.AC_DEFAULT_STYLE)
+        self.m_animation_ctrl.SetInactiveBitmap(wx.NullBitmap)
+        static_box_3.Add(self.m_animation_ctrl, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_19.Add(static_box_3, wx.SizerFlags().Border(wx.ALL))
 

--- a/python_tests/python/mainframe.py
+++ b/python_tests/python/mainframe.py
@@ -274,3 +274,14 @@ class MainFrame(wx.Frame):
         dlg = python_dlg.PythonDlg(self, title="PythonDlg")
         dlg.ShowModal()
         dlg.Destroy()
+
+class MyApp(wx.App):
+    def OnInit(self):
+        frame = MainFrame(None)
+        self.SetTopWindow(frame)
+
+        frame.Show(True)
+        return True
+
+app = MyApp()
+app.MainLoop()

--- a/python_tests/python_tests.wxui
+++ b/python_tests/python_tests.wxui
@@ -381,6 +381,10 @@
                     style="wxBU_EXACTFIT"
                     var_name="m_toggleBtn_2"
                     wxEVT_TOGGLEBUTTON="[this](wxCommandEvent&amp;)@@{@@if (m_toggleBtn->GetValue()) @@{@@    m_animation_ctrl->Play();@@    m_checkPlayAnimation->SetValue(true);@@}@@else @@{  @@    m_animation_ctrl->Stop();@@    m_checkPlayAnimation->SetValue(false);@@}@@@@}[python:OnToggleButton]" />
+                  <node
+                    class="wxAnimationCtrl"
+                    animation="Embed;art/clr_hourglass.gif"
+                    inactive_bitmap="Embed;art/disabled.png" />
                 </node>
               </node>
             </node>

--- a/python_tests/run_pytest.cmd
+++ b/python_tests/run_pytest.cmd
@@ -8,4 +8,7 @@
 echo Generating python files...
 ..\build\stage\bin\debug\wxUiEditor.exe --gen_python python_tests.wxui
 type python_tests.log
-python pytest.py
+cd python
+python mainframe.py
+cd ..
+

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -77,17 +77,13 @@ bool AnimationGenerator::ConstructionCode(Code& code)
         else
         {
             tt_view_vector parts(code.node()->as_string(prop_animation), ';');
-            tt_string name(parts[IndexImage].filename());
-            name.remove_extension();
-            name.LeftTrim();
-            if (parts[IndexType].starts_with("Embed"))
-            {
-                if (auto embed = ProjectImages.GetEmbeddedImage(parts[IndexImage]); embed)
-                {
-                    name = "" + embed->array_name;
-                }
-            }
-            // GenerateSingleBitmapCode(code, code.node()->value(prop_animation));
+            tt_string name(parts[IndexImage]);
+            name.make_absolute();
+            auto form_path = MakePythonPath(code.node());
+            name.make_relative(form_path);
+            name.backslashestoforward();
+
+            code.Str("wx.adv.Animation(").QuotedString(name) += ")";
         }
     }
     else

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -761,7 +761,7 @@ tt_string MakePythonPath(Node* node)
         }
     }
     if (path.empty())
-        path = "./z";
+        path = "./";
     path.make_absolute();
     path.remove_filename();
     return path;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This copies the python app code from pytest.py to mainframe.py so that testing can be run from the python/ directory by calling `python mainframe.py`. That solves the issue of external art files not being relative to the module's file location.

With the art files being loaded, this allowed for fixing the wx.AnimationCtrl to load the art file externally and have it work in our test case. This should work in the most common scenario where all the python files (generated and user-created) are in the same directory so that they can more easily be packaged.