### PR TITLE
Add ability to import Dialogblocks XML projects (instead of just XRC export)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ All notable changes to this project will be documented in this file.
 
 - The C++ Settings in forms now have a `initial_enum_string` property that allows you to set the initial enumeration value to something other than the default "wxID_HIGHEST + 1".
 - wxMenu and wxMenu items now have a stock_id property allowing you to choose from wxWidgets stock items.
+- You can now import DialogBlocks projects directly (instead of exporting an XRC) as long as the project was saved in XML format rather than binary format.
 
 ### Changed
 
 - Improved generation of default filenames for a class when the class name is changed
-- wxFrame and the form version of wxPanel now also support 2-step construction
-- Handle embedded filenames that contain characters that are invalid as variable names
+- wxFrame and the form version of wxPanel now also support 2-step construction.
+- Embedded image filenames can now contain characters that are invalid as part of a variable name.
 - Allow custom ids to have an assignment to a value as part of the id. In C++, the id will then be generated as a `static const int` instead of an enumerated value. In Python, this will be added verbatim after any auto-generated ids.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ In addition to creating new projects, the following project types can be importe
 - **wxFormBuilder** (Click [here](docs/import_formbuilder.md) for more information)
 - **wxGlade**
 - **wxSmith**
+- **DialogBlocks** (Click [here](docs/import_dialogblocks.md) for more information)
 - **XRC** (including exports from **DialogBlocks**)
 - **Windows Resource Dialogs** (Click [here](docs/import_winres.md) for more information)
 

