### PR TITLE
Fix issues with building a non-Internal Release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 project(wxUiEditor
     LANGUAGES CXX
-    VERSION 1.0.1
+    VERSION 1.1.0
     DESCRIPTION "wxWidgets UI designer"
     HOMEPAGE_URL "https://github.com/KeyWorksRW/wxUiEditor")
 

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -283,19 +283,19 @@ set (file_list
 
     ui/preview_settings_events.cpp  # Event handlers for PreviewSettings dialog
 
-    # Debug-only files
+    # Debug-only files from wxui_internal.cmake
     $<$<CONFIG:Debug>:internal/code_compare.cpp>    # Compare code generation
-    $<$<CONFIG:Debug>:internal/convert_img.cpp>     # Convert image
-    $<$<CONFIG:Debug>:internal/import_panel.cpp>    # Panel to display original imported file
+    $<$<CONFIG:Debug>:internal/convert_img_base.cpp>
+    $<$<CONFIG:Debug>:internal/debugsettings.cpp>  # Settings while running the Debug version of wxUiEditor
+    $<$<CONFIG:Debug>:internal/msgframe_base.cpp>       # wxUiEditor generated file
     $<$<CONFIG:Debug>:internal/node_info.cpp>       # Node memory usage dialog
+    $<$<CONFIG:Debug>:internal/node_search_dlg.cpp> # Dialog to search for a node
     $<$<CONFIG:Debug>:internal/xrcpreview.cpp>      # Test XRC
 
-    $<$<CONFIG:Debug>:internal/debugsettings.cpp>  # Settings while running the Debug version of wxUiEditor
-    $<$<CONFIG:Debug>:internal/msg_logging.cpp>    # Message logging class
+    $<$<CONFIG:Debug>:internal/convert_img.cpp>     # Convert image
+    $<$<CONFIG:Debug>:internal/import_panel.cpp>    # Panel to display original imported file
     $<$<CONFIG:Debug>:internal/msgframe.cpp>       # Stores messages
-
-    $<$<CONFIG:Debug>:internal/convert_img_base.cpp>
-    $<$<CONFIG:Debug>:internal/msgframe_base.cpp>       # wxUiEditor generated file
+    $<$<CONFIG:Debug>:internal/msg_logging.cpp>    # Message logging class
 
     $<$<CONFIG:Debug>:tests/test_xrc_import.cpp>  # XRC Import tests
 )

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -437,10 +437,12 @@ bool App::IsPjtMemberPrefix() const
     return (Preferences().GetProjectFlags() & PREFS::PREFS_PJT_MEMBER_PREFIX);
 }
 
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
 bool App::AutoMsgWindow() const
 {
     return (Preferences().GetDebugFlags() & PREFS::PREFS_MSG_WINDOW);
 }
+#endif
 
 #if defined(_DEBUG) && defined(wxUSE_ON_FATAL_EXCEPTION) && defined(wxUSE_STACKWALKER)
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -207,6 +207,10 @@ MainFrame::MainFrame() :
 
     m_toolbar->Realize();
 
+#else
+    // For version 1.1.0.0, preview isn't reliable enough to be included in the release version
+    m_menuTools->Delete(m_mi_preview);
+    m_toolbar->DeleteTool(id_PreviewForm);
 #endif
 
     CreateStatusBar(StatusPanels);

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -528,7 +528,13 @@ NodeSharedPtr NodeCreator::CreateProjectNode(pugi::xml_node* xml_obj, bool allow
     return new_node;
 }
 
-bool ProjectHandler::ImportProject(tt_wxString& file, bool allow_ui)
+bool ProjectHandler::ImportProject(tt_wxString& file,
+#if defined(INTERNAL_TESTING)
+                                   bool allow_ui
+#else
+                                   bool /* allow_ui */
+#endif
+)
 {
 #if defined(INTERNAL_TESTING)
     // Importers will change the file extension, so make a copy here

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -8,9 +8,6 @@
 // clang-format off
 
 #include <wx/artprov.h>
-#include <wx/bitmap.h>
-#include <wx/icon.h>
-#include <wx/image.h>
 
 #include "ui_images.h"
 
@@ -54,7 +51,7 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
 
     if (!Create(parent, id, title, pos, size, style, name))
         return;
-    SetSizeHints(wxSize(800, 800));
+    SetMinSize(wxSize(800, 800));
 
     m_menubar = new wxMenuBar();
 
@@ -251,11 +248,11 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     menu_item19->SetBitmap(wxueBundleSVG(wxue_img::generate_svg, 780, 2716, wxSize(16, 16)));
 
     m_menuTools->Append(menu_item19);
-    auto* menu_item_8 = new wxMenuItem(m_menuTools, id_PreviewForm, "&Preview Form...\tF5",
+    m_mi_preview = new wxMenuItem(m_menuTools, id_PreviewForm, "&Preview Form...\tF5",
         "Preview form using XRC and/or C++", wxITEM_NORMAL);
-    menu_item_8->SetBitmap(wxueBundleSVG(wxue_img::xrc_preview_svg, 469, 1326, wxSize(16, 16)));
+    m_mi_preview->SetBitmap(wxueBundleSVG(wxue_img::xrc_preview_svg, 469, 1326, wxSize(16, 16)));
 
-    m_menuTools->Append(menu_item_8);
+    m_menuTools->Append(m_mi_preview);
     m_menubar->Append(m_menuTools, "&Tools");
 
     m_menuHelp = new wxMenu();

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -9,9 +9,12 @@
 
 #pragma once
 
+#include <wx/bitmap.h>
 #include <wx/event.h>
 #include <wx/frame.h>
 #include <wx/gdicmn.h>
+#include <wx/icon.h>
+#include <wx/image.h>
 #include <wx/menu.h>
 #include <wx/toolbar.h>
 
@@ -97,6 +100,7 @@ protected:
     wxMenu* m_menuTools;
     wxMenu* m_submenu_recent;
     wxMenuBar* m_menubar;
+    wxMenuItem* m_mi_preview;
     wxToolBar* m_toolbar;
 };
 

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -570,11 +570,12 @@
             <node
               class="wxMenuItem"
               bitmap="SVG;../art_src/xrc_preview.svg;[16,16]"
+              class_access="protected:"
               help="Preview form using XRC and/or C++"
               id="id_PreviewForm"
               label="&amp;Preview Form..."
               shortcut="F5"
-              var_name="menu_item_8"
+              var_name="m_mi_preview"
               wxEVT_MENU="OnPreviewXrc" />
           </node>
           <node


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR verifies that a non-Internal build can be built without errors or warnings, and removes the Preview menu and toolbar command. While Preview was not marked as Internal, it's got enough problems that I don't want it included in this release.