### PR TITLE
Generate Python code for custom ids

### DIFF
--- a/python_tests/cpp/file_list.cmake
+++ b/python_tests/cpp/file_list.cmake
@@ -12,22 +12,14 @@ set (file_list
 # Manually maintained from wxui_code.cmake
 set(wxui_file_list
 
-    booktest_dlg.cpp    
-    choicebook.cpp
+    booktest_dlg.cpp
     commonctrls.cpp
-    dlgmultitest.cpp
     form_toolbar_base.cpp
-    import_test.cpp
-    listbook.cpp
+    images.cpp
     mainframe.cpp
-    my_images.cpp
-    notebook.cpp
-    other_ctrls.cpp
+    maintestdialog.cpp
     popupwin.cpp
     python_dlg.cpp
-    ribbondlg.cpp
-    toolbook.cpp
-    treebook.cpp
     wizard.cpp
 
 )

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1149,6 +1149,7 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     m_header->writeLine("};");
 }
 
+// This should only be called to generate C++ code.
 void BaseCodeGenerator::GenEnumIds(Node* class_node)
 {
     ASSERT(m_language == GEN_LANG_CPLUSPLUS);
@@ -1168,7 +1169,10 @@ void BaseCodeGenerator::GenEnumIds(Node* class_node)
     size_t item = 0;
     for (auto& iter: set_ids)
     {
-        m_header->write(iter);
+        if (iter.starts_with("self."))
+            m_header->write(iter.c_str() + (sizeof("self.") - 1));
+        else
+            m_header->write(iter);
         if (item == 0)
         {
             m_header->write(" = wxID_HIGHEST + 1", true);

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1298,6 +1298,7 @@ void BaseCodeGenerator::GenerateClassConstructor(Node* form_node, EventVector& e
     }
 }
 
+// This is a static function
 void BaseCodeGenerator::CollectIDs(Node* node, std::set<std::string>& set_ids)
 {
     for (auto& iter: node->get_props_vector())

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -82,6 +82,8 @@ public:
 
     bool is_cpp() const { return m_language == GEN_LANG_CPLUSPLUS; }
 
+    static void CollectIDs(Node* node, std::set<std::string>& set_ids);
+
 protected:
     // Generate extern references to images used in the current form that are defined in the
     // gen_Images node.
@@ -117,7 +119,6 @@ protected:
     tt_string GetDeclaration(Node* node);
 
     void CollectEventHandlers(Node* node, EventVector& events);
-    void CollectIDs(Node* node, std::set<std::string>& set_ids);
     void CollectImageHeaders(Node* node, std::set<std::string>& embedset);
     void CollectIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr);
     void CollectMemberVariables(Node* node, Permission perm, std::set<std::string>& code_lines);
@@ -184,6 +185,7 @@ private:
 
     std::vector<const EmbeddedImage*> m_embedded_images;
     std::set<wxBitmapType> m_type_generated;
+    std::set<std::string> m_set_ids;
 
     Node* m_form_node { nullptr };
     Node* m_ImagesForm { nullptr };

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -344,6 +344,18 @@ void BaseCodeGenerator::GeneratePythonClass(Node* form_node, PANEL_PAGE panel_ty
         }
     }
 
+    m_set_ids.clear();
+    BaseCodeGenerator::CollectIDs(form_node, m_set_ids);
+    // set to highest wx
+    auto id_value = 1;
+    for (auto& iter: m_set_ids)
+    {
+        if (!iter.starts_with("self."))
+        {
+            m_source->writeLine(tt_string() << iter << " = wxID_HIGHEST + " << id_value++);
+        }
+    }
+
     thrd_collect_img_headers.join();
     if (m_embedded_images.size())
     {
@@ -424,6 +436,20 @@ void BaseCodeGenerator::GeneratePythonClass(Node* form_node, PANEL_PAGE panel_ty
         m_source->writeLine();
         m_source->Indent();
         m_source->Indent();
+
+        id_value = 1;
+        for (auto& iter: m_set_ids)
+        {
+            if (iter.starts_with("self."))
+            {
+                m_source->writeLine(tt_string() << iter << " = wxID_HIGHEST + " << id_value++);
+            }
+        }
+        if (id_value > 1)
+        {
+            // If at least one id was set, add a blank line
+            m_source->writeLine();
+        }
     }
 
     code.clear();

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -485,6 +485,14 @@ bool WxGlade::HandleNormalProperty(const pugi::xml_node& xml_obj, Node* node, No
             return true;
         }
     }
+    else if (wxue_prop == prop_id)
+    {
+        tt_string id = xml_obj.text().as_string();
+        id.erase_from('=');
+        id.trim();
+        node->prop_set_value(prop_id, id);
+        return true;
+    }
 
     return false;
 }

--- a/src/xml/aui_xml.xml
+++ b/src/xml/aui_xml.xml
@@ -114,7 +114,8 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 			help="Help string used in the tooltip." />
 		<property name="statusbar" type="string_edit"
 			help="This string is shown in the statusbar (if any) of the parent frame when the mouse pointer is inside the tool." />
