### PR TITLE
Fix prop_const_values generation

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1213,9 +1213,21 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, EventVector& events
     {
         code.clear();
         if (form_node->HasProp(prop_id))
-            code.Eol(eol_if_needed).Str("const int form_id = ").Str(prop_id) += ";";
+        {
+            code.Eol(eol_if_needed).Str("const int form_id = ");
+            if (form_node->value(prop_id).size())
+                code.Str(prop_id) += ";";
+            else
+                code.Str("wxID_ANY;");
+        }
         if (form_node->HasProp(prop_style))
-            code.Eol(eol_if_needed).Str("const int form_style = ").Str(prop_style) += ";";
+        {
+            code.Eol(eol_if_needed).Str("const int form_style = ");
+            if (form_node->value(prop_style).size())
+                code.Str(prop_style) += ";";
+            else
+                code.Str("0;");
+        }
         if (form_node->HasProp(prop_pos))
             code.Eol(eol_if_needed).Str("const wxPoint form_pos = ").Pos(prop_pos, no_dlg_units) += ";";
         if (form_node->HasProp(prop_size))

--- a/tests/sdi/cpp/dlgissue_960.h
+++ b/tests/sdi/cpp/dlgissue_960.h
@@ -16,6 +16,12 @@
 class DlgIssue_960 : public wxDialog
 {
 public:
+    const int form_id = wxID_ANY;
+    const int form_style = 0;
+    const wxPoint form_pos = wxDefaultPosition;
+    const wxSize form_size = wxDefaultSize;
+    static const wxString form_title() { return wxEmptyString; }
+
     DlgIssue_960() {}
     DlgIssue_960(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString,
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,

--- a/tests/sdi/python/dlgissue_960.py
+++ b/tests/sdi/python/dlgissue_960.py
@@ -29,8 +29,8 @@ Ainsi_c3_a_se_passe_png = PyEmbeddedImage(
 
 class DlgIssue_960(wx.Dialog):
     def __init__(self, parent, id=wx.ID_ANY, title="", pos=
-                wx.DefaultPosition, size=wx.DefaultSize,
-                style=wx.DEFAULT_DIALOG_STYLE, name=wx.DialogNameStr):
+                wx.DefaultPosition, size=wx.DefaultSize, style=0,
+                name=wx.DialogNameStr):
         wx.Dialog.__init__(self)
 
         if not self.Create(parent, id, title, pos, size, style, name):

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -2096,6 +2096,7 @@
         class="wxDialog"
         class_name="DlgIssue_960"
         base_file="dlgissue_960"
+        generate_const_values="1"
         derived_class_name="DlgIssue_960Derived"
         derived_file="dlgissue_960_derived"
         python_file="dlgissue_960"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR checks for an empty string and changes the assigned value to something appropriate if there is no string value to assign. This is for when `prop_const_values` is checked and the code is generating the const assignments.

I added a test case to the dlgissue_960 dialog rather then creating an entirely new dialog to test -- the dialog no longer has a style set, and const_values is checked. Previously the generated code would not compile with this fix.

Closes #1020