### PR TITLE
Add stock_id property to wxMenu

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -366,6 +366,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_stc_wrap_start_indent, "wrap_start_indent" },
     { prop_stc_wrap_visual_flag, "wrap_visual_flag" },
     { prop_stc_wrap_visual_location, "wrap_visual_location" },
+    { prop_stock_id, "stock_id" },
     { prop_style, "style" },
     { prop_symbol_margin, "symbol_margin" },
     { prop_symbol_mouse_sensitive, "symbol_mouse_sensitive" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -372,6 +372,7 @@ namespace GenEnum
         prop_stc_wrap_start_indent,
         prop_stc_wrap_visual_flag,
         prop_stc_wrap_visual_location,
+        prop_stock_id,
         prop_style,
         prop_symbol_margin,
         prop_symbol_mouse_sensitive,

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -164,6 +164,11 @@ public:
     // Call this to retrieve hint text for the property
     virtual std::optional<tt_string> GetHint(NodeProperty*);
 
+    // Called by MainFrame when the user modifies a property. Return false to let MainFrame
+    // call PushUndoAction() to push a single prop change to the undo stack. Return true if
+    // the generator handles pushing to the undo stack.
+    virtual bool ModifyProperty(NodeProperty* /* prop */, tt_string_view /* value */) { return false; }
+
     // Call this to use different help text then GetPropDeclaration()->GetDescription()
     virtual std::optional<tt_string> GetPropertyDescription(NodeProperty*) { return {}; }
 

--- a/src/generate/gen_menu.cpp
+++ b/src/generate/gen_menu.cpp
@@ -29,7 +29,16 @@ bool MenuGenerator::AdditionalCode(Code& code, GenEnum::GenCodeType cmd)
         auto parent_type = node->GetParent()->gen_type();
         if (parent_type == type_menubar)
         {
-            code.ParentName().Function("Append(").NodeName().Comma().QuotedString(prop_label).EndFunction();
+            code.ParentName().Function("Append(").NodeName().Comma();
+            if (node->value(prop_stock_id) != "none")
+            {
+                code.Add("wxGetStockLabel(").Add(node->value(prop_stock_id)).Str(")");
+            }
+            else
+            {
+                code.QuotedString(prop_label);
+            }
+            code.EndFunction();
         }
         else if (parent_type == type_menubar_form)
         {

--- a/src/generate/gen_menu.h
+++ b/src/generate/gen_menu.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Menu Generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -16,6 +16,9 @@ public:
     bool AdditionalCode(Code& code, GenEnum::GenCodeType cmd) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
+    void ChangeEnableState(wxPropertyGridManager*, NodeProperty*) override;
+    bool ModifyProperty(NodeProperty* prop, tt_string_view value) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -39,9 +39,14 @@ wxObject* MenuBarBase::CreateMockup(Node* node, wxObject* parent)
     {
         for (const auto& iter: node->GetChildNodePtrs())
         {
-            auto label = new wxStaticText(panel, wxID_ANY, iter->prop_as_wxString(prop_label));
-            sizer->Add(label, wxSizerFlags().Border(wxALL));
-            label->Bind(wxEVT_LEFT_DOWN, &MenuBarBase::OnLeftMenuClick, this);
+            wxString label;
+            if (iter->value(prop_stock_id) != "none")
+                label = wxGetStockLabel(NodeCreation.GetConstantAsInt(iter->value(prop_stock_id)));
+            else
+                label = iter->as_wxString(prop_label);
+            auto menu_name = new wxStaticText(panel, wxID_ANY, label);
+            sizer->Add(menu_name, wxSizerFlags().Border(wxALL));
+            menu_name->Bind(wxEVT_LEFT_DOWN, &MenuBarBase::OnLeftMenuClick, this);
         }
     }
 
@@ -57,7 +62,7 @@ void MenuBarBase::OnLeftMenuClick(wxMouseEvent& event)
     // child, and create a popup menu based on that child.
 
     auto menu_label = wxStaticCast(event.GetEventObject(), wxStaticText);
-    tt_string text = menu_label->GetLabel().utf8_str().data();
+    tt_string text = menu_label->GetLabel().utf8_string();
 
     Node* menu_node = nullptr;
 
@@ -69,7 +74,12 @@ void MenuBarBase::OnLeftMenuClick(wxMouseEvent& event)
     {
         for (const auto& child: m_node_menubar->GetChildNodePtrs())
         {
-            if (child->prop_as_string(prop_label) == text)
+            wxString label;
+            if (child->value(prop_stock_id) != "none")
+                label = wxGetStockLabel(NodeCreation.GetConstantAsInt(child->value(prop_stock_id)));
+            else
+                label = child->as_wxString(prop_label);
+            if (label == text)
             {
                 menu_node = child.get();
                 break;

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Main window frame
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -1565,7 +1565,10 @@ void MainFrame::ModifyProperty(NodeProperty* prop, tt_string_view value)
 {
     if (prop && value != prop->as_string())
     {
-        PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
+        if (auto* gen = prop->GetNode()->GetGenerator(); !gen || !gen->ModifyProperty(prop, value))
+        {
+            PushUndoAction(std::make_shared<ModifyPropertyAction>(prop, value));
+        }
     }
 }
 

--- a/src/xml/menus_xml.xml
+++ b/src/xml/menus_xml.xml
@@ -44,6 +44,13 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="wxMenu" image="menu" type="menu">
 		<property name="var_name" type="string">m_menu</property>
+		<property name="stock_id" type="option">
+			<option name="none" />
+			<option name="wxID_FILE" help="Use wxGetStockLabel(wxID_FILE) to retrieve the label." />
+			<option name="wxID_EDIT" help="Use wxGetStockLabel(wxID_EDIT) to retrieve the label."/>
+			<option name="wxID_HELP" help="Use wxGetStockLabel(wxID_HELP) to retrieve the label."/>
+			none
+		</property>
 		<property name="label" type="string_escapes">MyMenu</property>
 	</gen>
 

--- a/tests/sdi/cpp/mainframe.cpp
+++ b/tests/sdi/cpp/mainframe.cpp
@@ -8,7 +8,6 @@
 // clang-format off
 
 #include <wx/artprov.h>
-#include <wx/menu.h>
 
 #include "images.h"
 
@@ -85,6 +84,11 @@ bool MainFrame::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     auto* menubar = new wxMenuBar();
 
+    menu = new wxMenu();
+    auto* menuItem4 = new wxMenuItem(menu, wxID_EXIT, "Exit");
+    menu->Append(menuItem4);
+    menubar->Append(menu, wxGetStockLabel(wxID_FILE));
+
     auto* menuDialogs = new wxMenu();
     auto* menu_item_3 = new wxMenuItem(menuDialogs, wxID_ANY, "MainTestDlg");
     menu_item_3->SetBitmap(
@@ -150,9 +154,6 @@ bool MainFrame::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     submenu->Append(menu_item_5);
     menuDialogs->AppendSubMenu(submenu, "Issue Dialogs");
-    menuDialogs->AppendSeparator();
-    auto* menuItem4 = new wxMenuItem(menuDialogs, wxID_EXIT, "Exit");
-    menuDialogs->Append(menuItem4);
     menubar->Append(menuDialogs, "&Dialogs");
 
     SetMenuBar(menubar);
@@ -207,13 +208,13 @@ bool MainFrame::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     Centre(wxBOTH);
 
     // Event handlers
+    Bind(wxEVT_MENU, &MainFrame::OnQuit, this, wxID_EXIT);
     Bind(wxEVT_MENU, &MainFrame::OnMainTestDlg, this, menu_item_3->GetId());
     Bind(wxEVT_MENU, &MainFrame::OnBookTestDlg, this, menu_item_4->GetId());
     Bind(wxEVT_MENU, &MainFrame::OnPythonDlg, this, menu_item_2->GetId());
     Bind(wxEVT_MENU, &MainFrame::OnCommonDialog, this, menuItem_2->GetId());
     Bind(wxEVT_MENU, &MainFrame::OnWizard, this, menuItem3->GetId());
     Bind(wxEVT_MENU, &MainFrame::OnDlgIssue_956, this, menu_item_5->GetId());
-    Bind(wxEVT_MENU, &MainFrame::OnQuit, this, wxID_EXIT);
     Bind(wxEVT_TOOL, &MainFrame::OnMainTestDlg, this, tool_4->GetId());
     Bind(wxEVT_TOOL, &MainFrame::OnBookTestDlg, this, tool_5->GetId());
     Bind(wxEVT_TOOL, &MainFrame::OnPythonDlg, this, tool_3->GetId());

--- a/tests/sdi/cpp/mainframe.h
+++ b/tests/sdi/cpp/mainframe.h
@@ -16,6 +16,7 @@
 #include <wx/grid.h>
 #include <wx/icon.h>
 #include <wx/image.h>
+#include <wx/menu.h>
 #include <wx/propgrid/manager.h>
 #include <wx/propgrid/propgrid.h>
 #include <wx/splitter.h>
@@ -52,6 +53,7 @@ protected:
     // Class member variables
 
     wxGrid* grid;
+    wxMenu* menu;
     wxPGProperty* propertyGridItem;
     wxPGProperty* propertyGridItem_2;
     wxPGProperty* propertyGridItem_3;

--- a/tests/sdi/python/mainframe.py
+++ b/tests/sdi/python/mainframe.py
@@ -151,6 +151,11 @@ class MainFrame(wx.Frame):
 
         menubar = wx.MenuBar()
 
+        self.menu = wx.Menu()
+        menuItem4 = wx.MenuItem(self.menu, wx.ID_EXIT, "Exit")
+        self.menu.Append(menuItem4)
+        menubar.Append(self.menu, wx.GetStockLabel(wx.ID_FILE))
+
         menuDialogs = wx.Menu()
         menu_item_3 = wx.MenuItem(menuDialogs, wx.ID_ANY, "MainTestDlg")
         menu_item_3.SetBitmap(wx.BitmapBundle.FromBitmap(debug_32_png.Bitmap))
@@ -177,9 +182,6 @@ class MainFrame(wx.Frame):
         menu_item_5.SetBitmap(wx.BitmapBundle.FromBitmap(debug_32_png.Bitmap))
         submenu.Append(menu_item_5)
         menuDialogs.AppendSubMenu(submenu, "Issue Dialogs")
-        menuDialogs.AppendSeparator()
-        menuItem4 = wx.MenuItem(menuDialogs, wx.ID_EXIT, "Exit")
-        menuDialogs.Append(menuItem4)
         menubar.Append(menuDialogs, "&Dialogs")
 
         self.SetMenuBar(menubar)
@@ -207,13 +209,13 @@ class MainFrame(wx.Frame):
         self.Centre(wx.BOTH)
 
         # Bind Event handlers
+        self.Bind(wx.EVT_MENU, self.OnQuit, id=wx.ID_EXIT)
         self.Bind(wx.EVT_MENU, self.OnMainTestDlg, id=menu_item_3.GetId())
         self.Bind(wx.EVT_MENU, self.OnBookTestDlg, id=menu_item_4.GetId())
         self.Bind(wx.EVT_MENU, self.OnPythonDlg, id=menu_item_2.GetId())
         self.Bind(wx.EVT_MENU, self.OnCommonDialog, id=menuItem_2.GetId())
         self.Bind(wx.EVT_MENU, self.OnWizard, id=menuItem3.GetId())
         self.Bind(wx.EVT_MENU, self.OnDlgIssue_956, id=menu_item_5.GetId())
-        self.Bind(wx.EVT_MENU, self.OnQuit, id=wx.ID_EXIT)
         self.Bind(wx.EVT_TOOL, self.OnMainTestDlg, id=tool_4.GetId())
         self.Bind(wx.EVT_TOOL, self.OnBookTestDlg, id=tool_5.GetId())
         self.Bind(wx.EVT_TOOL, self.OnPythonDlg, id=tool_3.GetId())

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -123,6 +123,18 @@
         var_name="menubar">
         <node
           class="wxMenu"
+          label=""
+          stock_id="wxID_FILE"
+          var_name="menu">
+          <node
+            class="wxMenuItem"
+            id="wxID_EXIT"
+            label="Exit"
+            var_name="menuItem4"
+            wxEVT_MENU="OnQuit" />
+        </node>
+        <node
+          class="wxMenu"
           class_access="none"
           label="&amp;Dialogs"
           var_name="menuDialogs">
@@ -169,14 +181,6 @@
               var_name="menu_item_5"
               wxEVT_MENU="OnDlgIssue_956" />
           </node>
-          <node
-            class="separator" />
-          <node
-            class="wxMenuItem"
-            id="wxID_EXIT"
-            label="Exit"
-            var_name="menuItem4"
-            wxEVT_MENU="OnQuit" />
         </node>
       </node>
       <node


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `stock_id` property to `wxMenu`. The default value is `none` which causes the `label` property to work normally. The `stock_id` dropdown contains `wxID_FILE`, `wxID_EDIT` and `wxID_HELP`. If chosen, the `label` property will be disabled, and the label replaced by `wxGetStockLabel()`. Both the the stock_id and label property changes are stored as a single command on the Undo stack, so a single undo request will restore both properties. Note that if the stock_id is set to `none`, the `label` property will remain unchanged.

As an example, setting `stock_id` will result in the following code generation:

```C++
    menubar->Append(menu, wxGetStockLabel(wxID_FILE));
```

This is related to #972 -- this adds it to wxMenu first to figure out the underlying changes that need to be made to also support wxMenuItem.