--- a/docs/import_dialogblocks.md
+++ b/docs/import_dialogblocks.md
@@ -1,0 +1,10 @@
+# Importing DialogBlocks projects
+
+wxUiEditor can only import a DialogBlocks project if it was saved as an XML file rather than in a binary format. You can change how the project file is saved using the following steps:
+
+1) Open the project in DialogBlocks and select the project
+2) Either click the Settings toolbar button or choose the Settings command from the View menu
+3) In the Settings dialog, select Project and check "Save as XML"
+4) Click OK and then click the Save toolbar button or the Save Project command from the File menu
+
+As an alternative, you can also use DialogBlocks to export your project as an XRC file. However, the XRC will usually contain less information and the wxUiEditor-generated code may not work the same as the DialogBlocks-generated code.

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -228,6 +228,7 @@ set (file_list
     # Importers (also see Windows Resource importer below)
 
     import/import_crafter_maps.cpp  # wxCrafter mappings
+    import/import_dialogblocks.cpp  # Import a DialogBlocks project
     import/import_formblder.cpp     # Import a wxFormBuider project
     import/import_wxcrafter.cpp     # Import a wxCrafter project
     import/import_wxglade.cpp       # Import a Import a wxGlade file
@@ -346,6 +347,7 @@ set (doc_list
     ../docs/DEV_NOTES.md
     ../docs/images.md
     ../docs/import_crafter.md
+    ../docs/import_dialogblocks.md
     ../docs/import_formbuilder.md
     ../docs/import_winres.md
     ../docs/xrc.md

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -21,7 +21,9 @@
  *
  * The styles are not separated into individual properties -- they can aply to prop_style,
  * prop_ex_style, prop_window_style, prop_window_ex_style, prop_alignment, prop_borders, etc.
-*/
+ */
+
+#include <set>
 
 #include "import_dialogblocks.h"
 
@@ -97,9 +99,27 @@ bool DialogBlocks::Import(const tt_wxString& filename, bool write_doc)
             {
                 if (auto Windows = project.child("document"); Windows)
                 {
+                    NodeSharedPtr parent = m_project;
                     for (auto& form: Windows.children("document"))
                     {
-                        CreateFormNode(form);
+                        if (CreateFormNode(form, parent))
+                            continue;
+                        else if (CreateFolderNode(form, parent))
+                            continue;
+#if defined(_DEBUG)
+                        if (auto first_child = form.first_child(); first_child)
+                        {
+                            auto first_attr = first_child.first_attribute();
+                            if (first_attr)
+                            {
+                                auto sv_name = first_attr.name();
+                                auto sv_value = first_attr.value();
+                                auto data = first_child.text().as_sview();
+                                auto name = first_attr.name();
+                            }
+                        }
+#endif  // _DEBUG
+                        FAIL_MSG("Missing proxy-Base class -- unable to determine class to create")
                     }
                 }
             }
@@ -121,19 +141,118 @@ bool DialogBlocks::Import(const tt_wxString& filename, bool write_doc)
     return true;
 }
 
-void DialogBlocks::CreateFormNode(pugi::xml_node& form_xml)
+bool DialogBlocks::CreateFolderNode(pugi::xml_node& form_xml, const NodeSharedPtr& parent)
+{
+    if (auto folder = form_xml.find_child_by_attribute("string", "name", "type");
+        folder && folder.text().as_sview() == "\"html-folder-document\"")
+    {
+        if (auto folder_name = form_xml.find_child_by_attribute("string", "name", "title"); folder_name)
+        {
+            auto gen_folder_type = parent->isGen(gen_folder) ? gen_sub_folder : gen_folder;
+            if (auto new_parent = NodeCreation.CreateNode(gen_folder_type, parent.get()); new_parent)
+            {
+                new_parent->set_value(prop_label, ExtractQuotedString(folder_name));
+                parent->Adopt(new_parent);
+                for (auto& form: form_xml.children("document"))
+                {
+                    if (CreateFormNode(form, new_parent))
+                        continue;
+                    else if (CreateFolderNode(form, new_parent))
+                        continue;
+                }
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/*
+ * The wxWidgets class is determined via the proxy-type attribute. This will have a "wb"
+ * prefix, which is replaced with "wx", and a "Proxy" suffix, which is removed. In most cases,
+ * this will then be the same names as proxy-Base class, but if not it means the user wants the
+ * base class to be a derived class that they have created.
+ */
+
+bool DialogBlocks::CreateFormNode(pugi::xml_node& form_xml, const NodeSharedPtr& parent)
 {
     GenEnum::GenName gen_name = gen_unknown;
-    if (auto base_class = form_xml.find_child_by_attribute("string", "name", "proxy-Base class"); base_class)
+    if (auto widgets_class = form_xml.find_child_by_attribute("string", "name", "proxy-type"); widgets_class)
     {
-        gen_name = MapClassName(ExtractQuotedString(base_class));
-        auto form = NodeCreation.CreateNode(gen_name, m_project.get());
+        auto type_name = ExtractQuotedString(widgets_class);
+        if (type_name.starts_with("wb"))
+        {
+            type_name[1] = 'x';
+        }
+        type_name.Replace("Proxy", "");
+
+        gen_name = MapClassName(type_name);
+        if (gen_name == gen_unknown)
+        {
+            ASSERT_MSG(gen_name != gen_unknown, tt_string("Unrecognized proxy-type class: ") << type_name);
+            m_errors.emplace(tt_string("Unrecognized form class: ") << type_name);
+            return false;
+        }
+
+        auto form = NodeCreation.CreateNode(gen_name, parent.get());
         if (!form)
         {
-            m_errors.emplace(tt_string("Unable to create ") << ExtractQuotedString(base_class));
-            return;
+            if (parent->isGen(gen_Project) || parent->isGen(gen_folder) || parent->isGen(gen_sub_folder))
+            {
+                switch (gen_name)
+                {
+                    default:
+                        m_errors.emplace(tt_string("Unable to create ") << type_name);
+                        return false;
+
+                    case gen_wxPanel:
+                        gen_name = gen_PanelForm;
+                        break;
+
+                    case gen_wxMenuBar:
+                        gen_name = gen_MenuBar;
+                        break;
+
+                    case gen_wxToolBar:
+                        gen_name = gen_ToolBar;
+                        break;
+
+                    case gen_wxRibbonBar:
+                        gen_name = gen_RibbonBar;
+                        break;
+
+                    case gen_wxMenu:
+                        gen_name = gen_PopupMenu;
+                        break;
+                }
+                if (form = NodeCreation.CreateNode(gen_name, parent.get()); !form)
+                {
+                    m_errors.emplace(tt_string("Unable to create ") << type_name);
+                    return false;
+                }
+            }
+            else
+            {
+                m_errors.emplace(tt_string("Unable to create ") << type_name);
+                return false;
+            }
         }
-        m_project->Adopt(form);
+        parent->Adopt(form);
+        if (auto derived_class = form_xml.find_child_by_attribute("string", "name", "proxy-Base class"); derived_class)
+        {
+            auto derived_name = ExtractQuotedString(derived_class);
+            if (derived_name != type_name)
+            {
+                form->set_value(prop_derived_class, derived_name);
+            }
+        }
+
+        m_class_uses_dlg_units = false;
+        if (auto dlg_units = form_xml.find_child_by_attribute("bool", "name", "proxy-Dialog units");
+            dlg_units && dlg_units.text().as_bool())
+        {
+            m_class_uses_dlg_units = true;
+        }
 
         // Start be setting properties common to most forms
 
@@ -151,6 +270,16 @@ void DialogBlocks::CreateFormNode(pugi::xml_node& form_xml)
             {
                 auto file = ExtractQuotedString(value);
                 file.remove_extension();
+                prop->set_value(file);
+            }
+        }
+
+        if (auto prop = form->get_prop_ptr(prop_xrc_file); prop)
+        {
+            if (auto value = form_xml.find_child_by_attribute("string", "name", "proxy-XRC filename"); value)
+            {
+                auto file = ExtractQuotedString(value);
+                // Note that unlike the base file, we do *not* remove the XRC file extension
                 prop->set_value(file);
             }
         }
@@ -176,21 +305,27 @@ void DialogBlocks::CreateFormNode(pugi::xml_node& form_xml)
             }
         }
 
+        SetNodeDimensions(form_xml, form);  // Set pos and size
+        SetNodeID(form_xml, form);          // Set ID
+        ProcessStyles(form_xml, form);      // Set all styles for the current node
+        ProcessEvents(form_xml, form);      // Add all events for the current node
+
         for (auto& child_xml: form_xml.children("document"))
         {
-            CreateChildNode(child_xml, form);
+            CreateChildNode(child_xml, form.get());
         }
+        return true;
     }
     else
     {
-        FAIL_MSG("Missing proxy-Base class -- unable to determine class to create")
+        return false;
     }
 }
 
-void DialogBlocks::CreateChildNode(pugi::xml_node& child_xml, const NodeSharedPtr& parent)
+void DialogBlocks::CreateChildNode(pugi::xml_node& child_xml, Node* parent)
 {
-    auto gen = FindGenerator(child_xml);
-    if (gen == gen_unknown)
+    auto gen_name = FindGenerator(child_xml, parent);
+    if (gen_name == gen_unknown)
     {
         auto type = child_xml.find_child_by_attribute("string", "name", "proxy-type");
         if (!type)
@@ -204,58 +339,537 @@ void DialogBlocks::CreateChildNode(pugi::xml_node& child_xml, const NodeSharedPt
         return;
     }
 
-    auto node = NodeCreation.CreateNode(gen, parent.get());
-    ASSERT(node);
+    auto node = NodeCreation.CreateNode(gen_name, parent);
     if (!node)
     {
-        m_errors.emplace(tt_string("Unable to create ") << map_GenNames[gen]);
+        if (parent->IsSizer() && parent->get_parent()->IsForm())
+        {
+            node = NodeCreation.CreateNode(gen_name, parent->get_parent());
+            if (node)
+            {
+                parent = parent->get_parent();
+            }
+        }
+
+        // DialogBlocks will sometimes put the statusbar nested under two sizers.
+        else if (gen_name == gen_wxStatusBar)
+        {
+            if (auto form = parent->get_form(); form)
+            {
+                node = NodeCreation.CreateNode(gen_name, form);
+                if (node)
+                {
+                    parent = form;
+                }
+            }
+        }
+    }
+    if (!node)
+    {
+        ASSERT_MSG(node, tt_string("Unable to create ")
+                             << map_GenNames[gen_name] << " as child of " << map_GenNames[parent->gen_name()]);
+        m_errors.emplace(tt_string("Unable to create ") << map_GenNames[gen_name]);
         return;
     }
 
     parent->Adopt(node);
 
-    for (auto& grand_child_xml: child_xml.children("document"))
+    if (auto prop = node->get_prop_ptr(prop_label); prop)
     {
-        CreateChildNode(grand_child_xml, node);
-    }
-}
-
-GenEnum::GenName DialogBlocks::FindGenerator(pugi::xml_node& node)
-{
-    GenEnum::GenName gen = gen_unknown;
-
-    if (auto class_name = node.find_child_by_attribute("string", "name", "proxy-Base class"); class_name)
-    {
-        gen = MapClassName(ExtractQuotedString(class_name));
-    }
-
-    if (gen == gen_unknown)
-    {
-        // proxy-type starts with "wb" and ends with "Proxy". Change the "wb" to "wx" and remove
-        // the "Proxy" to get the class name.
-
-        if (auto type = node.find_child_by_attribute("string", "name", "proxy-type"); type)
+        if (auto value = child_xml.find_child_by_attribute("string", "name", "proxy-Label"); value)
         {
-            auto type_name = ExtractQuotedString(type);
-            if (type_name.starts_with("wb"))
-            {
-                type_name[1] = 'x';
-            }
-            type_name.Replace("Proxy", "");
-            gen = MapClassName(type_name);
+            prop->set_value(ExtractQuotedString(value));
         }
     }
 
-    return gen;
+    // These Set...() functions can be called whether or not the property exists, so no need to
+    // check for it first.
+
+    SetNodeState(child_xml, node);        // Set disabled and hidden states
+    SetNodeDimensions(child_xml, node);   // Set pos and size
+    SetNodeVarname(child_xml, node);      // Set var_name and class access
+    SetNodeID(child_xml, node);           // Set ID
+    SetNodeValidator(child_xml, node);    // Set validator
+    SetNodeHelpTipText(child_xml, node);  // Set prop_context_help and prop_tooltip
+
+    ProcessStyles(child_xml, node);  // Set all styles for the current node
+    ProcessEvents(child_xml, node);  // Add all events for the current node
+
+    // Now add all the children of this child node
+    for (auto& grand_child_xml: child_xml.children("document"))
+    {
+        CreateChildNode(grand_child_xml, node.get());
+    }
 }
 
-tt_string DialogBlocks::ExtractQuotedString(pugi::xml_node& str_node)
+GenEnum::GenName DialogBlocks::FindGenerator(pugi::xml_node& node_xml, Node* parent)
+{
+    GenEnum::GenName gen_name = gen_unknown;
+
+    // proxy-type starts with "wb" and ends with "Proxy". Change the "wb" to "wx" and remove
+    // the "Proxy" to get the class name.
+
+    if (auto type = node_xml.find_child_by_attribute("string", "name", "proxy-type"); type)
+    {
+        auto type_name = ExtractQuotedString(type);
+        if (type_name.starts_with("wb"))
+        {
+            type_name[1] = 'x';
+        }
+        type_name.Replace("Proxy", "");
+        gen_name = MapClassName(type_name);
+    }
+    if (gen_name == gen_wxPanel)
+    {
+        if (parent->DeclName().contains("book"))
+            gen_name = gen_BookPage;
+    }
+    else if (gen_name == gen_wxWindow)
+    {
+        gen_name = gen_CustomControl;
+    }
+
+    return gen_name;
+}
+
+// Sets var_name and class access for a node
+void DialogBlocks::SetNodeVarname(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)
+{
+    if (auto prop = new_node->get_prop_ptr(prop_var_name); prop)
+    {
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-Member variable name"); value)
+        {
+            auto name = ExtractQuotedString(value);
+            if (name.size())
+            {
+                prop->set_value(name);
+                // DialogBlocks makes the variable public:, but we force it to protected: so
+                // that only the base and any derived classes can access it directly.
+                new_node->set_value(prop_class_access, "protected:");
+            }
+            else if (value = node_xml.find_child_by_attribute("string", "name", "identifier"); value)
+            {
+                name = ExtractQuotedString(value);
+                if (name.size())
+                {
+                    prop->set_value(name);
+                    new_node->set_value(prop_class_access, "none");
+                }
+            }
+        }
+    }
+}
+
+void DialogBlocks::SetNodeID(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)
+{
+    if (auto prop = new_node->get_prop_ptr(prop_id); prop)
+    {
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-Id name"); value)
+        {
+            auto name = ExtractQuotedString(value);
+            if (name != "wxID_ANY")
+            {
+                if (!name.starts_with("wxID_"))
+                {
+                    if (value = node_xml.find_child_by_attribute("long", "name", "proxy-Id value"); value)
+                    {
+                        auto id_value = value.text().as_int();
+                        if (id_value != -1)
+                        {
+                            name << " = " << id_value;
+                        }
+                    }
+                }
+                prop->set_value(name);
+            }
+        }
+    }
+}
+
+// Sets disabled and hidden states for a node
+void DialogBlocks::SetNodeState(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)
+{
+    if (auto prop = new_node->get_prop_ptr(prop_disabled); prop)
+    {
+        if (auto value = node_xml.find_child_by_attribute("bool", "name", "proxy-Enabled"); value && !value.text().as_bool())
+        {
+            prop->set_value(true);
+        }
+    }
+
+    if (auto prop = new_node->get_prop_ptr(prop_hidden); prop)
+    {
+        if (auto value = node_xml.find_child_by_attribute("bool", "name", "proxy-Hidden"); value && value.text().as_bool())
+        {
+            prop->set_value(true);
+        }
+    }
+}
+
+void DialogBlocks::SetNodeDimensions(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)
+{
+    if (auto prop = new_node->get_prop_ptr(prop_size); prop)
+    {
+        wxSize size { -1, -1 };
+        if (auto value = node_xml.find_child_by_attribute("long", "name", "proxy-Width"); value)
+        {
+            size.SetWidth(value.text().as_int());
+        }
+        if (auto value = node_xml.find_child_by_attribute("long", "name", "proxy-Height"); value)
+        {
+            size.SetHeight(value.text().as_int());
+        }
+        prop->set_value(size);
+        if (m_class_uses_dlg_units)
+        {
+            prop->get_value() << 'd';
+        }
+    }
+
+    if (auto prop = new_node->get_prop_ptr(prop_pos); prop)
+    {
+        wxPoint pos { -1, -1 };
+        if (auto value = node_xml.find_child_by_attribute("long", "name", "proxy-X"); value)
+        {
+            pos.x = value.text().as_int();
+        }
+        if (auto value = node_xml.find_child_by_attribute("long", "name", "proxy-Y"); value)
+        {
+            pos.y = value.text().as_int();
+        }
+        prop->set_value(pos);
+        if (m_class_uses_dlg_units)
+        {
+            prop->get_value() << 'd';
+        }
+    }
+}
+
+void DialogBlocks::SetNodeValidator(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)
+{
+    // Note that while DialogBlocks allows the user to set the properties, it doesn't actually
+    // correctly set the validator in code.
+    if (auto prop = new_node->get_prop_ptr(prop_validator_variable); prop)
+    {
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-Data variable"); value)
+        {
+            prop->set_value(ExtractQuotedString(value));
+
+            if (value = node_xml.find_child_by_attribute("string", "name", "proxy-Data validator"); value)
+            {
+                new_node->set_value(prop_validator_type, ExtractQuotedString(value));
+            }
+        }
+    }
+}
+
+void DialogBlocks::SetNodeHelpTipText(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)
+{
+    if (auto prop = new_node->get_prop_ptr(prop_context_help); prop)
+    {
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-Help text"); value)
+        {
+            prop->set_value(ExtractQuotedString(value));
+        }
+    }
+
+    if (auto prop = new_node->get_prop_ptr(prop_tooltip); prop)
+    {
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-Tooltip text"); value)
+        {
+            prop->set_value(ExtractQuotedString(value));
+        }
+    }
+}
+
+void DialogBlocks::ProcessEvents(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)
+{
+    for (int event_count = 0;; ++event_count)
+    {
+        if (auto value = node_xml.find_child_by_attribute("string", "name", tt_string("event-handler-") << event_count);
+            value)
+        {
+            auto event_text = ExtractQuotedString(value);
+            tt_view_vector event_parts(event_text, '|');
+            ASSERT(event_parts.size() > 1);
+            if (event_parts.size() > 1)
+            {
+                if (auto node_event = new_node->GetEvent(GetCorrectEventName(event_parts[0])); node_event)
+                {
+                    node_event->set_value(event_parts[1]);
+                }
+            }
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+tt_string DialogBlocks::ExtractQuotedString(pugi::xml_node& str_xml)
 {
     tt_string str;
-    auto view = str_node.text().as_sview();
+    auto view = str_xml.text().as_sview();
     if (view.starts_with("\""))
         str.ExtractSubString(view);
     else
         str = view;
     return str;
+}
+
+auto lst_window_styles = std::to_array({
+    "wxBORDER_DEFAULT",
+    "wxBORDER_NONE",
+    "wxBORDER_STATIC",
+    "wxBORDER_SIMPLE",
+    "wxBORDER_RAISED",
+    "wxBORDER_SUNKEN",
+    "wxBORDER_DOUBLE",
+    "wxBORDER_THEME",
+    "wxTRANSPARENT_WINDOW",
+    "wxTAB_TRAVERSAL",
+    "wxWANTS_CHARS",
+    "wxVSCROLL",
+    "wxHSCROLL",
+    "wxALWAYS_SHOW_SB",
+    "wxCLIP_CHILDREN",
+    "wxNO_FULL_REPAINT_ON_RESIZE",
+});
+
+auto lst_exwindow_styles = std::to_array({
+
+    "wxWS_EX_VALIDATE_RECURSIVELY",
+    "wxWS_EX_BLOCK_EVENTS",
+    "wxWS_EX_TRANSIENT",
+    "wxWS_EX_PROCESS_IDLE",
+    "wxWS_EX_PROCESS_UI_UPDATES",
+
+});
+
+auto lst_dialog_styles = std::to_array({
+
+    "wxCAPTION",
+    "wxMINIMIZE_BOX",
+    "wxMAXIMIZE_BOX",
+    "wxSYSTEM_MENU",
+    "wxRESIZE_BORDER",
+    "wxCLOSE_BOX",
+    "wxDEFAYLT_DIALOG_STYLE",
+    "wxSTAY_ON_TOP",
+    "wxDIALOG_NO_PARENT",
+    "wxWANTS_CHARS",
+
+});
+
+auto lst_exdialog_styles = std::to_array({
+
+    "wxDIALOG_EX_CONTEXTHELP",
+    "wxDIALOG_EX_METAL",
+    "wxWS_EX_BLOCK_EVENTS",
+    "wxWS_EX_PROCESS_IDLE",
+    "wxWS_EX_PROCESS_UI_UPDATES",
+    "wxWS_EX_VALIDATE_RECURSIVELY",
+
+});
+
+auto lst_alignment_styles = std::to_array({
+
+    "wxALIGN_TOP",
+    "wxALIGN_BOTTOM",
+    "wxALIGN_CENTER_VERTICAL",
+    "wxALIGN_LEFT",
+    "wxALIGN_RIGHT",
+    "wxALIGN_CENTER_HORIZONTAL",
+    "wxALIGN_CENTER",
+
+});
+
+auto lst_layout_flags = std::to_array({
+
+    "wxEXPAND",
+    "wxSHAPED",
+    "wxFIXED_MINSIZE",
+    "wxRESERVE_SPACE_EVEN_IF_HIDDEN",
+
+});
+
+auto lst_borders_flags = std::to_array({
+
+    "wxALL",
+    "wxLEFT",
+    "wxRIGHT",
+    "wxTOP",
+    "wxBOTTOM",
+
+});
+
+std::map<std::string_view, std::string_view, std::less<>> s_map_old_borders = {
+
+    { "wxDOUBLE_BORDER", "wxBORDER_DOUBLE" },
+    { "wxSUNKEN_BORDER", "wxBORDER_SUNKEN" },
+    { "wxRAISED_BORDER", "wxBORDER_RAISED" },
+    { "wxBORDER", "wxBORDER_SIMPLE" },
+    { "wxSIMPLE_BORDER", "wxBORDER_SIMPLE" },
+    { "wxSTATIC_BORDER", "wxBORDER_STATIC" },
+    {
+        "wxNO_BORDER",
+        "wxBORDER_NONE",
+    },
+
+};
+
+void DialogBlocks::ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)
+{
+    std::set<std::string> styles;
+
+    for (auto& form: node_xml.children("bool"))
+    {
+        // We only collect styles that have been set, and ignore the rest
+        if (!form.text().as_bool())
+            continue;
+        auto name = form.attribute("name").as_std_str();
+        if (!name.starts_with("proxy-"))
+            continue;
+        name.erase(0, sizeof("proxy-") - 1);
+        if (!name.starts_with("wx"))
+            continue;
+        if (auto result = s_map_old_borders.find(name); result != s_map_old_borders.end())
+        {
+            name = result->second;
+        }
+
+        styles.emplace(name);
+    }
+
+    if (styles.empty())
+        return;
+
+    tt_string style_str;
+    // Not all styles are valid for all forms, but we'll assume that DialogBlocks didn't add
+    // any invalid ones. I *think* unused ones will be ignored...
+    for (auto& style: lst_window_styles)
+    {
+        if (styles.contains(style))
+        {
+            if (style_str.size())
+                style_str << '|';
+            style_str << style;
+        }
+    }
+    if (style_str.size())
+    {
+        new_node->set_value(prop_window_style, style_str);
+    }
+
+    style_str.clear();
+    for (auto& style: lst_exwindow_styles)
+    {
+        if (styles.contains(style))
+        {
+            if (style_str.size())
+                style_str << '|';
+            style_str << style;
+        }
+    }
+    if (style_str.size())
+    {
+        new_node->set_value(prop_window_extra_style, style_str);
+    }
+
+    if (new_node->isGen(gen_wxDialog))
+    {
+        style_str.clear();
+        for (auto& style: lst_dialog_styles)
+        {
+            if (styles.contains(style))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << style;
+            }
+        }
+        if (style_str.size())
+        {
+            new_node->set_value(prop_style, style_str);
+        }
+
+        style_str.clear();
+        for (auto& style: lst_exdialog_styles)
+        {
+            if (styles.contains(style))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << style;
+            }
+        }
+        if (style_str.size())
+        {
+            new_node->set_value(prop_extra_style, style_str);
+        }
+    }
+
+    // For wxUE, these are sizer_child settings, however DialogBlocks doesn't use any form of sizerchild, so
+    // we look for alignment before attempting to set these. That's because the wxLEFT, wxRIGHT, etc. can be used
+    // for other things besides where the border should be.
+
+    if (new_node->HasProp(prop_alignment))
+    {
+        style_str.clear();
+        for (auto& style: lst_alignment_styles)
+        {
+            if (styles.contains(style))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << style;
+            }
+        }
+        if (style_str.size())
+        {
+            new_node->set_value(prop_alignment, style_str);
+        }
+
+        // Check for layout flags
+        style_str.clear();
+        for (auto& style: lst_layout_flags)
+        {
+            if (styles.contains(style))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << style;
+            }
+        }
+        if (style_str.size())
+        {
+            new_node->set_value(prop_flags, style_str);
+        }
+
+        // Check for border flags
+        style_str.clear();
+        for (auto& style: lst_borders_flags)
+        {
+            if (styles.contains(style))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << style;
+            }
+        }
+        if (style_str.size())
+        {
+            if (style_str.contains("wxLEFT") && style_str.contains("wxRIGHT") && style_str.contains("wxTOP") &&
+                style_str.contains("wxBOTTOM"))
+            {
+                style_str.clear();
+                style_str << "wxALL";
+            }
+            new_node->set_value(prop_borders, style_str);
+        }
+    }
+
+    // REVIEW: [Randalphwa - 05-07-2023] What happens when something like wxRIGHT is used to indicate a bitmap position?
+    // wxBannerWindow has a direction property that also uses wxLEFT, wxRIGHT etc.
 }

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -382,6 +382,26 @@ void DialogBlocks::CreateChildNode(pugi::xml_node& child_xml, Node* parent)
         }
     }
 
