### PR TITLE
Create MDI class as forms underneath a folder

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -58,6 +58,8 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_template_filter, "template_filter" },
     { prop_template_view_name, "template_view_name" },
     { prop_template_visible, "template_visible" },
+    { prop_mdi_class_name, "mdi_class_name" },
+    { prop_mdi_doc_name, "mdi_doc_name" },
 
     { prop_Apply, "Apply" },
     { prop_BottomDockable, "BottomDockable" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -64,6 +64,8 @@ namespace GenEnum
         prop_template_filter,
         prop_template_view_name,
         prop_template_visible,
+        prop_mdi_class_name,
+        prop_mdi_doc_name,
 
         prop_Apply,
         prop_BottomDockable,

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -81,6 +81,9 @@ public:
     // Generate the code used to construct the object using either C++ or Python
     virtual bool ConstructionCode(Code&) { return false; }
 
+    // Generate code after the class has been constructed in the source file
+    virtual bool AfterConstructionCode(Code&) { return false; }
+
     // Generate any settings the object needs using either C++ or Python
     virtual bool SettingsCode(Code&) { return false; }
 
@@ -89,9 +92,15 @@ public:
     // Code will be written with indent::auto_keep_whitespace set
     virtual bool AfterChildrenCode(Code&) { return false; }
 
+    // Called if code needs to be generated before the class definition is generated
+    virtual bool PreClassHeaderCode(Code&) { return false; }
+
     // Generate code to add to a C++ header file -- this is normally the class header
     // definition
     virtual bool HeaderCode(Code&) { return false; }
+
+    // Called to add protected members to the class definition
+    virtual void AddProtectedHdrMembers(std::set<std::string>&) {}
 
     // Called when generating a C++ header -- this should return the actual name of the class
     // or it's derived class name. I.e., PanelForm adds wxPanel.

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -75,7 +75,7 @@ public:
     auto GetHeaderWriter() { return m_header; }
     auto GetSrcWriter() { return m_source; }
 
-    // Write code to m_source that will load any handlers needed by the form's class
+    // Write code to m_source that will load any image handlers needed by the form's class
     void GenerateHandlers();
 
     PANEL_PAGE GetPanelType() { return m_panel_type; }

--- a/src/generate/gen_doc_textctrl.cpp
+++ b/src/generate/gen_doc_textctrl.cpp
@@ -10,7 +10,7 @@
 #include "code.h"  // Code -- Helper class for generating code
 
 inline constexpr const auto txt_TextCtrlViewBlock =
-    R"===(wxIMPLEMENT_DYNAMIC_CLASS(%class%, wxDocument);
+R"===(wxIMPLEMENT_DYNAMIC_CLASS(%class%, wxDocument);
 
 bool %class%::OnCreate(const wxString& path, long flags)
 {
@@ -82,13 +82,22 @@ bool TextDocumentGenerator::ConstructionCode(Code& code)
     {
         tt_string_vector lines;
         lines.ReadString(txt_TextCtrlViewBlock);
-        tt_string class_name = code.node()->value(prop_class_name);
+        tt_string class_name = code.node()->GetParent()->value(prop_class_name);
         for (auto& line: lines)
         {
             line.Replace("%class%", class_name, true);
             code.Str(line).Eol();
         }
     }
+
+    return true;
+}
+
+bool TextDocumentGenerator::GetIncludes(Node* /* node */, std::set<std::string>& set_src, std::set<std::string>& /* set_hdr */)
+{
+    set_src.insert("#include <wx/docmdi.h");
+    set_src.insert("#include <wx/docview.h");
+    set_src.insert("#include <wx/textctrl.h");
 
     return true;
 }

--- a/src/generate/gen_doc_textctrl.h
+++ b/src/generate/gen_doc_textctrl.h
@@ -11,4 +11,6 @@ class TextDocumentGenerator : public BaseGenerator
 {
 public:
     bool ConstructionCode(Code&) override;
+
+    bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };

--- a/src/generate/gen_doc_view_app.cpp
+++ b/src/generate/gen_doc_view_app.cpp
@@ -7,9 +7,8 @@
 #include "gen_doc_view_app.h"
 
 #include "code.h"  // Code -- Helper class for generating code
-
-inline constexpr const auto txt_DocViewAppHeader =
-    R"===("// Base class for wxDocument/wxView applications.
+inline constexpr const auto txt_DocViewPreHeader =
+R"===(// Base class for wxDocument/wxView applications.
 // App class should inherit from this in addition to wxApp.
 
 // In your app's OnRun() function, call this class's Create() function to
@@ -28,40 +27,31 @@ class wxMenuBar;
 class wxDocTemplate;
 
 // Yout application's App class should inherit from this in addition to wxApp, e.g.
-//     class App : public wxApp, public DocViewApp
-class %class%
-{
-public:
-    wxFrame* Create(wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString,
-        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
-        long style = wxDEFAULT_FRAME_STYLE, const wxString& name = wxFrameNameStr);
+//     class App : public wxApp, public %class%
+)===";
 
-    // Call this from the Application's OnExit() function. It will save the
-    // file history and delete the document manager.
-    void PrepForExit();
+inline constexpr const auto txt_DocViewAppHeader = R"===(
+wxFrame* Create(wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString,
+    const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+    long style = wxDEFAULT_FRAME_STYLE, const wxString& name = wxFrameNameStr);
 
-    auto GetFrame() const { return m_frame; }
-    wxDocManager* GetDocumentManager() const { return m_docManager; }
-    wxMenuBar* GetMenuBar() const { return m_menuBar; }
-    auto GetDocTemplates() const { return m_docTemplates; }
+// Call this from the Application's OnExit() function. It will save the
+// file history and delete the document manager.
+void PrepForExit();
 
-    wxFrame* CreateChildFrame(wxView* view);
+auto GetFrame() const { return m_frame; }
+wxDocManager* GetDocumentManager() const { return m_docManager; }
+wxMenuBar* GetMenuBar() const { return m_menuBar; }
+auto GetDocTemplates() const { return m_docTemplates; }
 
-    bool Show(bool show = true) { return m_frame->Show(show); }
+wxFrame* CreateChildFrame(wxView* view);
 
-protected:
-    wxFrame* m_frame { nullptr };
-    wxDocManager* m_docManager { nullptr };
-    wxMenuBar* m_menuBar { nullptr };
+bool Show(bool show = true) { return m_frame->Show(show); }
 
-    std::vector<wxDocTemplate*> m_docTemplates;
-};
 )===";
 
 inline constexpr const auto txt_DocViewAppCppSrc =
-    R"===("
-
-wxFrame* %class%::Create(wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style,
+R"===(wxFrame* %class%::Create(wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style,
                                 const wxString& name)
 {
     m_docManager = new wxDocManager;
@@ -75,8 +65,11 @@ wxFrame* %class%::Create(wxWindowID id, const wxString& title, const wxPoint& po
     m_frame->SetMenuBar(m_menuBar);
 
     return m_frame;
-}
 
+)===";
+
+inline constexpr const auto txt_DocViewAppAfterCtor =
+R"===(
 wxFrame* %class%::CreateChildFrame(wxView* view)
 {
     auto doc = view->GetDocument();
@@ -136,6 +129,59 @@ bool DocViewAppGenerator::ConstructionCode(Code& code)
     return true;
 }
 
