### PR TITLE
Add stock_id property to wxMenuItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- wxMenu and wxMenu items now have a stock_id property allowing you to choose from wxWidgets stock items.
+
 ### Changed
 
 - Improved generation of default filenames for a class when the class name is changed

--- a/src/generate/gen_menuitem.h
+++ b/src/generate/gen_menuitem.h
@@ -17,5 +17,8 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 
+    void ChangeEnableState(wxPropertyGridManager*, NodeProperty*) override;
+    bool ModifyProperty(NodeProperty* prop, tt_string_view value) override;
+
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 };

--- a/src/xml/menus_xml.xml
+++ b/src/xml/menus_xml.xml
@@ -63,6 +63,45 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="wxMenuItem" image="menuitem" type="menuitem">
 		<property name="var_name" type="string">menu_item</property>
+		<!-- These need to be the same as the ones in lst_menu_ids in gen_menuitem.cpp -->
+		<property name="stock_id" type="option">
+			<option name="none" />
+			<option name="wxID_ABOUT" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_ADD" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_CLEAR" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_CLOSE" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_CONVERT" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_COPY" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_CUT" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_DELETE" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_EDIT" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_EXIT" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_FIND" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_FIRST" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_HELP" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_INDEX" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_INDENT" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_INFO" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_LAST" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_NEW" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_NEW" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_OPEN" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_PASTE" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_PREFERENCES" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_PREVIEW" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_PRINT" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_PROPERTIES" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_REDO" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_REMOVE" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_REPLACE" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_SAVE" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_SAVEAS" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_SELECTALL" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_UNDELETE" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_UNDO" help="Sets the label and help text, and changes the id to the stock id." />
+			<option name="wxID_UNINDENT" help="Sets the label and help text, and changes the id to the stock id." />
+			none
+		</property>
 		<property name="label" type="string_escapes"
 			help="Text for the menu item, as shown on the menu. An accelerator key can be specified using the ampersand &quot;&amp;&quot; character.">MyMenuItem</property>
 		<property name="shortcut" type="string_escapes"

--- a/tests/sdi/cpp/mainframe.cpp
+++ b/tests/sdi/cpp/mainframe.cpp
@@ -85,7 +85,15 @@ bool MainFrame::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     auto* menubar = new wxMenuBar();
 
     menu = new wxMenu();
-    auto* menuItem4 = new wxMenuItem(menu, wxID_EXIT, "Exit");
+    auto* menuItem4 = new wxMenuItem(menu, wxID_EXIT);
+    menuItem4->SetBitmap(
+#if wxCHECK_VERSION(3, 1, 6)
+        wxArtProvider::GetBitmapBundle(wxART_QUIT, wxART_MENU)
+#else
+        wxBitmap(wxArtProvider::GetBitmap(wxART_QUIT, wxART_MENU))
+#endif
+    );
+
     menu->Append(menuItem4);
     menubar->Append(menu, wxGetStockLabel(wxID_FILE));
 

--- a/tests/sdi/python/mainframe.py
+++ b/tests/sdi/python/mainframe.py
@@ -152,7 +152,8 @@ class MainFrame(wx.Frame):
         menubar = wx.MenuBar()
 
         self.menu = wx.Menu()
-        menuItem4 = wx.MenuItem(self.menu, wx.ID_EXIT, "Exit")
+        menuItem4 = wx.MenuItem(self.menu, wx.ID_EXIT)
+        menuItem4.SetBitmap(wx.ArtProvider.GetBitmapBundle(wx.ART_QUIT, wx.ART_MENU))
         self.menu.Append(menuItem4)
         menubar.Append(self.menu, wx.GetStockLabel(wx.ID_FILE))
 

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -123,13 +123,16 @@
         var_name="menubar">
         <node
           class="wxMenu"
-          label=""
+          label="&amp;File"
           stock_id="wxID_FILE"
           var_name="menu">
           <node
             class="wxMenuItem"
+            bitmap="Art;wxART_QUIT|wxART_MENU"
+            help="Quit this program"
             id="wxID_EXIT"
-            label="Exit"
+            label="&amp;Quit"
+            stock_id="wxID_EXIT"
             var_name="menuItem4"
             wxEVT_MENU="OnQuit" />
         </node>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds stock_id to wxMenuItem. When a stock id is specified, this will fill in label, help text and id based on the stock_id chosen. If there is a matching stock art file, that will be set as well.

Note that if the user chooses a stock id, and then chooses `none` as the id, the fields will be re-enabled, but the changes will remain intact (in case the user just wants to quickly fill in some items and then customized the results). If instead the user choose `Undo` then all changed fields will be reverted to their previous values.

This closes #972