+    if (auto prop = node->get_prop_ptr(prop_orientation); prop)
+    {
+        if (auto value = child_xml.find_child_by_attribute("string", "name", "proxy-Orientation"); value)
+        {
+            auto direction = ExtractQuotedString(value);
+            if (direction.is_sameas("Vertical", tt::CASE::either))
+            {
+                prop->set_value("wxVERTICAL");
+            }
+            else if (direction.is_sameas("Horizontal", tt::CASE::either))
+            {
+                prop->set_value("wxHORIZONTAL");
+            }
+            else
+            {
+                m_errors.emplace(tt_string("Unrecognized orientation: ") << direction);
+            }
+        }
+    }
+
     // These Set...() functions can be called whether or not the property exists, so no need to
     // check for it first.
 
@@ -704,6 +724,14 @@ auto lst_borders_flags = std::to_array({
 
 });
 
+// These are used to set prop_style
+auto lst_style = std::to_array({
+
+    "wxLI_HORIZONTAL",
+    "wxLI_VERTICAL",
+
+});
+
 std::map<std::string_view, std::string_view, std::less<>> s_map_old_borders = {
 
     { "wxDOUBLE_BORDER", "wxBORDER_DOUBLE" },
@@ -777,6 +805,21 @@ void DialogBlocks::ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& 
         new_node->set_value(prop_window_extra_style, style_str);
     }
 
