### PR TITLE
Complete initialization of IE Editor dialog

### DIFF
--- a/src/wxui/id_editor_dlg.cpp
+++ b/src/wxui/id_editor_dlg.cpp
@@ -223,6 +223,11 @@ void IDEditorDlg::OnInit(wxInitDialogEvent& event)
         m_comboSuffix->SetSelection(0);
     }
 
+    if (Project.ProjectNode()->HasValue(prop_id_prefixes) || Project.ProjectNode()->HasValue(prop_id_suffixes))
+    {
+        SelectPrefixSuffix(m_node->get_form());
+    }
+
     event.Skip();  // transfer all validator data to their windows and update UI
 }
 
@@ -323,4 +328,58 @@ void IDEditorDlg::OnAffirmative(wxUpdateUIEvent& event)
     }
 
     event.Skip();
+}
+
+bool IDEditorDlg::SelectPrefixSuffix(Node* node)
+{
+    if (node->HasProp(prop_id))
+    {
+        auto& id = node->value(prop_id);
+        if (!id.starts_with("wxID_"))
+        {
+            if (!m_prefix_selected)
+            {
+                tt_string_vector prefixes;
+                prefixes.SetString(Project.ProjectNode()->value(prop_id_prefixes), '"', tt::TRIM::both);
+                for (auto& iter: prefixes)
+                {
+                    if (id.starts_with(iter))
+                    {
+                        m_comboPrefixes->SetStringSelection(iter);
+                        m_prefix_selected = true;
+                        break;
+                    }
+                }
+            }
+            if (!m_suffix_selected)
+            {
+                tt_string_vector suffixes;
+                suffixes.SetString(Project.ProjectNode()->value(prop_id_prefixes), '"', tt::TRIM::both);
+                for (auto& iter: suffixes)
+                {
+                    if (id.ends_with(iter))
+                    {
+                        m_comboSuffix->SetStringSelection(iter);
+                        m_suffix_selected = true;
+                        break;
+                    }
+                }
+            }
+
+            if (m_prefix_selected && m_suffix_selected)
+            {
+                return true;
+            }
+        }
+    }
+
+    for (auto& iter: node->GetChildNodePtrs())
+    {
+        if (SelectPrefixSuffix(iter.get()))
+        {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/wxui/id_editor_dlg.h
+++ b/src/wxui/id_editor_dlg.h
@@ -39,9 +39,7 @@ public:
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
     wxString GetResults() { return m_result; }
-
     void SetNode(Node* node) { m_node = node; }
-
     bool SelectPrefixSuffix(Node* node);
 
 protected:
@@ -76,13 +74,9 @@ private:
     wxTextCtrl* m_textValue;
 
     Node* m_node;
-
     wxString m_result;
-
     bool m_prefix_selected { false };
-
     bool m_suffix_selected { false };
-
 };
 
 // ************* End of generated code ***********

--- a/src/wxui/id_editor_dlg.h
+++ b/src/wxui/id_editor_dlg.h
@@ -42,6 +42,8 @@ public:
 
     void SetNode(Node* node) { m_node = node; }
 
+    bool SelectPrefixSuffix(Node* node);
+
 protected:
 
     // Event handlers
@@ -76,6 +78,11 @@ private:
     Node* m_node;
 
     wxString m_result;
+
+    bool m_prefix_selected { false };
+
+    bool m_suffix_selected { false };
+
 };
 
 // ************* End of generated code ***********

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -2581,8 +2581,8 @@
         title="ID Editor"
         base_file="id_editor_dlg"
         base_hdr_includes="class Node;"
-        class_members="&quot;Node* m_node;&quot; &quot;wxString m_result;&quot;"
-        class_methods="&quot;wxString GetResults() { return m_result; }&quot; &quot;void SetNode(Node* node) { m_node = node; }&quot;"
+        class_members="&quot;Node* m_node;&quot; &quot;wxString m_result;&quot; &quot;bool m_prefix_selected { false };&quot; &quot;bool m_suffix_selected { false };&quot; &quot;&quot; &quot;&quot;"
+        class_methods="&quot;wxString GetResults() { return m_result; }&quot; &quot;void SetNode(Node* node) { m_node = node; }&quot; &quot;bool SelectPrefixSuffix(Node* node);&quot;"
         private_members="1"
         use_derived_class="0"
         wxEVT_INIT_DIALOG="OnInit">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates the `IDEditorDlg` initialization code so that it is correctly initialized when the user is editing an existing custom id. This includes setting the correct prefix and suffix if they were used, as well as setting the current value (if used).

Fixes #984