+bool DocViewAppGenerator::AfterConstructionCode(Code& code)
+{
+    if (code.is_cpp())
+    {
+        tt_string_vector lines;
+        lines.ReadString(txt_DocViewAppAfterCtor);
+        tt_string class_name = code.node()->value(prop_class_name);
+        for (auto& line: lines)
+        {
+            line.Replace("%class%", class_name, true);
+            code.Str(line).Eol();
+        }
+    }
+
+    return true;
+}
+
+bool DocViewAppGenerator::HeaderCode(Code& code)
+{
+    tt_string_vector lines;
+    lines.ReadString(txt_DocViewAppHeader);
+    tt_string class_name = code.node()->value(prop_class_name);
+    for (auto& line: lines)
+    {
+        line.Replace("%class%", class_name, true);
+        code.Str(line).Eol();
+    }
+
+    return true;
+}
+
+bool DocViewAppGenerator::PreClassHeaderCode(Code& code)
+{
+    tt_string_vector lines;
+    lines.ReadString(txt_DocViewPreHeader);
+    tt_string class_name = code.node()->value(prop_class_name);
+    for (auto& line: lines)
+    {
+        line.Replace("%class%", class_name, true);
+        code.Str(line).Eol();
+    }
+
+    return true;
+}
+
+void DocViewAppGenerator::AddProtectedHdrMembers(std::set<std::string>& code_lines)
+{
+    code_lines.emplace("wxFrame* m_frame { nullptr };");
+    code_lines.emplace("wxDocManager* m_docManager { nullptr };");
+    code_lines.emplace("wxMenuBar* m_menuBar { nullptr };");
+    code_lines.emplace("std::vector<wxDocTemplate*> m_docTemplates;");
+}
+
 bool DocViewAppGenerator::GetIncludes(Node* /* node */, std::set<std::string>& set_src, std::set<std::string>& /* set_hdr */)
 {
     set_src.insert("#include <wx/aui/tabmdi.h");
@@ -146,3 +192,5 @@ bool DocViewAppGenerator::GetIncludes(Node* /* node */, std::set<std::string>& s
 
     return true;
 }
+
+auto foo = wxID_LOWEST;

--- a/src/generate/gen_doc_view_app.h
+++ b/src/generate/gen_doc_view_app.h
@@ -10,6 +10,10 @@ class DocViewAppGenerator : public BaseGenerator
 {
 public:
     bool ConstructionCode(Code&) override;
+    bool AfterConstructionCode(Code&) override;
+    bool HeaderCode(Code&) override;
+    bool PreClassHeaderCode(Code&) override;
+    void AddProtectedHdrMembers(std::set<std::string>&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };

--- a/src/generate/gen_initialize.cpp
+++ b/src/generate/gen_initialize.cpp
@@ -196,6 +196,9 @@ void NodeCreator::InitGenerators()
     SET_GENERATOR(gen_separator, SeparatorGenerator)
     SET_GENERATOR(gen_wxContextMenuEvent, CtxMenuGenerator)
 
+    SET_GENERATOR(gen_MdiFrameMenuBar, MdiFrameMenuBar)
+    SET_GENERATOR(gen_MdiDocMenuBar, MdiDocumentMenuBar)
+
     SET_GENERATOR(gen_Images, ImagesGenerator)
     SET_GENERATOR(gen_embedded_image, EmbeddedImageGenerator)
 

--- a/src/generate/gen_mdi_menu.cpp
+++ b/src/generate/gen_mdi_menu.cpp
@@ -9,4 +9,22 @@
 
 #include "gen_mdi_menu.h"
 
-//////////////////////////////////////////  MenuBarBase  //////////////////////////////////////////
+#include "gen_common.h"    // GeneratorLibrary -- Generator classes
+
+//////////////////////////////////////////  MdiFrameMenuBar  //////////////////////////////////////////
+
+bool MdiFrameMenuBar::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
+{
+    InsertGeneratorInclude(node, "#include <wx/menu.h>", set_src, set_hdr);
+
+    return true;
+}
+
+//////////////////////////////////////////  MdiDocumentMenuBar  //////////////////////////////////////////
+
+bool MdiDocumentMenuBar::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
+{
+    InsertGeneratorInclude(node, "#include <wx/menu.h>", set_src, set_hdr);
+
+    return true;
+}

--- a/src/generate/gen_mdi_menu.h
+++ b/src/generate/gen_mdi_menu.h
@@ -12,6 +12,9 @@
 class MdiFrameMenuBar : public BaseGenerator
 {
 public:
+
+    bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
 private:
     // Node* m_node_menubar;
 };
@@ -19,6 +22,9 @@ private:
 class MdiDocumentMenuBar : public BaseGenerator
 {
 public:
+
+    bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
 private:
     // Node* m_node_menubar;
 };

--- a/src/generate/gen_view_textctrl.h
+++ b/src/generate/gen_view_textctrl.h
@@ -11,4 +11,6 @@ class TextViewGenerator : public BaseGenerator
 {
 public:
     bool ConstructionCode(Code&) override;
+
+    bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
 };

--- a/src/newdialogs/new_mdi.cpp
+++ b/src/newdialogs/new_mdi.cpp
@@ -69,9 +69,10 @@ void NewMdiForm::CreateNode()
     }
     if (m_view_type == "Text Control")
     {
-        auto doc_node = NodeCreation.CreateNode(gen_DocumentTextCtrl, form_node.get());
+        auto doc_node = NodeCreation.CreateNode(gen_DocumentTextCtrl, folder.get());
         ASSERT(doc_node);
-        form_node->Adopt(doc_node);
+        folder->Adopt(doc_node);
+        doc_node->prop_set_value(prop_mdi_class_name, form_node->value(prop_class_name));
         if (m_description.size())
         {
             doc_node->prop_set_value(prop_template_description, m_description);
@@ -270,9 +271,10 @@ void NewMdiForm::CreateNode()
         doc_menu->Adopt(help_menu);
 
         doc_node->Adopt(doc_menu);
-        auto view = NodeCreation.CreateNode(gen_ViewTextCtrl, doc_node.get());
+        auto view = NodeCreation.CreateNode(gen_ViewTextCtrl, folder.get());
         ASSERT(view);
-        doc_node->Adopt(view);
+        view->prop_set_value(prop_mdi_doc_name, doc_node->value(prop_class_name));
+        folder->Adopt(view);
     }
 
     auto parent_node = wxGetFrame().GetSelectedNode();

--- a/src/newdialogs/new_mdi.cpp
+++ b/src/newdialogs/new_mdi.cpp
@@ -38,6 +38,7 @@ void NewMdiForm::OnOK(wxCommandEvent& WXUNUSED(event))
             m_description = "Text";
         }
 
+#if 0
         if (m_doc_name.empty())
         {
             m_doc_name = "Text Document";
@@ -46,6 +47,7 @@ void NewMdiForm::OnOK(wxCommandEvent& WXUNUSED(event))
         {
             m_view_name = "Text View";
         }
+#endif
     }
 
     ASSERT(IsModal());
@@ -54,10 +56,13 @@ void NewMdiForm::OnOK(wxCommandEvent& WXUNUSED(event))
 
 void NewMdiForm::CreateNode()
 {
-    auto form_node = NodeCreation.CreateNode(gen_DocViewApp, nullptr);
+    auto folder = NodeCreation.CreateNode(gen_folder, nullptr);
+    folder->prop_set_value(prop_label, get_folder_name());
+    auto form_node = NodeCreation.CreateNode(gen_DocViewApp, folder.get());
     ASSERT(form_node);
+    folder->Adopt(form_node);
 
-    form_node->prop_set_value(prop_class_name, m_base_class.utf8_string());
+    form_node->prop_set_value(prop_class_name, get_app_class().utf8_string());
     if (form_node->prop_as_string(prop_class_name) != form_node->prop_default_value(prop_class_name))
     {
         UpdateFormClass(form_node.get());
@@ -79,13 +84,13 @@ void NewMdiForm::CreateNode()
         {
             doc_node->prop_set_value(prop_template_extension, m_default_extension);
         }
-        if (m_view_name.size())
+        if (get_view_class().size())
         {
-            doc_node->prop_set_value(prop_template_view_name, m_view_name);
+            doc_node->prop_set_value(prop_template_view_name, get_view_class());
         }
-        if (m_doc_name.size())
+        if (get_doc_class().size())
         {
-            doc_node->prop_set_value(prop_template_doc_name, m_doc_name);
+            doc_node->prop_set_value(prop_template_doc_name, get_doc_class());
         }
 
         auto frame_menu = NodeCreation.CreateNode(gen_MdiFrameMenuBar, doc_node.get());
@@ -283,10 +288,11 @@ void NewMdiForm::CreateNode()
     wxGetFrame().SelectNode(parent_node);
 
     tt_string undo_str("New MDI App");
-    wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(form_node.get(), parent_node, undo_str, -1));
-    wxGetFrame().FireCreatedEvent(form_node);
-    wxGetFrame().SelectNode(form_node, evt_flags::fire_event | evt_flags::force_selection);
-    wxGetFrame().GetNavigationPanel()->ChangeExpansion(form_node.get(), true, true);
+
+    wxGetFrame().PushUndoAction(std::make_shared<InsertNodeAction>(folder.get(), parent_node, undo_str, -1));
+    wxGetFrame().FireCreatedEvent(folder);
+    wxGetFrame().SelectNode(folder, evt_flags::fire_event | evt_flags::force_selection);
+    wxGetFrame().GetNavigationPanel()->ChangeExpansion(folder.get(), true, true);
 }
 
 // Called whenever m_classname changes

--- a/src/newdialogs/new_mdi.cpp
+++ b/src/newdialogs/new_mdi.cpp
@@ -93,25 +93,48 @@ void NewMdiForm::CreateNode()
 
         auto file_menu = NodeCreation.CreateNode(gen_wxMenu, frame_menu.get());
         ASSERT(file_menu);
-        file_menu->prop_set_value(prop_label, "wxID_FILE");
+        file_menu->prop_set_value(prop_stock_id, "wxID_FILE");
+        file_menu->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_FILE")));
+
         auto menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_NEW");
         menu_item->prop_set_value(prop_id, "wxID_NEW");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_NEW")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_NEW")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_NEW|wxART_MENU");
         file_menu->Adopt(menu_item);
