### PR TITLE
Initial commit for doc/view app classes

### DIFF
--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -164,6 +164,13 @@ set (file_list
     generate/gen_popup_trans_win.cpp    # wxPopupTransientWindow generator
     generate/gen_wizard.cpp             # wxWizard generator
 
+    # Document Management
+
+    generate/gen_doc_view_app.cpp   # Generates base class for wxDocument/wView applications
+
+    generate/gen_doc_textctrl.cpp   # wxTextCtrl document class
+    generate/gen_view_textctrl.cpp  # wxTextCtrl view class
+
     # Menus
 
     generate/menu_widgets.cpp      # Menu generation classes

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -51,6 +51,13 @@ std::unordered_map<std::string_view, PropType, str_view_hash, std::equal_to<>> G
 
 std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
 
+    { prop_template_description, "template_description" },
+    { prop_template_directory, "template_directory" },
+    { prop_template_extension, "template_extension" },
+    { prop_template_filter, "template_filter" },
+    { prop_template_visible, "template_visible" },
+    { prop_template_view_name, "prop_template_view_name" },
+
     { prop_Apply, "Apply" },
     { prop_BottomDockable, "BottomDockable" },
     { prop_Cancel, "Cancel" },
@@ -500,6 +507,13 @@ std::map<GenType, std::string_view> GenEnum::map_GenTypes = {
     { type_wizard, "wizard" },
     { type_wizardpagesimple, "wizardpagesimple" },
 
+    { type_DocViewApp, "DocViewApp" },
+    { type_wx_document, "wx_document" },
+    { type_wx_view, "wx_view" },
+
+    { type_empty_menubar, "empty_menubar" },
+    { type_doc_menubar, "type_doc_menubar" },
+
 };
 
 std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
@@ -541,6 +555,12 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_Images, "Images" },
     { gen_folder, "folder" },
     { gen_sub_folder, "sub_folder" },