+    style_str.clear();
+    for (auto& style: lst_style)
+    {
+        if (styles.contains(style))
+        {
+            if (style_str.size())
+                style_str << '|';
+            style_str << style;
+        }
+    }
+    if (style_str.size())
+    {
+        new_node->set_value(prop_style, style_str);
+    }
+
     if (new_node->isGen(gen_wxDialog))
     {
         style_str.clear();
@@ -826,6 +869,38 @@ void DialogBlocks::ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& 
                 style_str << style;
             }
         }
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-AlignH"); value)
+        {
+            auto alignment = ExtractQuotedString(value);
+            if (alignment.is_sameas("Right", tt::CASE::either))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << "wxRIGHT";
+            }
+            else if (alignment.is_sameas("Centre", tt::CASE::either))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << "wxALIGN_CENTER";
+            }
+        }
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-AlignV"); value)
+        {
+            auto alignment = ExtractQuotedString(value);
+            if (alignment.is_sameas("Bottom", tt::CASE::either))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << "wxBOTTOM";
+            }
+            else if (alignment.is_sameas("Centre", tt::CASE::either))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << "wxALIGN_CENTER";
+            }
+        }
         if (style_str.size())
         {
             new_node->set_value(prop_alignment, style_str);
@@ -842,6 +917,26 @@ void DialogBlocks::ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& 
                 style_str << style;
             }
         }
