### PR TITLE
Fix bug generating contents property used by wxCheckListBox 

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -658,8 +658,17 @@ void MainFrame::OnAbout(wxCommandEvent&)
     aboutInfo.SetName(txtVersion);
 
     // Use trailing spaces to make the dialog width a bit wider
-    aboutInfo.SetDescription(tt_string() << "wxWidgets GUI designer for C++/XRC applications  \n\n\tBuilt using "
-                                         << wxVERSION_STRING << '\n');
+    tt_string description;
+    description << "wxUiEditor is a GUI designer for C++/XRC applications.  \n\n\tBuilt using " << wxVERSION_STRING << "\n";
+
+    if (wxGetApp().isTestingMenuEnabled())
+    {
+        description << "\n" << Project.ProjectFile().ToStdString() << "  \n";
+        description << "Original Project version: " << Project.GetOriginalProjectVersion() << "\n";
+        description << "wxUE Project version: " << curSupportedVer << "\n";
+    }
+
+    aboutInfo.SetDescription(description);
     aboutInfo.SetCopyright(txtCopyRight);
     aboutInfo.SetWebSite("https://github.com/KeyWorksRW/wxUiEditor");
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -267,6 +267,30 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent, boo
                 {
                     prop->set_value(iter.as_bool());
                 }
+                else if (prop->get_name() == prop_contents && Project.GetOriginalProjectVersion() < 18)
+                {
+                    if (new_node->isGen(gen_wxCheckListBox) && iter.as_sview().size() && iter.as_sview()[0] == '"')
+                    {
+                        auto items = ConvertToArrayString(iter.as_sview());
+                        tt_string value;
+                        for (auto& item: items)
+                        {
+                            if (value.size())
+                                value << ';';
+                            value << item;
+                        }
+                        prop->set_value(value);
+                        if (Project.GetProjectVersion() < minRequiredVer + 1)
+                        {
+                            Project.ForceProjectVersion(minRequiredVer + 1);
+                            Project.SetProjectUpdated();
+                        }
+                    }
+                    else
+                    {
+                        prop->set_value(iter.as_sview());
+                    }
+                }
 
                 // Imported projects will be set as version ImportProjectVersion to get the fixups of constant to
                 // friendly name, and bit flag conflict resolution.

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -63,6 +63,7 @@ bool ProjectHandler::LoadProject(const tt_wxString& file, bool allow_ui)
     NodeSharedPtr project;
 
     m_ProjectVersion = root.attribute("data_version").as_int(curSupportedVer);
+    m_OriginalProjectVersion = m_ProjectVersion;
 
     if (m_ProjectVersion > curSupportedVer)
     {

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -69,6 +69,7 @@ public:
     void FixupDuplicatedNode(Node* new_node);
 
     auto GetProjectVersion() { return m_ProjectVersion; }
+    auto GetOriginalProjectVersion() { return m_OriginalProjectVersion; }
     void ForceProjectVersion(int version) { m_ProjectVersion = version; }
     void SetProjectUpdated() { m_isProject_updated = true; }
 
@@ -114,6 +115,7 @@ private:
     tt_wxString m_projectPath;
 
     int m_ProjectVersion;
+    int m_OriginalProjectVersion;
 
     bool m_allow_ui { true };
     bool m_isProject_updated { false };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The PR fixes the bug that results in an invalid contents for wxCheckListBox. In order to find the source of the problem, I also added 3 new lines the the Help::About dialog box _if_ the Testing menu has been enabled:

- full path to current project file
- original project file version
- wxUiEditor current project version

Closes #1056