### PR TITLE
Try window_style if form has no style property

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1228,6 +1228,14 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, EventVector& events
             else
                 code.Str("0;");
         }
+        else if (form_node->HasProp(prop_window_style))
+        {
+            code.Eol(eol_if_needed).Str("const int form_style = ");
+            if (form_node->value(prop_window_style).size())
+                code.Str(prop_window_style) += ";";
+            else
+                code.Str("0;");
+        }
         if (form_node->HasProp(prop_pos))
             code.Eol(eol_if_needed).Str("const wxPoint form_pos = ").Pos(prop_pos, no_dlg_units) += ";";
         if (form_node->HasProp(prop_size))


### PR DESCRIPTION
This PR fixes a bug that occurs when the `const_values` property is checked, but the form doesn't have a `style` property. Since not all forms have a style property, if none is available then check for a window_style, and if that is available, use it instead.

Closes #1019

Bug was encountered for wxPanel. That's currently the only form that doesn't have a style but does have a window_style, but in case a form is added in the future, the fix in this commit will handle it the same way as wxPanel.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
