### PR TITLE
Replace wx_str() with utf8_string() and new make_wxString()

### DIFF
--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -10,11 +10,8 @@ When you create a debug build, there will be an additional **Internal** menu to 
 
 ## Strings
 
-The only time **wxString** should be used in **wxUiEditor** is when a string will be used for UI or for filenames. The **ttLib** class `ttString` derives from `wxString` and is often used instead of `wxString` since it has more automatic conversion of the UTF8 strings that are used throughout the code.
+Internally strings are normally placed into `tt_string`, `tt_stringview` and `tt_wxString` classes. These classes inherit from `std::string`, `std::string_view` and `wxString` respectively, and provide additional functionality common across all three of these classes. When you need to convert a tt_string or tt_stringview to a wxString to pass to wxWidgets, use the method `make_wxString()`. If you need to pass a wxString to tt_string, use `utf8_string()`. These two methods ensure that UTF8/16 conversion is correctly handled on Windows. It also ensure a seamless transition between wxWidgets 3.2 and 3.3 where the underlying wxString is changed from UTF16 to UTF8.
 
-Both `ttString` and `ttlib::cstr` have a `wx_str()` method that will perform UTF8<->UTF16 conversion when compiled for Windows, and no conversion when compiled for other platforms. `ttlib::cstr` is essentially `std::string` with additional methods including `wx_str()`. Note that when constructing a `wxString` from a `std::string` or `std::string_view` on Windows, you will get an ANSI to UTF16 conversion. If you construct a `ttString` from `std::string` or `std::string_view` on Windows, it will perform a UTF8 to UTF16 conversion (no conversion at all if not on Windows). Since wxUiEditor works exclusively with UTF8 strings, `ttString` is preferable to `wxString` in most cases.
-
-You will generally see `ttlib::sview` used instead of `std::string_view`. Like `ttlib::cstr`, this class provides dozens of additional methods beside the standard base class.
 
 ## size_t and int_t
 
@@ -22,7 +19,7 @@ These two types are used to ensure optimal bit-width for the current platform (c
 
 ### Debugging macros
 
-The `ASSERT...` and `FAIL...` macros are the preferred macros for debug checks. On Windows, they provide the option to break into a debugger if running a Debug build.
+The `ASSERT`, `ASSERT_MSG` and `FAIL_MSG` macros are the preferred macros for debug checks. On Windows, they provide the option to break into a debugger if running a Debug build.
 
 The `MSG_...` macros allow for display information in the custom logging window. The custom logging window has filters so that you can limit which messages are displayed. Unlike the `wxLog...` macros, none of these messages will ever be displayed to the user -- they are for your debugging use only.
 

--- a/src/assertion_dlg.cpp
+++ b/src/assertion_dlg.cpp
@@ -30,7 +30,7 @@ bool AssertionDlg(const std::source_location& location, const char* cond, std::s
     str << "Function: " << location.function_name() << "\n";
     str << "Line: " << (size_t) location.line() << "\n";
 
-    wxMessageDialog dlg(nullptr, str.wx_str(), "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
+    wxMessageDialog dlg(nullptr, str.make_wxString(), "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
     dlg.SetYesNoCancelLabels("wxTrap", "Continue", "Exit program");
 
     auto answer = dlg.ShowModal();
@@ -66,7 +66,7 @@ bool AssertionDlg(const char* filename, const char* function, int line, const ch
     str << "Line: " << line << "\n\n";
     str << "Press Yes to call wxTrap, No to continue, Cancel to exit program.";
 
-    wxMessageDialog dlg(nullptr, str.wx_str(), "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
+    wxMessageDialog dlg(nullptr, str.make_wxString(), "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
     dlg.SetYesNoCancelLabels("wxTrap", "Continue", "Exit program");
 
     auto answer = dlg.ShowModal();

--- a/src/bitmaps.cpp
+++ b/src/bitmaps.cpp
@@ -270,7 +270,7 @@ wxImage GetHeaderImage(tt_string_view filename, size_t* p_original_size, tt_wxSt
                 if (!*buf_ptr)
                 {
                     FAIL_MSG(tt_string() << filename << " doesn't contain a closing brace");
-                    wxMessageBox((tt_string() << filename << " doesn't contain a closing brace").wx_str());
+                    wxMessageBox((tt_string() << filename << " doesn't contain a closing brace").make_wxString());
                     return image;
                 }
             }
@@ -475,7 +475,7 @@ bool GetAnimationImage(wxAnimation& animation, tt_string_view filename)
                 if (!*buf_ptr)
                 {
                     FAIL_MSG(tt_string() << filename << " doesn't contain a closing brace");
-                    wxMessageBox((tt_string() << filename << " doesn't contain a closing brace").wx_str());
+                    wxMessageBox((tt_string() << filename << " doesn't contain a closing brace").make_wxString());
                     return animation.IsOk();
                 }
             }

--- a/src/customprops/art_prop_dlg.cpp
+++ b/src/customprops/art_prop_dlg.cpp
@@ -32,7 +32,7 @@ ArtBrowserDialog::ArtBrowserDialog(wxWindow* parent, const ImageProperties& img_
 
     if (auto pos = img_props.image.find('|'); tt::is_found(pos))
     {
-        m_client = img_props.image.subview(pos + 1).wx_str();
+        m_client = img_props.image.subview(pos + 1).make_wxString();
     }
     else
     {

--- a/src/customprops/custom_param_prop.cpp
+++ b/src/customprops/custom_param_prop.cpp
@@ -51,7 +51,7 @@ public:
             static_text << m_node->prop_as_string(prop_var_name) << " = new " << m_node->prop_as_string(prop_class_name);
             static_text << m_textCtrl->GetValue().utf8_string() << ';';
         }
-        m_static_hdr_text->SetLabel(static_text.wx_str());
+        m_static_hdr_text->SetLabel(static_text.make_wxString());
     }
 
 private:

--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -31,7 +31,7 @@ constexpr size_t EVENT_PAGE_PYTHON = 1;
 EventHandlerDlg::EventHandlerDlg(wxWindow* parent, NodeEvent* event) : EventHandlerDlgBase(parent), m_event(event)
 {
     m_is_python_code = (Project.value(prop_code_preference) == "Python");
-    m_value = event->get_value().wx_str();
+    m_value = event->get_value().make_wxString();
 
     m_cpp_stc_lambda->SetLexer(wxSTC_LEX_CPP);
 
@@ -126,7 +126,7 @@ void EventHandlerDlg::OnInit(wxInitDialogEvent& WXUNUSED(event))
 
                 m_cpp_function_box->GetStaticBox()->Enable(true);
                 m_cpp_radio_use_function->SetValue(true);
-                m_cpp_text_function->SetValue(value.wx_str());
+                m_cpp_text_function->SetValue(value.make_wxString());
             }
         }
 
@@ -150,7 +150,7 @@ void EventHandlerDlg::OnInit(wxInitDialogEvent& WXUNUSED(event))
                 // remove leading and trailing brackets
                 value.erase(pos_lambda, sizeof("[python:lambda]") - 1);
 
-                m_py_text_lambda->SetValue(value.wx_str());
+                m_py_text_lambda->SetValue(value.make_wxString());
                 m_is_python_lambda = true;
             }
             else
@@ -166,7 +166,7 @@ void EventHandlerDlg::OnInit(wxInitDialogEvent& WXUNUSED(event))
                     }
                 }
 
-                m_py_text_function->SetValue(value.wx_str());
+                m_py_text_function->SetValue(value.make_wxString());
                 m_py_radio_use_function->SetValue(true);
                 m_py_radio_use_lambda->SetValue(false);
             }
@@ -370,7 +370,7 @@ void EventHandlerDlg::FormatBindText()
         code.Add(m_event->GetNode()->get_node_name()).Function("Bind(").Add(handler).EndFunction();
     }
 
-    m_static_bind_text->SetLabel(code.wx_str());
+    m_static_bind_text->SetLabel(code.make_wxString());
 }
 
 void EventHandlerDlg::CollectMemberVariables(Node* node, std::set<std::string>& variables)
@@ -459,13 +459,13 @@ void EventHandlerDlg::Update_m_value()
 
     if (py_value.empty())
     {
-        m_value = cpp_value.wx_str();
+        m_value = cpp_value.make_wxString();
         return;
     }
 
     if (cpp_value.empty())
     {
-        m_value = py_value.wx_str();
+        m_value = py_value.make_wxString();
         return;
     }
 
@@ -473,7 +473,7 @@ void EventHandlerDlg::Update_m_value()
 
     if (cpp_value == py_value && !m_cpp_radio_use_function->GetValue())
     {
-        m_value = cpp_value.wx_str();
+        m_value = cpp_value.make_wxString();
         return;
     }
 
@@ -481,7 +481,7 @@ void EventHandlerDlg::Update_m_value()
     // one of them is using a lambda.
 
     tt_string combined_value = cpp_value + py_value;
-    m_value = combined_value.wx_str();
+    m_value = combined_value.make_wxString();
     return;
 }
 

--- a/src/customprops/img_string_prop.h
+++ b/src/customprops/img_string_prop.h
@@ -27,7 +27,7 @@ class ImageStringProperty : public wxStringProperty
 {
 public:
     ImageStringProperty(const wxString& label, ImageProperties& img_props) :
-        wxStringProperty(label, wxPG_LABEL, img_props.image.wx_str()), m_img_props(img_props)
+        wxStringProperty(label, wxPG_LABEL, img_props.image.make_wxString()), m_img_props(img_props)
     {
     }
 

--- a/src/customprops/pg_animation.cpp
+++ b/src/customprops/pg_animation.cpp
@@ -78,8 +78,8 @@ void PropertyGrid_Animation::RefreshChildren()
         m_old_type = m_img_props.type;
     }
 