+
         menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_OPEN");
         menu_item->prop_set_value(prop_id, "wxID_OPEN");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_OPEN")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_OPEN")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_FILE_OPEN|wxART_MENU");
         file_menu->Adopt(menu_item);
+
         menu_item = NodeCreation.CreateNode(gen_separator, file_menu.get());
         file_menu->Adopt(menu_item);
+
         menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_EXIT");
         menu_item->prop_set_value(prop_id, "wxID_EXIT");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_EXIT")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_EXIT")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_QUIT|wxART_MENU");
         file_menu->Adopt(menu_item);
 
         auto help_menu = NodeCreation.CreateNode(gen_wxMenu, frame_menu.get());
         ASSERT(help_menu);
-        help_menu->prop_set_value(prop_label, "wxID_HELP");
-        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, help_menu.get());
+        help_menu->prop_set_value(prop_stock_id, "wxID_HELP");
+        help_menu->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_HELP")));
+
+        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_ABOUT");
         menu_item->prop_set_value(prop_id, "wxID_ABOUT");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_ABOUT")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_ABOUT")));
         help_menu->Adopt(menu_item);
+
         frame_menu->Adopt(file_menu);
         frame_menu->Adopt(help_menu);
 
@@ -120,50 +143,123 @@ void NewMdiForm::CreateNode()
         ASSERT(doc_menu);
         file_menu = NodeCreation.CreateNode(gen_wxMenu, doc_menu.get());
         ASSERT(file_menu);
-        file_menu->prop_set_value(prop_label, "wxID_FILE");
+        file_menu->prop_set_value(prop_stock_id, "wxID_FILE");
+        file_menu->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_FILE")));
+
         menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_NEW");
         menu_item->prop_set_value(prop_id, "wxID_NEW");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_NEW")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_NEW")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_NEW|wxART_MENU");
         file_menu->Adopt(menu_item);
+
         menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_OPEN");
         menu_item->prop_set_value(prop_id, "wxID_OPEN");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_OPEN")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_OPEN")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_FILE_OPEN|wxART_MENU");
         file_menu->Adopt(menu_item);
+
         menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
-        menu_item->prop_set_value(prop_id, "wxID_CLOSE");
-        file_menu->Adopt(menu_item);
-        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_SAVE");
         menu_item->prop_set_value(prop_id, "wxID_SAVE");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_SAVE")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_SAVE")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_FILE_SAVE|wxART_MENU");
         file_menu->Adopt(menu_item);
+
         menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
-        menu_item->prop_set_value(prop_id, "wxID_SAVE");
-        file_menu->Adopt(menu_item);
-        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_SAVEAS");
         menu_item->prop_set_value(prop_id, "wxID_SAVEAS");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_SAVEAS")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_SAVEAS")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_FILE_SAVE_AS|wxART_MENU");
         file_menu->Adopt(menu_item);
+
         menu_item = NodeCreation.CreateNode(gen_separator, file_menu.get());
         file_menu->Adopt(menu_item);
+
         menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_PRINT");
+        menu_item->prop_set_value(prop_id, "wxID_PRINT");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_PRINT")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_PRINT")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_PRINT|wxART_MENU");
+        file_menu->Adopt(menu_item);
+
+        menu_item = NodeCreation.CreateNode(gen_separator, file_menu.get());
+        file_menu->Adopt(menu_item);
+
+        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_CLOSE");
+        menu_item->prop_set_value(prop_id, "wxID_CLOSE");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_CLOSE")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_CLOSE")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_CLOSE|wxART_MENU");
+        file_menu->Adopt(menu_item);
+
+        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_EXIT");
         menu_item->prop_set_value(prop_id, "wxID_EXIT");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_EXIT")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_EXIT")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_QUIT|wxART_MENU");
         file_menu->Adopt(menu_item);
 
         auto edit_menu = NodeCreation.CreateNode(gen_wxMenu, doc_menu.get());
         ASSERT(edit_menu);
