### PR TITLE
Fix wxStdDialogButtonSizer source/header member variable code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Code generation for wxToolBar drop-down tools with menu items fixed.
 - Code generation for wxGridBagSizer when growablecols or growablerows specified
 - Code generation for Wizard using wxWidgets 3.1 corrected
+- Header file code generation could create uninitialized wxStdDialogButtonSizer buttons under special circumstances -- this has been fixed.
 
 ## [Released (1.1.0)]
 

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -912,24 +912,27 @@ tt_string BaseCodeGenerator::GetDeclaration(Node* node)
 
         if (class_name == "wxStdDialogButtonSizer")
         {
-            if (node->prop_as_bool(prop_OK))
-                code << "\n\twxButton* " << node->get_node_name() << "OK;";
-            if (node->prop_as_bool(prop_Yes))
-                code << "\n\twxButton* " << node->get_node_name() << "Yes;";
-            if (node->prop_as_bool(prop_Save))
-                code << "\n\twxButton* " << node->get_node_name() << "Save;";
-            if (node->prop_as_bool(prop_Apply))
-                code << "\n\twxButton* " << node->get_node_name() << "Apply;";
-            if (node->prop_as_bool(prop_No))
-                code << "\n\twxButton* " << node->get_node_name() << "No;";
-            if (node->prop_as_bool(prop_Cancel))
-                code << "\n\twxButton* " << node->get_node_name() << "Cancel;";
-            if (node->prop_as_bool(prop_Close))
-                code << "\n\twxButton* " << node->get_node_name() << "Close;";
-            if (node->prop_as_bool(prop_Help))
-                code << "\n\twxButton* " << node->get_node_name() << "Help;";
-            if (node->prop_as_bool(prop_ContextHelp))
-                code << "\n\twxButton* " << node->get_node_name() << "ContextHelp;";
+            if (!node->get_form()->isGen(gen_wxDialog) || node->as_bool(prop_Save) || node->as_bool(prop_ContextHelp))
+            {
+                if (node->prop_as_bool(prop_OK))
+                    code << "\n\twxButton* " << node->get_node_name() << "OK;";
+                if (node->prop_as_bool(prop_Yes))
+                    code << "\n\twxButton* " << node->get_node_name() << "Yes;";
+                if (node->prop_as_bool(prop_Save))
+                    code << "\n\twxButton* " << node->get_node_name() << "Save;";
+                if (node->prop_as_bool(prop_Apply))
+                    code << "\n\twxButton* " << node->get_node_name() << "Apply;";
+                if (node->prop_as_bool(prop_No))
+                    code << "\n\twxButton* " << node->get_node_name() << "No;";
+                if (node->prop_as_bool(prop_Cancel))
+                    code << "\n\twxButton* " << node->get_node_name() << "Cancel;";
+                if (node->prop_as_bool(prop_Close))
+                    code << "\n\twxButton* " << node->get_node_name() << "Close;";
+                if (node->prop_as_bool(prop_Help))
+                    code << "\n\twxButton* " << node->get_node_name() << "Help;";
+                if (node->prop_as_bool(prop_ContextHelp))
+                    code << "\n\twxButton* " << node->get_node_name() << "ContextHelp;";
+            }
         }
         else if (class_name == "wxStaticBitmap")
         {

--- a/src/generate/gen_std_dlgbtn_sizer.cpp
+++ b/src/generate/gen_std_dlgbtn_sizer.cpp
@@ -223,6 +223,7 @@ bool StdDialogButtonSizerGenerator::ConstructionCode(Code& code)
 
     if (!node->IsLocal())
     {
+        code.Eol(eol_if_needed);
         if (node->prop_as_bool(prop_OK))
             code.NodeName() << "OK = wxStaticCast(FindWindowById(wxID_OK), wxButton);\n";
         if (node->prop_as_bool(prop_Yes))


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR correctly matches source and header file code generation of wxStdDialogButtonSizer member variables. This fixes a bug where member variables were generated in the header file but never assigned.

Closes #998