-    Item(IndexType)->SetValue(m_img_props.type.wx_str());
-    Item(IndexImage)->SetValue(m_img_props.image.wx_str());
+    Item(IndexType)->SetValue(m_img_props.type.make_wxString());
+    Item(IndexImage)->SetValue(m_img_props.image.make_wxString());
 }
 
 wxVariant PropertyGrid_Animation::ChildChanged(wxVariant& thisValue, int childIndex, wxVariant& childValue) const
@@ -123,6 +123,6 @@ wxVariant PropertyGrid_Animation::ChildChanged(wxVariant& thisValue, int childIn
             break;
     }
 
-    value = img_props.CombineValues().wx_str();
+    value = img_props.CombineValues().make_wxString();
     return value;
 }

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -145,8 +145,8 @@ void PropertyGrid_Image::RefreshChildren()
         SetAutoComplete();
     }
 
-    Item(IndexType)->SetValue(m_img_props.type.wx_str());
-    Item(IndexImage)->SetValue(m_img_props.image.wx_str());
+    Item(IndexType)->SetValue(m_img_props.type.make_wxString());
+    Item(IndexImage)->SetValue(m_img_props.image.make_wxString());
     Item(IndexSize)->SetValue(m_img_props.CombineDefaultSize());
 }
 
@@ -264,6 +264,6 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
             break;
     }
 
-    value = img_props.CombineValues().wx_str();
+    value = img_props.CombineValues().make_wxString();
     return value;
 }

--- a/src/frame_status_bar.cpp
+++ b/src/frame_status_bar.cpp
@@ -52,7 +52,7 @@ public:
         wxStatusBar::DoUpdateStatusText(number);
     }
 
-    void setText(const tt_string& txt, int pane = 1) { SetStatusText(txt.wx_str(), pane); }
+    void setText(const tt_string& txt, int pane = 1) { SetStatusText(txt.make_wxString(), pane); }
 };
 
 wxStatusBar* MainFrame::OnCreateStatusBar(int number, long style, wxWindowID id, const wxString& name)

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1434,7 +1434,7 @@ void Code::GenFontColourSettings()
 
             Eol(eol_if_needed).Str("font_info.");
             if (fontprop.GetFaceName().size() && fontprop.GetFaceName() != "default")
-                Str("FaceName(").QuotedString(tt_string() << fontprop.GetFaceName().wx_str()) += ").";
+                Str("FaceName(").QuotedString(tt_string() << fontprop.GetFaceName().utf8_string()) += ").";
             if (fontprop.GetFamily() != wxFONTFAMILY_DEFAULT)
                 Str("Family(").Str(font_family_pairs.GetValue(fontprop.GetFamily())) += ").";
             if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)

--- a/src/generate/file_codewriter.cpp
+++ b/src/generate/file_codewriter.cpp
@@ -43,6 +43,7 @@ const char* python_end_cmt_line = "# ************* End of generated code";
 
 int FileCodeWriter::WriteFile(int language, int flags)
 {
+    ASSERT_MSG(m_filename.size(), "Filename must be set before calling WriteFile()");
     bool file_exists = m_filename.file_exists();
     if (!file_exists && (flags & flag_test_only))
         return write_needed;

--- a/src/generate/file_codewriter.h
+++ b/src/generate/file_codewriter.h
@@ -40,6 +40,18 @@ public:
         m_buffer.clear();
         m_buffer.reserve(reserved_amount);
     }
+    FileCodeWriter(const tt_string& file, size_t reserved_amount = 8 * 1024)
+    {
+        // REVIEW: [Randalphwa - 06-18-2023] Both of these *should* work! However, we end up
+        // with m_filename being empty.
+
+        // m_filename.FromUTF8(file);
+        // m_filename.FromUTF8(file.data(), file.size());
+
+        m_filename = file.make_wxString();
+        m_buffer.clear();
+        m_buffer.reserve(reserved_amount);
+    }
 
     void Clear() override { m_buffer.clear(); };
     tt_string& GetString() { return m_buffer; };

--- a/src/generate/gen_bitmap_combo.cpp
+++ b/src/generate/gen_bitmap_combo.cpp
@@ -28,7 +28,7 @@ wxObject* BitmapComboBoxGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
         for (auto& iter: array)
