### PR TITLE
Refactor OnPropertyGridChanged() for readability

### DIFF
--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -80,6 +80,11 @@ protected:
     void ModifyProperty(NodeProperty* prop, const wxString& str);
     void modifyProperty(NodeProperty* prop, tt_string_view str);
 
+    void ModifyBitlistProperty(NodeProperty* node_prop, wxPGProperty* grid_prop);
+    void ModifyBoolProperty(NodeProperty* node_prop, wxPGProperty* grid_prop);
+    void ModifyFileProperty(NodeProperty* node_prop, wxPGProperty* grid_prop);
+    void ModifyOptionsProperty(NodeProperty* node_prop, wxPGProperty* grid_prop);
+
     int GetBitlistValue(const wxString& strVal, wxPGChoices& bit_flags);
 
     // Event handlers


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors PropGridPanel::OnPropertyGridChanged() to break up the 360+ line switch statement into functions so that it's easier to find how a specific property modification is handled.