-		<property name="id" type="id">wxID_ANY</property>
+		<property name="id" type="id"
+			help="Specifies the tool identifier. When generating Python code, a non wx.Widgets id will be global unless prefixed with self.">wxID_ANY</property>
 		<event name="wxEVT_TOOL" class="wxCommandEvent"
 		help="Same as wxEVT_MENU -- generated when the item is chosen in the toolbar or menu (if the same id was added to a menu)." />
 		<event name="wxEVT_UPDATE_UI" class="wxUpdateUIEvent"
@@ -135,7 +136,9 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 		<property name="var_name" type="string">tool</property>
 		<property name="label" type="string_escapes">My Label</property>
 		<property name="width" type="int">-1</property>
-		<property name="id" type="id">wxID_ANY</property>
+		<property name="id" type="id"
+			help="Specifies the label identifier. When generating Python code, a non wx.Widgets id will be global unless prefixed with self.">wxID_ANY</property>
+
 		<event name="wxEVT_TOOL" class="wxCommandEvent"
 			help="Same as wxEVT_MENU -- generated when the item is chosen in the toolbar or menu (if the same id was added to a menu)." />
 		<event name="wxEVT_UPDATE_UI" class="wxUpdateUIEvent"

--- a/src/xml/menus_xml.xml
+++ b/src/xml/menus_xml.xml
@@ -62,7 +62,8 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 			help="Additional accelerators. The syntax is any combination of &quot;CTRL&quot;, &quot;ALT&quot; and &quot;SHIFT&quot; strings (case doesn't matter) separated by either '-' or '+' characters and followed by the accelerator itself. The accelerator may be any alphanumeric character, or any function key (from F1 to F12)" />
 		<property name="help" type="string_edit"
 			help="Optional string that will be shown on the status bar." />
-		<property name="id" type="id">wxID_ANY</property>
+		<property name="id" type="id"
+			help="Specifies the menu item identifier. When generating Python code, a non wx.Widgets id will be global unless prefixed with self.">wxID_ANY</property>
 		<property name="bitmap" type="image"
 			help="Bitmap for the menu item. This doubles as the checked bitmap if the menu item is wxITEM_CHECK." />
 		<property name="unchecked_bitmap" type="image"

--- a/src/xml/ribbon_xml.xml
+++ b/src/xml/ribbon_xml.xml
@@ -147,7 +147,7 @@ inline const char* ribbon_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="ribbonTool" image="ribbon_button" type="ribbontool">
 		<property name="id" type="id"
-			help="The identifier of the tool (used for event callbacks)." />
+			help="The identifier of the tool (used for event callbacks). When generating Python code, a non wx.Widgets id will be global unless prefixed with self." />
 		<property name="bitmap" type="image"
 			help="ribbonTool bitmap." />
 		<property name="help" type="string_escapes"

--- a/src/xml/toolbars_xml.xml
+++ b/src/xml/toolbars_xml.xml
@@ -106,7 +106,8 @@ inline const char* toolbars_xml = R"===(<?xml version="1.0"?>
 			help="String to display in the tooltip." />
 		<property name="statusbar" type="string_edit"
 			help="This string is shown in the statusbar (if any) of the parent frame when the mouse pointer is inside the tool." />
-		<property name="id" type="id">wxID_ANY</property>
+		<property name="id" type="id"
+			help="Specifies the tool identifier. When generating Python code, a non wx.Widgets id will be global unless prefixed with self.">wxID_ANY</property>
 		<event name="wxEVT_TOOL" class="wxCommandEvent"
 			help="" />
 		<event name="wxEVT_TOOL_DROPDOWN" class="wxCommandEvent"
@@ -128,7 +129,8 @@ inline const char* toolbars_xml = R"===(<?xml version="1.0"?>
 			help="String to display in the tooltip." />
 		<property name="statusbar" type="string_edit"
 			help="This string is shown in the statusbar (if any) of the parent frame when the mouse pointer is inside the tool." />
-		<property name="id" type="id">wxID_ANY</property>
+		<property name="id" type="id"
+			help="Specifies the tool identifier. When generating Python code, a non wx.Widgets id will be global unless prefixed with self.">wxID_ANY</property>
 		<event name="wxEVT_TOOL_DROPDOWN" class="wxCommandEvent"
 			help="" />
 		<event name="wxEVT_UPDATE_UI" class="wxUpdateUIEvent"

--- a/src/xml/window_interfaces_xml.xml
+++ b/src/xml/window_interfaces_xml.xml
@@ -29,7 +29,8 @@ inline const char* window_interfaces_xml = R"===(<?xml version="1.0"?>
 	</gen>
 
 	<gen class="wxWindow" type="interface">
-		<property name="id" type="id">wxID_ANY</property>
+		<property name="id" type="id"
+			help="Specifies the window identifier. When generating Python code, a non wx.Widgets id will be global unless prefixed with self.">wxID_ANY</property>
 		<property name="minimum_size" type="wxSize"
 			help="Sets the minimum size of the window. Any positive value will override the automatic size calculation that would normally be done." />
 		<property name="variant" type="option"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR generates use-declared ids for Python. If the id has a `self.` prefix, then it will be added at the top of the class constructor. Otherwise, it will be added at the top of the module. The `self.` prefix will be removed in C++ code generation so it will work for both languages.

This also updates wxGlade project importing by removing any assignment as part of the id.

Closes #874