-            widget->Append(iter.wx_str());
+            widget->Append(iter.make_wxString());
 
         if (node->HasValue(prop_selection_string))
         {

--- a/src/generate/gen_check_listbox.cpp
+++ b/src/generate/gen_check_listbox.cpp
@@ -29,14 +29,14 @@ wxObject* CheckListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         for (auto& iter: items)
         {
-            auto pos = widget->Append(iter.label.wx_str());
-            if (iter.checked.wx_str() == "1")
+            auto pos = widget->Append(iter.label.make_wxString());
+            if (iter.checked == "1")
                 widget->Check(pos);
         }
 
         if (node->prop_as_string(prop_selection_string).size())
         {
-            widget->SetStringSelection(wxString::FromUTF8(node->prop_as_string(prop_selection_string)));
+            widget->SetStringSelection(node->as_wxString(prop_selection_string));
         }
         else
         {

--- a/src/generate/gen_choice.cpp
+++ b/src/generate/gen_choice.cpp
@@ -25,7 +25,7 @@ wxObject* ChoiceGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
         for (auto& iter: array)
-            widget->Append(iter.wx_str());
+            widget->Append(iter.make_wxString());
 
         if (node->HasValue(prop_selection_string))
         {

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -126,11 +126,11 @@ void GenThreadCpp(GenData& gen_data, Node* form)
     BaseCodeGenerator codegen(GEN_LANG_CPLUSPLUS);
 
     path.replace_extension(header_ext);
-    auto h_cw = std::make_unique<FileCodeWriter>(path.wx_str());
+    auto h_cw = std::make_unique<FileCodeWriter>(path);
     codegen.SetHdrWriteCode(h_cw.get());
 
     path.replace_extension(source_ext);
-    auto cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
+    auto cpp_cw = std::make_unique<FileCodeWriter>(path);
     codegen.SetSrcWriteCode(cpp_cw.get());
 
     codegen.GenerateCppClass(form);
@@ -390,11 +390,11 @@ void GenInhertedClass(GenResults& results)
         BaseCodeGenerator codegen(GEN_LANG_CPLUSPLUS);
 
         path.replace_extension(header_ext);
-        auto h_cw = std::make_unique<FileCodeWriter>(path.wx_str());
+        auto h_cw = std::make_unique<FileCodeWriter>(path);
         codegen.SetHdrWriteCode(h_cw.get());
 
         path.replace_extension(source_ext);
-        auto cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
+        auto cpp_cw = std::make_unique<FileCodeWriter>(path);
         codegen.SetSrcWriteCode(cpp_cw.get());
 
         auto retval = codegen.GenerateDerivedClass(Project.ProjectNode(), form);
@@ -583,11 +583,11 @@ void GenerateTmpFiles(const std::vector<tt_string>& ClassList, pugi::xml_node ro
                 BaseCodeGenerator codegen(language);
 
                 path.replace_extension(header_ext);
-                auto h_cw = std::make_unique<FileCodeWriter>(path.wx_str());
+                auto h_cw = std::make_unique<FileCodeWriter>(path);
                 codegen.SetHdrWriteCode(h_cw.get());
 
                 path.replace_extension(source_ext);
-                auto cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
+                auto cpp_cw = std::make_unique<FileCodeWriter>(path);
                 codegen.SetSrcWriteCode(cpp_cw.get());
 
                 if (language == GEN_LANG_CPLUSPLUS)
@@ -622,11 +622,11 @@ void GenerateTmpFiles(const std::vector<tt_string>& ClassList, pugi::xml_node ro
                     }
 
                     tmp_path.replace_extension(header_ext);
-                    h_cw = std::make_unique<FileCodeWriter>(tmp_path.wx_str());
+                    h_cw = std::make_unique<FileCodeWriter>(tmp_path);
                     codegen.SetHdrWriteCode(h_cw.get());
 
                     tmp_path.replace_extension(source_ext);
-                    cpp_cw = std::make_unique<FileCodeWriter>(tmp_path.wx_str());
+                    cpp_cw = std::make_unique<FileCodeWriter>(tmp_path);
                     codegen.SetSrcWriteCode(cpp_cw.get());
 
                     if (language == GEN_LANG_CPLUSPLUS)

--- a/src/generate/gen_combobox.cpp
+++ b/src/generate/gen_combobox.cpp
@@ -28,7 +28,7 @@ wxObject* ComboBoxGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
         for (auto& iter: array)
-            widget->Append(iter.wx_str());
+            widget->Append(iter.make_wxString());
 
         if (node->HasValue(prop_selection_string))
         {

--- a/src/generate/gen_grid.cpp
+++ b/src/generate/gen_grid.cpp
@@ -292,12 +292,12 @@ bool GridGenerator::SettingsCode(Code& code)
 
     if (code.HasValue(prop_col_label_values))
     {
-        auto labels = code.node()->as_wxArrayString(prop_col_label_values);
+        auto labels = code.node()->as_ArrayString(prop_col_label_values);
         int num_cols = code.IntValue(prop_cols);
         for (int col = 0; col < (int) labels.size() && col < num_cols; ++col)
         {
             code.Eol().NodeName().Function("SetColLabelValue(").itoa(col);
-            code.Comma().QuotedString(tt_string() << labels[col].wx_str()).EndFunction();
+            code.Comma().QuotedString(labels[col]).EndFunction();
         }
     }
 
@@ -327,12 +327,12 @@ bool GridGenerator::SettingsCode(Code& code)
 
     if (code.HasValue(prop_col_label_values))
     {
-        auto labels = code.node()->as_wxArrayString(prop_col_label_values);
+        auto labels = code.node()->as_ArrayString(prop_col_label_values);
         int num_cols = code.IntValue(prop_cols);
         for (int col = 0; col < (int) labels.size() && col < num_cols; ++col)
         {
             code.Eol().NodeName().Function("SetColLabelValue(").itoa(col);
-            code.Comma().QuotedString(tt_string() << labels[col].wx_str()).EndFunction();
+            code.Comma().QuotedString(labels[col]).EndFunction();
         }
     }
 

--- a/src/generate/gen_html_listbox.cpp
+++ b/src/generate/gen_html_listbox.cpp
@@ -26,7 +26,7 @@ wxObject* HtmlListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
         for (auto& iter: array)
-            widget->Append(iter.wx_str());
+            widget->Append(iter.make_wxString());
 
         if (node->HasValue(prop_selection_string))
         {

--- a/src/generate/gen_listbox.cpp
+++ b/src/generate/gen_listbox.cpp
@@ -26,11 +26,11 @@ wxObject* ListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         auto array = ConvertToArrayString(items);
         for (auto& iter: array)
-            widget->Append(wxString::FromUTF8(iter));
+            widget->Append(iter.make_wxString());
 
         if (node->prop_as_string(prop_selection_string).size())
         {
-            widget->SetStringSelection(wxString::FromUTF8(node->prop_as_string(prop_selection_string)));
+            widget->SetStringSelection(node->as_wxString(prop_selection_string));
         }
         else
         {

--- a/src/generate/gen_listview.cpp
+++ b/src/generate/gen_listview.cpp
@@ -23,7 +23,7 @@ wxObject* ListViewGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         auto headers = ConvertToArrayString(node->prop_as_string(prop_column_labels));
         for (auto& label: headers)
-            widget->AppendColumn(label.wx_str());
+            widget->AppendColumn(label.make_wxString());
 
         if (node->HasValue(prop_contents))
         {
@@ -39,7 +39,7 @@ wxObject* ListViewGenerator::CreateMockup(Node* node, wxObject* parent)
                 tt_string_vector columns(row, ';', tt::TRIM::both);
                 for (size_t column = 0; column < columns.size() && column < headers.size(); ++column)
                 {
-                    widget->SetItem(index, (to_int) column, columns[column].wx_str());
+                    widget->SetItem(index, (to_int) column, columns[column].make_wxString());
                 }
             }
         }

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -128,11 +128,11 @@ bool GeneratePythonFiles(GenResults& results, std::vector<tt_string>* pClassList
         {
             BaseCodeGenerator codegen(GEN_LANG_PYTHON);
 
-            auto h_cw = std::make_unique<FileCodeWriter>(path.wx_str());
+            auto h_cw = std::make_unique<FileCodeWriter>(path);
             codegen.SetHdrWriteCode(h_cw.get());
 
             path.replace_extension(".py");
-            auto cpp_cw = std::make_unique<FileCodeWriter>(path.wx_str());
+            auto cpp_cw = std::make_unique<FileCodeWriter>(path);
             codegen.SetSrcWriteCode(cpp_cw.get());
 
             codegen.GeneratePythonClass(form);

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -27,14 +27,14 @@ wxObject* RearrangeCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
     {
         for (auto& iter: items)
         {
-            auto pos = widget->GetList()->Append(iter.label.wx_str());
-            if (iter.checked.wx_str() == "1")
+            auto pos = widget->GetList()->Append(iter.label.make_wxString());
+            if (iter.checked == "1")
                 widget->GetList()->Check(pos);
         }
 
         if (node->prop_as_string(prop_selection_string).size())
         {
-            widget->GetList()->SetStringSelection(wxString::FromUTF8(node->prop_as_string(prop_selection_string)));
+            widget->GetList()->SetStringSelection(node->as_wxString(prop_selection_string));
         }
         else
         {

--- a/src/generate/gen_web_view.cpp
+++ b/src/generate/gen_web_view.cpp
@@ -23,7 +23,7 @@
 
 wxObject* WebViewGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    auto widget = wxWebView::New(wxStaticCast(parent, wxWindow), wxID_ANY, node->prop_as_string(prop_url).wx_str(),
+    auto widget = wxWebView::New(wxStaticCast(parent, wxWindow), wxID_ANY, node->as_wxString(prop_url),
                                  DlgPoint(parent, node, prop_pos), DlgSize(parent, node, prop_size), wxWebViewBackendDefault,
                                  GetStyleInt(node));
 

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -372,7 +372,7 @@ bool GenerateXrcFiles(GenResults& results, tt_string out_file, std::vector<tt_st
 
         if (path.file_exists())
         {
-            wxFile file_original(path.wx_str(), wxFile::read);
+            wxFile file_original(path.make_wxString(), wxFile::read);
             if (file_original.IsOpened())
             {
                 std::ostringstream xml_stream;

--- a/src/generate/images_list.cpp
+++ b/src/generate/images_list.cpp
@@ -60,11 +60,11 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
                     }
                     list << iter;
                 }
-                m_image_name->SetLabel(list.wx_str());
+                m_image_name->SetLabel(list.make_wxString());
             }
             else
             {
-                m_image_name->SetLabel(mstr[1].wx_str());
+                m_image_name->SetLabel(mstr[1].make_wxString());
             }
         }
         else

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -140,7 +140,7 @@ bool DialogBlocks::Import(const tt_wxString& filename, bool write_doc)
     if (m_errors.size())
     {
         tt_string errMsg("Not everything in the DialogBlocks project could be converted:\n\n");
-        MSG_ERROR(tt_string() << "------  " << m_importProjectFile.filename().wx_str() << "------");
+        MSG_ERROR(tt_string() << "------  " << m_importProjectFile.filename().utf8_string() << "------");
         for (auto& iter: m_errors)
         {
             MSG_ERROR(iter);

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -160,7 +160,7 @@ bool FormBuilder::Import(const tt_wxString& filename, bool write_doc)
     if (m_errors.size())
     {
         tt_string errMsg("Not everything in the wxFormBuilder project could be converted:\n\n");
-        MSG_ERROR(tt_string() << "------  " << m_importProjectFile.filename().wx_str() << "------");
+        MSG_ERROR(tt_string() << "------  " << m_importProjectFile.filename().utf8_string() << "------");
         for (auto& iter: m_errors)
         {
             MSG_ERROR(iter);
@@ -960,10 +960,10 @@ void FormBuilder::BitmapProperty(pugi::xml_node& xml_prop, NodeProperty* prop)
         else
         {
             tt_string bitmap("Embed;");
-            tt_wxString relative(filename.wx_str());
+            tt_wxString relative(filename.make_wxString());
             relative.make_relative_wx(wxGetCwd());
             relative.backslashestoforward();
-            bitmap << relative.wx_str();
+            bitmap << relative.utf8_string();
             bitmap << ";[-1,-1]";
             prop->set_value(bitmap);
         }

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -68,7 +68,7 @@ WxCrafter::WxCrafter() {}
 
 bool WxCrafter::Import(const tt_wxString& filename, bool write_doc)
 {
-    std::ifstream input(filename.wx_str(), std::ifstream::binary);
+    std::ifstream input(filename.utf8_string(), std::ifstream::binary);
     if (!input.is_open())
     {
         wxMessageBox(wxString() << "Cannot open " << filename, "Import wxCrafter project");
@@ -147,7 +147,7 @@ bool WxCrafter::Import(const tt_wxString& filename, bool write_doc)
     if (m_errors.size())
     {
         tt_string errMsg("Not everything in the wxCrafter project could be converted:\n\n");
-        MSG_ERROR(tt_string() << "------  " << m_importProjectFile.filename().wx_str() << "------");
+        MSG_ERROR(tt_string() << "------  " << m_importProjectFile.filename().utf8_string() << "------");
         for (auto& iter: m_errors)
         {
             MSG_ERROR(iter);
@@ -1350,7 +1350,7 @@ bool WxCrafter::ProcessFont(Node* node, const Value& object)
                 if (mstr.size() > 4 && mstr[4] == "1")
                     font_info.Underlined();
                 if (mstr.size() > 5)
-                    font_info.FaceName(mstr[5].wx_str());
+                    font_info.FaceName(mstr[5].make_wxString());
             }
         }
 
@@ -1575,7 +1575,7 @@ tt_string rapidjson::ConvertColour(const rapidjson::Value& colour)
             }
             else if (colour.GetString()[0] == '#')
             {
-                wxColour clr(clr_string.wx_str());
+                wxColour clr(clr_string.make_wxString());
                 return ConvertColourToString(clr);
             }
             else if (clr_string.starts_with("wx"))

--- a/src/import/import_wxsmith.cpp
+++ b/src/import/import_wxsmith.cpp
@@ -61,7 +61,7 @@ bool WxSmith::Import(const tt_wxString& filename, bool write_doc)
     if (m_errors.size())
     {
         tt_string errMsg("Not everything in the project could be converted:\n\n");
-        MSG_ERROR(tt_string() << "------  " << m_importProjectFile.filename().wx_str() << "------");
+        MSG_ERROR(tt_string() << "------  " << m_importProjectFile.filename().utf8_string() << "------");
         for (auto& iter: m_errors)
         {
             MSG_ERROR(iter);

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -130,7 +130,7 @@ std::optional<pugi::xml_document> ImportXML::LoadDocFile(const tt_wxString& file
 {
     pugi::xml_document doc;
 
-    if (auto result = doc.load_file(file.wx_str()); !result)
+    if (auto result = doc.load_file(file.utf8_string().c_str()); !result)
     {
         wxMessageBox(wxString("Cannot open ") << file << "\n\n" << result.description(), "Import wxFormBuilder project");
         return {};
@@ -1069,10 +1069,10 @@ void ImportXML::ProcessBitmap(const pugi::xml_node& xml_obj, Node* node, GenEnum
             // path to be incorrect
             file.Replace(":\\\\", ":\\");
 
-            tt_wxString relative(file.wx_str());
+            tt_wxString relative(file.make_wxString());
             relative.make_relative_wx(wxGetCwd());
             relative.backslashestoforward();
-            bitmap << relative.wx_str();
+            bitmap << relative.utf8_string();
             bitmap << ";[-1,-1]";
 
             if (auto prop = node->get_prop_ptr(prop_bitmap); prop)

--- a/src/internal/code_compare.cpp
+++ b/src/internal/code_compare.cpp
@@ -137,7 +137,7 @@ void CodeCompare::OnInit(wxInitDialogEvent& /* event */)
     {
         for (auto& iter: m_class_list)
         {
-            m_list_changes->AppendString(iter.wx_str());
+            m_list_changes->AppendString(iter.make_wxString());
         }
         m_btn->Enable();
     }
@@ -154,7 +154,7 @@ void CodeCompare::OnCPlusPlus(wxCommandEvent& /* event */)
     {
         for (auto& iter: m_class_list)
         {
-            m_list_changes->AppendString(iter.wx_str());
+            m_list_changes->AppendString(iter.make_wxString());
         }
         m_btn->Enable();
     }
@@ -171,7 +171,7 @@ void CodeCompare::OnPython(wxCommandEvent& /* event */)
     {
         for (auto& iter: m_class_list)
         {
-            m_list_changes->AppendString(iter.wx_str());
+            m_list_changes->AppendString(iter.make_wxString());
         }
         m_btn->Enable();
     }

--- a/src/internal/convert_img.cpp
+++ b/src/internal/convert_img.cpp
@@ -534,7 +534,7 @@ void ConvertImageDlg::ImageInXpmOut()
 
         if (m_xpmImage.SaveFile(out_name, wxBITMAP_TYPE_XPM))
         {
-            size_t output_size = std::filesystem::file_size(std::filesystem::path(out_name.wx_str()));
+            size_t output_size = std::filesystem::file_size(std::filesystem::path(out_name.utf8_string()));
             m_staticSave->SetLabelText(wxString() << out_name << " saved.");
             m_staticSave->Show();
             m_staticSize->SetLabelText(

--- a/src/internal/msg_logging.cpp
+++ b/src/internal/msg_logging.cpp
@@ -151,7 +151,7 @@ void MsgLogging::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogR
         case wxLOG_Error:
             {
                 auto& str = m_Msgs.emplace_back("wxError: ");
-                str << msg.wx_str() << '\n';
+                str << msg.utf8_string() << '\n';
 
                 if ((Preferences().GetDebugFlags() & PREFS::PREFS_MSG_WINDOW) && !m_isFirstShown)
                 {
@@ -179,7 +179,7 @@ void MsgLogging::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogR
             if (Preferences().GetDebugFlags() & PREFS::PREFS_MSG_WARNING)
             {
                 auto& str = m_Msgs.emplace_back("wxWarning: ");
-                str << msg.wx_str() << '\n';
+                str << msg.utf8_string() << '\n';
 
                 if ((Preferences().GetDebugFlags() & PREFS::PREFS_MSG_WINDOW) && !m_isFirstShown)
                 {
@@ -208,7 +208,7 @@ void MsgLogging::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogR
             if (Preferences().GetDebugFlags() & PREFS::PREFS_MSG_INFO)
             {
                 auto& str = m_Msgs.emplace_back("wxInfo: ");
-                str << msg.wx_str() << '\n';
+                str << msg.utf8_string() << '\n';
 
                 if ((Preferences().GetDebugFlags() & PREFS::PREFS_MSG_WINDOW) && !m_isFirstShown)
                 {
@@ -234,7 +234,7 @@ void MsgLogging::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogR
             {
                 auto frame = wxGetApp().GetMainFrame();
                 if (frame && frame->IsShown())
-                    frame->SetRightStatusField(tt_string() << msg.wx_str());
+                    frame->SetRightStatusField(tt_string() << msg.utf8_string());
             }
             break;
 

--- a/src/internal/msgframe.cpp
+++ b/src/internal/msgframe.cpp
@@ -59,39 +59,39 @@ MsgFrame::MsgFrame(std::vector<tt_string>* pMsgs, bool* pDestroyed, wxWindow* pa
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxRED));
             m_textCtrl->AppendText("Error: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-            m_textCtrl->AppendText(iter.view_stepover().wx_str());
+            m_textCtrl->AppendText(iter.view_stepover().make_wxString());
         }
         if (iter.starts_with("wxError:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxRED));
             m_textCtrl->AppendText("wxError: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-            m_textCtrl->AppendText(iter.view_stepover().wx_str());
+            m_textCtrl->AppendText(iter.view_stepover().make_wxString());
         }
         else if (iter.starts_with("Warning:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLUE));
             m_textCtrl->AppendText("Warning: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-            m_textCtrl->AppendText(iter.view_stepover().wx_str());
+            m_textCtrl->AppendText(iter.view_stepover().make_wxString());
         }
         else if (iter.starts_with("wxWarning:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLUE));
             m_textCtrl->AppendText("wxWarning: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-            m_textCtrl->AppendText(iter.view_stepover().wx_str());
+            m_textCtrl->AppendText(iter.view_stepover().make_wxString());
         }
         else if (iter.starts_with("wxInfo:"))
         {
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxCYAN));
             m_textCtrl->AppendText("wxInfo: ");
             m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-            m_textCtrl->AppendText(iter.view_stepover().wx_str());
+            m_textCtrl->AppendText(iter.view_stepover().make_wxString());
         }
         else
         {
-            m_textCtrl->AppendText(iter.wx_str());
+            m_textCtrl->AppendText(iter.make_wxString());
         }
     }
 
@@ -126,7 +126,7 @@ void MsgFrame::AddWarningMsg(tt_string_view msg)
         m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLUE));
         m_textCtrl->AppendText("Warning: ");
         m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-        m_textCtrl->AppendText(msg.wx_str());
+        m_textCtrl->AppendText(msg.make_wxString());
     }
 }
 
@@ -137,7 +137,7 @@ void MsgFrame::Add_wxWarningMsg(tt_string_view msg)
         m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLUE));
         m_textCtrl->AppendText("wxWarning: ");
         m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-        m_textCtrl->AppendText(msg.wx_str());
+        m_textCtrl->AppendText(msg.make_wxString());
     }
 }
 
@@ -148,7 +148,7 @@ void MsgFrame::Add_wxInfoMsg(tt_string_view msg)
         m_textCtrl->SetDefaultStyle(wxTextAttr(*wxCYAN));
         m_textCtrl->AppendText("wxInfo: ");
         m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-        m_textCtrl->AppendText(msg.wx_str());
+        m_textCtrl->AppendText(msg.make_wxString());
     }
 }
 
@@ -159,7 +159,7 @@ void MsgFrame::AddErrorMsg(tt_string_view msg)
     m_textCtrl->SetDefaultStyle(wxTextAttr(*wxRED));
     m_textCtrl->AppendText("Error: ");
     m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-    m_textCtrl->AppendText(msg.wx_str());
+    m_textCtrl->AppendText(msg.make_wxString());
 }
 
 void MsgFrame::Add_wxErrorMsg(tt_string_view msg)
@@ -169,7 +169,7 @@ void MsgFrame::Add_wxErrorMsg(tt_string_view msg)
     m_textCtrl->SetDefaultStyle(wxTextAttr(*wxRED));
     m_textCtrl->AppendText("wxError: ");
     m_textCtrl->SetDefaultStyle(wxTextAttr(*wxBLACK));
-    m_textCtrl->AppendText(msg.wx_str());
+    m_textCtrl->AppendText(msg.make_wxString());
 }
 
 void MsgFrame::OnClose(wxCloseEvent& event)
@@ -190,10 +190,10 @@ void MsgFrame::OnSaveAs(wxCommandEvent& WXUNUSED(event))
     auto totalLines = m_textCtrl->GetNumberOfLines();
     for (int curLine = 0; curLine < totalLines; ++curLine)
     {
-        file.addEmptyLine().utf(m_textCtrl->GetLineText(curLine).wx_str());
+        file.addEmptyLine() << m_textCtrl->GetLineText(curLine).utf8_string();
     }
 
-    if (auto result = file.WriteFile(tt_string().utf(filename.wx_str())); !result)
+    if (auto result = file.WriteFile(filename.utf8_string()); !result)
     {
         wxMessageBox(wxString("Cannot create or write to the file ") << filename, "Save messages");
     }
@@ -327,12 +327,12 @@ void MsgFrame::UpdateNodeInfo()
             {
                 gen_label << "wxWidgets";
             }
-            m_hyperlink->SetLabel(gen_label.wx_str());
+            m_hyperlink->SetLabel(gen_label.make_wxString());
             wxString url("https://docs.wxwidgets.org/trunk/");
             auto file = generator->GetHelpURL(cur_sel);
             if (file.size())
             {
-                url << "class" << file.wx_str();
+                url << "class" << file.make_wxString();
             }
             m_hyperlink->SetURL(url);
         }

--- a/src/internal/msgframe.h
+++ b/src/internal/msgframe.h
@@ -24,8 +24,8 @@ public:
     void AddWarningMsg(tt_string_view msg);
     void Add_wxWarningMsg(tt_string_view msg);
 
-    void AddInfoMsg(tt_string_view msg) { m_textCtrl->AppendText(msg.wx_str()); };
-    void AddEventMsg(tt_string_view msg) { m_textCtrl->AppendText(msg.wx_str()); };
+    void AddInfoMsg(tt_string_view msg) { m_textCtrl->AppendText(msg.make_wxString()); };
+    void AddEventMsg(tt_string_view msg) { m_textCtrl->AppendText(msg.make_wxString()); };
 
     void Add_wxInfoMsg(tt_string_view msg);
 

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -295,7 +295,7 @@ void XrcPreview::OnExport(wxCommandEvent& WXUNUSED(event))
         pugi::xml_document doc;
         doc.load_string(buf.c_str());
 
-        if (!doc.save_file(filename.wx_str(), "\t"))
+        if (!doc.save_file(filename.utf8_string().c_str(), "\t"))
         {
             wxMessageBox(wxString("An unexpected error occurred exportin ") << filename, "Export XRC");
         }

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -529,7 +529,7 @@ protected:
         if (frame.HasSourceLocation())
         {
             tt_string source;
-            source << frame.GetFileName().wx_str() << ':' << (to_int) frame.GetLine();
+            source << frame.GetFileName().utf8_string() << ':' << (to_int) frame.GetLine();
 
             wxString params;
             if (auto paramCount = frame.GetParamCount(); paramCount > 0)
@@ -551,12 +551,12 @@ protected:
             if (params.size() > 100)
                 params = "(...)";
 
-            m_calls.emplace_back() << (to_int) frame.GetLevel() << ' ' << frame.GetName().wx_str() << params.wx_str() << ' '
-                                   << source;
+            m_calls.emplace_back() << (to_int) frame.GetLevel() << ' ' << frame.GetName().utf8_string()
+                                   << params.utf8_string() << ' ' << source;
         }
         else
         {
-            m_calls.emplace_back() << (to_int) frame.GetLevel() << ' ' << frame.GetName().wx_str();
+            m_calls.emplace_back() << (to_int) frame.GetLevel() << ' ' << frame.GetName().utf8_string();
         }
     }
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -959,7 +959,7 @@ void MainFrame::OnBrowseDocs(wxCommandEvent& WXUNUSED(event))
             {
                 // wxString url("https://docs.wxwidgets.org/trunk/class");
                 wxString url("https://docs.wxwidgets.org/3.2.0/class");
-                url << file.wx_str();
+                url << file.make_wxString();
                 wxLaunchDefaultBrowser(url);
                 return;
             }
@@ -981,7 +981,7 @@ void MainFrame::OnUpdateBrowseDocs(wxUpdateUIEvent& event)
                 label << "wxWidgets";
             }
             label << " Documentation";
-            event.SetText(label.wx_str());
+            event.SetText(label.make_wxString());
             return;
         }
     }
@@ -999,7 +999,7 @@ void MainFrame::OnBrowsePython(wxCommandEvent& WXUNUSED(event))
             if (file.size())
             {
                 wxString url("https://docs.wxpython.org/");
-                url << file.wx_str();
+                url << file.make_wxString();
                 wxLaunchDefaultBrowser(url);
                 return;
             }
@@ -1020,7 +1020,7 @@ void MainFrame::OnUpdateBrowsePython(wxUpdateUIEvent& event)
                 label << "wxPython";
             }
             label << " Documentation";
-            event.SetText(label.wx_str());
+            event.SetText(label.make_wxString());
             return;
         }
     }

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -396,7 +396,7 @@ void MockupContent::SetWindowProperties(Node* node, wxWindow* window, wxWindow* 
 
     if (auto& tooltip = node->value(prop_tooltip); tooltip.size())
     {
-        window->SetToolTip(tooltip.wx_str());
+        window->SetToolTip(tooltip.make_wxString());
     }
 }
 

--- a/src/nodes/category.h
+++ b/src/nodes/category.h
@@ -20,7 +20,7 @@ public:
     NodeCategory(std::string_view name) { m_name.assign(name.data(), name.size()); }
 
     const wxString& GetName() { return m_name; }
-    tt_string getName() { return tt_string(m_name.wx_str()); }
+    tt_string getName() { return tt_string(m_name.utf8_string()); }
 
     void AddProperty(PropName name) { m_prop_names.emplace_back(name); }
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -483,6 +483,14 @@ const ImageBundle* Node::prop_as_image_bundle(PropName name) const
         return nullptr;
 }
 
+std::vector<tt_string> Node::as_ArrayString(PropName name) const
+{
+    if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+        return m_properties[result->second].as_ArrayString();
+    else
+        return std::vector<tt_string>();
+}
+
 wxArrayString Node::prop_as_wxArrayString(PropName name) const
 {
     if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -273,6 +273,9 @@ public:
     wxArrayString as_wxArrayString(PropName name) const { return prop_as_wxArrayString(name); }
     wxBitmapBundle as_wxBitmapBundle(PropName name) const { return prop_as_wxBitmapBundle(name); }
 
+    // Assumes all values are within quotes
+    std::vector<tt_string> as_ArrayString(PropName name) const;
+
     // On Windows this will first convert to UTF-16 unless wxUSE_UNICODE_UTF8 is set.
     //
     // The string will be empty if the property doesn't exist.

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -107,8 +107,11 @@ public:
     wxSize as_size() const;
     wxArrayString as_wxArrayString() const;
 
+    // Assumes all values are within quotes
+    std::vector<tt_string> as_ArrayString() const;
+
     // On Windows this will first convert to UTF-16 unless wxUSE_UNICODE_UTF8 is set.
-    wxString as_wxString() const { return m_value.wx_str(); }
+    wxString as_wxString() const { return m_value.make_wxString(); }
 
     wxBitmapBundle as_bitmap_bundle() const;
     const ImageBundle* as_image_bundle() const;

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -426,8 +426,8 @@ void NavigationPanel::InsertNode(Node* node)
     ASSERT(node_parent);
     auto tree_parent = m_node_tree_map[node_parent];
     ASSERT(tree_parent);
-    auto new_item = m_tree_ctrl->InsertItem(tree_parent, node_parent->GetChildPosition(node), GetDisplayName(node).wx_str(),
-                                            GetImageIndex(node), -1);
+    auto new_item = m_tree_ctrl->InsertItem(tree_parent, node_parent->GetChildPosition(node),
+                                            GetDisplayName(node).make_wxString(), GetImageIndex(node), -1);
     m_node_tree_map[node] = new_item;
     m_tree_node_map[new_item] = node;
 
@@ -451,7 +451,7 @@ void NavigationPanel::AddAllChildren(Node* node_parent)
     for (const auto& iter_child: node_parent->GetChildNodePtrs())
     {
         auto node = iter_child.get();
-        auto new_item = m_tree_ctrl->AppendItem(tree_parent, GetDisplayName(node).wx_str(), GetImageIndex(node), -1);
+        auto new_item = m_tree_ctrl->AppendItem(tree_parent, GetDisplayName(node).make_wxString(), GetImageIndex(node), -1);
 
         m_node_tree_map[node] = new_item;
         m_tree_node_map[new_item] = node;
@@ -480,7 +480,7 @@ int NavigationPanel::GetImageIndex(Node* node)
 
 void NavigationPanel::UpdateDisplayName(wxTreeItemId id, Node* node)
 {
-    m_tree_ctrl->SetItemText(id, GetDisplayName(node).wx_str());
+    m_tree_ctrl->SetItemText(id, GetDisplayName(node).make_wxString());
 }
 
 tt_string NavigationPanel::GetDisplayName(Node* node) const
@@ -629,7 +629,7 @@ void NavigationPanel::OnNodeSelected(CustomEvent& event)
     else
     {
         FAIL_MSG(tt_string("There is no tree item associated with this object.\n\tClass: ")
-                 << node->DeclName() << "\n\tName: " << node->prop_as_string(prop_var_name).wx_str());
+                 << node->DeclName() << "\n\tName: " << node->value(prop_var_name));
     }
 }
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -265,84 +265,83 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
 {
     auto type = prop->type();
 
-    // Note that prop->as_string() does NOT do a UTF16 conversion on Windows unless you call wx_str().
-    // prop->as_wxString() automatically calls wx_str().
-
     switch (type)
     {
         case type_id:
-            return new ID_Property(prop->DeclName().wx_str(), prop);
+            return new ID_Property(prop->DeclName().make_wxString(), prop);
 
         case type_int:
-            return new wxIntProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_int());
+            return new wxIntProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_int());
 
         case type_uint:
-            return new wxUIntProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_int());
+            return new wxUIntProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_int());
 
         case type_statbar_fields:
             // This includes a button that triggers a dialog to edit the fields.
-            return new SBarFieldsProperty(prop->DeclName().wx_str(), prop);
+            return new SBarFieldsProperty(prop->DeclName().make_wxString(), prop);
 
         case type_checklist_item:
             // This includes a button that triggers a dialog to edit the fields.
-            return new RearrangeProperty(prop->DeclName().wx_str(), prop);
+            return new RearrangeProperty(prop->DeclName().make_wxString(), prop);
 
         case type_string_code_single:
             // This includes a button that triggers a small single-line custom text editor dialog
-            return new EditParamProperty(prop->DeclName().wx_str(), prop);
+            return new EditParamProperty(prop->DeclName().make_wxString(), prop);
 
         case type_string_escapes:
             // This first doubles the backslash in escaped characters: \n, \t, \r, and \.
-            return new wxStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_escape_text().wx_str());
+            return new wxStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL,
+                                        prop->as_escape_text().make_wxString());
 
         case type_string:
-            return new wxStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_wxString());
+            return new wxStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxString());
 
         case type_string_edit_escapes:
             // This includes a button that triggers a small text editor dialog
             // This doubles the backslash in escaped characters: \n, \t, \r, and \.
-            return new wxLongStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_escape_text().wx_str());
+            return new wxLongStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL,
+                                            prop->as_escape_text().make_wxString());
 
         case type_string_edit:
             // This includes a button that triggers a small text editor dialog
-            return new wxLongStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_wxString());
+            return new wxLongStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxString());
 
         case type_string_edit_single:
             // This includes a button that triggers a small single-line custom text editor dialog
