### PR TITLE
Add Testing menu controlled by cmdline switch

### DIFF
--- a/src/internal/code_compare.cpp
+++ b/src/internal/code_compare.cpp
@@ -7,8 +7,6 @@
 
 // clang-format off
 
-#if defined(INTERNAL_TESTING)
-
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
@@ -73,8 +71,6 @@ bool CodeCompare::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     return true;
 }
-
-#endif  // defined(INTERNAL_TESTING)
 
 // ************* End of generated code ***********
 // DO NOT EDIT THIS COMMENT BLOCK!

--- a/src/internal/node_info.cpp
+++ b/src/internal/node_info.cpp
@@ -7,8 +7,6 @@
 
 // clang-format off
 
-#if defined(INTERNAL_TESTING)
-
 #include <wx/button.h>
 #include <wx/sizer.h>
 #include <wx/statbox.h>
@@ -58,8 +56,6 @@ bool NodeInfo::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     return true;
 }
-
-#endif  // defined(INTERNAL_TESTING)
 
 // ************* End of generated code ***********
 // DO NOT EDIT THIS COMMENT BLOCK!

--- a/src/internal/node_search_dlg.cpp
+++ b/src/internal/node_search_dlg.cpp
@@ -7,8 +7,6 @@
 
 // clang-format off
 
-#if defined(INTERNAL_TESTING)
-
 #include <wx/button.h>
 #include <wx/sizer.h>
 #include <wx/statbox.h>
@@ -99,8 +97,6 @@ bool NodeSearchDlg::Create(wxWindow* parent, wxWindowID id, const wxString& titl
 
     return true;
 }
-
-#endif  // defined(INTERNAL_TESTING)
 
 // ************* End of generated code ***********
 // DO NOT EDIT THIS COMMENT BLOCK!

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -124,6 +124,10 @@ App::App() {}
 
 bool App::OnInit()
 {
+#if defined(INTERNAL_TESTING) || defined(_DEBUG)
+    m_TestingMenuEnabled = true;
+#endif
+
 #if defined(_WIN32) && defined(_DEBUG)
     #if !defined(USE_CRT_MEMORY_DUMP)
 
@@ -206,7 +210,15 @@ int App::OnRun()
     parser.AddLongSwitch("test_cpp", "generate C++ files and exit", wxCMD_LINE_HIDDEN);
     parser.AddLongSwitch("test_xrc", "generate XRC files and exit", wxCMD_LINE_HIDDEN);
 
+    parser.AddLongSwitch("test_menu", "create test menu to the right of the Help menu",
+                         wxCMD_LINE_HIDDEN | wxCMD_LINE_SWITCH_NEGATABLE);
+
     parser.Parse();
+    if (auto result = parser.FoundSwitch("test_menu"); result != wxCMD_SWITCH_NOT_FOUND)
+    {
+        m_TestingMenuEnabled = (result == wxCMD_SWITCH_ON ? true : false);
+    }
+
     if (parser.GetParamCount() || parser.GetArguments().size())
     {
         tt_wxString filename;

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -59,6 +59,8 @@ public:
     bool isDarkMode() const noexcept { return m_isDarkMode; }
     bool isDarkHighContrast() const noexcept { return m_isDarkHighContrast; }
 
+    bool isTestingMenuEnabled() const noexcept { return m_TestingMenuEnabled; }
+
 protected:
     bool OnInit() override;
 
@@ -82,6 +84,7 @@ private:
     int m_ProjectVersion;
     bool m_isMainFrameClosing { false };
     bool m_isProject_updated { false };
+    bool m_TestingMenuEnabled { false };
 
 #if (DARK_MODE)
     bool m_isDarkMode { true };

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -298,7 +298,6 @@ protected:
     void OnQueueSelect(CustomEvent& event);
 
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
-    void OnCodeCompare(wxCommandEvent& event);
     void OnConvertImageDlg(wxCommandEvent& event);
     void OnFindWidget(wxCommandEvent& event);
     void OnGeneratePython(wxCommandEvent& event);

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -4771,7 +4771,6 @@
       <node
         class="wxDialog"
         class_name="CodeCompare"
-        cpp_conditional="defined(INTERNAL_TESTING)"
         title="Compare Code Generation"
         base_file="..\internal\code_compare"
         derived_class_name="CodeCompare"
@@ -5130,7 +5129,6 @@
       <node
         class="wxDialog"
         class_name="NodeInfo"
-        cpp_conditional="defined(INTERNAL_TESTING)"
         title="Node Information"
         base_file="..\internal\node_info"
         base_hdr_includes="#include &quot;node_classes.h&quot;"
@@ -5270,7 +5268,6 @@
       <node
         class="wxDialog"
         class_name="NodeSearchDlg"
-        cpp_conditional="defined(INTERNAL_TESTING)"
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Node Search"
         base_file="..\internal\node_search_dlg"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds an optional Testing menu that if enabled will appear to the right of the Help menu. It is enabled if INTERNAL_TESTING or _DEBUG is defined, or if the user specified `--test_menu` on the command line. Currently the menu has three items that used to be in the Internal menu:

- Compare Code &Generation...
- &Find Widget...
- Node &Information...

The three dialogs had the `cpp_conditional` property cleared so that they are built into release versions.

Closes #1012