### PR TITLE
Allow creating new forms in folders and subfolders

### DIFF
--- a/src/newdialogs/new_dialog.cpp
+++ b/src/newdialogs/new_dialog.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog for creating a new project dialog
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -80,10 +80,20 @@ void NewDialog::CreateNode()
         UpdateFormClass(form_node.get());
     }
 
-    wxGetFrame().SelectNode(Project.ProjectNode());
+    auto parent_node = wxGetFrame().GetSelectedNode();
+    if (!parent_node)
+    {
+        parent_node = Project.ProjectNode();
+    }
+    else
+    {
+        parent_node = parent_node->get_ValidFormParent();
+    }
+
+    wxGetFrame().SelectNode(parent_node);
 
     tt_string undo_str("New wxDialog");
-    wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), Project.ProjectNode(), undo_str, -1));
+    wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), parent_node, undo_str, -1));
     wxGetFrame().FireCreatedEvent(form_node);
     wxGetFrame().SelectNode(form_node, evt_flags::fire_event | evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);

--- a/src/newdialogs/new_frame.cpp
+++ b/src/newdialogs/new_frame.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog for creating a new project wxFrame
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -65,10 +65,20 @@ void NewFrame::CreateNode()
         UpdateFormClass(form_node.get());
     }
 
-    wxGetFrame().SelectNode(Project.ProjectNode());
+    auto parent_node = wxGetFrame().GetSelectedNode();
+    if (!parent_node)
+    {
+        parent_node = Project.ProjectNode();
+    }
+    else
+    {
+        parent_node = parent_node->get_ValidFormParent();
+    }
+
+    wxGetFrame().SelectNode(parent_node);
 
     tt_string undo_str("New wxFrame");
-    wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), Project.ProjectNode(), undo_str, -1));
+    wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), parent_node, undo_str, -1));
     wxGetFrame().FireCreatedEvent(form_node);
     wxGetFrame().SelectNode(form_node, evt_flags::fire_event | evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);

--- a/src/newdialogs/new_panel.cpp
+++ b/src/newdialogs/new_panel.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog for creating a new form panel
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -98,10 +98,20 @@ void NewPanel::CreateNode()
             UpdateFormClass(new_node.get());
         }
 
-        wxGetFrame().SelectNode(Project.ProjectNode());
+        auto parent_node = wxGetFrame().GetSelectedNode();
+        if (!parent_node)
+        {
+            parent_node = Project.ProjectNode();
+        }
+        else
+        {
+            parent_node = parent_node->get_ValidFormParent();
+        }
+
+        wxGetFrame().SelectNode(parent_node);
 
         tt_string undo_str("New wxPanel");
-        wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), Project.ProjectNode(), undo_str, -1));
+        wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent_node, undo_str, -1));
     }
 
     wxGetFrame().FireCreatedEvent(new_node);

--- a/src/newdialogs/new_ribbon.cpp
+++ b/src/newdialogs/new_ribbon.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog for creating a new wxRibbonBar
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -98,10 +98,20 @@ void NewRibbon::CreateNode()
             UpdateFormClass(bar_node.get());
         }
 
-        wxGetFrame().SelectNode(Project.ProjectNode());
+        auto parent_node = wxGetFrame().GetSelectedNode();
+        if (!parent_node)
+        {
+            parent_node = Project.ProjectNode();
+        }
+        else
+        {
+            parent_node = parent_node->get_ValidFormParent();
+        }
+
+        wxGetFrame().SelectNode(parent_node);
 
         tt_string undo_str("New wxRibbonBar");
-        wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(bar_node.get(), Project.ProjectNode(), undo_str, -1));
+        wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(bar_node.get(), parent_node, undo_str, -1));
     }
 
     wxGetFrame().FireCreatedEvent(bar_node);

--- a/src/newdialogs/new_wizard.cpp
+++ b/src/newdialogs/new_wizard.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog for creating a new wizard
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -61,10 +61,20 @@ void NewWizard::CreateNode()
         UpdateFormClass(new_node.get());
     }
 
-    wxGetFrame().SelectNode(Project.ProjectNode());
+    auto parent_node = wxGetFrame().GetSelectedNode();
+    if (!parent_node)
+    {
+        parent_node = Project.ProjectNode();
+    }
+    else
+    {
+        parent_node = parent_node->get_ValidFormParent();
+    }
+
+    wxGetFrame().SelectNode(parent_node);
 
     tt_string undo_str("New wxWizard");
-    wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), Project.ProjectNode(), undo_str, -1));
+    wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent_node, undo_str, -1));
     wxGetFrame().FireCreatedEvent(new_node);
     wxGetFrame().SelectNode(new_node, evt_flags::fire_event | evt_flags::force_selection);
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(new_node.get(), true, true);

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -167,6 +167,21 @@ Node* Node::get_folder() noexcept
     return nullptr;
 }
 
+Node* Node::get_ValidFormParent() noexcept
+{
+    auto parent = this;
+    while (parent)
+    {
+        if (parent->IsFormParent())
+        {
+            return parent;
+        }
+        parent = parent->GetParent();
+    }
+
+    return nullptr;
+}
+
 bool Node::Adopt(NodeSharedPtr child)
 {
     ASSERT_MSG(child != GetSharedPtr(), "A node can't adopt itself!");

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -143,6 +143,10 @@ public:
     // Returns the folder node if there is one, nullptr otherwise.
     Node* get_folder() noexcept;
 
+    // This will walk up the parent tree until it finds a sub-folder, folder, or project
+    // node. Use this to find a parent for a new form.
+    Node* get_ValidFormParent() noexcept;
+
     NodeDeclaration* GetNodeDeclaration() { return m_declaration; }
 
     // Returns true if the property exists, has a value (!= wxDefaultSize, !=


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes all of the `New Form` dialogs so that the parent of the form can be a folder, sub-folder or project. Previously, the parent was always set to the project.

Closes #961