+
+    // These are for wxDocManager
+
+    { gen_DocViewApp, "DocViewApp" },
+    { gen_DocumentTextCtrl, "DocumentTextCtrl" },
+    { gen_ViewTextCtrl, "ViewTextCtrl" },
 
     // The following are the regular generators
 

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -57,6 +57,13 @@ namespace GenEnum
 
     enum PropName : size_t
     {
+        prop_template_description,
+        prop_template_directory,
+        prop_template_extension,
+        prop_template_filter,
+        prop_template_visible,
+        prop_template_view_name,
+
         prop_Apply,
         prop_BottomDockable,
         prop_Cancel,
@@ -520,6 +527,13 @@ namespace GenEnum
         type_wizard,
         type_wizardpagesimple,
 
+        type_DocViewApp,
+        type_wx_document,
+        type_wx_view,
+
+        type_empty_menubar,
+        type_doc_menubar,
+
         // This must always be the last item as it is used to calculate the array size needed to store all items
         gen_type_array_size,
         gen_type_unknown = gen_type_array_size
@@ -564,9 +578,18 @@ namespace GenEnum
         gen_wxTopLevelWindow,
         gen_wxWindow,
 
+        // These are special purpose generators. gen_Images is used for code, but gen_folder is
+        // just for organtizing forms in the Navigation panel.
+
         gen_Images,
         gen_folder,
         gen_sub_folder,
+
+        // These are for DocViewApp
+
+        gen_DocViewApp,
+        gen_DocumentTextCtrl,
+        gen_ViewTextCtrl,
 
         // The following are the rergular generators
 

--- a/src/generate/gen_doc_textctrl.cpp
+++ b/src/generate/gen_doc_textctrl.cpp
@@ -10,7 +10,7 @@
 #include "code.h"  // Code -- Helper class for generating code
 
 inline constexpr const auto txt_TextCtrlViewBlock =
-R"===(wxIMPLEMENT_DYNAMIC_CLASS(%class%, wxDocument);
+    R"===(wxIMPLEMENT_DYNAMIC_CLASS(%class%, wxDocument);
 
 bool %class%::OnCreate(const wxString& path, long flags)
 {

--- a/src/generate/gen_doc_textctrl.cpp
+++ b/src/generate/gen_doc_textctrl.cpp
@@ -1,0 +1,94 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   wxTextCtrl document class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "gen_doc_textctrl.h"
+
+#include "code.h"  // Code -- Helper class for generating code
+
+inline constexpr const auto txt_TextCtrlViewBlock =
+R"===(wxIMPLEMENT_DYNAMIC_CLASS(%class%, wxDocument);
+
+bool %class%::OnCreate(const wxString& path, long flags)
+{
+    if (!wxDocument::OnCreate(path, flags))
+        return false;
+
+    GetTextCtrl()->Bind(wxEVT_TEXT, &%class%::OnTextChange, this);
+
+    return true;
+}
+
+// Since text windows have their own method for saving to/loading from files, we override
+// DoSaveDocument/DoOpenDocument instead of Save/LoadObject
+
+bool %class%::DoOpenDocument(const wxString& filename)
+{
+    if (!GetTextCtrl()->LoadFile(filename))
+        return false;
+
+    Modify(false);
+
+    return true;
+}
+
+bool %class%::DoSaveDocument(const wxString& filename)
+{
+    auto result = GetTextCtrl()->SaveFile(filename);
+    if (auto view = GetFirstView(); view)
+    {
+        wxStaticCast(view, TextEditView)->GetFrame()->SetTitle(tt_wxString(filename).filename());
+    }
+    return result;
+}
+
+bool %class%::IsModified() const
+{
+    auto text_ctrl = GetTextCtrl();
+    return wxDocument::IsModified() || (text_ctrl && text_ctrl->IsModified());
+}
+
+void %class%::Modify(bool modified)
+{
+    wxDocument::Modify(modified);
+
+    if (auto text_ctrl = GetTextCtrl(); text_ctrl && !modified)
+    {
+        // This doesn't save the text, it just resets the modified flag.
+        text_ctrl->DiscardEdits();
+    }
+}
+
+wxTextCtrl* %class%::GetTextCtrl() const
+{
+    auto view = GetFirstView();
+    return view ? wxStaticCast(view, TextEditView)->GetText() : nullptr;
+}
+
+void %class%::OnTextChange(wxCommandEvent& event)
+{
+    Modify(true);
+
+    event.Skip();
+}
+)===";
+
+bool TextDocumentGenerator::ConstructionCode(Code& code)
+{
+    if (code.is_cpp())
+    {
+        tt_string_vector lines;
+        lines.ReadString(txt_TextCtrlViewBlock);
+        tt_string class_name = code.node()->value(prop_class_name);
+        for (auto& line: lines)
+        {
+            line.Replace("%class%", class_name, true);
+            code.Str(line).Eol();
+        }
+    }
+
+    return true;
+}

--- a/src/generate/gen_doc_textctrl.h
+++ b/src/generate/gen_doc_textctrl.h
@@ -1,0 +1,15 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   wxTextCtrl document class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "base_generator.h"  // BaseGenerator -- Base Generator class
+
+class TextDocumentGenerator : public BaseGenerator
+{
+public:
+    bool ConstructionCode(Code&) override;
+
+};

--- a/src/generate/gen_doc_textctrl.h
+++ b/src/generate/gen_doc_textctrl.h
@@ -11,5 +11,4 @@ class TextDocumentGenerator : public BaseGenerator
 {
 public:
     bool ConstructionCode(Code&) override;
-
 };

--- a/src/generate/gen_doc_view_app.cpp
+++ b/src/generate/gen_doc_view_app.cpp
@@ -1,0 +1,148 @@
+// Purpose:   Generates base class for wxDocument/wView applications
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "gen_doc_view_app.h"
+
+#include "code.h"  // Code -- Helper class for generating code
+
+inline constexpr const auto txt_DocViewAppHeader =
+    R"===("// Base class for wxDocument/wxView applications.
+// App class should inherit from this in addition to wxApp.
+
+// In your app's OnRun() function, call this class's Create() function to
+// create the main frame, and then call Show() to display it. Do this before
+// returning wxApp::OnRun();
+
+// In your app's OnExit() function, call this class's PrepForExit() function to
+// save the file history and delete the document manager. Do this before
+// returning wxApp::OnExit();
+
+#include <vector>
+
+class wxFrame;
+class wxDocManager;
+class wxMenuBar;
+class wxDocTemplate;
+
+// Yout application's App class should inherit from this in addition to wxApp, e.g.
+//     class App : public wxApp, public DocViewApp
+class %class%
+{
+public:
+    wxFrame* Create(wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString,
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_FRAME_STYLE, const wxString& name = wxFrameNameStr);
+
+    // Call this from the Application's OnExit() function. It will save the
+    // file history and delete the document manager.
+    void PrepForExit();
+
+    auto GetFrame() const { return m_frame; }
+    wxDocManager* GetDocumentManager() const { return m_docManager; }
+    wxMenuBar* GetMenuBar() const { return m_menuBar; }
+    auto GetDocTemplates() const { return m_docTemplates; }
+
+    wxFrame* CreateChildFrame(wxView* view);
+
+    bool Show(bool show = true) { return m_frame->Show(show); }
+
+protected:
+    wxFrame* m_frame { nullptr };
+    wxDocManager* m_docManager { nullptr };
+    wxMenuBar* m_menuBar { nullptr };
+
+    std::vector<wxDocTemplate*> m_docTemplates;
+};
+)===";
+
+inline constexpr const auto txt_DocViewAppCppSrc =
+    R"===("
+
+wxFrame* %class%::Create(wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style,
+                                const wxString& name)
+{
+    m_docManager = new wxDocManager;
+
+    %doc_templates%
+
+    m_frame = new wxDocParentFrameAny<wxAuiMDIParentFrame>(m_docManager, nullptr, id, title, pos, size, style, name);
+
+    m_menuBar = new wxMenuBar;
+    %default_menu%
+    m_frame->SetMenuBar(m_menuBar);
+
+    return m_frame;
+}
+
+wxFrame* %class%::CreateChildFrame(wxView* view)
+{
+    auto doc = view->GetDocument();
+    auto child_frame = new wxDocChildFrameAny<wxAuiMDIChildFrame, wxAuiMDIParentFrame>(
+        doc, view, static_cast<wxDocParentFrameAny<wxAuiMDIParentFrame>*>(m_frame), wxID_ANY, "Child Frame",
+        wxDefaultPosition, wxSize(300, 300));
+
+    auto menuFile = new wxMenu;
+
+    menuFile->Append(wxID_NEW);
+    menuFile->Append(wxID_OPEN);
+    menuFile->Append(wxID_CLOSE);
+    menuFile->Append(wxID_SAVE);
+    menuFile->Append(wxID_SAVEAS);
+    menuFile->Append(wxID_REVERT, "Re&vert...");
+
+    menuFile->AppendSeparator();
+    menuFile->Append(wxID_EXIT);
+
+    doc->GetDocumentManager()->FileHistoryAddFilesToMenu(menuFile);
+
+    auto menuEdit = new wxMenu;
+    menuEdit->Append(wxID_COPY);
+    menuEdit->Append(wxID_PASTE);
+    menuEdit->Append(wxID_SELECTALL);
+
+    auto menubar = new wxMenuBar;
+    %document_menu%
+    m_frame->SetMenuBar(child_frame);
+    child_frame->SetMenuBar(menubar);
+    child_frame->SetIcon(wxICON(notepad));
+
+    return child_frame;
+}
+
+void %class%::PrepForExit()
+{
+    m_docManager->FileHistorySave(*wxConfig::Get());
+    delete m_docManager;
+}
+)===";
+
+bool DocViewAppGenerator::ConstructionCode(Code& code)
+{
+    if (code.is_cpp())
+    {
+        tt_string_vector lines;
+        lines.ReadString(txt_DocViewAppCppSrc);
+        tt_string class_name = code.node()->value(prop_class_name);
+        for (auto& line: lines)
+        {
+            line.Replace("%class%", class_name, true);
+            code.Str(line).Eol();
+        }
+    }
+
+    return true;
+}
+
+bool DocViewAppGenerator::GetIncludes(Node* /* node */, std::set<std::string>& set_src, std::set<std::string>& /* set_hdr */)
+{
+    set_src.insert("#include <wx/aui/tabmdi.h");
+    set_src.insert("#include <wx/config.h");
+    set_src.insert("#include <wx/docmdi.h");
+    set_src.insert("#include <wx/docview.h");
+    set_src.insert("#include <wx/menu.h");
+
+    return true;
+}