+
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-AlignH"); value)
+        {
+            if (ExtractQuotedString(value).is_sameas("Expand", tt::CASE::either))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << "wxEXPAND";
+            }
+        }
+        if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-AlignV"); value)
+        {
+            if (ExtractQuotedString(value).is_sameas("Expand", tt::CASE::either))
+            {
+                if (style_str.size())
+                    style_str << '|';
+                style_str << "wxEXPAND";
+            }
+        }
+
         if (style_str.size())
         {
             new_node->set_value(prop_flags, style_str);

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -1,0 +1,261 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Import a DialogBlocks project
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+/*
+ * DialogBlocks uses <document> for objects, and all properties are stored as <string>, <long>
+ * or <bool> nodes.
+ *
+ * Note that the text for <strings> is typically in quotes, so call ExtractQuotedString() to
+ * get the string without quotes.
+ *
+ * Class names are stored in either "proxy-Base class" or "proxy-type" attributes. For the
+ * latter, change "wb" to "wx" and remove "Proxy" from the end to get the wxWidgets class name.
+ *
+ * Styles are typically stored as a series of <bool> notes with the name containing a prefix of
+ * "proxy-" followed by the style name. For example, "proxy-wxTAB_TRAVERSAL" would be the name
+ * for the wxTAB_TRAVERSAL style.
+ *
+ * The styles are not separated into individual properties -- they can aply to prop_style,
+ * prop_ex_style, prop_window_style, prop_window_ex_style, prop_alignment, prop_borders, etc.
+*/
+
+#include "import_dialogblocks.h"
+
+#include "node.h"          // Node class
+#include "node_creator.h"  // NodeCreator class
+
+DialogBlocks::DialogBlocks() {}
+
+bool DialogBlocks::Import(const tt_wxString& filename, bool write_doc)
+{
+    auto result = LoadDocFile(filename);
+    if (!result)
+    {
+        wxMessageBox(wxString() << "Unable to load " << filename << " -- was it saved as a binary file?",
+                     "Import DialogBlocks project");
+        return false;
+    }
+
+    auto root = result.value().first_child();
+
+    if (!tt::is_sameas(root.name(), "anthemion-project", tt::CASE::either))
+    {
+        wxMessageBox(wxString() << filename << " is not a DialogBlocks file", "Import DialogBlocks project");
+        return false;
+    }
+
+    // Using a try block means that if at any point it becomes obvious the formbuilder file is invalid and we cannot recover,
+    // then we can throw an error and give a standard response about an invalid file.
+
+    try
+    {
+        auto header = root.child("header");
+        if (!header)
+        {
+            FAIL_MSG("DialogBlocks project file does not have a root \"header\" node.")
+            throw std::runtime_error("Invalid project file");
+        }
+
+        m_project = NodeCreation.CreateNode(gen_Project, nullptr);
+        m_project->set_value(prop_code_preference, "C++");
+
+        auto option = header.find_child_by_attribute("string", "name", "target_wx_version");
+        if (option)
+        {
+            auto version = ExtractQuotedString(option);
+            if (version == "3.1.0")
+                m_project->set_value(prop_wxWidgets_version, "3.1");
+            else if (version == "3.2.0")
+                m_project->set_value(prop_wxWidgets_version, "3.2");
+        }
+
+        option = header.find_child_by_attribute("bool", "name", "translate_strings");
+        if (option && option.text().as_bool())
+        {
+            m_project->set_value(prop_internationalize, true);
+        }
+
+        option = header.find_child_by_attribute("bool", "name", "use_enums");
+        if (option)
+        {
+            m_use_enums = option.text().as_bool();
+        }
+
+        option = header.find_child_by_attribute("string", "name", "xrc_filename");
+        if (option)
+        {
+            m_project->set_value(prop_combined_xrc_file, ExtractQuotedString(option));
+        }
+
+        if (auto documents = root.child("documents"); documents)
+        {
+            if (auto project = documents.child("document"); project)
+            {
+                if (auto Windows = project.child("document"); Windows)
+                {
+                    for (auto& form: Windows.children("document"))
+                    {
+                        CreateFormNode(form);
+                    }
+                }
+            }
+        }
+
+        if (write_doc)
+            m_project->CreateDoc(m_docOut);
+        return true;
+    }
+
+    catch (const std::exception& TESTING_PARAM(e))
+    {
+        MSG_ERROR(e.what());
+        wxMessageBox(wxString("This DialogBlocks project file is invalid and cannot be loaded: ") << filename,
+                     "Import DialogBlocks project");
+        return false;
+    }
+
+    return true;
+}
+
+void DialogBlocks::CreateFormNode(pugi::xml_node& form_xml)
+{
+    GenEnum::GenName gen_name = gen_unknown;
+    if (auto base_class = form_xml.find_child_by_attribute("string", "name", "proxy-Base class"); base_class)
+    {
+        gen_name = MapClassName(ExtractQuotedString(base_class));
+        auto form = NodeCreation.CreateNode(gen_name, m_project.get());
+        if (!form)
+        {
+            m_errors.emplace(tt_string("Unable to create ") << ExtractQuotedString(base_class));
+            return;
+        }
+        m_project->Adopt(form);
+
+        // Start be setting properties common to most forms
+
+        if (auto prop = form->get_prop_ptr(prop_class_name); prop)
+        {
+            if (auto value = form_xml.find_child_by_attribute("string", "name", "proxy-Class"); value)
+            {
+                prop->set_value(ExtractQuotedString(value));
+            }
+        }
+
+        if (auto prop = form->get_prop_ptr(prop_base_file); prop)
+        {
+            if (auto value = form_xml.find_child_by_attribute("string", "name", "proxy-Implementation filename"); value)
+            {
+                auto file = ExtractQuotedString(value);
+                file.remove_extension();
+                prop->set_value(file);
+            }
+        }
+
+        if (auto prop = form->get_prop_ptr(prop_title); prop)
+        {
+            if (auto value = form_xml.find_child_by_attribute("string", "name", "proxy-Title"); value)
+            {
+                prop->set_value(ExtractQuotedString(value));
+            }
+        }
+
+        if (auto prop = form->get_prop_ptr(prop_center); prop)
+        {
+            if (auto value = form_xml.find_child_by_attribute("bool", "name", "proxy-Centre");
+                value && value.text().as_bool())
+            {
+                prop->set_value("wxBOTH");
+            }
+            else
+            {
+                prop->set_value("no");
+            }
+        }
+
+        for (auto& child_xml: form_xml.children("document"))
+        {
+            CreateChildNode(child_xml, form);
+        }
+    }
+    else
+    {
+        FAIL_MSG("Missing proxy-Base class -- unable to determine class to create")
+    }
+}
+
+void DialogBlocks::CreateChildNode(pugi::xml_node& child_xml, const NodeSharedPtr& parent)
+{
+    auto gen = FindGenerator(child_xml);
+    if (gen == gen_unknown)
+    {
+        auto type = child_xml.find_child_by_attribute("string", "name", "proxy-type");
+        if (!type)
+        {
+            m_errors.emplace(tt_string("Unable to determine class due to missing \"proxy-type\" property."));
+        }
+        else
+        {
+            m_errors.emplace(tt_string("Unrecognized class in \"proxy-type\" property: ") << ExtractQuotedString(type));
+        }
+        return;
+    }
+
+    auto node = NodeCreation.CreateNode(gen, parent.get());
+    ASSERT(node);
+    if (!node)
+    {
+        m_errors.emplace(tt_string("Unable to create ") << map_GenNames[gen]);
+        return;
+    }
+
+    parent->Adopt(node);
+
+    for (auto& grand_child_xml: child_xml.children("document"))
+    {
+        CreateChildNode(grand_child_xml, node);
+    }
+}
+
+GenEnum::GenName DialogBlocks::FindGenerator(pugi::xml_node& node)
+{
+    GenEnum::GenName gen = gen_unknown;
+
+    if (auto class_name = node.find_child_by_attribute("string", "name", "proxy-Base class"); class_name)
+    {
+        gen = MapClassName(ExtractQuotedString(class_name));
+    }
+
+    if (gen == gen_unknown)
+    {
+        // proxy-type starts with "wb" and ends with "Proxy". Change the "wb" to "wx" and remove
+        // the "Proxy" to get the class name.
+
+        if (auto type = node.find_child_by_attribute("string", "name", "proxy-type"); type)
+        {
+            auto type_name = ExtractQuotedString(type);
+            if (type_name.starts_with("wb"))
+            {
+                type_name[1] = 'x';
+            }
+            type_name.Replace("Proxy", "");
+            gen = MapClassName(type_name);
+        }
+    }
+
+    return gen;
+}
+
+tt_string DialogBlocks::ExtractQuotedString(pugi::xml_node& str_node)
+{
+    tt_string str;
+    auto view = str_node.text().as_sview();
+    if (view.starts_with("\""))
+        str.ExtractSubString(view);
+    else
+        str = view;
+    return str;
+}

--- a/src/import/import_dialogblocks.h
+++ b/src/import/import_dialogblocks.h
@@ -20,6 +20,8 @@ public:
 
     bool Import(const tt_wxString& filename, bool write_doc = true) override;
 
+    int GetLanguage() const override { return GEN_LANG_CPLUSPLUS; }
+
 protected:
     void CreateFormNode(pugi::xml_node& form_xml);
     void CreateChildNode(pugi::xml_node& child_node, const NodeSharedPtr& parent);

--- a/src/import/import_dialogblocks.h
+++ b/src/import/import_dialogblocks.h
@@ -23,12 +23,37 @@ public:
     int GetLanguage() const override { return GEN_LANG_CPLUSPLUS; }
 
 protected:
-    void CreateFormNode(pugi::xml_node& form_xml);
-    void CreateChildNode(pugi::xml_node& child_node, const NodeSharedPtr& parent);
+    // Sets prop_context_help and prop_tooltip
+    void SetNodeHelpTipText(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);
+
+    // Sets validator variable name and variable handler type
+    void SetNodeValidator(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);
+
+    // Sets the node id (and optionally assigns it a value) if it isn't wxID_ANY
+    void SetNodeID(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);
+
+    // Sets var_name and class access for a node
+    void SetNodeVarname(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);
+
+    // Sets pos and size
+    void SetNodeDimensions(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);
+
+    // Sets disabled and hidden states for a node
+    void SetNodeState(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);
+
+    bool CreateFormNode(pugi::xml_node& form_xml, const NodeSharedPtr& parent);
+    bool CreateFolderNode(pugi::xml_node& form_xml, const NodeSharedPtr& parent);
+    void CreateChildNode(pugi::xml_node& child_node, Node* parent);
+
+    // Process all the style-like attributes for the current node
+    void ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);
+
+    // Add all events for the current node
+    void ProcessEvents(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);
 
     // This will try to determine the generator to use based on either "proxy-Base class" or
     // "proxy-type" attributes.
