### PR TITLE
Add class_members and class_properties to C++ settings

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -123,6 +123,8 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_checked, "checked" },
     { prop_class_access, "class_access" },
     { prop_class_decoration, "class_decoration" },
+    { prop_class_members, "class_members" },
+    { prop_class_methods, "class_methods" },
     { prop_class_name, "class_name" },
     { prop_close_button, "close_button" },
     { prop_cmake_file, "cmake_file" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -129,6 +129,8 @@ namespace GenEnum
         prop_checked,
         prop_class_access,
         prop_class_decoration,
+        prop_class_members,
+        prop_class_methods,
         prop_class_name,
         prop_close_button,
         prop_cmake_file,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1134,6 +1134,17 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     GenValidatorFunctions(form_node);
     m_header->writeLine();
 
+    if (m_form_node->HasValue(prop_class_methods))
+    {
+        m_header->writeLine();
+        tt_string_vector class_list(m_form_node->as_string(prop_class_methods), "\"", tt::TRIM::both);
+        for (auto& iter: class_list)
+        {
+            m_header->writeLine(iter);
+        }
+        m_header->writeLine();
+    }
+
     GenEnumIds(form_node);
 
     if (m_form_node->HasValue(prop_inserted_hdr_code))
@@ -1173,6 +1184,15 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
         m_header->writeLine("// Class member variables");
         m_header->writeLine();
         WriteSetLines(m_header, code_lines);
+    }
+
+    if (m_form_node->HasValue(prop_class_members))
+    {
+        tt_string_vector class_list(m_form_node->as_string(prop_class_members), "\"", tt::TRIM::both);
+        for (auto& iter: class_list)
+        {
+            m_header->writeLine(iter);
+        }
     }
 
     m_header->Unindent();

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -8,8 +8,6 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 			help="This preamble is added in addition to any src_preamble specified for the entire project. It will be placed unchanged at the top of the generated base src file after any (optional) precompiled header file. It is typically used to add header files needed for lambdas used as event handlers." />
 		<property name="base_hdr_includes" type="code_edit"
 			help="This preamble is placed unchanged in the generated base file after all wx/ include files. It is normally used to include additional header files." />
-		<property name="inserted_hdr_code" type="code_edit"
-			help="Specify code to insert into the header file at the end of the public: section. You may add protected: and private: sections as needed for additional methods and member variables." />
 		<property name="use_derived_class" type="bool"
 			help="Check this if you will be creating a derived class. If not checked, you will need to create a source file implementing any event handlers.">
 			1</property>
@@ -17,6 +15,12 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 			help="The name of the derived class. Ignored if use_derived_class is unchecked." />
 		<property name="derived_file" type="file"
 			help="The filename of the derived class. You can leave this empty if you have already generated the file. Ignored if use_derived_class is unchecked." />
+		<property name="class_methods" type="stringlist_escapes"
+			help="Additional class methods to add (useful if you are *not* using a derived class." />
+		<property name="class_members" type="stringlist_escapes"
+			help="Additional class variable members to add (useful if you are *not* using a derived class." />
+		<property name="inserted_hdr_code" type="code_edit"
+			help="Specify code to insert into the header file at the end of the public: section. You may add protected: and private: sections as needed for additional methods and member variables." />
 		<property name="private_members" type="bool"
 			help="Check this to make all protected: members private:. This can only be done if you are NOT creating a derived class (use_derived_class is unchecked)." />
 		<property name="class_decoration" type="string"


### PR DESCRIPTION
Each of these is a list of single-line entries that will be inserted into the generated header file. These can be used in place of, or in addition to the inserted_hdr_code property. See #980 for details.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Both C++ and XRC dialog preview are ignoring the "disabled" state of a radio static box. You can see this in the `ID Editor` dialog.
This PR adds class_members and class_methods to the C+ Settings category. These are a somewhat easier way to add functions and variables to a generated class that will be implemented directly at the end of the generated block rather than by creating a derived class. The goal is to make it easier to utilize a single source file and single header file for the entire class's declaration and definition.

Closes #980