-        edit_menu->prop_set_value(prop_label, "wxID_EDIT");
-        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, edit_menu.get());
+        edit_menu->prop_set_value(prop_stock_id, "wxID_EDIT");
+        edit_menu->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_EDIT")));
+
+        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_CUT");
+        menu_item->prop_set_value(prop_id, "wxID_CUT");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_CUT")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_CUT")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_CUT|wxART_MENU");
+        edit_menu->Adopt(menu_item);
+
+        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_COPY");
         menu_item->prop_set_value(prop_id, "wxID_COPY");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_COPY")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_COPY")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_COPY|wxART_MENU");
         edit_menu->Adopt(menu_item);
-        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, edit_menu.get());
+
+        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_PASTE");
         menu_item->prop_set_value(prop_id, "wxID_PASTE");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_PASTE")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_PASTE")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxID_PASTE|wxART_MENU");
         edit_menu->Adopt(menu_item);
-        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, edit_menu.get());
+
+        menu_item = NodeCreation.CreateNode(gen_separator, file_menu.get());
+        edit_menu->Adopt(menu_item);
+
+        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_SELECTALL");
         menu_item->prop_set_value(prop_id, "wxID_SELECTALL");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_SELECTALL")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_SELECTALL")));
+        menu_item->prop_set_value(prop_bitmap, "Art;wxART_PASTE|wxART_MENU");
         edit_menu->Adopt(menu_item);
 
         help_menu = NodeCreation.CreateNode(gen_wxMenu, doc_menu.get());
         ASSERT(help_menu);
         help_menu->prop_set_value(prop_label, "wxID_HELP");
-        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, help_menu.get());
+        help_menu->prop_set_value(prop_stock_id, "wxID_HELP");
+
+        menu_item = NodeCreation.CreateNode(gen_wxMenuItem, file_menu.get());
+        menu_item->prop_set_value(prop_stock_id, "wxID_ABOUT");
         menu_item->prop_set_value(prop_id, "wxID_ABOUT");
+        menu_item->prop_set_value(prop_label, wxGetStockLabel(NodeCreation.GetConstantAsInt("wxID_ABOUT")));
+        menu_item->prop_set_value(prop_help, wxGetStockHelpString(NodeCreation.GetConstantAsInt("wxID_ABOUT")));
         help_menu->Adopt(menu_item);
+
         doc_menu->Adopt(file_menu);
         doc_menu->Adopt(edit_menu);
         doc_menu->Adopt(help_menu);

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -28,6 +28,9 @@ inline const GenType lst_form_types[] =
 {
 
     type_DocViewApp,
+    type_wx_document,
+    type_wx_view,
+
     type_form,
     type_frame_form,
     type_images,

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -196,8 +196,6 @@ static const ParentChild lstParentChild[] = {
 
     // Forms
 
-    { type_DocViewApp, type_wx_document, infinite },
-
     { type_frame_form, type_gbsizer, one },
     { type_frame_form, type_sizer, one },
 
@@ -229,7 +227,6 @@ static const ParentChild lstParentChild[] = {
     { type_images, type_embed_image, infinite },
     { type_wizard, type_wizardpagesimple, infinite },
 
-    { type_project, type_DocViewApp, infinite },
     { type_project, type_form, infinite },
     { type_project, type_folder, infinite },
     { type_project, type_frame_form, infinite },
@@ -255,6 +252,9 @@ static const ParentChild lstParentChild[] = {
     { type_folder, type_ribbonbar_form, infinite },
     { type_folder, type_toolbar_form, infinite },
     { type_folder, type_wizard, infinite },
+    { type_folder, type_DocViewApp, one },
+    { type_folder, type_wx_document, infinite },
+    { type_folder, type_wx_view, infinite },
 
     { type_sub_folder, type_form, infinite },
     { type_sub_folder, type_sub_folder, infinite },
@@ -358,7 +358,6 @@ static const ParentChild lstParentChild[] = {
 
     { type_treelistctrl, type_treelistctrlcolumn, infinite },
 
-    { type_wx_document, type_wx_view, infinite },
     { type_wx_document, type_mdi_menubar, one },  // default menu bar when no document is loaded
     { type_wx_document, type_doc_menubar, one },  // menu bar when a document is loaded
     { type_mdi_menubar, type_menu, infinite },

--- a/src/wxui/newmdi_base.cpp
+++ b/src/wxui/newmdi_base.cpp
@@ -61,8 +61,9 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     staticText_9->SetToolTip("Change this to something unique to your project.");
     box_sizer_2->Add(staticText_9, wxSizerFlags().Center().Border(wxALL));
 
-    auto* app_classname = new wxTextCtrl(this, wxID_ANY, "MdiAppBase");
+    auto* app_classname = new wxTextCtrl(this, wxID_ANY, "DocViewAppBase");
     app_classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_app_class));
+    app_classname->SetMinSize(ConvertDialogToPixels(wxSize(100, -1)));
     app_classname->SetToolTip("Change this to something unique to your project.");
     box_sizer_2->Add(app_classname, wxSizerFlags(1).Border(wxALL));
 
@@ -106,18 +107,6 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     auto* static_box_3 = new wxStaticBoxSizer(wxVERTICAL, this, "Document");
 
-    auto* box_sizer_6 = new wxBoxSizer(wxHORIZONTAL);
-
-    auto* box_sizer_5 = new wxBoxSizer(wxHORIZONTAL);
-
-    box_sizer_6->Add(box_sizer_5, wxSizerFlags().Border(wxALL));
-
-    auto* box_sizer_4 = new wxBoxSizer(wxHORIZONTAL);
-
-    box_sizer_6->Add(box_sizer_4, wxSizerFlags().Expand().Border(wxALL));
-
-    static_box_3->Add(box_sizer_6, wxSizerFlags().Expand().Border(wxALL));
-
     auto* flex_grid_sizer = new wxFlexGridSizer(4, 0, 0);
     flex_grid_sizer->SetFlexibleDirection(wxHORIZONTAL);
 
@@ -135,8 +124,9 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     staticText_10->SetToolTip("Change this to something unique to your project.");
     flex_grid_sizer->Add(staticText_10, wxSizerFlags().Center().Border(wxALL));
 
-    auto* doc_classname = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, "TextDocumentBase");
+    auto* doc_classname = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, "DocumentTextCtrlBase");
     doc_classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_doc_class));
+    doc_classname->SetMinSize(ConvertDialogToPixels(wxSize(100, -1)));
     doc_classname->SetToolTip("Change this to something unique to your project.");
     flex_grid_sizer->Add(doc_classname, wxSizerFlags(1).Border(wxALL));
 
@@ -158,11 +148,11 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     filter->SetToolTip("An appropriate file filter such as \"*.txt\". ");
     flex_grid_sizer->Add(filter, wxSizerFlags().Expand().Border(wxALL));
 
-    static_box_3->Add(flex_grid_sizer, wxSizerFlags().Border(wxALL));
+    static_box_3->Add(flex_grid_sizer, wxSizerFlags().Expand().Border(wxALL));
 
     box_sizer_3->Add(static_box_3, wxSizerFlags().Expand().Border(wxALL));
 
