### PR TITLE
Completely overhaul NodeSearchDlg (Find Widget)

### DIFF
--- a/src/internal/node_search_dlg.h
+++ b/src/internal/node_search_dlg.h
@@ -9,12 +9,18 @@
 
 #pragma once
 
-#include <wx/combobox.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
+#include <wx/listbox.h>
 #include <wx/radiobut.h>
-#include <wx/stc/stc.h>
+
+class Node;
+
+#include <map>
+#include <set>
+
+#include "gen_enums.h"
 
 class NodeSearchDlg : public wxDialog
 {
@@ -32,20 +38,31 @@ public:
         long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr);
 
     bool isSearchGenerators() const { return m_search_generators; }
-    const wxString& get_GenName() const { return m_gen_name; }
     bool isSearchVarnames() const { return m_search_varnames; }
-    const wxString& get_VarName() const { return m_var_name; }
     bool isSearchLabels() const { return m_search_labels; }
-    const wxString& get_Label() const { return m_label_name; }
+
+    std::string& GetName() { return m_name; }
+    Node* GetForm() { return m_form; }
+    void FindGenerators(Node* node);
+    void FindVariables(Node* node);
+    void FindLabels(Node* node);
+
+    struct FoundInfo
+    {
+        const char* name;
+        std::vector<Node*> forms;
+    };
 
 protected:
 
     // Event handlers
 
+    void OnGenerators(wxCommandEvent& event);
     void OnInit(wxInitDialogEvent& event);
-    void OnRadioSearchGenerators(wxCommandEvent& event);
-    void OnRadioSearchLabels(wxCommandEvent& event);
-    void OnRadioSearchVarNames(wxCommandEvent& event);
+    void OnLabels(wxCommandEvent& event);
+    void OnOK(wxCommandEvent& event);
+    void OnSelectLocated(wxCommandEvent& event);
+    void OnVariables(wxCommandEvent& event);
 
 private:
 
@@ -54,19 +71,18 @@ private:
     bool m_search_generators { true };
     bool m_search_labels { false };
     bool m_search_varnames { false };
-    wxString m_gen_name;
-    wxString m_label_name;
-    wxString m_var_name;
 
     // Class member variables
 
-    wxComboBox* m_combo_generators;
-    wxComboBox* m_combo_labels;
-    wxComboBox* m_combo_variables;
-    wxRadioButton* m_radio_generators;
-    wxRadioButton* m_radio_labels;
-    wxRadioButton* m_radio_var_names;
-    wxStyledTextCtrl* m_scintilla;
+    wxListBox* m_listbox;
+    wxListBox* m_listbox_forms;
+    wxRadioButton* m_radioBtn;
+    wxRadioButton* m_radioBtn_3;
+    wxRadioButton* m_radio_variables;
+
+    std::string m_name;  // could be gen_name, var_name or label
+    Node* m_form;
+    std::map<std::string, std::set<Node*>> m_map_found;
 };
 
 // ************* End of generated code ***********

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -5347,8 +5347,16 @@
         class_name="NodeSearchDlg"
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Node Search"
+        minimum_size="-1,-1d"
         base_file="..\internal\node_search_dlg"
+        header_preamble="class Node;"
+        local_hdr_includes="gen_enums.h"
+        local_src_includes="node.h;mainframe.h;../panels/nav_panel.h;project_handler.h"
+        system_hdr_includes="map;set"
+        class_members="&quot;std::string m_name;  // could be gen_name, var_name or label&quot; &quot;Node* m_form;&quot; &quot;std::map&lt;std::string, std::set&lt;Node*>> m_map_found;&quot;"
+        class_methods="&quot;std::string&amp; GetName() { return m_name; }&quot; &quot;Node* GetForm() { return m_form; }&quot; &quot;void FindGenerators(Node* node);&quot; &quot;void FindVariables(Node* node);&quot; &quot;void FindLabels(Node* node);&quot;"
         derived_class_name="NodeSearchDlg"
+        inserted_hdr_code="struct FoundInfo@@{@@    const char* name;@@    std::vector&lt;Node*> forms;@@};"
         private_members="1"
         use_derived_class="0"
         wxEVT_INIT_DIALOG="OnInit">
@@ -5356,81 +5364,84 @@
           class="wxBoxSizer"
           orientation="wxVERTICAL"
           var_name="dlg_sizer"
+          minimum_size="-1,-1d"
           flags="wxEXPAND">
           <node
             class="wxBoxSizer"