-            return new EditStringProperty(prop->DeclName().wx_str(), prop);
+            return new EditStringProperty(prop->DeclName().make_wxString(), prop);
 
         case type_code_edit:
             // This includes a button that triggers a small single-line custom text editor dialog
-            return new EditCodeProperty(prop->DeclName().wx_str(), prop);
+            return new EditCodeProperty(prop->DeclName().make_wxString(), prop);
 
         case type_html_edit:
             // This includes a button that triggers a small single-line custom text editor dialog
-            return new EditHtmlProperty(prop->DeclName().wx_str(), prop);
+            return new EditHtmlProperty(prop->DeclName().make_wxString(), prop);
 
         case type_bool:
-            return new wxBoolProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_string() == "1");
+            return new wxBoolProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_string() == "1");
 
         case type_wxPoint:
-            return new CustomPointProperty(prop->DeclName().wx_str(), prop, CustomPointProperty::type_point);
+            return new CustomPointProperty(prop->DeclName().make_wxString(), prop, CustomPointProperty::type_point);
 
         case type_wxSize:
-            return new CustomPointProperty(prop->DeclName().wx_str(), prop, CustomPointProperty::type_size);
+            return new CustomPointProperty(prop->DeclName().make_wxString(), prop, CustomPointProperty::type_size);
 
         case type_wxFont:
             // This includes a button that triggers a custom font selector dialog