-    GenEnum::GenName FindGenerator(pugi::xml_node& node);
+    GenEnum::GenName FindGenerator(pugi::xml_node& node, Node* parent);
 
     // Most strings in a DialogBlocks project are quoted, but some are not. This will return
     // the string without quotes.
@@ -36,4 +61,5 @@ protected:
 
 private:
     bool m_use_enums { true };
+    bool m_class_uses_dlg_units { false };
 };

--- a/src/import/import_dialogblocks.h
+++ b/src/import/import_dialogblocks.h
@@ -1,0 +1,37 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Import a DialogBlocks project
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "gen_enums.h"     // Enumerations for generators
+#include "node_classes.h"  // Forward defintions of Node classes
+
+#include "import_xml.h"  // ImportXML -- Base class for XML importing
+
+class DialogBlocks : public ImportXML
+{
+public:
+    DialogBlocks();
+    ~DialogBlocks() {};
+
+    bool Import(const tt_wxString& filename, bool write_doc = true) override;
+
+protected:
+    void CreateFormNode(pugi::xml_node& form_xml);
+    void CreateChildNode(pugi::xml_node& child_node, const NodeSharedPtr& parent);
+
+    // This will try to determine the generator to use based on either "proxy-Base class" or
+    // "proxy-type" attributes.
+    GenEnum::GenName FindGenerator(pugi::xml_node& node);
+
+    // Most strings in a DialogBlocks project are quoted, but some are not. This will return
+    // the string without quotes.
+    tt_string ExtractQuotedString(pugi::xml_node& str_node);
+
+private:
+    bool m_use_enums { true };
+};

--- a/src/import/import_wxcrafter.h
+++ b/src/import/import_wxcrafter.h
@@ -29,6 +29,9 @@ public:
     bool Import(const tt_wxString& filename, bool write_doc = true) override;
     NodeSharedPtr CreateFbpNode(pugi::xml_node& xml_prop, Node* parent, Node* sizeritem = nullptr);
 
+    // wxCrafter only supports C++ code generation
+    int GetLanguage() const override { return GEN_LANG_CPLUSPLUS; }
+
 protected:
     bool ProcessFont(Node* node, const rapidjson::Value& object);
     bool ProcessScintillaProperty(Node* node, const rapidjson::Value& object);

--- a/src/import/import_wxsmith.h
+++ b/src/import/import_wxsmith.h
@@ -17,4 +17,7 @@ public:
     WxSmith();
 
     bool Import(const tt_wxString& filename, bool write_doc = true) override;
+
+    // wxSmith only supports C++ code generation
+    int GetLanguage() const override { return GEN_LANG_CPLUSPLUS; }
 };

--- a/src/import/import_xml.h
+++ b/src/import/import_xml.h
@@ -29,7 +29,7 @@ public:
     auto GetErrors() { return m_errors; }
 
     // Returns a GEN_LANG_* value -- default is GEN_LANG_NONE
