### PR TITLE
Remove obsolete ttlib references

### DIFF
--- a/src/pch.h
+++ b/src/pch.h
@@ -22,7 +22,7 @@
 #define wxUSE_NO_MANIFEST 1
 #define wxUSE_UNICODE     1
 
-// Allows ttLib additions to pugixml
+// Allows tt additions to pugixml (e.g. as_sview(), as_cstr(), etc.)
 #define TTLIB_ADDITIONS 1
 
 #ifdef _MSC_VER

--- a/src/tt/tt.h
+++ b/src/tt/tt.h
@@ -23,7 +23,6 @@ class tt_string;
 
 namespace tt
 {
-#if not defined(_TTLIB_WX_HEADER_)
     /// Use to compare a size_t against -1
     constexpr size_t npos = static_cast<size_t>(-1);
 
@@ -47,7 +46,6 @@ namespace tt
         once = false,
         all = true,
     };
-#endif
 
     extern const std::string emptystring;
 

--- a/src/tt/tt_string.cpp
+++ b/src/tt/tt_string.cpp
@@ -1091,7 +1091,7 @@ tt_string& tt_string::Format(std::string_view format, ...)
     }
     catch (const std::exception& /* e */)
     {
-        assert(!"exception in ttlib::tt_string.Format()");
+        assert(!"exception in tt_string.Format()");
     }
 
     va_end(args);

--- a/src/wxui.natvis
+++ b/src/wxui.natvis
@@ -62,14 +62,7 @@
 
     <!-- ttLib visualizers -->
 
-    <Type Name="ttlib::winff">
-      <DisplayString>{m_filename,s}</DisplayString>
-    </Type>
-    <Type Name="ttlib::openfile">
-      <DisplayString>{m_filename,s}</DisplayString>
-    </Type>
-
-    <Type Name="ttlib::cview">
+    <Type Name="tt_string_view">
       <Intrinsic Name="size" Expression="_Mysize" />
       <Intrinsic Name="data" Expression="_Mydata" />
       <DisplayString>{_Mydata,s8}</DisplayString>
@@ -82,7 +75,7 @@
       </Expand>
     </Type>
 
-    <Type Name="ttlib::cstr">
+    <Type Name="tt_string">
         <DisplayString Condition="_Myres &lt; _BUF_SIZE">{_Bx._Buf,s8}</DisplayString>
         <DisplayString Condition="_Myres &gt;= _BUF_SIZE">{_Bx._Ptr,s8}</DisplayString>
         <StringView Condition="_Myres &lt; _BUF_SIZE">_Bx._Buf,s8</StringView>
@@ -97,6 +90,41 @@
             </ArrayItems>
         </Expand>
     </Type>
+
+    <Type Name="tt_wxString">
+        <DisplayString>"{m_impl,sb}"</DisplayString>
+        <StringView>m_impl</StringView>
+    </Type>
+
+    <Type Name="tt_string_vector">
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <DisplayString>{m_filename,s8}</DisplayString>
+        <Intrinsic Name="size" Expression="_Mypair._Myval2._Mylast - _Mypair._Myval2._Myfirst" />
+        <Intrinsic Name="capacity" Expression="_Mypair._Myval2._Myend - _Mypair._Myval2._Myfirst" />
+        <Expand>
+          <Item Name="[capacity]" ExcludeView="simple">capacity()</Item>
+          <Item Name="[allocator]" ExcludeView="simple">_Mypair</Item>
+          <ArrayItems>
+            <Size>size()</Size>
+            <ValuePointer>_Mypair._Myval2._Myfirst</ValuePointer>
+            </ArrayItems>
+        </Expand>
+        </Type>
+
+    <Type Name="tt_view_vector">
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <DisplayString>{m_filename,s8}</DisplayString>
+        <Intrinsic Name="size" Expression="_Mypair._Myval2._Mylast - _Mypair._Myval2._Myfirst" />
+        <Intrinsic Name="capacity" Expression="_Mypair._Myval2._Myend - _Mypair._Myval2._Myfirst" />
+        <Expand>
+          <Item Name="[capacity]" ExcludeView="simple">capacity()</Item>
+          <Item Name="[allocator]" ExcludeView="simple">_Mypair</Item>
+          <ArrayItems>
+            <Size>size()</Size>
+            <ValuePointer>_Mypair._Myval2._Myfirst</ValuePointer>
+            </ArrayItems>
+        </Expand>
+        </Type>
 
     <!-- pugixml visualizers -->
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR cleans up some code that still referenced ttLib classes instead of the newer tt classes.