-            return new FontStringProperty(prop->DeclName().wx_str(), prop);
+            return new FontStringProperty(prop->DeclName().make_wxString(), prop);
 
         case type_path:
-            return new DirectoryProperty(prop->DeclName().wx_str(), prop);
+            return new DirectoryProperty(prop->DeclName().make_wxString(), prop);
 
         case type_animation:
-            return new PropertyGrid_Animation(prop->DeclName().wx_str(), prop);
+            return new PropertyGrid_Animation(prop->DeclName().make_wxString(), prop);
 
         case type_image:
-            return new PropertyGrid_Image(prop->DeclName().wx_str(), prop);
+            return new PropertyGrid_Image(prop->DeclName().make_wxString(), prop);
 
         case type_float:
-            return new wxFloatProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_float());
+            return new wxFloatProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_float());
 
         default:
             break;
@@ -362,7 +361,7 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
         }
 
         int val = GetBitlistValue(prop->as_string(), bit_flags);
-        new_pg_property = new wxFlagsProperty(prop->DeclName().wx_str(), wxPG_LABEL, bit_flags, val);
+        new_pg_property = new wxFlagsProperty(prop->DeclName().make_wxString(), wxPG_LABEL, bit_flags, val);
 
         wxFlagsProperty* flagsProp = dynamic_cast<wxFlagsProperty*>(new_pg_property);
         if (flagsProp)