-    auto GetLanguage() const { return m_language; }
+    virtual int GetLanguage() const { return m_language; }
 
     // This will check for an obsolete event name, and if found, it will return the 3.x
     // version of the name. Otherwise, it returns name unmodified.

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -431,6 +431,7 @@ int App::OnRun()
                         wxFileDialog dialog(nullptr, "Open or Import Project", wxEmptyString, wxEmptyString,
                                             "wxUiEditor Project File (*.wxui)|*.wxui"
                                             "|wxCrafter Project File (*.wxcp)|*.wxcp"
+                                            "|DialogBlocks Project File (*.fjd)|*.fjd"
                                             "|wxFormBuilder Project File (*.fbp)|*.fbp"
                                             "|wxGlade File (*.wxg)|*.wxg"
                                             "|wxSmith File (*.wxs)|*.wxs"

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -409,6 +409,11 @@ void MainFrame::OnSaveAsProject(wxCommandEvent&)
             wxMessageBox("You cannot save the project as a wxFormBuilder project file", "Save Project As");
             return;
         }
+        else if (filename.extension().is_sameas(".fjd", tt::CASE::either))
+        {
+            wxMessageBox("You cannot save the project as a DialogBlocks project file", "Save Project As");
+            return;
+        }
         else if (filename.extension().is_sameas(".wxg", tt::CASE::either))
         {
             wxMessageBox("You cannot save the project as a wxGlade file", "Save Project As");
@@ -459,6 +464,7 @@ void MainFrame::OnOpenProject(wxCommandEvent&)
                         "wxUiEditor Project File (*.wxui)|*.wxui;*.wxue"
                         "|Windows Resource File (*.rc)|*.rc"
                         "|wxCrafter Project File (*.wxcp)|*.wxcp"
+                        "|DialogBlocks Project File (*.fjd)|*.fjd"
                         "|wxFormBuilder Project File (*.fbp)|*.fbp"
                         "|wxGlade File (*.wxg)|*.wxg"
                         "|wxSmith File (*.wxs)|*.wxs"
@@ -491,6 +497,19 @@ void MainFrame::OnAppendCrafter(wxCommandEvent&)
         wxArrayString files;
         dlg.GetPaths(files);
         Project.AppendCrafter(files);
+    }
+}
+
+void MainFrame::OnAppendDialogBlocks(wxCommandEvent&)
+{
+    tt_cwd cwd(true);
+    wxFileDialog dlg(this, "Open or Import Project", cwd, wxEmptyString, "DialogBlocks Project File (*.pjd)|*.pjd||",
+                     wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
+    if (dlg.ShowModal() == wxID_OK)
+    {
+        wxArrayString files;
+        dlg.GetPaths(files);
+        Project.AppendDialogBlocks(files);
     }
 }
 
@@ -584,6 +603,8 @@ void MainFrame::OnImportRecent(wxCommandEvent& event)
         Project.AppendSmith(files);
     else if (extension == ".xrc")
         Project.AppendXRC(files);
+    else if (extension == ".fjd")
+        Project.AppendDialogBlocks(files);
 }
 #endif  // defined(_DEBUG) || defined(INTERNAL_TESTING)
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -258,6 +258,7 @@ public:
 protected:
     void OnAbout(wxCommandEvent& event) override;
     void OnAppendCrafter(wxCommandEvent& event) override;
+    void OnAppendDialogBlocks(wxCommandEvent& event) override;
     void OnAppendFormBuilder(wxCommandEvent& event) override;
     void OnAppendGlade(wxCommandEvent& event) override;
     void OnAppendSmith(wxCommandEvent& event) override;

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -103,6 +103,10 @@ NodeSharedPtr NodeCreator::CreateNode(GenName name, Node* parent)
     NodeSharedPtr node;
     NodeDeclaration* node_decl;
 
+    ASSERT(name != gen_unknown);
+    if (name == gen_unknown)
+        return node;
+
     // This is a way for a ribbon panel button to indicate a wxBoxSizer with vertical orientation
     if (name == gen_VerticalBoxSizer)
         node_decl = m_a_declarations[gen_wxBoxSizer];

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -95,6 +95,7 @@ public:
     bool ImportProject(tt_wxString& file, bool allow_ui = true);
 
     void AppendCrafter(wxArrayString& files);
+    void AppendDialogBlocks(wxArrayString& files);
     void AppendFormBuilder(wxArrayString& files);
     void AppendGlade(wxArrayString& files);
     void AppendSmith(wxArrayString& files);

