### PR TITLE
Add derived_params property

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -170,6 +170,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_derived_directory, "derived_directory" },
     { prop_derived_file, "derived_file" },
     { prop_derived_header, "derived_header" },
+    { prop_derived_params, "derived_params" },
     { prop_digits, "digits" },
     { prop_direction, "direction" },
     { prop_disabled, "disabled" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -176,6 +176,7 @@ namespace GenEnum
         prop_derived_directory,
         prop_derived_file,
         prop_derived_header,
+        prop_derived_params,
         prop_digits,
         prop_direction,
         prop_disabled,

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -436,6 +436,14 @@ Code& Code::CreateClass(bool use_generic, tt_string_view override_name)
         {
             *this += m_node->prop_as_string(prop_derived_class);
             *this += '(';
+            if (m_node->HasValue(prop_derived_params))
+            {
+                *this += m_node->value(prop_derived_params);
+                if (back() != ',')
+                    *this += ", ";
+                if (back() != ' ')
+                    *this += ' ';
+            }
             return *this;
         }
     }

--- a/src/xml/window_interfaces_xml.xml
+++ b/src/xml/window_interfaces_xml.xml
@@ -111,6 +111,8 @@ inline const char* window_interfaces_xml = R"===(<?xml version="1.0"?>
 			help="Sets the help text to be used as context-sensitive help for this window." />
 		<property name="derived_class" type="string"
 			help="If you have derived a class from a wxWidget class and you want this component to use your derived class, then specify that class name here. You will need to add the header file for your class to the derived_header property." />
+		<property name="derived_params" type="string_escapes"
+			help="Specifies additional parameters to insert before the normal wxWidget class parameters." />
 		<property name="derived_header" type="file"
 			help="Specify the name of the header file that declares your derived class." />
 		<property name="window_name" type="string_escapes" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `derived_params` property to the wxWindow interface. If a control has specified a `derived_class` name, then any parameters specified in the `derived_params` property will be added before any default parameters. A check is made to be certain the last parameter ends with a comma and a space.

For more information, see the discussion #1003.