### PR TITLE
Correctly generate events from event dlg editor

### DIFF
--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -24,9 +24,10 @@
 
 #include "gen_base.h"
 
-#include "node.h"             // Node class
-#include "node_creator.h"     // NodeCreator class
-#include "project_handler.h"  // ProjectHandler class
+#include "../customprops/eventhandler_dlg.h"  // EventHandlerDlg static functions
+#include "node.h"                             // Node class
+#include "node_creator.h"                     // NodeCreator class
+#include "project_handler.h"                  // ProjectHandler class
 
 #include "write_code.h"  // Write code to Scintilla or file
 
@@ -368,11 +369,12 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
         std::set<std::string> generatedHandlers;
         for (auto event: events)
         {
+            auto event_code = EventHandlerDlg::GetCppValue(event->get_value());
             // Ignore lambda's and functions in another class
-            if (event->get_value().contains("[") || event->get_value().contains("::"))
+            if (event_code.contains("[") || event_code.contains("::"))
                 continue;
 
-            if (generatedHandlers.find(event->get_value()) == generatedHandlers.end())
+            if (generatedHandlers.find(event_code) == generatedHandlers.end())
             {
                 bool close_type_button { false };
                 for (auto& iter: lst_close_type_button)
@@ -392,12 +394,11 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
                     (close_type_button && m_form_node->prop_as_bool(prop_persist)))
                 {
                     // OnInitDialog needs to call event.Skip() in order to initialize validators and update the UI
-                    prototype.Format("%s(%s& event)", event->get_value().c_str(),
-                                     event->GetEventInfo()->get_event_class().c_str());
+                    prototype.Format("%s(%s& event)", event_code.c_str(), event->GetEventInfo()->get_event_class().c_str());
                 }
                 else
                 {
-                    prototype.Format("%s(%s& WXUNUSED(event))", event->get_value().c_str(),
+                    prototype.Format("%s(%s& WXUNUSED(event))", event_code.c_str(),
                                      event->GetEventInfo()->get_event_class().c_str());
                 }
                 m_header->writeLine(tt_string().Format("void %s override;", prototype.c_str()));
@@ -460,7 +461,7 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
                     }
                     else
                     {
-                        m_source->writeLine(tt_string().Format("    // TODO: Implement %s", event->get_value().c_str()),
+                        m_source->writeLine(tt_string().Format("    // TODO: Implement %s", event_code.c_str()),
                                             indent::auto_no_whitespace);
                     }
                     m_source->Unindent();
@@ -468,7 +469,7 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
                     m_source->writeLine("}");
                 }
 
-                generatedHandlers.insert(event->get_value());
+                generatedHandlers.insert(event_code);
             }
         }
     }

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -257,8 +257,9 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
 
         for (auto& event: events)
         {
+            auto event_code = EventHandlerDlg::GetCppValue(event->get_value());
             // Ignore lambda's and functions in another class
-            if (event->get_value().contains("[") || event->get_value().contains("::"))
+            if (event_code.contains("[") || event_code.contains("::"))
                 continue;
 
             tt_string code;
@@ -281,7 +282,7 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
 
                 if (has_handler)
                 {
-                    code << "void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class() << "& event);";
+                    code << "void " << event_code << "(" << event->GetEventInfo()->get_event_class() << "& event);";
                     code_lines.insert(code);
                     continue;
                 }
@@ -298,7 +299,7 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
                 }
                 else
                 {
-                    code << "void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class() << "& event);";
+                    code << "void " << event_code << "(" << event->GetEventInfo()->get_event_class() << "& event);";
                 }
                 code << "\n#endif";
             }
@@ -306,12 +307,12 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
             {
                 if (m_form_node->prop_as_bool(prop_use_derived_class))
                 {
-                    code << "virtual void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class()
+                    code << "virtual void " << event_code << "(" << event->GetEventInfo()->get_event_class()
                          << "& event) { event.Skip(); }";
                 }
                 else
                 {
-                    code << "void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class() << "& event);";
+                    code << "void " << event_code << "(" << event->GetEventInfo()->get_event_class() << "& event);";
                 }
             }
             code_lines.insert(code);
@@ -322,20 +323,21 @@ void BaseCodeGenerator::GenHdrEvents(const EventVector& events)
 
         for (const auto& event: m_CtxMenuEvents)
         {
+            auto event_code = EventHandlerDlg::GetCppValue(event->get_value());
             // Ignore lambda's and functions in another class
-            if (event->get_value().contains("[") || event->get_value().contains("::"))
+            if (event_code.contains("[") || event_code.contains("::"))
                 continue;
 
             tt_string code;
 
             if (m_form_node->prop_as_bool(prop_use_derived_class))
             {
-                code << "virtual void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class()
+                code << "virtual void " << event_code << "(" << event->GetEventInfo()->get_event_class()
                      << "& event) { event.Skip(); }";
             }
             else
             {
-                code << "void " << event->get_value() << "(" << event->GetEventInfo()->get_event_class() << "& event);";
+                code << "void " << event_code << "(" << event->GetEventInfo()->get_event_class() << "& event);";
             }
 
             code_lines.insert(code);

--- a/src/tools/global_ids_dlg_base.cpp
+++ b/src/tools/global_ids_dlg_base.cpp
@@ -35,11 +35,11 @@ bool GlobalCustomIDSBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_lb_folders->SetFocus();
     m_lb_folders->Append("Project");
     m_lb_folders->SetSelection(0);
-    m_lb_folders->SetMinSize(ConvertDialogToPixels(wxSize(120, 80)));
+    m_lb_folders->SetMinSize(ConvertDialogToPixels(wxSize(130, 80)));
     flex_grid_sizer->Add(m_lb_folders, wxSizerFlags().Border(wxALL));
 
     m_lb_forms = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_MULTIPLE|wxLB_SORT);
-    m_lb_forms->SetMinSize(ConvertDialogToPixels(wxSize(120, 80)));
+    m_lb_forms->SetMinSize(ConvertDialogToPixels(wxSize(130, 80)));
     flex_grid_sizer->Add(m_lb_forms, wxSizerFlags().Border(wxALL));
 
     auto* box_sizer_9 = new wxBoxSizer(wxHORIZONTAL);

--- a/src/tools/global_ids_dlg_base.h
+++ b/src/tools/global_ids_dlg_base.h
@@ -42,6 +42,7 @@ protected:
     virtual void OnAddPrefix(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAddSuffix(wxCommandEvent& event) { event.Skip(); }
     virtual void OnCommit(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnInit(wxInitDialogEvent& event) { event.Skip(); }
     virtual void OnRemovePrefix(wxCommandEvent& event) { event.Skip(); }
     virtual void OnRemoveSuffix(wxCommandEvent& event) { event.Skip(); }
     virtual void OnSelectAllFolders(wxCommandEvent& event) { event.Skip(); }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes event handler generating in base headers, and both derived src and header files. The problem arose when we added a custom editor for the Event property. By default, the editor adds both a C++ and Python event handler. Two functions are provided to extract the correct name depending on the language: `EventHandlerDlg::GetCppValue()` and `EventHandlerDlg::GetPythonValue()`. These two functions _always_ need to be called when getting the event handler.

Closes #1068