-    box_sizer->Add(box_sizer_3, wxSizerFlags().Border(wxALL));
+    box_sizer->Add(box_sizer_3, wxSizerFlags().Expand().Border(wxALL));
 
     auto* stdBtn = CreateStdDialogButtonSizer(wxOK|wxCANCEL);
     box_sizer->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));

--- a/src/wxui/newmdi_base.cpp
+++ b/src/wxui/newmdi_base.cpp
@@ -8,7 +8,10 @@
 // clang-format off
 
 #include <wx/button.h>
+#include <wx/choice.h>
+#include <wx/radiobut.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 #include <wx/valgen.h>
@@ -36,95 +39,128 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     m_infoBar->SetEffectDuration(500);
     box_sizer_3->Add(m_infoBar, wxSizerFlags().Expand().Border(wxALL));
 
+    auto* box_sizer_7 = new wxBoxSizer(wxHORIZONTAL);
+
+    auto* box_sizer_8 = new wxBoxSizer(wxHORIZONTAL);
+
+    auto* staticText_6 = new wxStaticText(this, wxID_ANY, "&Folder name:");
+    staticText_6->SetToolTip("Change this to something unique to your project.");
+    box_sizer_8->Add(staticText_6, wxSizerFlags().Center().Border(wxALL));
+
+    auto* folder_name = new wxTextCtrl(this, wxID_ANY, "Mdi Application");
+    folder_name->SetFocus();
+    folder_name->SetValidator(wxTextValidator(wxFILTER_NONE, &m_folder_name));
+    folder_name->SetToolTip("Change this to something unique to your project.");
+    box_sizer_8->Add(folder_name, wxSizerFlags(1).Border(wxALL));
+
+    box_sizer_7->Add(box_sizer_8, wxSizerFlags().Expand().Border(wxALL));
+
     auto* box_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
 
-    auto* staticText_9 = new wxStaticText(this, wxID_ANY, "&Base class name:");
+    auto* staticText_9 = new wxStaticText(this, wxID_ANY, "&App class:");
     staticText_9->SetToolTip("Change this to something unique to your project.");
     box_sizer_2->Add(staticText_9, wxSizerFlags().Center().Border(wxALL));
 
-    auto* classname = new wxTextCtrl(this, wxID_ANY, "MyMdiAppBase");
-    classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_base_class));
-    classname->SetToolTip("Change this to something unique to your project.");
-    box_sizer_2->Add(classname, wxSizerFlags(1).Border(wxALL));
+    auto* app_classname = new wxTextCtrl(this, wxID_ANY, "MdiAppBase");
+    app_classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_app_class));
+    app_classname->SetToolTip("Change this to something unique to your project.");
+    box_sizer_2->Add(app_classname, wxSizerFlags(1).Border(wxALL));
 
-    box_sizer_3->Add(box_sizer_2, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer_7->Add(box_sizer_2, wxSizerFlags().Expand().Border(wxALL));
 
-    auto* class_sizer = new wxBoxSizer(wxHORIZONTAL);
+    box_sizer_3->Add(box_sizer_7, wxSizerFlags().Border(wxALL));
 
-    auto* staticText = new wxStaticText(this, wxID_ANY, "&Frame type:");
-    class_sizer->Add(staticText, wxSizerFlags().Center().Border(wxALL));
+    auto* static_box = new wxStaticBoxSizer(wxHORIZONTAL, this, "Frame Type");
 
-    m_choice_type = new wxChoice(this, wxID_ANY);
-    m_choice_type->Append("wxAuiMDIParentFrame");
-    m_choice_type->Append("wxDocMDIParentFrame");
-    m_mdi_type = "wxDocMDIParentFrame";  // set validator variable
-    m_choice_type->SetValidator(wxGenericValidator(&m_mdi_type));
-    class_sizer->Add(m_choice_type, wxSizerFlags(1).Border(wxALL));
+    auto* radioBtn = new wxRadioButton(static_box->GetStaticBox(), wxID_ANY, "wxAuiMDIParentFrame", wxDefaultPosition,
+        wxDefaultSize, wxRB_GROUP);
+    radioBtn->SetValue(true);
+    radioBtn->SetValidator(wxGenericValidator(&m_aui_frame));
+    static_box->Add(radioBtn, wxSizerFlags().Border(wxALL));
 
-    box_sizer_3->Add(class_sizer, wxSizerFlags().Expand().Border(wxALL));
+    auto* radioBtn_2 = new wxRadioButton(static_box->GetStaticBox(), wxID_ANY, "wxDocMDIParentFrame");
+    radioBtn_2->SetValidator(wxGenericValidator(&m_doc_frame));
+    static_box->Add(radioBtn_2, wxSizerFlags().Border(wxALL));
 
-    auto* flex_grid_sizer = new wxFlexGridSizer(2, 0, 0);
-    {
-        flex_grid_sizer->AddGrowableCol(1, 1);
-    }
+    box_sizer_3->Add(static_box, wxSizerFlags().Expand().Border(wxALL));
 
-    auto* staticText_2 = new wxStaticText(this, wxID_ANY, "&Description:");
+    auto* static_box_2 = new wxStaticBoxSizer(wxHORIZONTAL, this, "View");
+
+    auto* choice_view = new wxChoice(static_box_2->GetStaticBox(), wxID_ANY);
+    choice_view->Append("Text Control");
+    choice_view->Append("Image");
+    m_view_type = "Text Control";  // set validator variable
+    choice_view->SetValidator(wxGenericValidator(&m_view_type));
+    static_box_2->Add(choice_view, wxSizerFlags(1).Border(wxALL));
+
+    auto* staticText_11 = new wxStaticText(static_box_2->GetStaticBox(), wxID_ANY, "Class name:");
+    staticText_11->SetToolTip("Change this to something unique to your project.");
+    static_box_2->Add(staticText_11, wxSizerFlags().Center().Border(wxALL));
+
+    auto* view_classname = new wxTextCtrl(static_box_2->GetStaticBox(), wxID_ANY, "TextViewBase");
+    view_classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_view_class));
+    view_classname->SetToolTip("Change this to something unique to your project.");
+    static_box_2->Add(view_classname, wxSizerFlags(1).Border(wxALL));
+
+    box_sizer_3->Add(static_box_2, wxSizerFlags().Expand().Border(wxALL));
+
+    auto* static_box_3 = new wxStaticBoxSizer(wxVERTICAL, this, "Document");
+
+    auto* box_sizer_6 = new wxBoxSizer(wxHORIZONTAL);
+
+    auto* box_sizer_5 = new wxBoxSizer(wxHORIZONTAL);
+
+    box_sizer_6->Add(box_sizer_5, wxSizerFlags().Border(wxALL));
+
+    auto* box_sizer_4 = new wxBoxSizer(wxHORIZONTAL);
+
+    box_sizer_6->Add(box_sizer_4, wxSizerFlags().Expand().Border(wxALL));
+
+    static_box_3->Add(box_sizer_6, wxSizerFlags().Expand().Border(wxALL));
+
+    auto* flex_grid_sizer = new wxFlexGridSizer(4, 0, 0);
+    flex_grid_sizer->SetFlexibleDirection(wxHORIZONTAL);
+
+    auto* staticText_2 = new wxStaticText(static_box_3->GetStaticBox(), wxID_ANY, "&Description:");
     flex_grid_sizer->Add(staticText_2, wxSizerFlags().Center().Border(wxALL));
 