--- a/src/generate/gen_doc_view_app.h
+++ b/src/generate/gen_doc_view_app.h
@@ -1,0 +1,15 @@
+// Purpose:   Generates base class for wxDocument/wView applications
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "base_generator.h"  // BaseGenerator -- Base Generator class
+
+class DocViewAppGenerator : public BaseGenerator
+{
+public:
+    bool ConstructionCode(Code&) override;
+
+    bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+};

--- a/src/generate/gen_initialize.cpp
+++ b/src/generate/gen_initialize.cpp
@@ -106,6 +106,11 @@
 #include "gen_ribbon_page.h"     // RibbonPageGenerator -- wxRibbonPage and wxRibbonPanel generators
 #include "gen_ribbon_tool.h"     // RibbonToolBarGenerator -- wxRibbonButtonBar generator
 
+#include "gen_doc_view_app.h"  // Generates base class for wxDocument/wView applications
+
+#include "gen_doc_textctrl.h"   // wxTextCtrl document class
+#include "gen_view_textctrl.h"  // wxTextCtrl view class
+
 #include "gen_enums.h"  // Enumerations for generators
 
 using namespace GenEnum;
@@ -260,6 +265,10 @@ void NodeCreator::InitGenerators()
     SET_GENERATOR(gen_TextSizer, TextSizerGenerator)
 
     SET_GENERATOR(gen_CustomControl, CustomControl)
