### PR TITLE
Add GroupUndoActions class to process multiple actions as if one

### DIFF
--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -62,14 +62,16 @@ void InsertNodeAction::Change()
 
     // Probably not necessary, but with both parameters set to false, this simply ensures the mainframe has it's selection
     // node set correctly.
-    wxGetFrame().SelectNode(m_node.get(), evt_flags::no_event);
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_node.get(), evt_flags::no_event);
 }
 
 void InsertNodeAction::Revert()
 {
     m_parent->RemoveChild(m_node);
     m_node->SetParent(NodeSharedPtr());  // Remove the parent pointer
-    wxGetFrame().SelectNode(m_old_selected.get());
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_old_selected.get());
 }
 
 ///////////////////////////////// RemoveNodeAction ////////////////////////////////////
@@ -99,11 +101,13 @@ void RemoveNodeAction::Change()
     if (m_parent->GetChildCount())
     {
         auto pos = (m_old_pos < m_parent->GetChildCount() ? m_old_pos : m_parent->GetChildCount() - 1);
-        wxGetFrame().SelectNode(m_parent->GetChild(pos));
+        if (isAllowedSelectEvent())
+            wxGetFrame().SelectNode(m_parent->GetChild(pos));
     }
     else
     {
-        wxGetFrame().SelectNode(m_parent.get());
+        if (isAllowedSelectEvent())
+            wxGetFrame().SelectNode(m_parent.get());
     }
 }
 
@@ -113,7 +117,8 @@ void RemoveNodeAction::Revert()
     m_node->SetParent(m_parent);
     m_parent->ChangeChildPosition(m_node, m_old_pos);
 
-    wxGetFrame().SelectNode(m_old_selected.get(), evt_flags::force_selection);
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_old_selected.get(), evt_flags::force_selection);
 }
 
 ///////////////////////////////// ModifyPropertyAction ////////////////////////////////////
@@ -243,14 +248,16 @@ void ChangePositionAction::Change()
 {
     m_parent->ChangeChildPosition(m_node, m_change_pos);
     wxGetFrame().FirePositionChangedEvent(this);
-    wxGetFrame().SelectNode(m_node);
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_node);
 }
 
 void ChangePositionAction::Revert()
 {
     m_parent->ChangeChildPosition(m_node, m_revert_pos);
     wxGetFrame().FirePositionChangedEvent(this);
-    wxGetFrame().SelectNode(m_node);
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_node);
 }
 
 ///////////////////////////////// ChangeSizerType ////////////////////////////////////
@@ -302,7 +309,8 @@ void ChangeSizerType::Change()
 
     wxGetFrame().FireDeletedEvent(m_old_node.get());
     wxGetFrame().FireCreatedEvent(m_node);
-    wxGetFrame().SelectNode(m_node.get());
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_node.get());
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(m_node.get(), true, true);
 }
 
@@ -316,7 +324,8 @@ void ChangeSizerType::Revert()
 
     wxGetFrame().FireDeletedEvent(m_node.get());
     wxGetFrame().FireCreatedEvent(m_old_node);
-    wxGetFrame().SelectNode(m_old_node.get());
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_old_node.get());
 }
 
 ///////////////////////////////// ChangeNodeType ////////////////////////////////////
@@ -409,7 +418,8 @@ void ChangeNodeType::Change()
 
     wxGetFrame().FireDeletedEvent(m_old_node.get());
     wxGetFrame().FireCreatedEvent(m_node);
-    wxGetFrame().SelectNode(m_node.get());
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_node.get());
     wxGetFrame().GetNavigationPanel()->ChangeExpansion(m_node.get(), true, true);
 }
 
@@ -423,7 +433,8 @@ void ChangeNodeType::Revert()
 
     wxGetFrame().FireDeletedEvent(m_node.get());
     wxGetFrame().FireCreatedEvent(m_old_node);