-    auto* description = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
+    auto* description = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, wxEmptyString);
     description->SetHint("Text");
     description->SetValidator(wxTextValidator(wxFILTER_NONE, &m_description));
     description->SetToolTip(
     "A short description of what the template is for. This string will be displayed in the file filter list of Windows file selectors. ");
     flex_grid_sizer->Add(description, wxSizerFlags().Expand().Border(wxALL));
 
-    auto* staticText_6 = new wxStaticText(this, wxID_ANY, "&View Type:");
-    flex_grid_sizer->Add(staticText_6, wxSizerFlags().Border(wxALL));
+    auto* staticText_10 = new wxStaticText(static_box_3->GetStaticBox(), wxID_ANY, "Class name:");
+    staticText_10->SetToolTip("Change this to something unique to your project.");
+    flex_grid_sizer->Add(staticText_10, wxSizerFlags().Center().Border(wxALL));
 
-    auto* choice_view = new wxChoice(this, wxID_ANY);
-    choice_view->Append("Text Control");
-    choice_view->Append("Image");
-    m_view_type = "Text Control";  // set validator variable
-    choice_view->SetValidator(wxGenericValidator(&m_view_type));
-    flex_grid_sizer->Add(choice_view, wxSizerFlags(1).Border(wxALL));
+    auto* doc_classname = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, "TextDocumentBase");
+    doc_classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_doc_class));
+    doc_classname->SetToolTip("Change this to something unique to your project.");
+    flex_grid_sizer->Add(doc_classname, wxSizerFlags(1).Border(wxALL));
 
-    auto* staticText_4 = new wxStaticText(this, wxID_ANY, "&Filter:");
-    flex_grid_sizer->Add(staticText_4, wxSizerFlags().Center().Border(wxALL));
-
-    auto* filter = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
-    filter->SetHint("*.txt");
-    filter->SetValidator(wxTextValidator(wxFILTER_NONE, &m_filter));
-    filter->SetToolTip("An appropriate file filter such as \"*.txt\". ");
-    flex_grid_sizer->Add(filter, wxSizerFlags().Expand().Border(wxALL));
-
-    auto* staticText_5 = new wxStaticText(this, wxID_ANY, "&Extension:");
+    auto* staticText_5 = new wxStaticText(static_box_3->GetStaticBox(), wxID_ANY, "&Extension:");
     flex_grid_sizer->Add(staticText_5, wxSizerFlags().Center().Border(wxALL));
 
-    auto* extension = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
+    auto* extension = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, wxEmptyString);
     extension->SetHint("txt");
     extension->SetValidator(wxTextValidator(wxFILTER_NONE, &m_default_extension));
     extension->SetToolTip("An appropriate file filter such as \"*.txt\". ");
     flex_grid_sizer->Add(extension, wxSizerFlags().Expand().Border(wxALL));
 
-    auto* staticText_7 = new wxStaticText(this, wxID_ANY, "D&oc Name:");
-    flex_grid_sizer->Add(staticText_7, wxSizerFlags().Border(wxALL));
+    auto* staticText_4 = new wxStaticText(static_box_3->GetStaticBox(), wxID_ANY, "&Filter:");
+    flex_grid_sizer->Add(staticText_4, wxSizerFlags().Center().Border(wxALL));
 
-    auto* doc_name = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
-    doc_name->SetHint("Text Document");
-    doc_name->SetValidator(wxTextValidator(wxFILTER_NONE, &m_doc_name));
-    doc_name->SetToolTip("An appropriate file filter such as \"*.txt\". ");
-    flex_grid_sizer->Add(doc_name, wxSizerFlags().Expand().Border(wxALL));
+    auto* filter = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, wxEmptyString);
+    filter->SetHint("*.txt");
+    filter->SetValidator(wxTextValidator(wxFILTER_NONE, &m_filter));
+    filter->SetToolTip("An appropriate file filter such as \"*.txt\". ");
+    flex_grid_sizer->Add(filter, wxSizerFlags().Expand().Border(wxALL));
 
-    auto* staticText_8 = new wxStaticText(this, wxID_ANY, "V&iew Name:");
-    flex_grid_sizer->Add(staticText_8, wxSizerFlags().Border(wxALL));
+    static_box_3->Add(flex_grid_sizer, wxSizerFlags().Border(wxALL));
 
-    auto* view_name = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
-    view_name->SetHint("Text View");
-    view_name->SetValidator(wxTextValidator(wxFILTER_NONE, &m_view_name));
-    view_name->SetToolTip("An appropriate file filter such as \"*.txt\". ");
-    flex_grid_sizer->Add(view_name, wxSizerFlags().Expand().Border(wxALL));
-
-    box_sizer_3->Add(flex_grid_sizer, wxSizerFlags(1).Expand().Border(wxALL));
+    box_sizer_3->Add(static_box_3, wxSizerFlags().Expand().Border(wxALL));
 
     box_sizer->Add(box_sizer_3, wxSizerFlags().Border(wxALL));
 
@@ -140,10 +176,21 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     Bind(wxEVT_INIT_DIALOG,
         [this](wxInitDialogEvent& event)
         {
-            m_choice_type->SetFocus();
             event.Skip();
         });
-    classname->Bind(wxEVT_TEXT,
+    folder_name->Bind(wxEVT_TEXT,
+        [this](wxCommandEvent&)
+        {VerifyClassName();
+        });
+    app_classname->Bind(wxEVT_TEXT,
+        [this](wxCommandEvent&)
+        {VerifyClassName();
+        });
+    view_classname->Bind(wxEVT_TEXT,
+        [this](wxCommandEvent&)
+        {VerifyClassName();
+        });
+    doc_classname->Bind(wxEVT_TEXT,
         [this](wxCommandEvent&)
         {VerifyClassName();
         });

--- a/src/wxui/newmdi_base.h
+++ b/src/wxui/newmdi_base.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <wx/choice.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
@@ -30,14 +29,16 @@ public:
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
-    const wxString& get_base_class() const { return m_base_class; }
-    const wxString& get_mdi_type() const { return m_mdi_type; }
-    const wxString& get_description() const { return m_description; }
+    const wxString& get_folder_name() const { return m_folder_name; }
+    const wxString& get_app_class() const { return m_app_class; }
+    bool is_aui_frame() const { return m_aui_frame; }
+    bool is_doc_frame() const { return m_doc_frame; }
     const wxString& get_view_type() const { return m_view_type; }
-    const wxString& get_filter() const { return m_filter; }
+    const wxString& get_view_class() const { return m_view_class; }
+    const wxString& get_description() const { return m_description; }
+    const wxString& get_doc_class() const { return m_doc_class; }
     const wxString& get_default_extension() const { return m_default_extension; }
-    const wxString& get_doc_name() const { return m_doc_name; }
-    const wxString& get_view_name() const { return m_view_name; }
+    const wxString& get_filter() const { return m_filter; }
 
     void CreateNode();
     void VerifyClassName();
@@ -56,18 +57,19 @@ private:
 
     // Validator variables
 
-    wxString m_base_class { "MyMdiAppBase" };
+    bool m_aui_frame { true };
+    bool m_doc_frame { false };
+    wxString m_app_class { "MdiAppBase" };
     wxString m_default_extension;
     wxString m_description;
-    wxString m_doc_name;
+    wxString m_doc_class { "TextDocumentBase" };
     wxString m_filter;
-    wxString m_mdi_type;
-    wxString m_view_name;
+    wxString m_folder_name { "Mdi Application" };
+    wxString m_view_class { "TextViewBase" };
     wxString m_view_type;
 
     // Class member variables
 
-    wxChoice* m_choice_type;
     wxInfoBar* m_infoBar;
 };
 