+
+    SET_GENERATOR(gen_DocViewApp, DocViewAppGenerator)
+    SET_GENERATOR(gen_DocumentTextCtrl, TextDocumentGenerator)
+    SET_GENERATOR(gen_ViewTextCtrl, TextViewGenerator)
 
     SET_GENERATOR(gen_Project, ProjectGenerator)
     SET_GENERATOR(gen_folder, FolderGenerator)

--- a/src/generate/gen_view_textctrl.cpp
+++ b/src/generate/gen_view_textctrl.cpp
@@ -1,0 +1,74 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   wxTextCtrl view class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "gen_view_textctrl.h"
+
+#include "code.h"  // Code -- Helper class for generating code
+
+inline constexpr const auto txt_TextCtrlViewBlock =
+R"===(wxIMPLEMENT_DYNAMIC_CLASS(%class%, wxView);
+
+%class%::%class%() : wxView(), m_text(NULL) {}
+
+bool %class%::OnCreate(wxDocument* doc, long flags)
+{
+    if (!wxView::OnCreate(doc, flags))
+        return false;
+
+    Bind(
+        wxEVT_MENU, [this](wxCommandEvent&) { m_text->Copy(); }, wxID_COPY);
+    Bind(
+        wxEVT_MENU, [this](wxCommandEvent&) { m_text->Paste(); }, wxID_PASTE);
+    Bind(
+        wxEVT_MENU, [this](wxCommandEvent&) { m_text->SelectAll(); }, wxID_SELECTALL);
+
+    m_frame = wxGetApp().CreateChildFrame(this);
+    m_text = new wxTextCtrl(m_frame, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE);
+    m_frame->SetTitle(tt_wxString(doc->GetFilename()).filename());
+    m_frame->Show();
+
+    return true;
+}
+
+void %class%::OnDraw(wxDC* WXUNUSED(dc))
+{
+    // nothing to do here, wxTextCtrl draws itself
+}
+
+bool TextE%class%ditView::OnClose(bool delete_window)
+{
+    if (!wxView::OnClose(delete_window))
+        return false;
+
+    Activate(false);
+
+    if (delete_window)
+    {
+        m_frame->Destroy();
+        SetFrame(nullptr);
+        m_frame = nullptr;
+    }
+    return true;
+}
+)===";
+
+bool TextViewGenerator::ConstructionCode(Code& code)
+{
+    if (code.is_cpp())
+    {
+        tt_string_vector lines;
+        lines.ReadString(txt_TextCtrlViewBlock);
+        tt_string class_name = code.node()->value(prop_class_name);
+        for (auto& line: lines)
+        {
+            line.Replace("%class%", class_name, true);
+            code.Str(line).Eol();
+        }
+    }
+
+    return true;
+}

