### PR TITLE
Create C++ Derived Class Settings category

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -540,6 +540,7 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_Code, "C++" },
     { gen_Code_Generation, "Code Generation" },
     { gen_Command_Bitmaps, "Command Bitmaps" },
+    { gen_DerivedCPlusSettings, "C++ Derived Class Settings" },
     { gen_DlgWindowSettings, "Dialog Window Settings" },
     { gen_Integer_Validator, "Integer Validator" },
     { gen_List_Validator, "List Validator" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -568,6 +568,7 @@ namespace GenEnum
         gen_Code,
         gen_Code_Generation,
         gen_Command_Bitmaps,
+        gen_DerivedCPlusSettings,
         gen_DlgWindowSettings,
         gen_Integer_Validator,
         gen_List_Validator,

--- a/src/xml/dialogs_xml.xml
+++ b/src/xml/dialogs_xml.xml
@@ -4,6 +4,7 @@ inline const char* dialogs_xml = R"===(<?xml version="1.0"?>
 	<gen class="wxDialog" image="wxDialog" type="form">
 		<inherits class="Dialog Window Settings" />
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="XRC Settings" />
 		<inherits class="wxTopLevelWindow" />
@@ -68,6 +69,7 @@ inline const char* dialogs_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="PanelForm" image="wxPanel" type="form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="XRC Settings" />
 		<property name="class_name" type="string"

--- a/src/xml/doc_view_app_xml.xml
+++ b/src/xml/doc_view_app_xml.xml
@@ -3,6 +3,7 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="DocViewApp" image="wxFrame" type="DocViewApp">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Frame Settings" />
 		<inherits class="wxMdiWindow" />
 		<inherits class="Window Events" />
@@ -63,6 +64,7 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="DocumentTextCtrl" image="wxTextCtrl" type="wx_document">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<property name="class_name" type="string"
 			help="The name of the class.">DocumentTextCtrlBase</property>
 		<property name="mdi_class_name" type="string"
@@ -85,6 +87,7 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="ViewTextCtrl" image="wxTextCtrl" type="wx_view">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxMdiWindow" />
 		<property name="class_name" type="string"
 			help="The name of the class.">ViewTextCtrlBase</property>

--- a/src/xml/forms_xml.xml
+++ b/src/xml/forms_xml.xml
@@ -3,6 +3,7 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="wxFrame" image="wxFrame" type="frame_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Frame Settings" />
 		<inherits class="XRC Settings" />
 		<inherits class="wxTopLevelWindow" />
@@ -70,6 +71,7 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="wxPopupTransientWindow" image="wxPopupTransientWindow" type="form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<property name="class_name" type="string"
 			help="The name of the base class.">MyPopupBase</property>
@@ -107,6 +109,7 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="RibbonBar" image="ribbon_bar" type="ribbonbar_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="XRC Settings" />
 		<inherits class="wxWindow">

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -8,6 +8,20 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 			help="This preamble is added in addition to any src_preamble specified for the entire project. It will be placed unchanged at the top of the generated base src file after any (optional) precompiled header file. It is typically used to add header files needed for lambdas used as event handlers." />
 		<property name="base_hdr_includes" type="code_edit"
 			help="This preamble is placed unchanged in the generated base file after all wx/ include files. It is normally used to include additional header files." />
+		<property name="generate_ids" type="bool"
+			help="If checked, any non-wxWidgets ids will be created as an enumerated list unless you specically assign the value of the id (e.g., myid=100).">
+			1</property>
+		<property name="initial_enum_string" type="string"
+			help="The first id in a generated enum will be set to this value.">
+			wxID_HIGHEST + 1</property>
+		<property name="generate_const_values" type="bool"
+			help="If checked, each form's header file will have const values declared for some of the possible parameters. E.g., const int form_id = your_id. You can use this when creating multiple instances of a form with different construction parameters.">
+			0</property>
+		<property name="class_decoration" type="string"
+			help="This specifies the keyword or macro to add to the class declaration (such as __declspec(dllexport) )." />
+	</gen>
+
+	<gen class="C++ Derived Class Settings" type="interface">
 		<property name="use_derived_class" type="bool"
 			help="Check this if you will be creating a derived class. If not checked, you will need to create a source file implementing any event handlers.">
 			1</property>
@@ -23,17 +37,6 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 			help="Specify code to insert into the header file at the end of the public: section. You may add protected: and private: sections as needed for additional methods and member variables." />
 		<property name="private_members" type="bool"
 			help="Check this to make all protected: members private:. This can only be done if you are NOT creating a derived class (use_derived_class is unchecked)." />
-		<property name="class_decoration" type="string"
-			help="This specifies the keyword or macro to add to the class declaration (such as __declspec(dllexport) )." />
-		<property name="generate_ids" type="bool"
-			help="If checked, any non-wxWidgets ids will be created as an enumerated list unless you specically assign the value of the id (e.g., myid=100).">
-			1</property>
-		<property name="initial_enum_string" type="string"
-			help="The first id in a generated enum will be set to this value.">
-			wxID_HIGHEST + 1</property>
-		<property name="generate_const_values" type="bool"
-			help="If checked, each form's header file will have const values declared for some of the possible parameters. E.g., const int form_id = your_id. You can use this when creating multiple instances of a form with different construction parameters.">
-			0</property>
 	</gen>
 
 	<gen class="wxPython Settings" type="interface">

--- a/src/xml/menus_xml.xml
+++ b/src/xml/menus_xml.xml
@@ -3,6 +3,7 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="MenuBar" image="wxMenuBar" type="menubar_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="XRC Settings" />
 		<inherits class="wxWindow">
@@ -21,6 +22,7 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="PopupMenu" image="menu" type="popup_menu">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="XRC Settings" />
 		<property name="class_name" type="string"

--- a/src/xml/toolbars_xml.xml
+++ b/src/xml/toolbars_xml.xml
@@ -3,6 +3,7 @@ inline const char* toolbars_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="ToolBar" image="wxToolBar" type="toolbar_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="XRC Settings" />
 		<inherits class="wxWindow">

--- a/src/xml/wizard_xml.xml
+++ b/src/xml/wizard_xml.xml
@@ -3,6 +3,7 @@ inline const char* wizard_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="wxWizard" image="wxWizard" type="wizard">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="XRC Settings" />
 		<inherits class="wxTopLevelWindow" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR creates a new `C++ Derived Class Settings` and moves the properties related to a derived class from `C++ Settings` into this class. This has no effect on code generation, it's simply a way to organize the properties into smaller related groups to make a specific property easier to locate. Note that the background color remains the same, and the new category auto-expands/collapses the same as the `C++ Settings` category.

Closes #1015