--- a/src/wxui/newmdi_base.h
+++ b/src/wxui/newmdi_base.h
@@ -59,10 +59,10 @@ private:
 
     bool m_aui_frame { true };
     bool m_doc_frame { false };
-    wxString m_app_class { "MdiAppBase" };
+    wxString m_app_class { "DocViewAppBase" };
     wxString m_default_extension;
     wxString m_description;
-    wxString m_doc_class { "TextDocumentBase" };
+    wxString m_doc_class { "DocumentTextCtrlBase" };
     wxString m_filter;
     wxString m_folder_name { "Mdi Application" };
     wxString m_view_class { "TextViewBase" };

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -3721,7 +3721,7 @@
         inserted_hdr_code="void CreateNode();@@void VerifyClassName();@@@@private:@@bool m_is_info_shown { false };"
         private_members="1"
         use_derived_class="0"
-        wxEVT_INIT_DIALOG="[this](wxInitDialogEvent&amp; event)@@{@@m_choice_type->SetFocus();@@event.Skip();@@}[python:OnInit]">
+        wxEVT_INIT_DIALOG="[this](wxInitDialogEvent&amp; event)@@{@@event.Skip();@@}[python:OnInit]">
         <node
           class="wxBoxSizer"
           orientation="wxVERTICAL"
@@ -3741,70 +3741,81 @@
               flags="wxEXPAND" />
             <node
               class="wxBoxSizer"
-              var_name="box_sizer_2"
-              flags="wxEXPAND">
+              var_name="box_sizer_7">
               <node
-                class="wxStaticText"
-                class_access="none"
-                label="&amp;Base class name:"
-                var_name="staticText_9"
-                tooltip="Change this to something unique to your project."
-                alignment="wxALIGN_CENTER_VERTICAL" />
+                class="wxBoxSizer"
+                var_name="box_sizer_8"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Folder name:"
+                  var_name="staticText_6"
+                  tooltip="Change this to something unique to your project."
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxTextCtrl"
+                  class_access="none"
+                  focus="1"
+                  value="Mdi Application"
+                  var_name="folder_name"
+                  get_function="get_folder_name"
+                  validator_variable="m_folder_name"
+                  tooltip="Change this to something unique to your project."
+                  proportion="1"
+                  wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />
+              </node>
               <node
-                class="wxTextCtrl"
-                class_access="none"
-                value="MyMdiAppBase"
-                var_name="classname"
-                get_function="get_base_class"
-                validator_variable="m_base_class"
-                tooltip="Change this to something unique to your project."
-                proportion="1"
-                wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />
+                class="wxBoxSizer"
+                var_name="box_sizer_2"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;App class:"
+                  var_name="staticText_9"
+                  tooltip="Change this to something unique to your project."
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxTextCtrl"
+                  class_access="none"
+                  value="MdiAppBase"
+                  var_name="app_classname"
+                  get_function="get_app_class"
+                  validator_variable="m_app_class"
+                  tooltip="Change this to something unique to your project."
+                  proportion="1"
+                  wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />
+              </node>
             </node>
             <node
-              class="wxBoxSizer"
-              var_name="class_sizer"
+              class="wxStaticBoxSizer"
+              label="Frame Type"
+              orientation="wxHORIZONTAL"
               flags="wxEXPAND">
               <node
-                class="wxStaticText"
+                class="wxRadioButton"
+                checked="1"
                 class_access="none"
-                label="&amp;Frame type:"
-                var_name="staticText"
-                alignment="wxALIGN_CENTER_VERTICAL" />
+                label="wxAuiMDIParentFrame"
+                style="wxRB_GROUP"
+                var_name="radioBtn"
+                get_function="is_aui_frame"
+                validator_variable="m_aui_frame" />
               <node
-                class="wxChoice"
-                contents="&quot;wxAuiMDIParentFrame&quot; &quot;wxDocMDIParentFrame&quot;"
-                selection_string="wxDocMDIParentFrame"
-                var_name="m_choice_type"
-                get_function="get_mdi_type"
-                validator_variable="m_mdi_type"
-                proportion="1" />
+                class="wxRadioButton"
+                class_access="none"
+                label="wxDocMDIParentFrame"
+                var_name="radioBtn_2"
+                get_function="is_doc_frame"
+                validator_variable="m_doc_frame" />
             </node>
             <node
-              class="wxFlexGridSizer"
-              growablecols="1:1"
-              flags="wxEXPAND"
-              proportion="1">
-              <node
-                class="wxStaticText"
-                class_access="none"
-                label="&amp;Description:"
-                var_name="staticText_2"
-                alignment="wxALIGN_CENTER_VERTICAL" />
-              <node
-                class="wxTextCtrl"
-                class_access="none"
-                hint="Text"
-                var_name="description"
-                get_function="get_description"
-                validator_variable="m_description"
-                tooltip="A short description of what the template is for. This string will be displayed in the file filter list of Windows file selectors. "
-                flags="wxEXPAND" />
-              <node
-                class="wxStaticText"
-                class_access="none"
-                label="&amp;View Type:"
-                var_name="staticText_6" />
+              class="wxStaticBoxSizer"
+              label="View"
+              orientation="wxHORIZONTAL"
+              var_name="static_box_2"
+              flags="wxEXPAND">
               <node
                 class="wxChoice"
                 class_access="none"
@@ -3818,61 +3829,105 @@
               <node
                 class="wxStaticText"
                 class_access="none"
-                label="&amp;Filter:"
-                var_name="staticText_4"
+                label="Class name:"
+                var_name="staticText_11"
+                tooltip="Change this to something unique to your project."
                 alignment="wxALIGN_CENTER_VERTICAL" />
               <node
                 class="wxTextCtrl"
                 class_access="none"
-                hint="*.txt"
-                var_name="filter"
-                get_function="get_filter"
-                validator_variable="m_filter"
-                tooltip="An appropriate file filter such as &quot;*.txt&quot;. "
-                flags="wxEXPAND" />
+                value="TextViewBase"
+                var_name="view_classname"
+                get_function="get_view_class"
+                validator_variable="m_view_class"
+                tooltip="Change this to something unique to your project."
+                proportion="1"
+                wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />
+            </node>
+            <node
+              class="wxStaticBoxSizer"
+              label="Document"
+              var_name="static_box_3"
+              flags="wxEXPAND">
               <node
-                class="wxStaticText"
-                class_access="none"
-                label="&amp;Extension:"
-                var_name="staticText_5"
-                alignment="wxALIGN_CENTER_VERTICAL" />
+                class="wxBoxSizer"
+                var_name="box_sizer_6"
+                flags="wxEXPAND">
+                <node
+                  class="wxBoxSizer"
+                  var_name="box_sizer_5" />
+                <node
+                  class="wxBoxSizer"
+                  var_name="box_sizer_4"
+                  flags="wxEXPAND" />
+              </node>
               <node
