### PR TITLE
Enable Python Custom Controls, complete parameter macro handling

### DIFF
--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -54,9 +54,24 @@ bool CustomControl::ConstructionCode(Code& code)
         if (parameters.find(iter.first) != tt::npos)
         {
             if (iter.second == prop_window_style && code.node()->as_string(iter.second).empty())
+            {
                 parameters.Replace(iter.first, "0");
+            }
             else
-                parameters.Replace(iter.first, code.view(iter.second));
+            {
+                // In C++ we can just replace the macro with the string from the property, but in Python we need to
+                // do additional processing on most strings.
+                if (code.is_cpp())
+                {
+                    parameters.Replace(iter.first, code.view(iter.second));
+                }
+                else
+                {
+                    Code macro(code.node(), GEN_LANG_PYTHON);
+                    macro.Add(code.view(iter.second));
+                    parameters.Replace(iter.first, macro);
+                }
+            }
         }
     }
 

--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -75,7 +75,12 @@ bool CustomControl::ConstructionCode(Code& code)
         }
     }
 
-    code.Str(prop_class_name).Str(parameters) << ';';
+    if (!parameters.starts_with("("))
+        parameters.insert(0, "(");
+    if (parameters.back() != ')')
+        parameters += ")";
+
+    code.Str(prop_class_name).Str(parameters).AddIfCpp(";");
 
     return true;
 }

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -451,6 +451,24 @@ bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
 
         return true;
     }
+    else if (node_name == "arguments" && node->isGen(gen_CustomControl))
+    {
+        tt_string parameters;
+        for (auto& argument: xml_obj.children())
+        {
+            tt_string param = argument.text().as_string();
+            param.Replace("$parent", "${parent}");
+            param.Replace("$id", "${id}");
+            if (parameters.size())
+                parameters += ", ";
+            parameters += param;
+        }
+
+        if (parameters.size())
+            node->set_value(prop_parameters, parameters);
+
+        return true;
+    }
     else if (node_name == "extracode_post")
     {
         // wxGlade adds this after the class is constructed, but before any Bind functions are called.

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -73,6 +73,7 @@ std::map<std::string_view, GenEnum::PropName, std::less<>> import_PropNames = {
  std::map<std::string_view, GenEnum::GenName, std::less<>> import_GenNames = {
 
     { "Custom", gen_CustomControl },
+    { "CustomWidget", gen_CustomControl },
     { "Dialog", gen_wxDialog },
     { "Frame", gen_wxFrame },
     { "Panel", gen_PanelForm },
@@ -1119,7 +1120,6 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
             is_generic_version = true;
             gen_name = gen_wxAnimationCtrl;
         }
-
         else
         {
             MSG_INFO(tt_string() << "Unrecognized object: " << object_name);

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -37,7 +37,6 @@ inline const std::vector<GenEnum::GenName> unsupported_gen_python = {
     gen_StaticRadioBtnBoxSizer,
 
     gen_wxContextMenuEvent,
-    gen_CustomControl,
 
 };
 

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -82,7 +82,7 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		<property name="class_name" type="string"
 			help="The name of the custom class.">CustomClass</property>
 		<property name="parameters" type="string_code_single"
-			help="The parameters to use when the class is constructed. When generating C++, self will be replaced with this. When generating Python, this will be replaced with self.">(this)</property>
+			help="The parameters to use when the class is constructed. The macros ${id}, ${pos}, ${size}, ${window_extra_style}, ${window_name}, and ${window_style} will be replaced with the matching property. In Python, this will be replaced with self.">(this)</property>
 		<property name="settings_code" type="code_edit"
 			help="Additional code to include after the class is constructed." />
 	</gen>

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -75,14 +75,14 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_custom</property>
-		<property name="class_name" type="string"
-			help="The name of the custom class.">CustomClass</property>
 		<property name="header" type="file"
 			help="The header file that declares the class." />
 		<property name="namespace" type="string"
 			help="The namespace the class is declared in." />
+		<property name="class_name" type="string"
+			help="The name of the custom class.">CustomClass</property>
 		<property name="parameters" type="string_code_single"
-			help="The parameters to use when the class is constructed.">(this)</property>
+			help="The parameters to use when the class is constructed. When generating C++, self will be replaced with this. When generating Python, this will be replaced with self.">(this)</property>
 		<property name="settings_code" type="code_edit"
 			help="Additional code to include after the class is constructed." />
 	</gen>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR enables Custom Controls in Python, tweaks the UI in the property grid to put the class name, parameters and settings together, and updates the property description to mention the available Macro names. Importing custom controls from wxGlade projects now works correctly.

Closes #824
