### PR TITLE
Add ability to set state flags when creating a wxAuiToolBar tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - The C++ Settings in forms now have a `initial_enum_string` property that allows you to set the initial enumeration value to something other than the default "wxID_HIGHEST + 1".
 - wxMenu and wxMenu items now have a stock_id property allowing you to choose from wxWidgets stock items.
 - You can now import DialogBlocks projects directly (instead of exporting an XRC) as long as the project was saved in XML format rather than binary format.
+- Added support for wxAUI_BUTTON_STATE flags when creating a wxAuiToolBar tool.
 
 ### Changed
 

--- a/src/generate/gen_aui_toolbar.h
+++ b/src/generate/gen_aui_toolbar.h
@@ -34,6 +34,7 @@ class AuiToolGenerator : public BaseGenerator
 {
 public:
     bool ConstructionCode(Code& code) override;
+    bool GetIncludes(Node*, std::set<std::string>& /* set_src */, std::set<std::string>& /* set_hdr */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     int GetRequiredVersion(Node* /*node*/) override;

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -270,6 +270,19 @@ int GetStyleInt(Node* node, const char* prefix)
     return result;
 }
 
+int GetBitlistInt(Node* node, GenEnum::PropName prop_name)
+{
+    int result = 0;
+    // Can't use multiview because GetConstantAsInt() searches an unordered_map which requires a std::string to pass to it
+    tt_string_vector mstr(node->value(prop_name), '|');
+    for (auto& iter: mstr)
+    {
+        // Friendly names will have already been converted, so normal lookup works fine.
+        result |= NodeCreation.GetConstantAsInt(iter);
+    }
+    return result;
+}
+
 struct BTN_BMP_TYPES
 {
     GenEnum::PropName prop_name;
@@ -1076,7 +1089,8 @@ void GenToolCode(Code& code, const bool is_bitmaps_list)
         code.NodeName() << " = ";
     }
 
-    if (node->IsLocal() && node->isGen(gen_tool_dropdown))
+    if (node->IsLocal() && node->isGen(gen_tool_dropdown) ||
+        (node->isGen(gen_auitool) && node->value(prop_initial_state) != "wxAUI_BUTTON_STATE_NORMAL"))
     {
         code.AddIfCpp("auto* ").NodeName().Add(" = ");
     }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1089,7 +1089,7 @@ void GenToolCode(Code& code, const bool is_bitmaps_list)
         code.NodeName() << " = ";
     }
 
-    if (node->IsLocal() && node->isGen(gen_tool_dropdown) ||
+    if ((node->IsLocal() && node->isGen(gen_tool_dropdown)) ||
         (node->isGen(gen_auitool) && node->value(prop_initial_state) != "wxAUI_BUTTON_STATE_NORMAL"))
     {
         code.AddIfCpp("auto* ").NodeName().Add(" = ");

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1184,6 +1184,12 @@ void GenToolCode(Code& code, const bool is_bitmaps_list)
         code.Comma().Add("wxNullBitmap").Comma().as_string(prop_kind).Comma();
 
         code.QuotedString(prop_tooltip).Comma().QuotedString(prop_statusbar);
+        if (node->isGen(gen_auitool))
+        {
+            code.Comma();
+            code.AddIfCpp("nullptr");
+            code.AddIfPython("None");
+        }
     }
     code.EndFunction();
 }

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -86,6 +86,11 @@ void GenStyle(Node* node, tt_string& code, const char* prefix = nullptr);
 // If style is a friendly name, add the prefix parameter to prefix lookups.
 int GetStyleInt(Node* node, const char* prefix = nullptr);
 
+// Returns the integer value of the type_bitlist property for the node.
+//
+// Note: requires each bitlist option to have been added to node_constants.cpp
+int GetBitlistInt(Node* node, GenEnum::PropName prop_name);
+
 // This generates code for the header file for Get() and Set() functions using function names
 // specified by the user in the project file.
 std::optional<tt_string> GenGetSetCode(Node* node);

--- a/src/nodes/node_constants.cpp
+++ b/src/nodes/node_constants.cpp
@@ -15,6 +15,7 @@
 #include <wx/anybutton.h>              // wxAnyButtonBase class
 #include <wx/aui/auibar.h>             // wxaui: wx advanced user interface - docking window manager
 #include <wx/aui/auibook.h>            // wxaui: wx advanced user interface - notebook
+#include <wx/aui/framemanager.h>       // wxaui: wx advanced user interface - docking window manager
 #include <wx/calctrl.h>                // date-picker control
 #include <wx/checkbox.h>               // wxCheckBox class interface
 #include <wx/choicebk.h>               // wxChoicebook: wxChoice and wxNotebook combination
@@ -510,6 +511,13 @@ void NodeCreator::AddAllConstants()
     ADD_CONSTANT(wxAUI_NB_MIDDLE_CLICK_CLOSE)
     ADD_CONSTANT(wxAUI_NB_TOP)
     ADD_CONSTANT(wxAUI_NB_BOTTOM)
+
+    ADD_CONSTANT(wxAUI_BUTTON_STATE_NORMAL)
+    ADD_CONSTANT(wxAUI_BUTTON_STATE_HOVER)
+    ADD_CONSTANT(wxAUI_BUTTON_STATE_PRESSED)
+    ADD_CONSTANT(wxAUI_BUTTON_STATE_DISABLED)
+    ADD_CONSTANT(wxAUI_BUTTON_STATE_HIDDEN)
+    ADD_CONSTANT(wxAUI_BUTTON_STATE_CHECKED)
 
     // wxFrame style macros
     ADD_CONSTANT(wxDEFAULT_FRAME_STYLE)

