### PR TITLE
Update tt classes to work better with UTF8 build of wxWidgets

### DIFF
--- a/src/tt/tt.cpp
+++ b/src/tt/tt.cpp
@@ -571,3 +571,21 @@ void tt::utf8to16(std::string_view str, std::wstring& dest)
         }
     }
 }
+
+#if (defined(_WIN32))
+
+    #include <shellapi.h>
+
+    #include <wx/string.h>  // wxString class
+
+HINSTANCE tt::ShellRun_wx(const wxString& filename, const wxString& args, const wxString& dir, INT nShow, HWND hwndParent)
+{
+    #if !(wxUSE_UNICODE_UTF8)
+    return ShellExecuteW(hwndParent, NULL, filename.c_str(), args.c_str(), dir.c_str(), nShow);
+    #else
+    return ShellExecuteW(hwndParent, NULL, tt::utf8to16(filename.utf8_string()).c_str(),
+                         tt::utf8to16(args.utf8_string()).c_str(), tt::utf8to16(dir.utf8_string()).c_str(), nShow);
+    #endif
+}
+
+#endif  // defined(_WX_DEFS_H_)

--- a/src/tt/tt.h
+++ b/src/tt/tt.h
@@ -210,5 +210,7 @@ namespace tt
         tt::LeftTrim(s);
         tt::RightTrim(s);
     }
-
+#if (defined(_WIN32))
+    HINSTANCE ShellRun_wx(const wxString& filename, const wxString& args, const wxString& dir, INT nShow, HWND hwndParent);
+#endif
 }  // namespace tt

--- a/src/tt/tt_string.cpp
+++ b/src/tt/tt_string.cpp
@@ -11,44 +11,6 @@
 
 #include "tt_string.h"
 
-tt_string::tt_string(const wxString& str)
-{
-#if defined(_WIN32)
-    #if (wxUSE_UNICODE_UTF8)
-    *this = str.utf8_str().data();
-    #else
-    tt::utf16to8(str.wx_str(), *this);
-    #endif
-#else
-    *this = str;
-#endif
-}
-
-tt_string& tt_string::assign_wx(const wxString& str)
-{
-#if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
-    clear();
-    tt::utf16to8(str.wx_str(), *this);
-#else
-    *this = str;
-#endif
-    return *this;
-}
-
-tt_string& tt_string::append_wx(const wxString& str)
-{
-#if defined(_WIN32)
-    #if (wxUSE_UNICODE_UTF8)
-    *this += str.utf8_str().data();
-    #else
-    tt::utf16to8(str.wx_str(), *this);
-    #endif
-#else
-    *this += str;
-#endif
-    return *this;
-}
-
 bool tt_string::is_sameas(std::string_view str, tt::CASE checkcase) const
 {
     if (size() != str.size())

--- a/src/tt/tt_string.h
+++ b/src/tt/tt_string.h
@@ -34,7 +34,7 @@ public:
 
     tt_string(const std::filesystem::directory_entry& dir) : std_base(dir.path().string(), dir.path().string().size()) {}
 
-    tt_string(const wxString& str);
+    tt_string(const wxString& str) { *this = str.utf8_string(); }
 
     tt_string& from_utf16(std::wstring_view str)
     {
@@ -59,7 +59,7 @@ public:
     }
 
 // If on Windows, and not a wxUSE_UNICODE_UTF8 build, return value converts to UTF16
-#if defined(_WIN32) && (!defined(wxUSE_UNICODE_UTF8) || !(wxUSE_UNICODE_UTF8))
+#if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
     std::wstring wx_str() const { return to_utf16(); };
 #else
     std::string wx_str() const { return substr(); }
@@ -354,7 +354,15 @@ public:
         return *this;
     }
 
-    tt_string& assign_wx(const wxString& str);
-    tt_string& append_wx(const wxString& str);
+    tt_string& assign_wx(const wxString& str)
+    {
+        *this = str.utf8_string();
+        return *this;
+    }
+    tt_string& append_wx(const wxString& str)
+    {
+        *this += str.utf8_string();
+        return *this;
+    }
 
 };  // end tt_string class

--- a/src/tt/tt_string_vector.h
+++ b/src/tt/tt_string_vector.h
@@ -8,7 +8,7 @@
 #pragma once  // NOLINT(#pragma once in main file)
 
 #if !(__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
-    #error "The contents of <tttextfile.h> are available only with C++17 or later."
+    #error "The contents of <tt_string_vector.h> are available only with C++17 or later."
 #endif
 
 #include <vector>
@@ -134,6 +134,17 @@ public:
             return at(index);
         }
         return emplace_back(str);
+    }
+
+    // Only adds the filename if it doesn't already exist. On Windows, the case of the
+    // filename is ignored when checking to see if the filename already exists.
+    tt_string& addfilename(std::string_view filename)
+    {
+#if defined(_WIN32)
+        return append(filename, tt::CASE::either);
+#else
+        return append(filename, tt::CASE::exact);
+#endif  // _WIN32
     }
 
     void RemoveLine(size_t line)

--- a/src/tt/tt_string_view.h
+++ b/src/tt/tt_string_view.h
@@ -25,19 +25,12 @@ public:
     tt_string_view(const char* str) : bsv(str) {}
     tt_string_view(std::string_view view) : bsv(view) {}
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
     /// Returns a copy of the string converted to UTF16 on Windows, or a normal copy on other platforms
     std::wstring wx_str() const { return to_utf16(); };
