### PR TITLE
Replace int_t with ptrdiff_t, update Developper Notes with current information

### DIFF
--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -2,20 +2,15 @@
 
 If you are planning on contributing code, the following sections contain information about the code that might not be immediately obvious. Reading these sections may make the code easier to understand, as well as ensuring that PR's are written in a way that matches the rest of the code base. In addition, some of the directories also have README files that provide explanations specific to the files in that directory. See [generate](../src/generate/README.md), [nodes](../src/nodes/README.md), [winres](../src/winres/README.md) and [xml](../src/xml/README.md).
 
-Note that the code requires a C++20 compliant compiler -- which means you should be using C++20 coding conventions. That includes using `std::string_view` (or `ttlib::sview`) for strings when practical. See the **Strings** section below for information about working with `wxString`.
+Note that the code requires a C++20 compliant compiler -- which means you should be using C++20 coding conventions. That includes using `std::string_view` (or `tt_stringview`) for strings when practical. See the **Strings** section below for information about working with `wxString`.
 
 ## Debug builds
 
-When you create a debug build, there will be an additional **Internal** menu to the right of the **Help** menu that will give you access to additional functionality for easier debugging.
+When you create a Debug build, there will be an additional `Testing` and `Internal` menu to the right of the **Help** menu that will give you access to additional functionality for easier debugging. You can also get these menus in a Release build if you set INTERNAL_BLD_TESTING to true in your CMake configuration.
 
 ## Strings
 
 Internally strings are normally placed into `tt_string`, `tt_stringview` and `tt_wxString` classes. These classes inherit from `std::string`, `std::string_view` and `wxString` respectively, and provide additional functionality common across all three of these classes. When you need to convert a tt_string or tt_stringview to a wxString to pass to wxWidgets, use the method `make_wxString()`. If you need to pass a wxString to tt_string, use `utf8_string()`. These two methods ensure that UTF8/16 conversion is correctly handled on Windows. It also ensure a seamless transition between wxWidgets 3.2 and 3.3 where the underlying wxString is changed from UTF16 to UTF8.
-
-
-## size_t and int_t
-
-These two types are used to ensure optimal bit-width for the current platform (currently 32-bit or 64-bit). Note that `int_t` is not a standard type, but declared in `pch.h` as `typedef ptrdiff_t int_t;` to provide more readable code than using `ptrdiff_t`.
 
 ### Debugging macros
 
@@ -25,6 +20,12 @@ The `MSG_...` macros allow for display information in the custom logging window.
 
 ## clang-format
 
-All PRs get run through a github action that runs clang-format. This will not change your code, but will report a failure if clang-format would have changed your code formatting. To ensure a successful PR submission, run your code through clang-format before committing it.
+All PRs get run through a github action that runs clang-format. This will report a failure if clang-format would have changed your code formatting. To ensure a successful PR submission, run your code through clang-format before committing it.
 
 If you are adding a comment to a function or variable in a header file, please wrap the comment to a maximum of 93 characters -- that makes the comment more likely to display correctly when displayed in a Intellisense popup.
+
+## Comments: // and /* */
+
+Prior to AI being available to generate code, comments in the code explained _why_ the code was written not _what_ the code did. The reasoning is that _what_ the code did should be obvious just by reading the code, but _why_ the code was written in a specific way might not be obvious.
+
+With AI, prefixing code with a comment that says _what_ the code should do will help the AI generate more accurate code. In addition, a comment that explains _what_ the code is doing can help AI training making the code more likely to be generated for someone else. This project is Open Source, and uses an Apache License, so there are no restrictions on how a section of the code is used in other projects.

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -260,7 +260,7 @@ bool Node::IsChildAllowed(NodeDeclaration* child)
     // Because m_children contains shared_ptrs, we don't want to use an iteration loop which will get/release the shared
     // ptr. Using an index into the vector lets us access the raw pointer.
 
-    int_t children = 0;
+    ptrdiff_t children = 0;
     for (size_t i = 0; i < m_children.size() && children <= max_children; ++i)
     {
         if (GetChild(i)->gen_type() == child->gen_type())
@@ -1180,7 +1180,7 @@ void Node::CollectUniqueNames(std::unordered_set<std::string>& name_set, Node* c
     }
 }
 