-    wxGetFrame().SelectNode(m_old_node.get());
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_old_node.get());
 }
 
 ///////////////////////////////// ChangeParentAction ////////////////////////////////////
@@ -460,7 +471,8 @@ void ChangeParentAction::Change()
             m_revert_parent->ChangeChildPosition(m_node, m_revert_position);
             // Since we deleted it from Navigation Panel, need to add it back
             wxGetFrame().FireParentChangedEvent(this);
-            wxGetFrame().SelectNode(m_node);
+            if (isAllowedSelectEvent())
+                wxGetFrame().SelectNode(m_node);
         }
     }
     else if (m_change_parent->AddChild(m_node))
@@ -468,7 +480,8 @@ void ChangeParentAction::Change()
         m_node->SetParent(m_change_parent);
 
         wxGetFrame().FireParentChangedEvent(this);
-        wxGetFrame().SelectNode(m_node);
+        if (isAllowedSelectEvent())
+            wxGetFrame().SelectNode(m_node);
     }
 }
 
@@ -485,7 +498,8 @@ void ChangeParentAction::Revert()
         prop->set_value(m_revert_col);
 
     wxGetFrame().FireParentChangedEvent(this);
-    wxGetFrame().SelectNode(m_node);
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_node);
 }
 
 ///////////////////////////////// AppendGridBagAction ////////////////////////////////////
@@ -531,7 +545,8 @@ void AppendGridBagAction::Change()
     }
 
     wxGetFrame().FireCreatedEvent(m_node);
-    wxGetFrame().SelectNode(m_node, evt_flags::fire_event | evt_flags::force_selection);
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_node, evt_flags::fire_event | evt_flags::force_selection);
 }
 
 void AppendGridBagAction::Revert()
@@ -540,7 +555,8 @@ void AppendGridBagAction::Revert()
     m_node->SetParent(NodeSharedPtr());
 
     wxGetFrame().FireDeletedEvent(m_node.get());
-    wxGetFrame().SelectNode(m_old_selected.get());
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_old_selected.get());
 }
 
 ///////////////////////////////// GridBagAction ////////////////////////////////////
@@ -592,7 +608,8 @@ void GridBagAction::Change()
         nav_panel->ExpandAllNodes(m_cur_gbsizer.get());
 
         wxGetFrame().FireGridBagActionEvent(this);
-        wxGetFrame().SelectNode(m_cur_gbsizer);
+        if (isAllowedSelectEvent())
+            wxGetFrame().SelectNode(m_cur_gbsizer);
     }
 }
 
@@ -619,7 +636,8 @@ void GridBagAction::Revert()
     nav_panel->ExpandAllNodes(m_cur_gbsizer.get());
 
     wxGetFrame().FireGridBagActionEvent(this);
-    wxGetFrame().SelectNode(m_cur_gbsizer);
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(m_cur_gbsizer);
 }
 
 void GridBagAction::Update()
@@ -680,7 +698,8 @@ void SortProjectAction::Change()
     }
 
     wxGetFrame().FireProjectUpdatedEvent();
-    wxGetFrame().SelectNode(Project.ProjectNode());
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(Project.ProjectNode());
 }
 
 void SortProjectAction::SortFolder(Node* folder)
@@ -706,5 +725,6 @@ void SortProjectAction::Revert()
     }
 
     wxGetFrame().FireProjectUpdatedEvent();
-    wxGetFrame().SelectNode(Project.ProjectNode());
+    if (isAllowedSelectEvent())
+        wxGetFrame().SelectNode(Project.ProjectNode());
 }

--- a/src/undo_stack.cpp
+++ b/src/undo_stack.cpp
@@ -7,6 +7,11 @@
 
 #include "undo_stack.h"  // UndoStack
 
+#include "mainframe.h"  // MainFrame -- Main window frame
+#include "node.h"       // Node class
+
+///////////////////////////////// UndoStack ////////////////////////////////////
+
 void UndoStack::Push(UndoActionPtr ptr)
 {
     if (!m_locked)
@@ -57,4 +62,41 @@ wxString UndoStack::GetRedoString()
         str = m_redo.back()->GetUndoString().wx_str();
     }
     return str;
