### PR TITLE
Adds initial_enum_string and id assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- The C++ Settings in forms now have a `initial_enum_string` property that allows you to set the initial enumeration value to something other than the default "wxID_HIGHEST + 1".
 - wxMenu and wxMenu items now have a stock_id property allowing you to choose from wxWidgets stock items.
 
 ### Changed
@@ -12,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Improved generation of default filenames for a class when the class name is changed
 - wxFrame and the form version of wxPanel now also support 2-step construction
 - Handle embedded filenames that contain characters that are invalid as variable names
+- Allow custom ids to have an assignment to a value as part of the id. In C++, the id will then be generated as a `static const int` instead of an enumerated value. In Python, this will be added verbatim after any auto-generated ids.
 
 ### Fixed
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -238,6 +238,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_include_advanced, "include_advanced" },
     { prop_indentation_guides, "indentation_guides" },
     { prop_initial, "initial" },
+    { prop_initial_enum_string, "initial_enum_string" },
     { prop_initial_filename, "initial_filename" },
     { prop_initial_folder, "initial_folder" },
     { prop_initial_font, "initial_font" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -244,6 +244,7 @@ namespace GenEnum
         prop_include_advanced,
         prop_indentation_guides,
         prop_initial,
+        prop_initial_enum_string,
         prop_initial_filename,
         prop_initial_folder,
         prop_initial_font,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1220,7 +1220,10 @@ void BaseCodeGenerator::GenEnumIds(Node* class_node)
                 m_header->write(iter);
             if (item == 0)
             {
-                m_header->write(" = wxID_HIGHEST + 1", true);
+                if (class_node->HasValue(prop_initial_enum_string))
+                    m_header->write(" = " + class_node->value(prop_initial_enum_string));
+                else
+                    m_header->write(" = wxID_HIGHEST + 1", true);
             }
 
             if (item < set_enum_ids.size() - 1)

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -82,7 +82,7 @@ public:
 
     bool is_cpp() const { return m_language == GEN_LANG_CPLUSPLUS; }
 
-    static void CollectIDs(Node* node, std::set<std::string>& set_ids);
+    static void CollectIDs(Node* node, std::set<std::string>& set_enum_ids, std::set<std::string>& set_const_ids);
 
 protected:
     // Generate extern references to images used in the current form that are defined in the
@@ -185,7 +185,8 @@ private:
 
     std::vector<const EmbeddedImage*> m_embedded_images;
     std::set<wxBitmapType> m_type_generated;
-    std::set<std::string> m_set_ids;
+    std::set<std::string> m_set_enum_ids;
+    std::set<std::string> m_set_const_ids;
 
     Node* m_form_node { nullptr };
     Node* m_ImagesForm { nullptr };

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -346,15 +346,23 @@ void BaseCodeGenerator::GeneratePythonClass(Node* form_node, PANEL_PAGE panel_ty
         }
     }
 
-    m_set_ids.clear();
-    BaseCodeGenerator::CollectIDs(form_node, m_set_ids);
+    m_set_enum_ids.clear();
+    m_set_const_ids.clear();
+    BaseCodeGenerator::CollectIDs(form_node, m_set_enum_ids, m_set_const_ids);
     // set to highest wx
     auto id_value = 1;
-    for (auto& iter: m_set_ids)
+    for (auto& iter: m_set_enum_ids)
     {
         if (!iter.starts_with("self."))
         {
             m_source->writeLine(tt_string() << iter << " = wxID_HIGHEST + " << id_value++);
+        }
+    }
+    for (auto& iter: m_set_const_ids)
+    {
+        if (!iter.starts_with("self."))
+        {
+            m_source->writeLine(iter);
         }
     }
 
@@ -461,7 +469,7 @@ void BaseCodeGenerator::GeneratePythonClass(Node* form_node, PANEL_PAGE panel_ty
         m_source->Indent();
 
         id_value = 1;
-        for (auto& iter: m_set_ids)
+        for (auto& iter: m_set_enum_ids)
         {
             if (iter.starts_with("self."))
             {

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -22,8 +22,11 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 		<property name="class_decoration" type="string"
 			help="This specifies the keyword or macro to add to the class declaration (such as __declspec(dllexport) )." />
 		<property name="generate_ids" type="bool"
-			help="If checked, any non-wxWidgets ids will be created as an enumerated list. If you want to use your own id values, uncheck this and add the header file containing the ids to either base_src_includes or base_hdr_includes.">
+			help="If checked, any non-wxWidgets ids will be created as an enumerated list unless you specically assign the value of the id (e.g., myid=100).">
 			1</property>
+		<property name="initial_enum_string" type="string"
+			help="The first id in a generated enum will be set to this value.">
+			wxID_HIGHEST + 1</property>
 		<property name="generate_const_values" type="bool"
 			help="If checked, each form's header file will have const values declared for some of the possible parameters. E.g., const int form_id = your_id. You can use this when creating multiple instances of a form with different construction parameters.">
 			0</property>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR has two parts. The first adds a new `initial_enum_string` property to the C++ Settings category in all forms. The default is "wxID_HIGHEST + 1", but the user can replace that with any string that they want. It can be a numeric value, a constant defined in an external header file, or simply a different offset such as "wxID_HIGHEST + 999".

The second part allows a custom id to contain a '=' character followed by a string similar to the string described above for `initial_enum_string`. When generating the header file for C++, the entire id string will be prefixed with `static const int `. When generating a Python file, the string will be added after all the automatic ids are generated.

For more information see Discusion #982 and Issue #984.