-int_t Node::FindInsertionPos(Node* child) const
+ptrdiff_t Node::FindInsertionPos(Node* child) const
 {
     if (child)
     {

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -343,8 +343,8 @@ public:
     // If prop_name is != prop_var_name, only that property is collected.
     void CollectUniqueNames(std::unordered_set<std::string>& name_set, Node* cur_node, PropName prop_name = prop_var_name);
 
-    int_t FindInsertionPos(Node* child) const;
-    int_t FindInsertionPos(const NodeSharedPtr& child) const { return FindInsertionPos(child.get()); }
+    ptrdiff_t FindInsertionPos(Node* child) const;
+    ptrdiff_t FindInsertionPos(const NodeSharedPtr& child) const { return FindInsertionPos(child.get()); }
 
     // Currently only called in debug builds, but available for release builds should we need it
     size_t GetNodeSize() const;
@@ -354,7 +354,7 @@ public:
 
     void CalcNodeHash(size_t& hash) const;
 
-    int_t GetAllowableChildren(GenType child_gen_type) const { return m_declaration->GetAllowableChildren(child_gen_type); }
+    ptrdiff_t GetAllowableChildren(GenType child_gen_type) const { return m_declaration->GetAllowableChildren(child_gen_type); }
 
     // Collect a vector of pointers to all children having the specified property with a
     // non-empty value.

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -354,7 +354,10 @@ public:
 
     void CalcNodeHash(size_t& hash) const;
 
-    ptrdiff_t GetAllowableChildren(GenType child_gen_type) const { return m_declaration->GetAllowableChildren(child_gen_type); }
+    ptrdiff_t GetAllowableChildren(GenType child_gen_type) const
+    {
+        return m_declaration->GetAllowableChildren(child_gen_type);
+    }
 
     // Collect a vector of pointers to all children having the specified property with a
     // non-empty value.

--- a/src/nodes/node_decl.cpp
+++ b/src/nodes/node_decl.cpp
@@ -139,7 +139,7 @@ bool NodeDeclaration::isSubclassOf(GenName gen_name) const
     return false;
 }
 
-int_t NodeDeclaration::GetAllowableChildren(GenType child_gen_type) const
+ptrdiff_t NodeDeclaration::GetAllowableChildren(GenType child_gen_type) const
 {
     if (m_gen_name == gen_wxFrame)
     {

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -84,7 +84,7 @@ public:
     const tt_string& GetGeneratorFlags() { return m_internal_flags; }
     void SetGeneratorFlags(std::string_view flags) { m_internal_flags = flags; }
 
-    int_t GetAllowableChildren(GenType child_gen_type) const;
+    ptrdiff_t GetAllowableChildren(GenType child_gen_type) const;
 
     void SetOverRideDefValue(GenEnum::PropName prop_name, std::string_view new_value)
     {

--- a/src/nodes/node_gridbag.cpp
+++ b/src/nodes/node_gridbag.cpp
@@ -64,7 +64,7 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
 
     if (dlg.GetAction() == GridBagItem::action_append)  // append the column
     {
-        int_t pos_append = 0;
+        ptrdiff_t pos_append = 0;
         int last_column = -1;
 
         // Both rows and columns can be in any random child position, so each node must be examined to find the last
@@ -77,7 +77,7 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
                 {
                     if (gbsizer->GetChild(pos)->prop_as_int(prop_column) > last_column)
                     {
-                        pos_append = static_cast<int_t>(pos);
+                        pos_append = static_cast<ptrdiff_t>(pos);
                         last_column = gbsizer->GetChild(pos)->prop_as_int(prop_column);
                     }
                 }
@@ -86,7 +86,7 @@ bool GridBag::InsertNode(Node* gbsizer, Node* new_node)
 
         // We need to add this after the last column found.
         ++pos_append;
-        if (pos_append >= static_cast<int_t>(gbsizer->GetChildCount()))
+        if (pos_append >= static_cast<ptrdiff_t>(gbsizer->GetChildCount()))
             pos_append = -1;  // Append the child at the very end
 
         wxGetFrame().PushUndoAction(std::make_shared<AppendGridBagAction>(new_node, gbsizer, pos_append));

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -141,7 +141,7 @@ struct ParentChild
     GenType parent;
     GenType child;
 
-    int_t max_children;
+    ptrdiff_t max_children;
 };
 
 // A child node can only be created if it is listed below as valid for the current parent.

--- a/src/nodes/node_types.h
+++ b/src/nodes/node_types.h
@@ -14,10 +14,10 @@ using namespace GenEnum;
 
 namespace child_count
 {
-    constexpr int_t none = 0;
-    constexpr int_t infinite = -1;
-    constexpr int_t one = 1;
-    constexpr int_t two = 2;
+    constexpr ptrdiff_t none = 0;
+    constexpr ptrdiff_t infinite = -1;
+    constexpr ptrdiff_t one = 1;
+    constexpr ptrdiff_t two = 2;
 };  // namespace child_count
 
 // Class for storing the type and amount of children the generator type can have.
@@ -31,7 +31,7 @@ public:
     GenType gen_type() const noexcept { return m_gen_type; }
     bool isType(GenType type) const noexcept { return (type == m_gen_type); }
 
-    int_t GetAllowableChildren(GenType child_gen_type) const
+    ptrdiff_t GetAllowableChildren(GenType child_gen_type) const
     {
         if (auto result = m_map_children.find(child_gen_type); result != m_map_children.end())
             return result->second;
@@ -39,10 +39,10 @@ public:
             return 0;
     }
 
-    void AddChild(GenType gen_type, int_t max_children) { m_map_children[gen_type] = max_children; }
+    void AddChild(GenType gen_type, ptrdiff_t max_children) { m_map_children[gen_type] = max_children; }
 
 private:
     GenType m_gen_type;
 
-    std::map<GenType, int_t> m_map_children;
+    std::map<GenType, ptrdiff_t> m_map_children;
 };

--- a/src/pch.h
+++ b/src/pch.h
@@ -89,13 +89,6 @@
 #include "tt/tt_view_vector.h"    // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "tt/tt_wxString.h"       // tt_wxString -- wxString with additional methods similar to tt_string
 
-#if !defined(int_t)
-
-// signed integer type, width determined by platform
-typedef ptrdiff_t int_t;
-
-#endif  // not !defined(int_t)
-
 enum class MoveDirection
 {
     Up = 1,


### PR DESCRIPTION
Much as I prefer the shorter int_t, it's not a standard type which will make it confusing for someone reading the code, and code snippets will not be reusable in other projects.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates the Developer Notes document to make it current with the code in wxUiEditor. This closes #978 which dealt with ttLib. I also added a section about comments in code since I'm switching from the more traditional readability form of comments (only comment the `why`) to the more AI approach (document the `what`).

This also removed the `int_t` type defined in `pch.h`, and changes all code that used it to `ptrdiff_t` instead. That makes the code more standard, as well as being easier to reuse code snippets from wxUiEditor in other projects.
