### PR TITLE
Remove wxSnapshot submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "wxSnapshot"]
-	path = wxSnapshot
-	url = https://github.com/KeyWorksRW/wxSnapshot.git
 [submodule "ttLib_wx"]
 	path = ttLib_wx
 	url = https://github.com/KeyWorksRW/ttLib_wx.git


### PR DESCRIPTION
The source code is now in wxWidgets/wx_3_2, so there is no longer a need for this submodule.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes the wxSnapshot submodule. Since the 3.2 sources were always required in order to build wxUiEditor, and wxSnapshot rarely changed, there was really no advantage to using a submodule.