@@ -407,11 +406,11 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
 
         if (type == type_editoption)
         {
-            new_pg_property = new wxEditEnumProperty(prop->DeclName().wx_str(), wxPG_LABEL, constants);
+            new_pg_property = new wxEditEnumProperty(prop->DeclName().make_wxString(), wxPG_LABEL, constants);
         }
         else
         {
-            new_pg_property = new wxEnumProperty(prop->DeclName().wx_str(), wxPG_LABEL, constants);
+            new_pg_property = new wxEnumProperty(prop->DeclName().make_wxString(), wxPG_LABEL, constants);
         }
 
         new_pg_property->SetValueFromString(value, 0);
@@ -437,11 +436,11 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
     else if (type == type_wxColour)
     {
         auto value = prop->as_string();
-        new_pg_property = new EditColourProperty(prop->DeclName().wx_str(), prop);
+        new_pg_property = new EditColourProperty(prop->DeclName().make_wxString(), prop);
     }
     else if (type == type_file)
     {
-        new_pg_property = new wxFileProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_string());
+        new_pg_property = new wxFileProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_string());
 
         // In order for the wxFileProperty file dialog to have the correct initial directory, you must
         // specify a *FULL* path for wxPG_FILE_INITIAL_PATH.
@@ -552,23 +551,23 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
     }
     else if (type == type_stringlist)
     {
-        new_pg_property = new wxArrayStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_wxArrayString());
+        new_pg_property = new wxArrayStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxArrayString());
         wxVariant var_quote("\"");
         new_pg_property->DoSetAttribute(wxPG_ARRAY_DELIMITER, var_quote);
     }
     else if (type == type_stringlist_escapes)
     {
-        new_pg_property = new wxArrayStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_wxArrayString());
+        new_pg_property = new wxArrayStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxArrayString());
         wxVariant var_quote("\"");
         new_pg_property->DoSetAttribute(wxPG_ARRAY_DELIMITER, var_quote);
     }
     else if (type == type_uintpairlist)
     {
-        new_pg_property = new wxStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_string());
+        new_pg_property = new wxStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_string());
     }
     else  // Unknown property
     {
-        new_pg_property = new wxStringProperty(prop->DeclName().wx_str(), wxPG_LABEL, prop->as_string());
+        new_pg_property = new wxStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_string());
         new_pg_property->SetAttribute(wxPG_BOOL_USE_DOUBLE_CLICK_CYCLING, wxVariant(true, "true"));
 
 #if defined(INTERNAL_TESTING)
@@ -615,7 +614,7 @@ void PropGridPanel::AddProperties(tt_string_view name, Node* node, NodeCategory&
                 {
                     if (auto result = gen->GetHint(prop); result)
                     {
-                        m_prop_grid->SetPropertyAttribute(pg, wxPG_ATTR_HINT, result->wx_str());
+                        m_prop_grid->SetPropertyAttribute(pg, wxPG_ATTR_HINT, result->make_wxString());
                     }
                 }
                 m_prop_grid->SetPropertyHelpString(pg, GetPropHelp(prop));
@@ -1029,7 +1028,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
         case type_string_escapes:
         case type_string_edit_escapes:
             {
-                auto value = ConvertEscapeSlashes(tt_string() << m_prop_grid->GetPropertyValueAsString(property).wx_str());
+                auto value = ConvertEscapeSlashes(m_prop_grid->GetPropertyValueAsString(property).utf8_string());
                 modifyProperty(prop, value);
             }
             break;
@@ -1178,7 +1177,7 @@ void PropGridPanel::OnEventGridChanged(wxPropertyGridEvent& event)
     {
         NodeEvent* evt = it->second;
         wxString handler = event.GetPropertyValue();
-        auto value = ConvertEscapeSlashes(tt_string() << handler.wx_str());
+        auto value = ConvertEscapeSlashes(handler.utf8_string());
         value.trim(tt::TRIM::both);
         wxGetFrame().ChangeEventHandler(evt, value);
     }
@@ -1235,7 +1234,7 @@ void PropGridPanel::OnNodePropChange(CustomEvent& event)
     }
 
     auto prop = event.GetNodeProperty();
-    auto grid_property = m_prop_grid->GetPropertyByLabel(prop->DeclName().wx_str());
+    auto grid_property = m_prop_grid->GetPropertyByLabel(prop->DeclName().make_wxString());
     if (!grid_property)
         return;
 
@@ -1258,7 +1257,7 @@ void PropGridPanel::OnNodePropChange(CustomEvent& event)
         case type_string_edit_escapes:
         case type_string_escapes:
         case type_stringlist_escapes:
-            grid_property->SetValueFromString(prop->as_escape_text().wx_str(), 0);
+            grid_property->SetValueFromString(prop->as_escape_text().make_wxString(), 0);
             break;
 
         case type_id:
@@ -1341,7 +1340,7 @@ void PropGridPanel::OnNodePropChange(CustomEvent& event)
 void PropGridPanel::ModifyProperty(NodeProperty* prop, const wxString& str)
 {
     m_isPropChangeSuspended = true;
-    wxGetFrame().ModifyProperty(prop, tt_string() << str.wx_str());
+    wxGetFrame().ModifyProperty(prop, str.utf8_string());
     m_isPropChangeSuspended = false;
 }
 
@@ -2051,7 +2050,7 @@ wxString PropGridPanel::GetPropHelp(NodeProperty* prop)
         // First let the generator specify the description
         if (auto result = gen->GetPropertyDescription(prop); result)
         {
-            description = result->wx_str();
+            description = result->make_wxString();
         }
     }
     if (description.empty())