-            var_name="box_sizer_2"
-            minimum_size="250,400d"
-            flags="wxEXPAND"
-            proportion="1">
+            var_name="box_sizer_3"
+            minimum_size="250,-1d"
+            flags="wxEXPAND">
+            <node
+              class="wxRadioButton"
+              checked="1"
+              label="&amp;Generators"
+              style="wxRB_GROUP"
+              get_function="isSearchGenerators"
+              validator_variable="m_search_generators"
+              wxEVT_RADIOBUTTON="OnGenerators" />
+            <node
+              class="wxRadioButton"
+              label="&amp;Variables"
+              var_name="m_radio_variables"
+              get_function="isSearchVarnames"
+              validator_variable="m_search_varnames"
+              wxEVT_RADIOBUTTON="OnVariables" />
+            <node
+              class="wxRadioButton"
+              label="&amp;Labels"
+              var_name="m_radioBtn_3"
+              get_function="isSearchLabels"
+              validator_variable="m_search_labels"
+              wxEVT_RADIOBUTTON="OnLabels" />
+          </node>
+          <node
+            class="wxBoxSizer"
+            var_name="box_sizer_4"
+            minimum_size="250,-1d"
+            borders="wxBOTTOM|wxRIGHT|wxLEFT"
+            flags="wxEXPAND">
             <node
               class="wxBoxSizer"
               orientation="wxVERTICAL"
-              flags="wxEXPAND">
+              var_name="box_sizer_5"
+              flags="wxEXPAND"
+              proportion="1">
               <node
-                class="StaticRadioBtnBoxSizer"
-                label="Search generators"
-                radiobtn_var_name="m_radio_generators"
-                flags="wxEXPAND"
-                get_function="isSearchGenerators"
-                validator_variable="m_search_generators"
-                wxEVT_RADIOBUTTON="OnRadioSearchGenerators">
-                <node
-                  class="wxComboBox"
-                  focus="1"
-                  style="wxCB_SORT"
-                  var_name="m_combo_generators"
-                  get_function="get_GenName"
-                  validator_variable="m_gen_name"
-                  minimum_size="100,-1d" />
-              </node>
+                class="wxStaticText"
+                class_access="none"
+                label="&amp;Located:"
+                var_name="staticText"
+                borders="wxTOP|wxRIGHT|wxLEFT" />
               <node
-                class="StaticRadioBtnBoxSizer"
-                checked="0"
-                label="Search var_names"
-                radiobtn_var_name="m_radio_var_names"
-                var_name="static_box_2"
+                class="wxListBox"
+                minimum_size="100,100d"
                 flags="wxEXPAND"
-                get_function="isSearchVarnames"
-                validator_variable="m_search_varnames"
-                wxEVT_RADIOBUTTON="OnRadioSearchVarNames">
-                <node
-                  class="wxComboBox"
-                  style="wxCB_SORT"
-                  var_name="m_combo_variables"
-                  get_function="get_VarName"
-                  validator_variable="m_var_name"
-                  minimum_size="100,-1d" />
-              </node>
-              <node
-                class="StaticRadioBtnBoxSizer"
-                checked="0"
-                label="Search labels"
-                radiobtn_var_name="m_radio_labels"
-                var_name="static_box_3"
-                flags="wxEXPAND"
-                get_function="isSearchLabels"
-                validator_variable="m_search_labels"
-                wxEVT_RADIOBUTTON="OnRadioSearchLabels">
-                <node
-                  class="wxComboBox"
-                  style="wxCB_SORT"
-                  var_name="m_combo_labels"
-                  get_function="get_Label"
-                  validator_variable="m_label_name"
-                  maximum_size="100,-1d"
-                  minimum_size="100,-1d" />
-              </node>
+                wxEVT_LISTBOX="OnSelectLocated" />
             </node>
             <node
-              class="wxStyledTextCtrl"
-              minimum_size="120,-1d"
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="box_sizer_6"
               flags="wxEXPAND"
-              proportion="1" />
+              proportion="1">
+              <node
+                class="wxStaticText"
+                class_access="none"
+                label="&amp;Forms:"
+                var_name="staticText_2"
+                borders="wxTOP|wxRIGHT|wxLEFT" />
+              <node
+                class="wxListBox"
+                style="wxLB_SORT"
+                var_name="m_listbox_forms"
+                minimum_size="-1,100d"
+                flags="wxEXPAND" />
+            </node>
           </node>
           <node
             class="wxStdDialogButtonSizer"
-            flags="wxEXPAND" />
+            flags="wxEXPAND"
+            OKButtonClicked="OnOK" />
         </node>
       </node>
       <node


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR completely replaces the `NodeSearchDlg` called by `Find Widget` under the `Testing` menu. The new dialog lists all the widgets, variables or labels that were located in a wxListBox on the left side. When an item in the left listbox is selected, the right listbox will list all the forms that item appears in. That means if the item you are looking for appears in more than one form, you can choose the form to locate the item in.

Closes #1045
