### PR TITLE
Support generating only a header file (no translation unit)

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -393,6 +393,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_title, "title" },
     { prop_toolbar_pane, "toolbar_pane" },
     { prop_tooltip, "tooltip" },
+    { prop_generate_translation_unit, "generate_translation_unit" },
     { prop_type, "type" },
     { prop_unchecked_bitmap, "unchecked_bitmap" },
     { prop_underlined, "underlined" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -399,6 +399,7 @@ namespace GenEnum
         prop_title,
         prop_toolbar_pane,
         prop_tooltip,
+        prop_generate_translation_unit,
         prop_type,
         prop_unchecked_bitmap,
         prop_underlined,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -225,10 +225,36 @@ void BaseCodeGenerator::GenerateCppClass(Node* form_node, PANEL_PAGE panel_type)
         hdr_includes.insert("#include <wx/event.h>");
     }
 
+    if (form_node->prop_as_bool(prop_persist))
+    {
+        src_includes.insert("#include <wx/persist.h>");
+        src_includes.insert("#include <wx/persist/toplevel.h>");
+    }
+
+    if (form_node->HasValue(prop_icon))
+    {
+        src_includes.insert("#include <wx/icon.h>");
+    }
+
+    thrd_need_img_func.join();
+
+    if (m_NeedArtProviderHeader)
+    {
+        src_includes.insert("#include <wx/artprov.h>");
+    }
+
     if (panel_type != CPP_PANEL)
     {
         // BUGBUG: [KeyWorks - 01-25-2021] Need to look for base_class_name property of all children, and add each name
         // as a forwarded class.
+
+        if (!m_TranslationUnit)
+        {
+            for (auto& iter: src_includes)
+            {
+                hdr_includes.insert(iter);
+            }
+        }
 
         // First output all the wxWidget header files
         for (auto& iter: hdr_includes)
@@ -268,32 +294,6 @@ void BaseCodeGenerator::GenerateCppClass(Node* form_node, PANEL_PAGE panel_type)
     {
         m_source->writeLine(tt_string() << "#include \"" << Project.value(prop_local_pch_file) << '"');
         m_source->writeLine();
-    }
-
-    if (form_node->prop_as_bool(prop_persist))
-    {
-        src_includes.insert("#include <wx/persist.h>");
-        src_includes.insert("#include <wx/persist/toplevel.h>");
-    }
-
-    if (form_node->HasValue(prop_icon))
-    {
-        src_includes.insert("#include <wx/icon.h>");
-    }
-
-    thrd_need_img_func.join();
-
-    if (m_NeedArtProviderHeader)
-    {
-        src_includes.insert("#include <wx/artprov.h>");
-    }
-
-    if (!m_TranslationUnit)
-    {
-        for (auto& iter: src_includes)
-        {
-            hdr_includes.insert(iter);
-        }
     }
 
     // Make certain there is a blank line before the the wxWidget #includes

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -177,7 +177,10 @@ void BaseCodeGenerator::GenerateCppClass(Node* form_node, PANEL_PAGE panel_type)
     if (m_panel_type == NOT_PANEL)
     {
         m_header->writeLine(txt_BaseCmtBlock);
-        m_source->writeLine(txt_BaseCmtBlock);
+        if (m_TranslationUnit)
+        {
+            m_source->writeLine(txt_BaseCmtBlock);
+        }
     }
 
     tt_string file;

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -124,7 +124,7 @@ protected:
     void CollectMemberVariables(Node* node, Permission perm, std::set<std::string>& code_lines);
     void CollectValidatorVariables(Node* node, std::set<std::string>& code_lines);
 
-    void GenerateClassHeader(Node* form_node, const EventVector& events);
+    void GenerateClassHeader(Node* form_node, EventVector& events);
     void GenerateClassConstructor(Node* form_node, EventVector& events);
 
     void GenSrcEventBinding(Node* class_node, EventVector& events);
@@ -203,4 +203,5 @@ private:
     bool m_NeedAnimationFunction { false };  // Set when an Animation image is used
     bool m_NeedSVGFunction { false };        // Set when SVG image type is used
     bool m_NeedImageFunction { false };      // Set when Embed type is used
+    bool m_TranslationUnit { true };         // Reflects form->as_bool(prop_generate_translation_unit)
 };

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -75,21 +75,21 @@ int WriteCMakeFile(Node* parent_node, std::vector<tt_string>& updated_files, std
     std::vector<Node*> forms;
     Project.CollectForms(forms, parent_node);
 
-    for (const auto& iter: forms)
+    for (const auto& form: forms)
     {
-        if (!iter->HasValue(prop_base_file))
+        if (!form->HasValue(prop_base_file))
             continue;
 
         if (parent_node == Project.ProjectNode())
         {
-            if (auto* node_folder = iter->get_folder(); node_folder && node_folder->HasValue(prop_folder_cmake_file))
+            if (auto* node_folder = form->get_folder(); node_folder && node_folder->HasValue(prop_folder_cmake_file))
             {
                 // This file already got added to a different .cmake file
                 continue;
             }
         }
 
-        // tt_string path = iter->prop_as_string(prop_base_file);
+        // tt_string path = form->prop_as_string(prop_base_file);
         tt_string path = Project.value(prop_base_directory);
         if (parent_node->isGen(gen_folder) && parent_node->HasValue(prop_folder_base_directory))
         {
@@ -97,11 +97,11 @@ int WriteCMakeFile(Node* parent_node, std::vector<tt_string>& updated_files, std
         }
         if (path.size())
         {
-            path.append_filename(iter->value(prop_base_file).filename());
+            path.append_filename(form->value(prop_base_file).filename());
         }
         else
         {
-            path = iter->value(prop_base_file);
+            path = form->value(prop_base_file);
         }
 
         if (cmake_file_dir.size())

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -77,8 +77,11 @@ int WriteCMakeFile(Node* parent_node, std::vector<tt_string>& updated_files, std
 
     for (const auto& form: forms)
     {
-        if (!form->HasValue(prop_base_file) || !form->as_bool(prop_generate_translation_unit))
+        if (!form->HasValue(prop_base_file) ||
+            (form->HasProp(prop_generate_translation_unit) && !form->as_bool(prop_generate_translation_unit)))
+        {
             continue;
+        }
 
         if (parent_node == Project.ProjectNode())
         {

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -77,7 +77,7 @@ int WriteCMakeFile(Node* parent_node, std::vector<tt_string>& updated_files, std
 
     for (const auto& form: forms)
     {
-        if (!form->HasValue(prop_base_file))
+        if (!form->HasValue(prop_base_file) || !form->as_bool(prop_generate_translation_unit))
             continue;
 
         if (parent_node == Project.ProjectNode())

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -171,6 +171,12 @@ void GenThreadCpp(GenData& gen_data, Node* form)
         gen_data.UpdateFileCount();
     }
 
+    if (!form->as_bool(prop_generate_translation_unit))
+    {
+        gen_data.UpdateFileCount();
+        return;
+    }
+
     path.replace_extension(source_ext);
     retval = cpp_cw->WriteFile(GEN_LANG_CPLUSPLUS, flags);
 
@@ -640,7 +646,7 @@ void GenerateTmpFiles(const std::vector<tt_string>& ClassList, pugi::xml_node ro
                         paths.append_child("right").text().set(tmp_path.c_str());
                         paths.append_child("right-readonly").text().set("1");
                     }
-                    if (new_src)
+                    if (new_src && form->as_bool(prop_generate_translation_unit))
                     {
                         auto paths = root.append_child("paths");
                         tmp_path.replace_extension(source_ext);

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -59,6 +59,12 @@ void BaseCodeGenerator::WriteImagePreConstruction(Code& code)
 // Generate code after the construcor for embedded images not defined in the gen_Images node.
 void BaseCodeGenerator::WriteImageConstruction(Code& code)
 {
+    WriteCode* save_writer = m_TranslationUnit ? nullptr : m_source;
+    if (!m_TranslationUnit)
+    {
+        m_source = m_header;
+    }
+
     code.clear();
 
     bool is_namespace_written = false;
@@ -153,6 +159,11 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
     if (code.size())
     {
         m_source->writeLine(code);
+    }
+
+    if (save_writer)
+    {
+        m_source = save_writer;
     }
 }
 

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -60,6 +60,7 @@ void BaseCodeGenerator::WriteImagePreConstruction(Code& code)
 void BaseCodeGenerator::WriteImageConstruction(Code& code)
 {
     WriteCode* save_writer = m_TranslationUnit ? nullptr : m_source;
+    bool inlined_warning = false;
     if (!m_TranslationUnit)
     {
         m_source = m_header;
@@ -91,7 +92,23 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             {
                 code.Eol(eol_if_needed).Str("// ").Str(iter_array->filename);
             }
-            code.Eol().Str("const unsigned char ").Str(iter_array->array_name);
+            code.Eol();
+
+            if (!m_TranslationUnit)
+            {
+                if (!inlined_warning)
+                {
+                    inlined_warning = true;
+                    code.Str("// WARNING: This will only work if compiled with C++17 or later.");
+                    code.Eol().Str("// Add an Images form and add your image to that to prevent it from being");
+                    code.Eol().Str("// added to this header file.").Eol();
+                }
+                // The header file can be included multiple times, so we need to set this to
+                // inline to avoid multiple definitions. Note that this requires C++17 --
+                // anything earlier will result in duplication.
+                code << "inline ";
+            }
+            code.Str("const unsigned char ").Str(iter_array->array_name);
             code.Str("[").itoa(max_pos).Str("] {");
             m_source->writeLine(code);
             code.clear();

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -4,6 +4,9 @@ inline const char* language_xml = R"===(<?xml version="1.0"?>
 	<gen class="C++ Settings" type="interface">
 		<property name="base_file" type="file"
 			help="The filename of the base class." />
+		<property name="generate_translation_unit" type="bool"
+			help="If checked, both a source file (translation unit) and a header file are generated. If not checked, all code is generated in the header file, and no source file is created.">
+			1</property>
 		<property name="base_src_includes" type="code_edit"
 			help="This preamble is added in addition to any src_preamble specified for the entire project. It will be placed unchanged at the top of the generated base src file after any (optional) precompiled header file. It is typically used to add header files needed for lambdas used as event handlers." />
 		<property name="base_hdr_includes" type="code_edit"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes it possible to generate all code to a header file, instead of both a translation unit and a header file. Note that if there is an embedded image, then it will be written to the header file with a warning that C++17 is required.

This was tested on an internal project, but is currently not used by our testing code or wxUiEditor code.

Closes #1007
