### PR TITLE
Add support for wxUSE_UNICODE_UTF8 internal build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,20 @@ option(INTERNAL_BLD_WX_CMAKE "When building fork, use wxWidgets build system")
 # option(INTERNAL_PGO_GENERATE "Create instrumented build for profiling run (MSVC only)" OFF)
 # option(INTERNAL_PGO_USEPROFILE "Create optimized build using profile data (MSVC only)" OFF)
 
+# This option is makes it possible to test against long-running branches from vadz's fork of
+# wxWidgets. Currently, this is being used internally to verfiy backports from 3.3 to 3.2, and
+# to verify the wxUSE_UNICODE_UTF8 build option for MSW.
+
+option(INTERNAL_BLD_VADZ "Assumes the existance of ../vadz/bld/CMakeLists.txt")
+
+if (INTERNAL_BLD_VADZ)
+    if (INTERNAL_BLD_FORK)
+        message(FATAL_ERROR "INTERNAL_BLD_FORK and INTERNAL_BLD_VADZ cannot be combined")
+    else()
+        message(NOTICE "Building with vadz version of wxWidgets")
+    endif()
+endif()
+
 ####################### Check for Multi-Config Generator #######################
 
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
@@ -121,21 +135,25 @@ endif()
 
 ####################### Set wxWidgets location macros #######################
 
-if (NOT INTERNAL_BLD_FORK)
+if (INTERNAL_BLD_FORK)
+    set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/../wxWidgets)
+elseif(INTERNAL_BLD_VADZ)
+    set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/../vadz)
+else()
     set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot)
     set (widget_cmake_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot)
 
     # This will build wxCLib.lib and wxWidgets.lib
     add_subdirectory(${widget_cmake_dir})
-else()
-    set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/../wxWidgets)
 endif()
 
 if (WIN32)
-    if (NOT INTERNAL_BLD_FORK)
-        set(setup_dir ${widget_cmake_dir}/win)
-    else()
+    if (INTERNAL_BLD_FORK)
         set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/../wxWidgets/bld/win)
+    elseif(INTERNAL_BLD_VADZ)
+        set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/../vadz/bld/win)
+    else()
+        set(setup_dir ${widget_cmake_dir}/win)
     endif()
 else()
     if (NOT INTERNAL_BLD_FORK)
@@ -144,7 +162,6 @@ else()
 endif()
 
 ####################### Libraries and Executables #######################
-
 
 # Setting CMAKE_MODULE_PATH causes ninja to fail rebuilding until CMake re-generates.
 # Specifying the full path and extension means ninja sees this as a normal dependency that
@@ -175,7 +192,15 @@ else()
     set(CLib wxCLib)
 endif()
 
-if (NOT INTERNAL_BLD_FORK)
+if (NOT INTERNAL_BLD_VADZ)
+    target_compile_definitions(wxUiEditor PRIVATE wxUSE_UNICODE=1)
+    target_compile_definitions(check_build PRIVATE wxUSE_UNICODE=1)
+else()
+    target_compile_definitions(wxUiEditor PRIVATE wxUSE_UNICODE_UTF8=1 wxUSE_UTF8_LOCALE_ONLY=1)
+    target_compile_definitions(check_build PRIVATE wxUSE_UNICODE_UTF8=1 wxUSE_UTF8_LOCALE_ONLY=1)
+endif()
+
+if (NOT INTERNAL_BLD_FORK AND NOT INTERNAL_BLD_VADZ)
     if (WIN32)
         target_link_libraries(wxUiEditor PRIVATE wxWidgets ${CLib} comctl32 Imm32 Shlwapi Version UxTheme)
     endif()

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -102,8 +102,8 @@ private:
     bool m_isProject_updated { false };
 
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
-    bool m_isDarkMode { true };
-    bool m_isDarkHighContrast { true };
+    bool m_isDarkMode { false };
+    bool m_isDarkHighContrast { false };
 #else
     bool m_isDarkMode { false };
     bool m_isDarkHighContrast { false };

--- a/src/pch.h
+++ b/src/pch.h
@@ -20,7 +20,6 @@
 
 #define wxUSE_GUI         1
 #define wxUSE_NO_MANIFEST 1
-#define wxUSE_UNICODE     1
 
 // Allows tt additions to pugixml (e.g. as_sview(), as_cstr(), etc.)
 #define TTLIB_ADDITIONS 1

--- a/src/tt/tt_string.cpp
+++ b/src/tt/tt_string.cpp
@@ -13,8 +13,12 @@
 
 tt_string::tt_string(const wxString& str)
 {
-#ifdef _WIN32
+#if defined(_WIN32)
+    #if (wxUSE_UNICODE_UTF8)
+    *this = str.utf8_str().data();
+    #else
     tt::utf16to8(str.wx_str(), *this);
+    #endif
 #else
     *this = str;
 #endif
@@ -22,7 +26,7 @@ tt_string::tt_string(const wxString& str)
 
 tt_string& tt_string::assign_wx(const wxString& str)
 {
-#ifdef _WIN32
+#if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
     clear();
     tt::utf16to8(str.wx_str(), *this);
 #else
@@ -33,8 +37,12 @@ tt_string& tt_string::assign_wx(const wxString& str)
 
 tt_string& tt_string::append_wx(const wxString& str)
 {
-#ifdef _WIN32
+#if defined(_WIN32)
+    #if (wxUSE_UNICODE_UTF8)
+    *this += str.utf8_str().data();
+    #else
     tt::utf16to8(str.wx_str(), *this);
+    #endif
 #else
     *this += str;
 #endif

--- a/src/tt/tt_wxString.cpp
+++ b/src/tt/tt_wxString.cpp
@@ -19,7 +19,7 @@ std::string tt_wxString::sub_cstr(size_type start_pos, size_type count) const
     std::string str;
     if (start_pos == 0 && count == tt::npos)
     {
-#if defined(_WIN32)
+#if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
         tt::utf16to8(wx_str(), str);
 #else
         str = *this;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
There is an experimental Windows build of wxWidgets using UTF8 for wxString instead of UTF16 in a fork maintained by vadz (lead maintainer of the wxWidgets project). We can't release a version of wxUiEditor using this, but we can certainly test it internally. Unfortunately, like the wxWidgets 3.3 fork, it does hard-code specific directories.

This PR enables building from a specific vadz directory containing the utf8 build to test.