--- a/src/ui/import_dlg.cpp
+++ b/src/ui/import_dlg.cpp
@@ -20,6 +20,7 @@ ImportDlg::ImportDlg(wxWindow* parent) : ImportBase(parent) {}
 enum
 {
     IMPORT_CRAFTER,
+    IMPORT_DIALOGBLOCKS,
     IMPORT_FB,
     IMPORT_WINRES,
     IMPORT_GLADE,
@@ -66,6 +67,10 @@ void ImportDlg::OnInitDialog(wxInitDialogEvent& WXUNUSED(event))
             m_radio_wxCrafter->SetValue(true);
             break;
 
+        case IMPORT_DIALOGBLOCKS:
+            m_radio_DialogBlocks->SetValue(true);
+            break;
+
         case IMPORT_WINRES:
             m_radio_WindowsResource->SetValue(true);
             m_staticImportList->SetLabel("&Files containing Dialogs or Menus:");
@@ -105,6 +110,8 @@ void ImportDlg::OnInitDialog(wxInitDialogEvent& WXUNUSED(event))
         dir.GetAllFiles(".", &files, "*.wxg");
     else if (m_radio_XRC->GetValue())
         dir.GetAllFiles(".", &files, "*.xrc");
+    else if (m_radio_DialogBlocks->GetValue())
+        dir.GetAllFiles(".", &files, "*.pjd");
     else if (m_radio_WindowsResource->GetValue())
     {
         dir.GetAllFiles(".", &files, "*.rc");
@@ -160,6 +167,8 @@ void ImportDlg::OnOK(wxCommandEvent& event)
         config->Write("import_type", static_cast<long>(IMPORT_XRC));
     else if (m_radio_WindowsResource->GetValue())
         config->Write("import_type", static_cast<long>(IMPORT_WINRES));
+    else if (m_radio_DialogBlocks->GetValue())
+        config->Write("import_type", static_cast<long>(IMPORT_DIALOGBLOCKS));
     else
         config->Write("import_type", static_cast<long>(IMPORT_FB));
 
@@ -206,6 +215,8 @@ void ImportDlg::OnDirectory(wxCommandEvent& WXUNUSED(event))
         dir.GetAllFiles(".", &files, "*.wxg");
     else if (m_radio_XRC->GetValue())
         dir.GetAllFiles(".", &files, "*.xrc");
+    else if (m_radio_DialogBlocks->GetValue())
+        dir.GetAllFiles(".", &files, "*.pjd");
     else if (m_radio_WindowsResource->GetValue())
     {
         dir.GetAllFiles(".", &files, "*.rc");
@@ -245,6 +256,8 @@ void ImportDlg::OnRecentDir(wxCommandEvent& WXUNUSED(event))
         dir.GetAllFiles(".", &files, "*.wxg");
     else if (m_radio_XRC->GetValue())
         dir.GetAllFiles(".", &files, "*.xrc");
+    else if (m_radio_DialogBlocks->GetValue())
+        dir.GetAllFiles(".", &files, "*.pjd");
     else if (m_radio_WindowsResource->GetValue())
     {
         dir.GetAllFiles(".", &files, "*.rc");
@@ -307,6 +320,19 @@ void ImportDlg::OnFormBuilder(wxCommandEvent& WXUNUSED(event))
     wxDir dir;
     wxArrayString files;
     dir.GetAllFiles(".", &files, "*.fbp");
+
+    if (files.size())
+        m_checkListProjects->InsertItems(files, 0);
+}
+
+void ImportDlg::OnDialogBlocks(wxCommandEvent& WXUNUSED(event))
+{
+    m_checkListProjects->Clear();
+    m_staticImportList->SetLabel("&Files:");
+
+    wxDir dir;
+    wxArrayString files;
+    dir.GetAllFiles(".", &files, "*.pjd");
 
     if (files.size())
         m_checkListProjects->InsertItems(files, 0);

--- a/src/ui/import_dlg.h
+++ b/src/ui/import_dlg.h
@@ -22,6 +22,7 @@ public:
     bool isImportSmith() { return m_radio_wxSmith->GetValue(); }
     bool isImportXRC() { return m_radio_XRC->GetValue(); }
     bool isImportWinRes() { return m_radio_WindowsResource->GetValue(); }
+    bool isImportDialogBlocks() { return m_radio_DialogBlocks->GetValue(); }
 
     std::vector<tt_wxString>& GetFileList() { return m_lstProjects; };
 
@@ -32,6 +33,7 @@ protected:
     void OnCrafter(wxCommandEvent& event) override;
     void OnDirectory(wxCommandEvent& event) override;
     void OnFormBuilder(wxCommandEvent& event) override;
+    void OnDialogBlocks(wxCommandEvent& event) override;
     void OnInitDialog(wxInitDialogEvent& event) override;
     void OnWxGlade(wxCommandEvent& event) override;
 

--- a/src/wxui/import_base.cpp
+++ b/src/wxui/import_base.cpp
@@ -62,6 +62,9 @@ bool ImportBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     m_radio_WindowsResource = new wxRadioButton(m_import_staticbox->GetStaticBox(), wxID_ANY, "&Windows Resource");
     flex_grid_sizer->Add(m_radio_WindowsResource, wxSizerFlags().Border(wxALL));
 
+    m_radio_DialogBlocks = new wxRadioButton(m_import_staticbox->GetStaticBox(), wxID_ANY, "&DialogBlocks File(s)");
+    flex_grid_sizer->Add(m_radio_DialogBlocks, wxSizerFlags().Border(wxALL));
+
     m_radio_XRC = new wxRadioButton(m_import_staticbox->GetStaticBox(), wxID_ANY, "&XRC File(s)");
     flex_grid_sizer->Add(m_radio_XRC, wxSizerFlags().Border(wxALL));
 
@@ -134,6 +137,7 @@ bool ImportBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     m_radio_wxGlade->Bind(wxEVT_RADIOBUTTON, &ImportBase::OnWxGlade, this);
     m_radio_wxSmith->Bind(wxEVT_RADIOBUTTON, &ImportBase::OnWxSmith, this);
     m_radio_WindowsResource->Bind(wxEVT_RADIOBUTTON, &ImportBase::OnWindowsResource, this);
+    m_radio_DialogBlocks->Bind(wxEVT_RADIOBUTTON, &ImportBase::OnDialogBlocks, this);
     m_radio_XRC->Bind(wxEVT_RADIOBUTTON, &ImportBase::OnXRC, this);
 
     return true;

--- a/src/wxui/import_base.h
+++ b/src/wxui/import_base.h
@@ -44,6 +44,7 @@ protected:
 
     virtual void OnCheckFiles(wxCommandEvent& event) { event.Skip(); }
     virtual void OnCrafter(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnDialogBlocks(wxCommandEvent& event) { event.Skip(); }
     virtual void OnDirectory(wxCommandEvent& event) { event.Skip(); }
     virtual void OnFormBuilder(wxCommandEvent& event) { event.Skip(); }
     virtual void OnInitDialog(wxInitDialogEvent& event) { event.Skip(); }
@@ -63,6 +64,7 @@ protected:
     wxButton* m_btnRemove;  // Remove file from history
     wxCheckListBox* m_checkListProjects;
     wxComboBox* m_combo_recent_dirs;
+    wxRadioButton* m_radio_DialogBlocks;
     wxRadioButton* m_radio_WindowsResource;
     wxRadioButton* m_radio_XRC;
     wxRadioButton* m_radio_wxCrafter;

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -99,6 +99,9 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     auto* menu_item_3 = new wxMenuItem(submenu, id_AppendSmith, "wxSmith Project...",
         "Append wxSmith project into current project", wxITEM_NORMAL);
     submenu->Append(menu_item_3);
+    auto* menu_item_8 = new wxMenuItem(submenu, id_AppendDialogBlocks, "DialogBlocks Project...",
+        "Append DialogBlocks project into current project", wxITEM_NORMAL);
+    submenu->Append(menu_item_8);
     auto* menu_item_5 = new wxMenuItem(submenu, id_AppendWinRes, "Windows Resource...",
         "Append Windows Resource into current project", wxITEM_NORMAL);
     submenu->Append(menu_item_5);
@@ -385,6 +388,7 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendFormBuilder, this, id_AppendFormBuilder);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendGlade, this, id_AppendGlade);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendSmith, this, id_AppendSmith);
+    Bind(wxEVT_MENU, &MainFrameBase::OnAppendDialogBlocks, this, id_AppendDialogBlocks);
     Bind(wxEVT_MENU, &MainFrameBase::OnImportWindowsResource, this, id_AppendWinRes);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendXRC, this, id_AppendXRC);
     Bind(wxEVT_MENU, &MainFrameBase::OnOptionsDlg, this, id_OptionsDlg);

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -42,6 +42,7 @@ public:
         id_AlignRight,
         id_AlignTop,
         id_AppendCrafter,
+        id_AppendDialogBlocks,
         id_AppendFormBuilder,
         id_AppendGlade,
         id_AppendSmith,
@@ -73,6 +74,7 @@ protected:
 
     virtual void OnAbout(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAppendCrafter(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnAppendDialogBlocks(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAppendFormBuilder(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAppendGlade(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAppendSmith(wxCommandEvent& event) { event.Skip(); }

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -279,6 +279,13 @@
                 wxEVT_MENU="OnAppendSmith" />
               <node
                 class="wxMenuItem"
+                help="Append DialogBlocks project into current project"
+                id="id_AppendDialogBlocks"
+                label="DialogBlocks Project..."
+                var_name="menu_item_8"
+                wxEVT_MENU="OnAppendDialogBlocks" />
+              <node
+                class="wxMenuItem"
                 help="Append Windows Resource into current project"
                 id="id_AppendWinRes"
                 label="Windows Resource..."
@@ -2934,6 +2941,13 @@
               var_name="m_radio_WindowsResource"
               row="1"
               wxEVT_RADIOBUTTON="OnWindowsResource" />
+            <node
+              class="wxRadioButton"
+              label="&amp;DialogBlocks File(s)"
+              var_name="m_radio_DialogBlocks"
+              column="1"
+              row="1"
+              wxEVT_RADIOBUTTON="OnDialogBlocks" />
             <node
               class="wxRadioButton"
               label="&amp;XRC File(s)"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability to import DialogBlocks projects directly instead of requiring the user to export the project as an XRC file. A lot of information about C++ code generation is lost when exporting to XRC, so importing the `.pjd` is definitely preferred. Not that it does require the user to save the project as an XML file instead of a binary file.

This code creates all the necessary UI and sets up the initial import functionality. It still needs quite a bit of refinement...