--- a/src/xml/aui_xml.xml
+++ b/src/xml/aui_xml.xml
@@ -111,6 +111,15 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 				help="A checkable tool which makes part of a radio group of tools each of which is automatically unchecked whenever another button in the group is checked." />
 			wxITEM_NORMAL
 		</property>
+		<property name="initial_state" type="bitlist">
+			<option name="wxAUI_BUTTON_STATE_NORMAL" help="Normal button state." />
+			<option name="wxAUI_BUTTON_STATE_HOVER" help="Hovered button state." />
+			<option name="wxAUI_BUTTON_STATE_PRESSED" help="Pressed button state." />
+			<option name="wxAUI_BUTTON_STATE_DISABLED" help="Disabled button state." />
+			<option name="wxAUI_BUTTON_STATE_HIDDEN" help="Hidden button state." />
+			<option name="wxAUI_BUTTON_STATE_CHECKED" help="Checked button state." />
+			wxAUI_BUTTON_STATE_NORMAL
+		</property>
 		<property name="context_menu" type="bool"
 			help="Specifies that a drop-down menu button will appear next to the tool button. Used only with wxAuiToolBar.">0</property>
 		<property name="tooltip" type="string_edit"

--- a/tests/sdi/cpp/python_dlg.cpp
+++ b/tests/sdi/cpp/python_dlg.cpp
@@ -13,6 +13,7 @@
     #include <wx/bitmap.h>
 #endif
 
+#include <wx/aui/framemanager.h>
 #include <wx/button.h>
 #include <wx/sizer.h>
 #include <wx/statbmp.h>
@@ -69,13 +70,14 @@ bool PythonDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     auiToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
         wxAUI_TB_PLAIN_BACKGROUND);
     auiToolBar->AddLabel(wxID_ANY, "Label");
-    auiToolBar->AddTool(wxID_ANY, "Search",
+    auto* tool_2 = auiToolBar->AddTool(wxID_ANY, "Search",
 #if wxCHECK_VERSION(3, 1, 6)
         wxue_img::bundle_fontPicker_png()
 #else
         wxBitmap(wxueImage(wxue_img::fontPicker_png, sizeof(wxue_img::fontPicker_png)))
 #endif
-    );
+    , wxNullBitmap, wxITEM_NORMAL, "This tool should be initially disabled.", "stat", nullptr);
+    tool_2->SetState(wxAUI_BUTTON_STATE_NORMAL|wxAUI_BUTTON_STATE_DISABLED);
     auiToolBar->AddSpacer(auiToolBar->FromDIP(10));
 
     spinCtrl = new wxSpinCtrl(auiToolBar);

--- a/tests/sdi/cpp/wxui_code.cmake
+++ b/tests/sdi/cpp/wxui_code.cmake
@@ -7,6 +7,7 @@ set (sdi_generated_code
     ${CMAKE_CURRENT_LIST_DIR}/booktest_dlg.cpp
     ${CMAKE_CURRENT_LIST_DIR}/commonctrls.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dlgissue_956.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dlgissue_960.cpp
     ${CMAKE_CURRENT_LIST_DIR}/form_toolbar_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/images.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mainframe.cpp

--- a/tests/sdi/python/python_dlg.py
+++ b/tests/sdi/python/python_dlg.py
@@ -76,8 +76,10 @@ class PythonDlg(wx.Dialog):
         self.auiToolBar = wx.aui.AuiToolBar(self, wx.ID_ANY, wx.DefaultPosition,
             wx.DefaultSize, wx.aui.AUI_TB_PLAIN_BACKGROUND|wx.aui.AUI_TB_DEFAULT_STYLE)
         self.auiToolBar.AddLabel(wx.ID_ANY, "Label")
-        self.auiToolBar.AddTool(wx.ID_ANY, "Search", wx.BitmapBundle.FromBitmap(
-            images.fontPicker_png.Bitmap))
+        tool_2 = self.auiToolBar.AddTool(wx.ID_ANY, "Search", wx.BitmapBundle.FromBitmap(
+            images.fontPicker_png.Bitmap), wx.NullBitmap, wx.ITEM_NORMAL,
+            "This tool should be initially disabled.", "stat", None)
+        tool_2.SetState(wx.aui.AUI_BUTTON_STATE_NORMAL|wx.aui.AUI_BUTTON_STATE_DISABLED)
         self.auiToolBar.AddSpacer(self.auiToolBar.FromDIP(10))
 
         self.spinCtrl = wx.SpinCtrl(self.auiToolBar)

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <wxUiEditorData
-  data_version="16">
+  data_version="17">
   <node
     class="Project"
     art_directory="art"
@@ -1510,7 +1510,10 @@
             <node
               class="auitool"
               bitmap="Embed;art/fontPicker.png"
+              initial_state="wxAUI_BUTTON_STATE_NORMAL|wxAUI_BUTTON_STATE_DISABLED"
               label="Search"
+              statusbar="This tool should be initially disabled."
+              tooltip="This tool should be initially disabled."
               var_name="tool_2" />
             <node
               class="auitool_spacer" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `initial_state` property to `wxAuiToolBar` tools so that a tool can be created disabled, hidden, checked, etc. It also changes one of the tools in one of the test dialogs to disabled so that we have coverage of the code generation. That uncovered a bug when an auitool was added with both short and long help text set, which has been fixed.

This fixes #944