### PR TITLE
Array conversion

### DIFF
--- a/src/generate/gen_bitmap_combo.cpp
+++ b/src/generate/gen_bitmap_combo.cpp
@@ -26,7 +26,7 @@ wxObject* BitmapComboBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
             widget->Append(iter.make_wxString());
 
@@ -119,7 +119,7 @@ bool BitmapComboBoxGenerator::SettingsCode(Code& code)
 
     if (code.HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(code.node()->as_string(prop_contents));
+        auto array = code.node()->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             code.Eol(eol_if_empty).NodeName().Function("Append(").QuotedString(iter).EndFunction();

--- a/src/generate/gen_choice.cpp
+++ b/src/generate/gen_choice.cpp
@@ -23,7 +23,7 @@ wxObject* ChoiceGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
             widget->Append(iter.make_wxString());
 
@@ -101,7 +101,7 @@ bool ChoiceGenerator::SettingsCode(Code& code)
 
     if (code.HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(code.node()->as_string(prop_contents));
+        auto array = code.node()->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             code.Eol(eol_if_empty).NodeName().Function("Append(").QuotedString(iter).EndFunction();
@@ -154,7 +154,7 @@ int ChoiceGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc
     if (node->HasValue(prop_contents))
     {
         auto content = item.append_child("content");
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             content.append_child("item").text().set(iter);

--- a/src/generate/gen_combobox.cpp
+++ b/src/generate/gen_combobox.cpp
@@ -26,7 +26,7 @@ wxObject* ComboBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
             widget->Append(iter.make_wxString());
 
@@ -104,7 +104,7 @@ bool ComboBoxGenerator::SettingsCode(Code& code)
 
     if (code.HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(code.node()->as_string(prop_contents));
+        auto array = code.node()->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             code.Eol(eol_if_empty).NodeName().Function("Append(").QuotedString(iter).EndFunction();
@@ -157,7 +157,7 @@ int ComboBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t x
     if (node->HasValue(prop_contents))
     {
         auto content = item.append_child("content");
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             content.append_child("item").text().set(iter);

--- a/src/generate/gen_edit_listbox.cpp
+++ b/src/generate/gen_edit_listbox.cpp
@@ -47,7 +47,7 @@ bool EditListBoxGenerator::SettingsCode(Code& code)
 {
     if (code.HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(code.node()->as_string(prop_contents));
+        auto array = code.node()->as_ArrayString(prop_contents);
         if (code.is_cpp())
         {
             code.OpenBrace().Str("wxArrayString tmp_array;");
@@ -95,7 +95,7 @@ int EditListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_
     if (node->HasValue(prop_contents))
     {
         auto content = item.append_child("content");
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             content.append_child("item").text().set(iter);

--- a/src/generate/gen_edit_listbox.cpp
+++ b/src/generate/gen_edit_listbox.cpp
@@ -23,7 +23,7 @@ wxObject* EditListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_contents))
     {
-        auto array = ConvertToWxArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_wxArrayString(prop_auto_complete);
         widget->SetStrings(array);
     }
 

--- a/src/generate/gen_html_listbox.cpp
+++ b/src/generate/gen_html_listbox.cpp
@@ -24,7 +24,7 @@ wxObject* HtmlListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
             widget->Append(iter.make_wxString());
 
@@ -82,7 +82,7 @@ bool HtmlListBoxGenerator::SettingsCode(Code& code)
 
     if (code.HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(code.node()->as_string(prop_contents));
+        auto array = code.node()->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             code.Eol(eol_if_empty).NodeName().Function("Append(").QuotedString(iter).EndFunction();
@@ -138,7 +138,7 @@ int HtmlListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_
     if (node->HasValue(prop_contents))
     {
         auto content = item.append_child("content");
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             content.append_child("item").text().set(iter);

--- a/src/generate/gen_listbox.cpp
+++ b/src/generate/gen_listbox.cpp
@@ -21,10 +21,9 @@ wxObject* ListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
         new wxListBox(wxStaticCast(parent, wxWindow), wxID_ANY, DlgPoint(parent, node, prop_pos),
                       DlgSize(parent, node, prop_size), 0, nullptr, node->prop_as_int(prop_type) | GetStyleInt(node));
 
-    auto& items = node->prop_as_string(prop_contents);
-    if (items.size())
+    if (node->HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(items);
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
             widget->Append(iter.make_wxString());
 
@@ -81,7 +80,7 @@ bool ListBoxGenerator::SettingsCode(Code& code)
 
     if (code.HasValue(prop_contents))
     {
-        auto array = ConvertToArrayString(code.node()->as_string(prop_contents));
+        auto array = code.node()->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             code.Eol(eol_if_empty).NodeName().Function("Append(").QuotedString(iter).EndFunction();
@@ -123,7 +122,7 @@ int ListBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xr
     if (node->HasValue(prop_contents))
     {
         auto content = item.append_child("content");
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             content.append_child("item").text().set(iter);

--- a/src/generate/gen_listview.cpp
+++ b/src/generate/gen_listview.cpp
@@ -21,7 +21,7 @@ wxObject* ListViewGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->prop_as_string(prop_mode) == "wxLC_REPORT" && node->HasValue(prop_column_labels))
     {
-        auto headers = ConvertToArrayString(node->prop_as_string(prop_column_labels));
+        auto headers = node->as_ArrayString(prop_column_labels);
         for (auto& label: headers)
             widget->AppendColumn(label.make_wxString());
 
@@ -30,7 +30,7 @@ wxObject* ListViewGenerator::CreateMockup(Node* node, wxObject* parent)
             wxListItem info;
             info.Clear();
 
-            auto strings = ConvertToArrayString(node->prop_as_string(prop_contents));
+            auto strings = node->as_ArrayString(prop_contents);
             long row_id = -1;
             for (auto& row: strings)
             {
@@ -71,7 +71,7 @@ bool ListViewGenerator::SettingsCode(Code& code)
             code.OpenBrace();
         }
 
-        auto headers = ConvertToArrayString(code.view(prop_column_labels));
+        auto headers = code.node()->as_ArrayString(prop_column_labels);
         for (auto& iter: headers)
         {
             code.Eol(eol_if_needed).NodeName().Function("AppendColumn(").QuotedString(iter).EndFunction();
@@ -84,7 +84,7 @@ bool ListViewGenerator::SettingsCode(Code& code)
                 code.Str("auto ");
             code.Str("info = ").Add("wxListItem(").EndFunction();
             code.Eol().Str("info.Clear(").EndFunction();
-            auto strings = ConvertToArrayString(code.view(prop_contents));
+            auto strings = code.node()->as_ArrayString(prop_contents);
             int row_id = -1;
             for (auto& row: strings)
             {
@@ -126,7 +126,7 @@ int ListViewGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t x
     GenXrcStylePosSize(node, item, prop_mode);
     GenXrcWindowSettings(node, item);
 
-    auto headers = ConvertToArrayString(node->value(prop_column_labels));
+    auto headers = node->as_ArrayString(prop_column_labels);
     for (auto& iter: headers)
     {
         auto child = item.append_child("object");

--- a/src/generate/gen_radio_box.cpp
+++ b/src/generate/gen_radio_box.cpp
@@ -62,7 +62,7 @@ void RadioBoxGenerator::OnRadioBox(wxCommandEvent& event)
 
 bool RadioBoxGenerator::ConstructionCode(Code& code)
 {
-    auto array = ConvertToArrayString(code.node()->as_string(prop_contents));
+    auto array = code.node()->as_ArrayString(prop_contents);
     tt_string choice_name;
     if (code.is_cpp() && array.size())
     {
@@ -150,7 +150,7 @@ int RadioBoxGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t x
     if (node->HasValue(prop_contents))
     {
         auto content = item.append_child("content");
-        auto array = ConvertToArrayString(node->prop_as_string(prop_contents));
+        auto array = node->as_ArrayString(prop_contents);
         for (auto& iter: array)
         {
             content.append_child("item").text().set(iter);

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -30,7 +30,7 @@ wxObject* TextCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
     if (node->HasValue(prop_auto_complete))
     {
-        auto array = ConvertToWxArrayString(node->prop_as_string(prop_auto_complete));
+        auto array = node->as_wxArrayString(prop_auto_complete);
         widget->AutoComplete(array);
     }
 

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -152,10 +152,10 @@ bool TextCtrlGenerator::SettingsCode(Code& code)
         {
             code.EnableAutoLineBreak(false);
             code.Add("{").Eol().Tab().Add("wxArrayString tmp_array;").Eol();
-            auto array = ConvertToArrayString(code.node()->prop_as_string(prop_auto_complete));
+            auto array = code.node()->as_ArrayString(prop_auto_complete);
             for (auto& iter: array)
             {
-                code.Tab().Add("tmp_array.push_back(wxString::FromUTF8(\"") << iter << "\"));";
+                code.Tab().Add("tmp_array.Add(").QuotedString(iter) << ");";
                 code.Eol();
             }
             code.Tab() << code.node()->get_node_name() << "->AutoComplete(tmp_array);";

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -380,29 +380,49 @@ std::vector<tt_string> NodeProperty::as_vector() const
 
 std::vector<tt_string> NodeProperty::as_ArrayString() const
 {
-    std::vector<tt_string> array;
-    if (m_value.empty())
-        return array;
-    tt_string parse;
-    auto pos = parse.ExtractSubString(m_value);
-    if (!tt::is_found(pos))
+    std::vector<tt_string> result;
+    if (m_value.size())
     {
-        // This usually means a property that was hand-edited incorrectly, or a newer version of the project
-        // file where the property is encoded differently.
-        return array;
-    }
-    array.emplace_back(parse);
-
-    for (auto tmp_m_value = tt::stepover(m_value.data() + pos); tmp_m_value.size();
-         tmp_m_value = tt::stepover(tmp_m_value.data() + pos))
-    {
-        pos = parse.ExtractSubString(tmp_m_value);
+#if 0
+        tt_string parse;
+        auto pos = parse.ExtractSubString(m_value);
         if (!tt::is_found(pos))
-            break;
-        array.emplace_back(parse);
-    }
+        {
+            // This usually means a property that was hand-edited incorrectly, or a newer version of the project
+            // file where the property is encoded differently.
+            return array;
+        }
+        result.emplace_back(parse);
 
-    return array;
+        for (auto tmp_m_value = tt::stepover(m_value.data() + pos); tmp_m_value.size();
+             tmp_m_value = tt::stepover(tmp_m_value.data() + pos))
+        {
+            pos = parse.ExtractSubString(tmp_m_value);
+            if (!tt::is_found(pos))
+                break;
+            result.emplace_back(parse);
+        }
+#else
+        if (m_value[0] == '"')
+        {
+            // REVIEW: [Randalphwa - 06-26-2023] This uses tt_string_view to parse the string.
+            auto view = m_value.view_substr(0, '"', '"');
+            while (view.size() > 0)
+            {
+                result.emplace_back(view);
+                view = tt::stepover(view.data() + view.size());
+                view = view.view_substr(0, '"', '"');
+            }
+        }
+        else
+        {
+            tt_string_vector array;
+            array.SetString(m_value, ";", tt::TRIM::both);
+            result = array;
+        }
+#endif
+    }
+    return result;
 }
 
 wxArrayString NodeProperty::as_wxArrayString() const

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -616,7 +616,7 @@ std::vector<NODEPROP_CHECKLIST_ITEM> NodeProperty::as_checklist_items() const
 
     if (m_value.size() && m_value[0] == '"' && wxGetApp().GetProjectVersion() <= minRequiredVer)
     {
-        auto array = ConvertToArrayString(m_value);
+        auto array = as_ArrayString();
         for (auto& iter: array)
         {
             NODEPROP_CHECKLIST_ITEM item;

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -557,8 +557,16 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
     else if (type == type_stringlist)
     {
         new_pg_property = new wxArrayStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxArrayString());
-        wxVariant var_quote("\"");
-        new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, var_quote);
+        if (prop->value().size() > 0 && prop->value()[0] != '"')
+        {
+            wxVariant delimiter(";");
+            new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, delimiter);
+        }
+        else
+        {
+            wxVariant delimiter("\"");
+            new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, delimiter);
+        }
     }
     else if (type == type_stringlist_escapes)
     {

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1039,6 +1039,48 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
             }
             break;
 
+        case type_stringlist:
+#if defined(_WIN32)
+            if (prop->isProp(prop_contents))
+            {
+                // REVIEW: [Randalphwa - 06-26-2023] This will only work if we use quotes to
+                // separate items.
+                tt_string newValue = property->GetValueAsString().utf8_string();
+                // Under Windows 10 using wxWidgets 3.1.3, the last character of the string is partially clipped.
+                // Adding a trailing space prevents this clipping.
+
+                if (m_currentSel->isGen(gen_wxRadioBox) && newValue.size())
+                {
+                    size_t result;
+                    for (size_t pos = 0; pos < newValue.size();)
+                    {
+                        result = newValue.find("\" \"", pos);
+                        if (tt::is_found(result))
+                        {
+                            if (newValue.at(result - 1) != ' ')
+                                newValue.insert(result, 1, ' ');
+                            pos = result + 3;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    result = newValue.find_last_of('"');
+                    if (tt::is_found(result))
+                    {
+                        if (newValue.at(result - 1) != ' ')
+                            newValue.insert(result, 1, ' ');
+                    }
+                    modifyProperty(prop, newValue);
+                    break;
+                }
+            }
+#endif  // _WIN32
+            modifyProperty(prop, property->GetValueAsString().utf8_string());
+            break;
+
         case type_bool:
             ModifyBoolProperty(prop, property);
             break;
@@ -1074,7 +1116,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
 
         default:
             {
-                tt_wxString newValue = property->GetValueAsString();
+                tt_string newValue = property->GetValueAsString().utf8_string();
 
                 if (prop->isProp(prop_var_name))
                 {
@@ -1086,44 +1128,11 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                         newValue = final_name.size() ? final_name : new_name;
 
                         auto grid_property = m_prop_grid->GetPropertyByLabel("var_name");
-                        grid_property->SetValueFromString(newValue, 0);
+                        grid_property->SetValueFromString(newValue.make_wxString(), 0);
                     }
                 }
-                else if (prop->isProp(prop_contents))
-                {
-#if defined(_WIN32)
-                    // Under Windows 10 using wxWidgets 3.1.3, the last character of the string is partially clipped.
-                    // Adding a trailing space prevents this clipping.
 
-                    if (m_currentSel->isGen(gen_wxRadioBox) && newValue.size())
-                    {
-                        size_t result;
-                        for (size_t pos = 0; pos < newValue.size();)
-                        {
-                            result = newValue.find("\" \"", pos);
-                            if (tt::is_found(result))
-                            {
-                                if (newValue.at(result - 1) != ' ')
-                                    newValue.insert(result, ' ');
-                                pos = result + 3;
-                            }
-                            else
-                            {
-                                break;
-                            }
-                        }
-
-                        result = newValue.find_last_of('"');
-                        if (tt::is_found(result))
-                        {
-                            if (newValue.at(result - 1) != ' ')
-                                newValue.insert(result, ' ');
-                        }
-                    }
-#endif  // _WIN32
-                }
-
-                ModifyProperty(prop, newValue);
+                modifyProperty(prop, newValue);
 
                 if (prop->isProp(prop_class_name))
                 {
@@ -1144,7 +1153,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                         if (!selected_node->HasValue(prop_derived_class_name))
                         {
                             ReplaceDerivedName(newValue, selected_node->get_prop_ptr(prop_derived_class_name));
-                            ReplaceDerivedFile(selected_node->prop_as_wxString(prop_derived_class_name),
+                            ReplaceDerivedFile(selected_node->value(prop_derived_class_name),
                                                selected_node->get_prop_ptr(prop_derived_file));
                         }
                     }
@@ -1946,9 +1955,9 @@ void PropGridPanel::CreateEventCategory(tt_string_view name, Node* node, NodeDec
     }
 }
 
-void PropGridPanel::ReplaceDerivedName(const wxString& newValue, NodeProperty* propType)
+void PropGridPanel::ReplaceDerivedName(const tt_string& newValue, NodeProperty* propType)
 {
-    auto drvName = newValue.utf8_string();
+    auto drvName = newValue;
     if (drvName.ends_with("Base"))
     {
         drvName.erase(drvName.size() - (sizeof("Base") - 1));
@@ -1959,32 +1968,32 @@ void PropGridPanel::ReplaceDerivedName(const wxString& newValue, NodeProperty* p
     }
 
     auto grid_property = m_prop_grid->GetPropertyByLabel("derived_class_name");
-    grid_property->SetValueFromString(drvName, 0);
-    ModifyProperty(propType, drvName);
+    grid_property->SetValueFromString(drvName.make_wxString(), 0);
+    modifyProperty(propType, drvName);
 }
 
-void PropGridPanel::ReplaceBaseFile(const wxString& newValue, NodeProperty* propType)
+void PropGridPanel::ReplaceBaseFile(const tt_string& newValue, NodeProperty* propType)
 {
     auto form_node = propType->GetNode()->get_form();
-    auto base_filename = CreateBaseFilename(form_node, newValue.utf8_string());
+    auto base_filename = CreateBaseFilename(form_node, newValue);
     auto grid_property = m_prop_grid->GetPropertyByLabel("base_file");
-    grid_property->SetValueFromString(base_filename, 0);
-    ModifyProperty(propType, base_filename);
+    grid_property->SetValueFromString(base_filename.make_wxString(), 0);
+    modifyProperty(propType, base_filename);
 
     if (Project.value(prop_code_preference) == "Python" && !form_node->HasValue(prop_python_file))
     {
         grid_property = m_prop_grid->GetPropertyByLabel("python_file");
-        grid_property->SetValueFromString(base_filename, 0);
-        ModifyProperty(form_node->get_prop_ptr(prop_python_file), base_filename);
+        grid_property->SetValueFromString(base_filename.make_wxString(), 0);
+        modifyProperty(form_node->get_prop_ptr(prop_python_file), base_filename);
     }
 }
 
-void PropGridPanel::ReplaceDerivedFile(const wxString& newValue, NodeProperty* propType)
+void PropGridPanel::ReplaceDerivedFile(const tt_string& newValue, NodeProperty* propType)
 {
-    auto derived_filename = CreateDerivedFilename(propType->GetNode()->get_form(), newValue.utf8_string());
+    auto derived_filename = CreateDerivedFilename(propType->GetNode()->get_form(), newValue);
     auto grid_property = m_prop_grid->GetPropertyByLabel("derived_file");
-    grid_property->SetValueFromString(derived_filename, 0);
-    ModifyProperty(propType, derived_filename);
+    grid_property->SetValueFromString(derived_filename.make_wxString(), 0);
+    modifyProperty(propType, derived_filename);
 }
 
 bool PropGridPanel::IsPropAllowed(Node* /* node */, NodeProperty* /* prop */)

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -558,13 +558,13 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
     {
         new_pg_property = new wxArrayStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxArrayString());
         wxVariant var_quote("\"");
-        new_pg_property->DoSetAttribute(wxPG_ARRAY_DELIMITER, var_quote);
+        new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, var_quote);
     }
     else if (type == type_stringlist_escapes)
     {
         new_pg_property = new wxArrayStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxArrayString());
         wxVariant var_quote("\"");
-        new_pg_property->DoSetAttribute(wxPG_ARRAY_DELIMITER, var_quote);
+        new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, var_quote);
     }
     else if (type == type_uintpairlist)
     {

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -64,9 +64,9 @@ protected:
     void AddProperties(tt_string_view name, Node* node, NodeCategory& category, PropNameSet& prop_set,
                        bool is_child_cat = false);
 
-    void ReplaceDerivedName(const wxString& formName, NodeProperty* propType);
-    void ReplaceBaseFile(const wxString& formName, NodeProperty* propType);
-    void ReplaceDerivedFile(const wxString& formName, NodeProperty* propType);
+    void ReplaceDerivedName(const tt_string& formName, NodeProperty* propType);
+    void ReplaceBaseFile(const tt_string& formName, NodeProperty* propType);
+    void ReplaceDerivedFile(const tt_string& formName, NodeProperty* propType);
 
     wxPGProperty* CreatePGProperty(NodeProperty* prop);
 

--- a/src/tt/tt_string.cpp
+++ b/src/tt/tt_string.cpp
@@ -128,7 +128,7 @@ tt_string& tt_string::trim(tt::TRIM where)
  * @param chBegin -- character that prefixes the string
  * @param chEnd -- character that terminates the string.
  */
-tt_string_view tt_string::view_substr(size_t offset, char chBegin, char chEnd)
+tt_string_view tt_string::view_substr(size_t offset, char chBegin, char chEnd) const
 {
     if (empty() || offset >= size())
     {

--- a/src/tt/tt_string.h
+++ b/src/tt/tt_string.h
@@ -191,7 +191,7 @@ public:
     //
     // Unless chBegin is a whitespace character, all whitespace characters starting with
     // offset will be ignored.
-    tt_string_view view_substr(size_t offset, char chBegin = '"', char chEnd = '"');
+    tt_string_view view_substr(size_t offset, char chBegin = '"', char chEnd = '"') const;
 
     // Assigns the string between chBegin and chEnd. This is typically used to copy the
     // contents of a quoted string. Returns the position of the ending character in src.

--- a/src/tt/tt_string_view.cpp
+++ b/src/tt/tt_string_view.cpp
@@ -473,7 +473,7 @@ int tt_string_view::comparei(std::string_view str) const
  * @param chBegin -- character that prefixes the string
  * @param chEnd -- character that terminates the string.
  */
-tt_string_view tt_string_view::view_substr(size_t offset, char chBegin, char chEnd)
+tt_string_view tt_string_view::view_substr(size_t offset, char chBegin, char chEnd) const
 {
     if (empty() || offset >= size())
     {

--- a/src/tt/tt_string_view.h
+++ b/src/tt/tt_string_view.h
@@ -155,7 +155,7 @@ public:
     ///
     /// Unless chBegin is a whitespace character, all whitespace characters starting with
     /// offset will be ignored.
-    tt_string_view view_substr(size_t offset, char chBegin = '"', char chEnd = '"');
+    tt_string_view view_substr(size_t offset, char chBegin = '"', char chEnd = '"') const;
 
     // All of the following view_() functions will return an empty tt_string_view if the specified character cannot be
     // found, or the start position is out of range (including start == npos).

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -420,25 +420,6 @@ std::vector<tt_string> ConvertToArrayString(tt_string_view value)
     return array;
 }
 
-wxArrayString ConvertToWxArrayString(tt_string_view value)
-{
-    wxArrayString array;
-    if (value.empty())
-        return array;
-    tt_string parse;
-    auto pos = parse.ExtractSubString(value);
-    array.push_back(parse.make_wxString());
-
-    for (auto tmp_value = tt::stepover(value.data() + pos); tmp_value.size();
-         tmp_value = tt::stepover(tmp_value.data() + pos))
-    {
-        pos = parse.ExtractSubString(tmp_value);
-        array.push_back(parse.make_wxString());
-    }
-
-    return array;
-}
-
 wxPoint DlgPoint(wxObject* parent, Node* node, GenEnum::PropName prop)
 {
     if (node->prop_as_string(prop).contains("d", tt::CASE::either))

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -53,9 +53,6 @@ tt_string ConvertEscapeSlashes(tt_string_view str);
 
 std::vector<tt_string> ConvertToArrayString(tt_string_view value);
 
-// Use ConvertToArrayString() to get a vector, this function to get a wxArrayString
-wxArrayString ConvertToWxArrayString(tt_string_view value);
-
 // Converts an unsigned char array into an image. This is typically used for loading internal
 // #included images
 wxImage LoadHeaderImage(const unsigned char* data, size_t size_data);

--- a/tests/sdi/cpp/wxui_code.cmake
+++ b/tests/sdi/cpp/wxui_code.cmake
@@ -4,17 +4,20 @@
 
 set (sdi_generated_code
 
+    # Non-base classes
     ${CMAKE_CURRENT_LIST_DIR}/booktest_dlg.cpp
     ${CMAKE_CURRENT_LIST_DIR}/commonctrls.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/dlgissue_956.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/dlgissue_960.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/form_toolbar_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/images.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mainframe.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/maintestdialog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/popupwin.cpp
     ${CMAKE_CURRENT_LIST_DIR}/python_dlg.cpp
     ${CMAKE_CURRENT_LIST_DIR}/testformpanel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/wizard.cpp
+
+    # Base classes
+    ${CMAKE_CURRENT_LIST_DIR}/dlgissue_956.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dlgissue_960.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/form_toolbar_base.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/maintestdialog.cpp
 
 )


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR mostly deals with eliminating duplicate code for generating either a wxStringArray or a std::vector<tt_string> array. It also changes the two as_array() functions so that they can handle either quoted items or semi-colon separated items.

The idea behind all of this is looking into adding a new stringlist type that uses semi-colons rather then quotes for separating items. The main advantage is that it's something a user can easily type, even if it's just a single item without any separator (which doesn't work if the item must be in quotes). There's a minor advantage to reducing the project file size since quotes have to be escaped in XML, unlike semi-colons. And finally it takes less memory and is faster to process.
