### PR TITLE
Add quoted substrings support to tt_string_vector

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1137,7 +1137,7 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     if (m_form_node->HasValue(prop_class_methods))
     {
         m_header->writeLine();
-        tt_string_vector class_list(m_form_node->as_string(prop_class_methods), "\"", tt::TRIM::both);
+        tt_string_vector class_list(m_form_node->as_string(prop_class_methods), '"', tt::TRIM::both);
         for (auto& iter: class_list)
         {
             m_header->writeLine(iter);
@@ -1188,7 +1188,8 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
 
     if (m_form_node->HasValue(prop_class_members))
     {
-        tt_string_vector class_list(m_form_node->as_string(prop_class_members), "\"", tt::TRIM::both);
+        tt_string_vector class_list(m_form_node->as_string(prop_class_members), '"', tt::TRIM::both);
+        m_header->writeLine();
         for (auto& iter: class_list)
         {
             m_header->writeLine(iter);

--- a/src/tt/tt_string_vector.cpp
+++ b/src/tt/tt_string_vector.cpp
@@ -14,6 +14,61 @@
 void tt_string_vector::SetString(std::string_view str, char separator, tt::TRIM trim)
 {
     clear();
+
+    // If the separator is a quote, then assume each substring is contained within quotes.
+    if (separator == '"')
+    {
+        auto start = str.find_first_of(separator);
+        if (start == tt::npos)
+        {
+            return;
+        }
+
+        str.remove_prefix(start);
+        emplace_back();
+        auto& first_item = back();
+        auto end = first_item.ExtractSubString(str);
+        if (first_item.empty())
+        {
+            // Ignore empty items
+            pop_back();
+        }
+        else
+        {
+            if (trim != tt::TRIM::none)
+            {
+                first_item.trim(trim);
+            }
+        }
+
+        while (end != tt::npos && end + 1 < str.length())
+        {
+            start = str.find_first_of(separator, end + 1);
+            if (start == tt::npos)
+            {
+                return;
+            }
+            str.remove_prefix(start);
+            emplace_back();
+            auto& last_item = back();
+            end = last_item.ExtractSubString(str);
+            if (last_item.empty())
+            {
+                // Ignore empty items
+                pop_back();
+            }
+            else
+            {
+                if (trim != tt::TRIM::none)
+                {
+                    last_item.trim(trim);
+                }
+            }
+        }
+
+        return;
+    }
+
     size_t start = 0;
     size_t end = str.find_first_of(separator);
 

--- a/src/tt/tt_string_vector.h
+++ b/src/tt/tt_string_vector.h
@@ -66,7 +66,10 @@ public:
     void ReadArray(const char** begin, size_t count);
 
     // Clears the current vector of parsed strings and creates a new vector
+    // If the separator is a quote, then assume each substring is contained within quotes.
     void SetString(std::string_view str, char separator = ';', tt::TRIM trim = tt::TRIM::none);
+
+    // Clears the current vector of parsed strings and creates a new vector
     void SetString(std::string_view str, std::string_view separator, tt::TRIM trim = tt::TRIM::none);
 
     // Writes each line to the file adding a '\n' to the end of the line.


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability to convert multiple quoted strings into a vector of unquoted strings using `tt_string_vector`. This is essentially what `wxArrayString` does, however using our own class means not converting to/from UTF16/UTF8 when using wxWidgets 3.2.

While `tt_string_vector` can be used internally, it cannot be used in any case where a wxArrayString needs to be passed to a wxWidgets class or function. In wxWidgets 3.3, it will be based on a std::vector, and will no longer be doing UTF16/UTF8 conversions on Windows. Until then, we'll need to use one version (`tt_string_vector`) internally, and wxArrayString for the rest.
