### PR TITLE
Workflows

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -1,7 +1,15 @@
 name: "Check Build"
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - src/art_src
+      - src/tests
+      - src/xml
+      - tests
+      - import_tests
+      - docs
+      - .github
 
 env:
   BUILD_TYPE: Debug

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -1,15 +1,17 @@
 name: "Check Build"
 
 on:
-  pull_request:
-    paths-ignore:
-      - src/art_src
-      - src/tests
-      - src/xml
-      - tests
-      - import_tests
-      - docs
-      - .github
+  workflow_dispatch:
+
+#  pull_request:
+#    paths-ignore:
+#      - src/art_src
+#      - src/tests
+#      - src/xml
+#      - tests
+#      - import_tests
+#      - docs
+#      - .github
 
 env:
   BUILD_TYPE: Debug

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,18 +1,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - src/art_src
-      - src/tests
-      - src/xml
-      - tests
-      - docs
-      - import_tests
-      - wxWidgets
-      - .github
+  schedule:
+    - cron: '17 3 * * *'
 
 env:
   BUILD_TYPE: Debug

--- a/.github/workflows/test_clang_format.yml
+++ b/.github/workflows/test_clang_format.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
     paths-ignore:
       - src/art_src
+      - src/tests
       - src/xml
       - src/import/rapidjson
-      - pugixml
       - tests
+      - docs
       - import_tests
-      - python_tests/python
-      - python_tests/art
+      - .github
 
 jobs:
   build:


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes CodeQL to now only run once per day.

A Check Build workflow has been added, but it currently only runs manually. There is a commneted out section that if the '#' was removed, it would run on pull requests. It currently takes about 5 1/2 minutes to run.

I'm not hooking up Check Build to PRs unless PRs are submitted that don't compile. The check for linking with wxWidgets is done in the daily build, and CodeQL handles securiy checks, so we should be covered on a daily basis at least.

This closes #1069