+}
+
+///////////////////////////////// GroupUndoActions ////////////////////////////////////
+
+GroupUndoActions::GroupUndoActions(const tt_string& undo_str, Node* sel_node) : UndoAction(undo_str.c_str())
+{
+    if (sel_node)
+    {
+        m_old_selected = wxGetFrame().GetSelectedNodePtr();
+        m_selected_node = sel_node->GetSharedPtr();
+    }
+}
+
+void GroupUndoActions::Change()
+{
+    for (auto& iter: m_actions)
+    {
+        iter->Change();
+    }
+
+    if (m_selected_node)
+    {
+        wxGetFrame().SelectNode(m_selected_node);
+    }
+}
+
+void GroupUndoActions::Revert()
+{
+    for (auto& iter: m_actions)
+    {
+        iter->Revert();
+    }
+
+    if (m_old_selected)
+    {
+        wxGetFrame().SelectNode(m_old_selected);
+    }
 }

--- a/src/undo_stack.h
+++ b/src/undo_stack.h
@@ -34,6 +34,12 @@ public:
     bool wasUndoSelectEventGenerated() { return m_UndoSelectEventGenerated; }
     bool wasRedoSelectEventGenerated() { return m_RedoSelectEventGenerated; }
 
+    // Note that these will affect individual UndoActions added to GroupUndoActions, but will
+    // not affect the GroupUndoActions class itself.
+
+    void AllowSelectEvent(bool allow) { m_AllowSelectEvent = allow; }
+    bool isAllowedSelectEvent() { return m_AllowSelectEvent; }
+
 protected:
     tt_string m_undo_string;
 
@@ -41,6 +47,8 @@ protected:
     bool m_RedoEventGenerated { false };
     bool m_UndoSelectEventGenerated { false };
     bool m_RedoSelectEventGenerated { false };
+
+    bool m_AllowSelectEvent { true };
 };
 
 class Node;

--- a/src/undo_stack.h
+++ b/src/undo_stack.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Maintain a undo and redo stack
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -43,7 +43,32 @@ protected:
     bool m_RedoSelectEventGenerated { false };
 };
 
+class Node;
 using UndoActionPtr = std::shared_ptr<UndoAction>;
+using NodeSharedPtr = std::shared_ptr<Node>;
+
+// This class can be used when you want to group multiple UndoActions into a single UndoAction
+// with a single undo string.
+class GroupUndoActions : public UndoAction
+{
+public:
+    // Specify sel_node if you want the current selection changed after all the UndoActions
+    // have been called by Change() or Revert()
+    GroupUndoActions(const tt_string& undo_str, Node* sel_node = nullptr);
+
+    // Called when pushed to the Undo stack and when Redo is called
+    void Change() override;
+
+    // Called when Undo is requested
+    void Revert() override;
+
+    void Add(UndoActionPtr ptr) { m_actions.push_back(ptr); }
+
+private:
+    std::vector<UndoActionPtr> m_actions;
+    NodeSharedPtr m_selected_node { nullptr };
+    NodeSharedPtr m_old_selected { nullptr };
+};
 
 class UndoStack
 {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `GroupUndoActions` class which makes it possible to group any number of Undo actions which can be changed or reverted as a single command with a single Undo string. The `Change()` and `Revert()` functions for this class simply walk through the array of UndoActions calling each action's `Change()` or `Revert()` function.

Unless `AllowSelectEvent(false)` is called for each UndoAction, the UndoAction may call `wxGetFrame().SelectNode()`. The constructor has an optional `Node* sel_node` parameter which if specified will be called after all the individual UndoActions have been called.

This PR has _not_ been tested yet -- it's going to get merged into the Image class auto-update action and used there which will then provide an actual use scenario.