@@ -2064,7 +2063,7 @@ wxString PropGridPanel::GetPropHelp(NodeProperty* prop)
         else
         {
             // If we still don't have a description, get whatever was in the XML interface
-            description = prop->GetPropDeclaration()->GetDescription().wx_str();
+            description = prop->GetPropDeclaration()->GetDescription().make_wxString();
         }
     }
     description.Replace("\\n", "\n", true);

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -33,7 +33,7 @@ void AllowDirectoryChange(wxPropertyGridEvent& event, NodeProperty* /* prop */, 
         // processing. Preserve the focus to avoid validating twice.
         auto focus = wxWindow::FindFocus();
 
-        auto result = wxMessageBox(tt_string() << "The directory \"" << newValue.wx_str()
+        auto result = wxMessageBox(tt_string() << "The directory \"" << newValue.utf8_string()
                                                << "\" does not exist. Do you want to use this name anyway?",
                                    "Directory doesn't exist", wxYES_NO | wxICON_WARNING, GetMainFrame());
         if (focus)
@@ -187,7 +187,7 @@ void OnPathChanged(wxPropertyGridEvent& event, NodeProperty* prop, Node* /* node
     // display isn't correct, it will be stored in the project file correctly.
 
     event.GetProperty()->SetValueFromString(newValue, 0);
-    tt_string value(newValue.wx_str());
+    tt_string value(newValue.utf8_string());
     if (value != prop->as_string())
     {
         if (prop->isProp(prop_derived_directory))

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -202,7 +202,8 @@ wxImage ImageHandler::GetPropertyBitmap(const tt_string_vector& parts, bool chec
         }
         else
         {
-            image = (wxArtProvider::GetBitmapBundle(parts[IndexArtID].wx_str(), wxART_MAKE_CLIENT_ID_FROM_STR("wxART_OTHER"))
+            image = (wxArtProvider::GetBitmapBundle(parts[IndexArtID].make_wxString(),
+                                                    wxART_MAKE_CLIENT_ID_FROM_STR("wxART_OTHER"))
                          .GetBitmapFor(wxGetFrame().GetWindow()))
                         .ConvertToImage();
         }
@@ -370,7 +371,7 @@ bool ImageHandler::AddEmbeddedImage(tt_string path, Node* form, bool is_animatio
 
 bool ImageHandler::AddNewEmbeddedImage(tt_string path, Node* form, std::unique_lock<std::mutex>& add_lock)
 {
-    wxFFileInputStream stream(path.wx_str());
+    wxFFileInputStream stream(path.make_wxString());
     if (!stream.IsOk())
     {
         add_lock.unlock();
@@ -731,7 +732,7 @@ bool ImageHandler::AddNewEmbeddedBundle(const tt_string_vector& parts, tt_string
 
 bool ImageHandler::AddEmbeddedBundleImage(tt_string path, Node* form)
 {
-    wxFFileInputStream stream(path.wx_str());
+    wxFFileInputStream stream(path.make_wxString());
     if (!stream.IsOk())
     {
         return false;
@@ -830,8 +831,8 @@ ImageBundle* ImageHandler::ProcessBundleProperty(const tt_string_vector& parts, 
         }
         else
         {
-            img_bundle.bundle =
-                wxArtProvider::GetBitmapBundle(parts[IndexArtID].wx_str(), wxART_MAKE_CLIENT_ID_FROM_STR("wxART_OTHER"));
+            img_bundle.bundle = wxArtProvider::GetBitmapBundle(parts[IndexArtID].make_wxString(),
+                                                               wxART_MAKE_CLIENT_ID_FROM_STR("wxART_OTHER"));
         }
 
         m_bundles[lookup_str] = std::move(img_bundle);
@@ -1186,7 +1187,7 @@ bool ImageHandler::AddSvgBundleImage(tt_string path, Node* form)
     memcpy(embed->array_data.get(), read_stream->GetBufferStart(), compressed_size);
 
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
-    wxFile file_original(path.wx_str(), wxFile::read);
+    wxFile file_original(path.make_wxString(), wxFile::read);
     if (file_original.IsOpened())
     {
         auto file_size = file_original.Length();

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -39,10 +39,10 @@ using namespace GenEnum;
 bool ProjectHandler::LoadProject(const tt_wxString& file, bool allow_ui)
 {
     pugi::xml_document doc;
-    auto result = doc.load_file(file.wx_str());
+    auto result = doc.load_file(file.utf8_string().c_str());
     if (!result)
     {
-        ASSERT_MSG(result, tt_string() << "pugi failed trying to load " << file.wx_str());
+        ASSERT_MSG(result, tt_string() << "pugi failed trying to load " << file.utf8_string());
         if (allow_ui)
         {
             wxMessageBox(wxString("Cannot open ") << file << "\n\n" << result.description(), "Load Project");
@@ -131,7 +131,7 @@ bool ProjectHandler::LoadProject(const tt_wxString& file, bool allow_ui)
 
     if (!project)
     {
-        ASSERT_MSG(project, tt_string() << "Failed trying to load " << file.wx_str());
+        ASSERT_MSG(project, tt_string() << "Failed trying to load " << file.utf8_string());
 
         if (allow_ui)
         {
@@ -624,7 +624,7 @@ bool ProjectHandler::Import(ImportXML& import, tt_wxString& file, bool append, b
         auto project = root.child("node");
         if (!project || project.attribute("class").as_string() != "Project")
         {
-            ASSERT_MSG(project, tt_string() << "Failed trying to load converted xml document: " << file.wx_str());
+            ASSERT_MSG(project, tt_string() << "Failed trying to load converted xml document: " << file.utf8_string());
 
             // TODO: [KeyWorks - 10-23-2020] Need to let the user know
             return false;
@@ -726,10 +726,10 @@ bool ProjectHandler::Import(ImportXML& import, tt_wxString& file, bool append, b
         if (m_project_node->GetChildCount() && file.file_exists())
         {
             doc.reset();
-            auto result = doc.load_file(file.wx_str());
+            auto result = doc.load_file(file.utf8_string().c_str());
             if (!result)
             {
-                ASSERT_MSG(result, tt_string() << "pugi failed trying to load " << file.wx_str());
+                ASSERT_MSG(result, tt_string() << "pugi failed trying to load " << file.utf8_string());
                 if (allow_ui)
                 {
                     wxMessageBox(wxString("Cannot open ") << file << "\n\n" << result.description(), "Load Project");
@@ -884,7 +884,7 @@ bool ProjectHandler::NewProject(bool create_empty, bool allow_ui)
 
                 if (imported_from.size())
                     imported_from << "@@";
-                imported_from << "// Imported from " << iter.wx_str();
+                imported_from << "// Imported from " << iter.utf8_string();
             }
             catch (const std::exception& /* e */)
             {

--- a/src/tt/tt.cpp
+++ b/src/tt/tt.cpp
@@ -527,7 +527,7 @@ void tt::utf8to16(std::string_view str, std::wstring& dest)
             uint32_t val = (str[pos] & 0xFF);
             if ((UINT8(str[pos]) >> 5) == 6)
             {
-                assertm(pos + 1 < str.size(), "Invalid UTF8 string");
+                ASSERT_MSG(pos + 1 < str.size(), "Invalid UTF8 string");
                 if (pos + 1 < str.size())
                 {
                     val = ((val << 6) & 0x7FF) + (str[++pos] & 0x3F);
@@ -536,7 +536,7 @@ void tt::utf8to16(std::string_view str, std::wstring& dest)
 
             else if ((UINT8(str[pos]) >> 4) == 14)
             {
-                assertm(pos + 2 < str.size(), "Invalid UTF8 string");
+                ASSERT_MSG(pos + 2 < str.size(), "Invalid UTF8 string");
                 if (pos + 2 < str.size())
                 {
                     val = ((val << 12) & 0xFFFF) + ((str[++pos] << 6) & 0xFFF);
@@ -546,7 +546,7 @@ void tt::utf8to16(std::string_view str, std::wstring& dest)
 
             else if ((UINT8(str[pos]) >> 3) == 30)
             {
-                assertm(pos + 3 < str.size(), "Invalid UTF8 string");
+                ASSERT_MSG(pos + 3 < str.size(), "Invalid UTF8 string");
                 if (pos + 3 < str.size())
                 {
                     val = ((val << 18) & 0x1FFFFF) + ((str[++pos] << 12) & 0x3FFFF);
@@ -556,7 +556,7 @@ void tt::utf8to16(std::string_view str, std::wstring& dest)
             }
             else
             {
-                assertm(str[pos], "Invalid UTF8 string");
+                ASSERT_MSG(str[pos], "Invalid UTF8 string");
             }
 
             if (val > 0xFFFF)

--- a/src/tt/tt.h
+++ b/src/tt/tt.h
@@ -14,11 +14,6 @@
 #include <filesystem>
 #include <string_view>
 
-#ifndef assertm
-// assert with a message
-    #define assertm(exp, msg) assert(((void) msg, exp))
-#endif
-
 class tt_string;
 
 namespace tt

--- a/src/tt/tt_string.h
+++ b/src/tt/tt_string.h
@@ -60,7 +60,7 @@ public:
 
     // FromUTF8() is very efficient if wxUSE_UNICODE_UTF8 is defined as no UTF conversion is
     // done.
-    wxString make_wxString() const { return wxString::FromUTF8(data()); }
+    wxString make_wxString() const { return wxString::FromUTF8(data(), size()); }
 
 // If on Windows, and not a wxUSE_UNICODE_UTF8 build, return value converts to UTF16
 #if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)

--- a/src/tt/tt_string.h
+++ b/src/tt/tt_string.h
@@ -58,6 +58,10 @@ public:
         return *this;
     }
 
+    // FromUTF8() is very efficient if wxUSE_UNICODE_UTF8 is defined as no UTF conversion is
+    // done.
+    wxString make_wxString() const { return wxString::FromUTF8(data()); }
+
 // If on Windows, and not a wxUSE_UNICODE_UTF8 build, return value converts to UTF16
 #if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
     std::wstring wx_str() const { return to_utf16(); };

--- a/src/tt/tt_string_vector.cpp
+++ b/src/tt/tt_string_vector.cpp
@@ -229,7 +229,7 @@ bool tt_string_vector::ReadFile(std::string_view filename)
     m_filename.assign(filename);
     clear();
 #if defined(_WIN32)
-    auto path = std::filesystem::path(m_filename.wx_str());
+    auto path = std::filesystem::path(m_filename.c_str());
     std::ifstream file(path, std::ios::binary);
 #else
     std::ifstream file(m_filename, std::ios::binary);

--- a/src/tt/tt_string_view.h
+++ b/src/tt/tt_string_view.h
@@ -25,6 +25,10 @@ public:
     tt_string_view(const char* str) : bsv(str) {}
     tt_string_view(std::string_view view) : bsv(view) {}
 
+    // FromUTF8() is very efficient if wxUSE_UNICODE_UTF8 is defined as no UTF conversion is
+    // done.
+    wxString make_wxString() const { return wxString::FromUTF8(data(), size()); }
+
 #if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
     /// Returns a copy of the string converted to UTF16 on Windows, or a normal copy on other platforms
     std::wstring wx_str() const { return to_utf16(); };

--- a/src/tt/tt_wxString.cpp
+++ b/src/tt/tt_wxString.cpp
@@ -33,7 +33,7 @@ tt_wxString& tt_wxString::append_view(std::string_view str, size_t posStart, siz
 {
     if (posStart >= str.size())
     {
-        assertm(posStart < str.size(), "invalid starting position for append_view");
+        ASSERT_MSG(posStart < str.size(), "invalid starting position for append_view");
         return *this;
     }
     if (len == tt::npos)
@@ -51,7 +51,7 @@ tt_wxString& tt_wxString::assign_view(std::string_view str, size_t posStart, siz
     }
     if (posStart >= str.size())
     {
-        assertm(posStart < str.size(), "invalid starting position for append_view");
+        ASSERT_MSG(posStart < str.size(), "invalid starting position for append_view");
         return *this;
     }
     if (len == tt::npos)
@@ -703,7 +703,7 @@ bool tt_wxString::ChangeDir(bool is_dir) const
     {
         if (is_dir)
         {
-            auto dir = std::filesystem::directory_entry(std::filesystem::path(wx_str()));
+            auto dir = std::filesystem::directory_entry(std::filesystem::path(utf8_string()));
             if (dir.exists())
             {
                 std::filesystem::current_path(dir);
@@ -716,7 +716,7 @@ bool tt_wxString::ChangeDir(bool is_dir) const
             tmp.remove_filename();
             if (tmp.empty())
                 return false;
-            auto dir = std::filesystem::directory_entry(std::filesystem::path(tmp.wx_str()));
+            auto dir = std::filesystem::directory_entry(std::filesystem::path(tmp.utf8_string()));
             if (dir.exists())
             {
                 std::filesystem::current_path(dir);
@@ -732,12 +732,12 @@ bool tt_wxString::ChangeDir(bool is_dir) const
 
 tt_wxString tt_wxString::find_file(const tt_wxString& dir, const tt_wxString& filename)
 {
-    auto dir_iterator = std::filesystem::recursive_directory_iterator(dir.wx_str());
+    auto dir_iterator = std::filesystem::recursive_directory_iterator(dir.utf8_string());
     for (auto& entry: dir_iterator)
     {
         if (entry.is_regular_file())
         {
-            if (entry.path().filename() == filename.wx_str())
+            if (entry.path().filename() == filename.utf8_string())
             {
                 return entry.path().string();
             }

--- a/src/ui/generate_xrc_dlg.cpp
+++ b/src/ui/generate_xrc_dlg.cpp
@@ -23,7 +23,7 @@ void GenerateXrcDlg::OnInit(wxInitDialogEvent& event)
 {
     if (Project.HasValue(prop_combined_xrc_file))
     {
-        m_filename = Project.value(prop_combined_xrc_file).wx_str();
+        m_filename = Project.value(prop_combined_xrc_file).make_wxString();
         m_filePicker->SetPath(m_filename);
     }
     std::vector<Node*> forms;

--- a/src/undo_stack.cpp
+++ b/src/undo_stack.cpp
@@ -49,7 +49,7 @@ wxString UndoStack::GetUndoString()
     wxString str;
     if (m_undo.size())
     {
-        str = m_undo.back()->GetUndoString().wx_str();
+        str = m_undo.back()->GetUndoString().make_wxString();
     }
     return str;
 }
@@ -59,7 +59,7 @@ wxString UndoStack::GetRedoString()
     wxString str;
     if (m_redo.size())
     {
-        str = m_redo.back()->GetUndoString().wx_str();
+        str = m_redo.back()->GetUndoString().make_wxString();
     }
     return str;
 }

--- a/src/utils/font_prop.cpp
+++ b/src/utils/font_prop.cpp
@@ -72,7 +72,7 @@ FontProperty::FontProperty(const wxFont& font)
 
 FontProperty::FontProperty(wxVariant font)
 {
-    Convert(tt_string() << font.GetString().wx_str());
+    Convert(font.GetString().utf8_string());
 }
 
 FontProperty::FontProperty(tt_string_view font)
@@ -177,7 +177,7 @@ void FontProperty::Convert(tt_string_view font)
     }
 
     m_isDefGuiFont = false;
-    FaceName(mstr[0].wx_str());
+    FaceName(mstr[0].make_wxString());
 
     // We have a facename, so now we need to determine if this is the new style that uses friendly names, or the old
     // wxFB-like style which used numbers. The second value for the wxFB-style is the font style which will be 90 or higher
@@ -369,7 +369,7 @@ wxString FontProperty::as_wxString() const
 
 tt_string FontProperty::as_string() const
 {
-    tt_string str(as_wxString().wx_str());
+    tt_string str(as_wxString().utf8_string());
     return str;
 }
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -427,13 +427,13 @@ wxArrayString ConvertToWxArrayString(tt_string_view value)
         return array;
     tt_string parse;
     auto pos = parse.ExtractSubString(value);
-    array.push_back(parse.wx_str());
+    array.push_back(parse.make_wxString());
 
     for (auto tmp_value = tt::stepover(value.data() + pos); tmp_value.size();
          tmp_value = tt::stepover(tmp_value.data() + pos))
     {
         pos = parse.ExtractSubString(tmp_value);
-        array.push_back(parse.wx_str());
+        array.push_back(parse.make_wxString());
     }
 
     return array;

--- a/src/wakatime.cpp
+++ b/src/wakatime.cpp
@@ -138,11 +138,11 @@ void WakaTime::SendHeartbeat(bool FileSavedEvent)
         {
             m_last_heartbeat = static_cast<intmax_t>(result);
             tt_wxString cmd;
-            cmd << m_waka_cli.wx_str()
+            cmd << m_waka_cli.make_wxString()
                 << " --plugin \"wxUiEditor/0.5.0 wxUiEditor-wakatime/0.5.0\" --category designing --project ";
             tt_wxString name = Project.ProjectFile().filename();
             name.remove_extension();
-            cmd << name.wx_str();
+            cmd << name;
             cmd << " --entity \"" << Project.ProjectFile() << "\"";
             if (FileSavedEvent)
             {

--- a/src/winres/import_winres.cpp
+++ b/src/winres/import_winres.cpp
@@ -17,7 +17,7 @@ WinResource::WinResource() {}
 bool WinResource::Import(const tt_wxString& filename, bool write_doc)
 {
     std::vector<tt_string> forms;
-    if (ImportRc(tt_string() << filename.wx_str(), forms))
+    if (ImportRc(filename.utf8_string(), forms))
     {
         if (write_doc)
             m_project->CreateDoc(m_docOut);
@@ -310,7 +310,7 @@ bool WinResource::ImportRc(const tt_string& rc_file, std::vector<tt_string>& for
         wxMessageBox((tt_string() << "Problem parsing " << m_RcFilename << " at around line " << tt::itoa(m_curline << 1)
                                   << "\n\n"
                                   << e.what())
-                         .wx_str(),
+                         .make_wxString(),
                      "RC Parser");
         return false;
     }
@@ -354,7 +354,7 @@ void WinResource::ParseDialog(tt_string_vector& file)
         MSG_ERROR(e.what());
         wxMessageBox((tt_string() << "Problem parsing " << m_RcFilename << " at around line " << m_curline + 1 << "\n\n"
                                   << e.what())
-                         .wx_str(),
+                         .make_wxString(),
                      "RC Parser");
     }
 }
@@ -381,7 +381,7 @@ void WinResource::ParseMenu(tt_string_vector& file)
         MSG_ERROR(e.what());
         wxMessageBox((tt_string() << "Problem parsing " << m_RcFilename << " at around line " << m_curline + 1 << "\n\n"
                                   << e.what())
-                         .wx_str(),
+                         .make_wxString(),
                      "RC Parser");
     }
 }

--- a/src/wxui/import_winres_dlg.cpp
+++ b/src/wxui/import_winres_dlg.cpp
@@ -114,14 +114,14 @@ void ImportWinRes::OnInit(wxInitDialogEvent& WXUNUSED(event))
     }
     else
     {
-        m_fileResource->SetPath(m_rcFilename.wx_str());
+        m_fileResource->SetPath(m_rcFilename.make_wxString());
         ReadRcFile();
     }
 }
 
 void ImportWinRes::ReadRcFile()
 {
-    m_rcFilename.utf(m_fileResource->GetPath().wx_str());
+    m_rcFilename = m_fileResource->GetPath().utf8_string();
     tt_string_vector rc_file;
     if (!rc_file.ReadFile(m_rcFilename))
     {
@@ -184,10 +184,10 @@ void ImportWinRes::OnOk(wxCommandEvent& event)
         if (m_checkListResUI->IsChecked(pos))
         {
             auto& name = m_dialogs.emplace_back();
-            name << m_checkListResUI->GetString(pos).wx_str();
+            name << m_checkListResUI->GetString(pos).utf8_string();
         }
     }
 
-    m_rcFilename.utf(m_fileResource->GetTextCtrlValue().wx_str());
+    m_rcFilename = m_fileResource->GetTextCtrlValue().utf8_string();
     event.Skip();
 }

--- a/src/wxui/insert_widget.cpp
+++ b/src/wxui/insert_widget.cpp
@@ -157,7 +157,7 @@ void InsertWidget::OnNameText(wxCommandEvent& WXUNUSED(event))
 
         if (name.empty() || iter->DeclName().contains(name, tt::CASE::either))
         {
-            m_listbox->AppendString(iter->DeclName().wx_str());
+            m_listbox->AppendString(iter->DeclName().make_wxString());
         }
     }
 
@@ -180,7 +180,7 @@ void InsertWidget::OnListBoxDblClick(wxCommandEvent& WXUNUSED(event))
 
 void InsertWidget::OnOK(wxCommandEvent& event)
 {
-    m_widget << m_listbox->GetStringSelection().wx_str();
+    m_widget << m_listbox->GetStringSelection().utf8_string();
     event.Skip();
 }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR replaces the use of `wx_str()` with `utf8_string()` when converting to tt_string or std::string, and `make_wxString()` when converting to wxString. The reason for this change is that it ensures that UTF8/UTF16 conversion will be performed _only_ if necessary (Windows build using wxWidgets 3.2). This prevents the problems I've been encountering when building Debug or Internal versions on 3.3 where all strings are UTF8 and then having the code fail when built on Github and/or a Release build which is using 3.2 where wxString is UTF16 on Windows.

There are going to be times where using a UTF conversion to change from narrow to wide strings will be inefficient because the string is ANSI. However, these conversions will have no noticeable effect for the user since they are done when processing UI elements. Always using UTF conversion reduces the chance of bugs occurring both when the string really was a UTF string, and when the string works fine on wxWidgets 3.3 and breaks the build on wxWidgets 3.2.

Closes #1035