--- a/src/generate/gen_view_textctrl.cpp
+++ b/src/generate/gen_view_textctrl.cpp
@@ -10,7 +10,7 @@
 #include "code.h"  // Code -- Helper class for generating code
 
 inline constexpr const auto txt_TextCtrlViewBlock =
-R"===(wxIMPLEMENT_DYNAMIC_CLASS(%class%, wxView);
+    R"===(wxIMPLEMENT_DYNAMIC_CLASS(%class%, wxView);
 
 %class%::%class%() : wxView(), m_text(NULL) {}
 

--- a/src/generate/gen_view_textctrl.h
+++ b/src/generate/gen_view_textctrl.h
@@ -11,5 +11,4 @@ class TextViewGenerator : public BaseGenerator
 {
 public:
     bool ConstructionCode(Code&) override;
-
 };

--- a/src/generate/gen_view_textctrl.h
+++ b/src/generate/gen_view_textctrl.h
@@ -1,0 +1,15 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   wxTextCtrl view class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "base_generator.h"  // BaseGenerator -- Base Generator class
+
+class TextViewGenerator : public BaseGenerator
+{
+public:
+    bool ConstructionCode(Code&) override;
+
+};

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -45,6 +45,7 @@ inline const char* lst_xml_interfaces[] = {
 #include "../xml/containers_xml.xml"
 #include "../xml/dataview_xml.xml"
 #include "../xml/dialogs_xml.xml"
+#include "../xml/doc_view_app_xml.xml"
 #include "../xml/forms_xml.xml"
 #include "../xml/grid_xml.xml"
 #include "../xml/images_xml.xml"
@@ -74,6 +75,7 @@ inline const char* lst_xml_generators[] = {
     containers_xml,
     dataview_xml,
     dialogs_xml,
+    doc_view_app_xml,
     forms_xml,
     grid_xml,
     images_xml,

--- a/src/xml/doc_view_app_xml.xml
+++ b/src/xml/doc_view_app_xml.xml
@@ -1,0 +1,12 @@
+inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
+<!DOCTYPE GeneratorDefinitions SYSTEM "gen.dtd">
+<GeneratorDefinitions>
+    <gen class="DocViewApp" image="wxFrame" type="DocViewApp">
+	</gen>
+
+    <gen class="DocumentTextCtrl" image="wxTextCtrl" type="wx_document">
+	</gen>
+
+    <gen class="ViewTextCtrl" image="wxTextCtrl" type="wx_view">
+	</gen>
+</GeneratorDefinitions>)===";


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR creates initial generators and properties for creating a form-level `DocumentViewApp` class (that the user's `App` class will inherit from) and a text-control based document and view class. It includes raw strings containing code for C++ versions of the classes, though more work needs to be done before these can actually be used.