### PR TITLE
Remove obsolete properties

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -339,7 +339,6 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_show_header, "show_header" },
     { prop_show_hidden, "show_hidden" },
     { prop_size, "size" },
-    { prop_smart_size, "smart_size" },
     { prop_source_ext, "source_ext" },
     { prop_spellcheck, "spellcheck" },
     { prop_splitmode, "splitmode" },
@@ -420,10 +419,8 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
 
     { prop_folder_python_combined_file, "folder_python_combined_file" },
     { prop_folder_python_output_folder, "folder_python_output_folder" },
-    { prop_python_call_skip, "python_call_skip" },
     { prop_python_combine_forms, "python_combine_forms" },
     { prop_python_combined_file, "python_combined_file" },
-    { prop_python_copy_art, "python_copy_art" },
     { prop_python_file, "python_file" },
     { prop_python_inherit_name, "python_inherit_name" },
     { prop_python_insert, "insert_python_code" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -345,7 +345,6 @@ namespace GenEnum
         prop_show_hidden,
         prop_show_header,
         prop_size,
-        prop_smart_size,
         prop_source_ext,
         prop_spellcheck,
         prop_splitmode,
@@ -426,10 +425,8 @@ namespace GenEnum
 
         prop_folder_python_combined_file,
         prop_folder_python_output_folder,
-        prop_python_call_skip,
         prop_python_combine_forms,
         prop_python_combined_file,
-        prop_python_copy_art,  // Copy art files to output folder
         prop_python_file,
         prop_python_inherit_name,
         prop_python_insert,

--- a/src/generate/gen_xrc_utils.cpp
+++ b/src/generate/gen_xrc_utils.cpp
@@ -116,10 +116,6 @@ void GenXrcSizerItem(Node* node, pugi::xml_node& object)
 
 void GenXrcComments(Node* node, pugi::xml_node& object, size_t supported_flags)
 {
-    if (node->HasValue(prop_smart_size))
-    {
-        object.append_child(pugi::node_comment).set_value(" smart size cannot be be set in the XRC file. ");
-    }
     if (node->HasValue(prop_maximum_size) && !(supported_flags & xrc::max_size_supported))
     {
         object.append_child(pugi::node_comment).set_value(" maximum size cannot be be set in the XRC file. ");

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -338,31 +338,12 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
 // Note that this is a static function also called by CreateMockupChildren in mockup_preview.cpp
 void MockupContent::SetWindowProperties(Node* node, wxWindow* window, wxWindow* convert_win)
 {
-    bool is_smart_size { false };  // true means prop_size and prop_minimum_size will be ignored
-
-    if (auto size = node->prop_as_wxSize(prop_smart_size); size != wxDefaultSize)
+    if (auto minsize = node->prop_as_wxSize(prop_minimum_size); minsize != wxDefaultSize)
     {
-        is_smart_size = true;
-        if (size.x > 0)
-            size.x = (size.x > window->GetBestSize().x ? size.x : -1);
-        if (size.y > 0)
-            size.y = (size.y > window->GetBestSize().y ? size.y : -1);
-
-        if (node->prop_as_string(prop_smart_size).contains("d", tt::CASE::either))
-            window->SetInitialSize(convert_win->ConvertDialogToPixels(size));
+        if (node->prop_as_string(prop_minimum_size).contains("d", tt::CASE::either))
+            window->SetMinSize(convert_win->ConvertDialogToPixels(minsize));
         else
-            window->SetInitialSize(size);
-    }
-
-    if (!is_smart_size)
-    {
-        if (auto minsize = node->prop_as_wxSize(prop_minimum_size); minsize != wxDefaultSize)
-        {
-            if (node->prop_as_string(prop_minimum_size).contains("d", tt::CASE::either))
-                window->SetMinSize(convert_win->ConvertDialogToPixels(minsize));
-            else
-                window->SetMinSize(minsize);
-        }
+            window->SetMinSize(minsize);
     }
 
     if (auto maxsize = node->prop_as_wxSize(prop_maximum_size); maxsize != wxDefaultSize)


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes some of the properties that are no longer used. In the case of `prop_smart_size`, this also removes the code that processed it since that code will never be called with the property gone.