-                class="wxTextCtrl"
-                class_access="none"
-                hint="txt"
-                var_name="extension"
-                get_function="get_default_extension"
-                validator_variable="m_default_extension"
-                tooltip="An appropriate file filter such as &quot;*.txt&quot;. "
-                flags="wxEXPAND" />
-              <node
-                class="wxStaticText"
-                class_access="none"
-                label="D&amp;oc Name:"
-                var_name="staticText_7" />
-              <node
-                class="wxTextCtrl"
-                class_access="none"
-                hint="Text Document"
-                var_name="doc_name"
-                get_function="get_doc_name"
-                validator_variable="m_doc_name"
-                tooltip="An appropriate file filter such as &quot;*.txt&quot;. "
-                flags="wxEXPAND" />
-              <node
-                class="wxStaticText"
-                class_access="none"
-                label="V&amp;iew Name:"
-                var_name="staticText_8" />
-              <node
-                class="wxTextCtrl"
-                class_access="none"
-                hint="Text View"
-                var_name="view_name"
-                get_function="get_view_name"
-                validator_variable="m_view_name"
-                tooltip="An appropriate file filter such as &quot;*.txt&quot;. "
-                flags="wxEXPAND" />
+                class="wxFlexGridSizer"
+                cols="4"
+                flexible_direction="wxHORIZONTAL">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Description:"
+                  var_name="staticText_2"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxTextCtrl"
+                  class_access="none"
+                  hint="Text"
+                  var_name="description"
+                  get_function="get_description"
+                  validator_variable="m_description"
+                  tooltip="A short description of what the template is for. This string will be displayed in the file filter list of Windows file selectors. "
+                  flags="wxEXPAND" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="Class name:"
+                  var_name="staticText_10"
+                  tooltip="Change this to something unique to your project."
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxTextCtrl"
+                  class_access="none"
+                  value="TextDocumentBase"
+                  var_name="doc_classname"
+                  get_function="get_doc_class"
+                  validator_variable="m_doc_class"
+                  tooltip="Change this to something unique to your project."
+                  proportion="1"
+                  wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Extension:"
+                  var_name="staticText_5"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxTextCtrl"
+                  class_access="none"
+                  hint="txt"
+                  var_name="extension"
+                  get_function="get_default_extension"
+                  validator_variable="m_default_extension"
+                  tooltip="An appropriate file filter such as &quot;*.txt&quot;. "
+                  flags="wxEXPAND" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Filter:"
+                  var_name="staticText_4"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxTextCtrl"
+                  class_access="none"
+                  hint="*.txt"
+                  var_name="filter"
+                  get_function="get_filter"
+                  validator_variable="m_filter"
+                  tooltip="An appropriate file filter such as &quot;*.txt&quot;. "
+                  flags="wxEXPAND" />
+              </node>
             </node>
           </node>
           <node

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -3729,7 +3729,8 @@
           <node
             class="wxBoxSizer"
             orientation="wxVERTICAL"
-            var_name="box_sizer_3">
+            var_name="box_sizer_3"
+            flags="wxEXPAND">
             <node
               class="wxStaticText"
               class_access="none"
@@ -3779,10 +3780,11 @@
                 <node
                   class="wxTextCtrl"
                   class_access="none"
-                  value="MdiAppBase"
+                  value="DocViewAppBase"
                   var_name="app_classname"
                   get_function="get_app_class"
                   validator_variable="m_app_class"
+                  minimum_size="100,-1d"
                   tooltip="Change this to something unique to your project."
                   proportion="1"
                   wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />
@@ -3850,21 +3852,10 @@
               var_name="static_box_3"
               flags="wxEXPAND">
               <node
-                class="wxBoxSizer"
-                var_name="box_sizer_6"
-                flags="wxEXPAND">
-                <node
-                  class="wxBoxSizer"
-                  var_name="box_sizer_5" />
-                <node
-                  class="wxBoxSizer"
-                  var_name="box_sizer_4"
-                  flags="wxEXPAND" />
-              </node>
-              <node
                 class="wxFlexGridSizer"
                 cols="4"
-                flexible_direction="wxHORIZONTAL">
+                flexible_direction="wxHORIZONTAL"
+                flags="wxEXPAND">
                 <node
                   class="wxStaticText"
                   class_access="none"
@@ -3890,10 +3881,11 @@
                 <node
                   class="wxTextCtrl"
                   class_access="none"
-                  value="TextDocumentBase"
+                  value="DocumentTextCtrlBase"
                   var_name="doc_classname"
                   get_function="get_doc_class"
                   validator_variable="m_doc_class"
+                  minimum_size="100,-1d"
                   tooltip="Change this to something unique to your project."
                   proportion="1"
                   wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />

--- a/src/xml/doc_view_app_xml.xml
+++ b/src/xml/doc_view_app_xml.xml
@@ -7,7 +7,7 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxMdiWindow" />
 		<inherits class="Window Events" />
 		<property name="class_name" type="string"
-			help="The name of the class.">DocViewApp</property>
+			help="The name of the class.">DocViewAppBase</property>
 		<property name="title" type="string_escapes"
 			help="The text to display on the frame's title bar." />
 		<property name="kind" type="option">
@@ -62,6 +62,11 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 	</gen>
 
 	<gen class="DocumentTextCtrl" image="wxTextCtrl" type="wx_document">
+		<inherits class="C++ Settings" />
+		<property name="class_name" type="string"
+			help="The name of the class.">DocumentTextCtrlBase</property>
+		<property name="mdi_class_name" type="string"
+			help="The name of the DocViewApp class.">DocViewAppBase</property>
 		<property name="template_description" type="string"
 			help="A short description of what the template is for. This string will be displayed in the file filter list of Windows file selectors. " />
 		<property name="template_filter" type="string"
@@ -79,8 +84,12 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 	</gen>
 
 	<gen class="ViewTextCtrl" image="wxTextCtrl" type="wx_view">
+		<inherits class="C++ Settings" />
 		<inherits class="wxMdiWindow" />
-		<property name="var_name" type="string">m_textCtrl</property>
+		<property name="class_name" type="string"
+			help="The name of the class.">ViewTextCtrlBase</property>
+		<property name="mdi_doc_name" type="string"
+			help="The name of the Document class to view." />
 		<property name="spellcheck" type="bitlist">
 			<option name="enabled"
 				help="Currently this is supported in wxMSW (when running under Windows 8 or later), wxGTK when using GTK 3 and wxOSX. In addition, wxMSW requires that the text control has the wxTE_RICH2 style set, while wxOSX requires that the control has the wxTE_MULTILINE style.\n\nAvailable since 3.1.6" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the MDI document and view classes into forms so that they can have their own generated filenames. Since there is no longer a hierarchy, the New MDI dialog creates a folder, and places the MDI forms into that folder. That's not strictly necessary since each view class contains the name of the document class that it is related to, and each document class contains the name of the MDI App class it is related to. If the classes are underneath a folder or sub-folder, then only that folder/sub-folder will be searched to find the associated "parent" class. If they are under the project, then all the top level forms of the project will be searched.