-    #if defined(_WX_DEFS_H_)
-    // Calls FromUTF8() on Windows, normal conversion on other platforms
-    wxString as_wxStr() const { return wxString::FromUTF8(data(), size()); }
-    #endif
 #else
     /// Returns a copy of the string converted to UTF16 on Windows, or a normal copy on other platforms
     std::string wx_str() const { return std::string(*this); }
-    #if defined(_WX_DEFS_H_)
-    wxString as_wxStr() const { return wxString(data(), size()); }
-    #endif
 #endif  // _WIN32
 
     std::string as_str() const { return std::string(*this); }

--- a/src/tt/tt_view_vector.h
+++ b/src/tt/tt_view_vector.h
@@ -8,7 +8,7 @@
 #pragma once  // NOLINT(#pragma once in main file)
 
 #if !(__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
-    #error "The contents of <tttextfile.h> are available only with C++17 or later."
+    #error "The contents of <tt_view_vector.h> are available only with C++17 or later."
 #endif
 
 #include <vector>

--- a/src/tt/tt_wxString.cpp
+++ b/src/tt/tt_wxString.cpp
@@ -36,13 +36,9 @@ tt_wxString& tt_wxString::append_view(std::string_view str, size_t posStart, siz
         assertm(posStart < str.size(), "invalid starting position for append_view");
         return *this;
     }
-    if (len == npos)
-        len = (str.size() - posStart);
-#if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
+    if (len == tt::npos)
+        len = str.size() - posStart;
     this->append(wxString::FromUTF8(str.data() + posStart, len));
-#else
-    this->append(str.data() + posStart, len);
-#endif  // _WIN32
     return *this;
 }
 
@@ -58,13 +54,9 @@ tt_wxString& tt_wxString::assign_view(std::string_view str, size_t posStart, siz
         assertm(posStart < str.size(), "invalid starting position for append_view");
         return *this;
     }
-    if (len == npos)
-        len = (str.size() - posStart);
-#if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
+    if (len == tt::npos)
+        len = str.size() - posStart;
     this->assign(wxString::FromUTF8(str.data() + posStart, len));
-#else
-    this->assign(str.data() + posStart, len);
-#endif  // _WIN32
     return *this;
 }
 
@@ -441,10 +433,8 @@ void tt_wxString::erase_from_wx(const wxString& sub)
 
 size_t tt_wxString::replace_view(std::string_view oldtext, std::string_view newtext, bool replace_all)
 {
-    tt_wxString old_text(oldtext);
-    tt_wxString new_text(newtext);
-
-    return Replace(old_text, new_text, replace_all);
+    return Replace(wxString::FromUTF8(oldtext.data(), oldtext.size()), wxString::FromUTF8(newtext.data(), newtext.size()),
+                   replace_all);
 }
 
 tt_wxString& tt_wxString::replace_extension(std::string_view newExtension)

--- a/src/tt/tt_wxString.h
+++ b/src/tt/tt_wxString.h
@@ -30,8 +30,11 @@ public:
     tt_wxString(const wxString& str) : wxString(str) {}
     tt_wxString(void) : wxString() {}
 
-#if defined(_WIN32) && !(wxUSE_UNICODE)
-    // When compiling for Windows, assume all char* are utf8 strings and convert them to utf16 before assigning them.
+#if defined(_WIN32)
+    // Currently, even with wxUSE_UNICODE_UTF8 enabled and a UTF8 code page enabled via /utf8
+    // compiler switch, and setting the app to UTF8 in the manifest, calling assign() still
+    // converts the string to UTF16 then back down to UTF8. So, we use FromUTF8() instead which
+    // is highly efficient if wxUSE_UNICODE_UTF8 is set.
 
     tt_wxString(const char* str) { this->assign(wxString::FromUTF8(str)); }
     tt_wxString(const std::string& str) { this->assign(wxString::FromUTF8(str.data(), str.size())); }

--- a/src/tt/tt_wxString.h
+++ b/src/tt/tt_wxString.h
@@ -30,7 +30,7 @@ public:
     tt_wxString(const wxString& str) : wxString(str) {}
     tt_wxString(void) : wxString() {}
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !(wxUSE_UNICODE)
     // When compiling for Windows, assume all char* are utf8 strings and convert them to utf16 before assigning them.
 
     tt_wxString(const char* str) { this->assign(wxString::FromUTF8(str)); }
@@ -102,11 +102,6 @@ public:
     //
     // This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.
     size_t find_oneof(std::string_view set) const;
-
-    // Find any one of the characters in a set. Returns offset if found, npos if not.
-    //
-    // This is equivalent to calling std::wcspbrk but returns an offset instead of a pointer.
-    size_t find_oneof_wx(const wxString& set) const;
 
     // Returns offset to the next whitespace character starting with pos. Returns npos if
     // there are no more whitespaces.

--- a/src/wxUiEditor.exe.manifest
+++ b/src/wxUiEditor.exe.manifest
@@ -29,6 +29,7 @@
     <asmv3:windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, system</dpiAwareness>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>

--- a/tests/sdi/cpp/cpptest.manifest
+++ b/tests/sdi/cpp/cpptest.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity
     version="1.1.0.0"
     processorArchitecture="*"
@@ -29,7 +29,7 @@
     <asmv3:windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, system</dpiAwareness>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-      <activeCodePage>UTF-8</activeCodePage>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR improves how the classes in `src/tt/` work both with regular UNICODE as well as UTF8 wxWidgets builds. The internal tool previously used to test ttLib and the newer tt classes now compiles the code from `src/tt` and runs it's series of tests on that code. There were several changes made as a result.