### PR TITLE
Add support for C++ multiple inheritance

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -77,6 +77,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_add_default_border, "add_default_border" },
     { prop_additional_carets_blink, "additional_carets_blink" },
     { prop_additional_carets_visible, "additional_carets_visible" },
+    { prop_additional_inheritance, "additional_inheritance" },
     { prop_align, "align" },
     { prop_alignment, "alignment" },
     { prop_allow_mouse_rectangle, "allow_mouse_rectangle" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -83,6 +83,7 @@ namespace GenEnum
         prop_add_default_border,
         prop_additional_carets_blink,
         prop_additional_carets_visible,
+        prop_additional_inheritance,
         prop_align,
         prop_alignment,
         prop_allow_mouse_rectangle,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1068,6 +1068,14 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, const EventVector& 
     code.Str(prop_class_name) += " : public ";
     if (generator->BaseClassNameCode(code))
     {
+        if (m_form_node->HasValue(prop_additional_inheritance))
+        {
+            tt_string_vector class_list(m_form_node->as_string(prop_additional_inheritance), '"', tt::TRIM::both);
+            for (auto& iter: class_list)
+            {
+                code.Str(", public ").Str(iter);
+            }
+        }
         m_header->writeLine(code);
     }
     else

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -29,6 +29,8 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 			help="The name of the derived class. Ignored if use_derived_class is unchecked." />
 		<property name="derived_file" type="file"
 			help="The filename of the derived class. You can leave this empty if you have already generated the file. Ignored if use_derived_class is unchecked." />
+		<property name="additional_inheritance" type="stringlist_escapes"
+			help="Additional classes to inherit from (these can be your own classes if you specified their header file in base_hdr_includes in the C++ Settings section above)." />
 		<property name="class_methods" type="stringlist_escapes"
 			help="Additional class methods to add (useful if you are *not* using a derived class." />
 		<property name="class_members" type="stringlist_escapes"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new `additional_inheritance` property to `C++ Derived Class Settings` that lets the user specify additional classes for a form to inherit from. Each class specified will be added to the class declaration in the header file. So for example, a `MyDialog` form with the additional inherited class of `MyInheritClass` would generate:

```c++
class MyDialog : public wxDialog, public MyInheritClass
```

The help description for the property indicates that it is the caller's responsibility to provide any required header file.

Closes #1004