### PR TITLE
Postpone work on two large features until after 1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to this project will be documented in this file.
 - The C++ Settings in forms now have a `initial_enum_string` property that allows you to set the initial enumeration value to something other than the default "wxID_HIGHEST + 1".
 - The C++ Settings in forms now have properties for local and system header files to include in either the generated source or header files.
 - wxMenu and wxMenu items now have a stock_id property allowing you to choose from wxWidgets stock items.
-- You can now import DialogBlocks projects directly (instead of exporting an XRC) as long as the project was saved in XML format rather than binary format.
 - Added support for wxAUI_BUTTON_STATE flags when creating a wxAuiToolBar tool.
 - Images List now has an auto_update property that will automatically add any embedded or SVG image used throughout your project. This allows you to generate all your embedded and SVG images in a single file.
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -520,6 +520,7 @@ void MainFrame::OnAppendCrafter(wxCommandEvent&)
     }
 }
 
+#if 0
 void MainFrame::OnAppendDialogBlocks(wxCommandEvent&)
 {
     tt_cwd cwd(true);
@@ -532,6 +533,7 @@ void MainFrame::OnAppendDialogBlocks(wxCommandEvent&)
         Project.AppendDialogBlocks(files);
     }
 }
+#endif
 
 void MainFrame::OnAppendFormBuilder(wxCommandEvent&)
 {

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -260,7 +260,7 @@ public:
 protected:
     void OnAbout(wxCommandEvent& event) override;
     void OnAppendCrafter(wxCommandEvent& event) override;
-    void OnAppendDialogBlocks(wxCommandEvent& event) override;
+    // void OnAppendDialogBlocks(wxCommandEvent& event) override;
     void OnAppendFormBuilder(wxCommandEvent& event) override;
     void OnAppendGlade(wxCommandEvent& event) override;
     void OnAppendSmith(wxCommandEvent& event) override;

--- a/src/wxui/import_base.cpp
+++ b/src/wxui/import_base.cpp
@@ -63,6 +63,7 @@ bool ImportBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     flex_grid_sizer->Add(m_radio_WindowsResource, wxSizerFlags().Border(wxALL));
 
     m_radio_DialogBlocks = new wxRadioButton(m_import_staticbox->GetStaticBox(), wxID_ANY, "&DialogBlocks File(s)");
+    m_radio_DialogBlocks->Hide();
     flex_grid_sizer->Add(m_radio_DialogBlocks, wxSizerFlags().Border(wxALL));
 
     m_radio_XRC = new wxRadioButton(m_import_staticbox->GetStaticBox(), wxID_ANY, "&XRC File(s)");

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -99,9 +99,6 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     auto* menu_item_3 = new wxMenuItem(submenu, id_AppendSmith, "wxSmith Project...",
         "Append wxSmith project into current project", wxITEM_NORMAL);
     submenu->Append(menu_item_3);
-    auto* menu_item_8 = new wxMenuItem(submenu, id_AppendDialogBlocks, "DialogBlocks Project...",
-        "Append DialogBlocks project into current project", wxITEM_NORMAL);
-    submenu->Append(menu_item_8);
     auto* menu_item_5 = new wxMenuItem(submenu, id_AppendWinRes, "Windows Resource...",
         "Append Windows Resource into current project", wxITEM_NORMAL);
     submenu->Append(menu_item_5);
@@ -388,7 +385,6 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendFormBuilder, this, id_AppendFormBuilder);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendGlade, this, id_AppendGlade);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendSmith, this, id_AppendSmith);
-    Bind(wxEVT_MENU, &MainFrameBase::OnAppendDialogBlocks, this, id_AppendDialogBlocks);
     Bind(wxEVT_MENU, &MainFrameBase::OnImportWindowsResource, this, id_AppendWinRes);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendXRC, this, id_AppendXRC);
     Bind(wxEVT_MENU, &MainFrameBase::OnOptionsDlg, this, id_OptionsDlg);

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -42,7 +42,6 @@ public:
         id_AlignRight,
         id_AlignTop,
         id_AppendCrafter,
-        id_AppendDialogBlocks,
         id_AppendFormBuilder,
         id_AppendGlade,
         id_AppendSmith,
@@ -74,7 +73,6 @@ protected:
 
     virtual void OnAbout(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAppendCrafter(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnAppendDialogBlocks(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAppendFormBuilder(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAppendGlade(wxCommandEvent& event) { event.Skip(); }
     virtual void OnAppendSmith(wxCommandEvent& event) { event.Skip(); }

--- a/src/wxui/ribbonpanel_base.cpp
+++ b/src/wxui/ribbonpanel_base.cpp
@@ -130,36 +130,6 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
     }
     forms_bar_images->Realize();
 
-    auto* rbnPage = new wxRibbonPage(m_rbnBar, wxID_ANY, "MDI");
-
-    auto* panel_mmdi = new wxRibbonPanel(rbnPage, wxID_ANY, "MDI");
-
-    auto* forms_bar_mdi = new wxRibbonToolBar(panel_mmdi, wxID_ANY);
-    {
-        forms_bar_mdi->AddTool(CreateMdiFrame, wxueImage(wxue_img::wxFrame_png, sizeof(wxue_img::wxFrame_png)),
-            "Creates MDI Frame and wxDocTemplate", wxRIBBON_BUTTON_NORMAL);
-        forms_bar_mdi->AddTool(CreateView, wxueImage(wxue_img::wxPopupTransientWindow_png, sizeof(
-            wxue_img::wxPopupTransientWindow_png)), "Creates a wxDocChildFrame view", wxRIBBON_BUTTON_DROPDOWN);
-    }
-    forms_bar_mdi->Realize();
-
-    auto* panel_bars_menu_2 = new wxRibbonPanel(rbnPage, wxID_ANY, "Menu");
-
-    auto* bars_bar_menu_2 = new wxRibbonToolBar(panel_bars_menu_2, wxID_ANY);
-    {
-        bars_bar_menu_2->AddTool(MdiMenuBar, wxueImage(wxue_img::wxmenuBar_png, sizeof(wxue_img::wxmenuBar_png)),
-            "Creates a frame or child window menu bar", wxRIBBON_BUTTON_DROPDOWN);
-        bars_bar_menu_2->AddTool(gen_wxMenu, wxueImage(wxue_img::menu_png, sizeof(wxue_img::menu_png)), "wxMenu",
-            wxRIBBON_BUTTON_NORMAL);
-        bars_bar_menu_2->AddTool(gen_wxMenuItem, wxueImage(wxue_img::menuitem_png, sizeof(wxue_img::menuitem_png)),
-            "wxMenuItem", wxRIBBON_BUTTON_NORMAL);
-        bars_bar_menu_2->AddTool(gen_submenu, wxueImage(wxue_img::submenu_png, sizeof(wxue_img::submenu_png)), "submenu",
-            wxRIBBON_BUTTON_NORMAL);
-        bars_bar_menu_2->AddTool(gen_separator, wxueImage(wxue_img::separator_png, sizeof(wxue_img::separator_png)),
-            "separator", wxRIBBON_BUTTON_NORMAL);
-    }
-    bars_bar_menu_2->Realize();
-
     auto* pg_sizer = new wxRibbonPage(m_rbnBar, wxID_ANY, "Sizers");
 
     auto* panel_basic = new wxRibbonPanel(pg_sizer, wxID_ANY, "Basic");
@@ -500,19 +470,18 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
     forms_bar_bars->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     forms_bar_bars_2->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     forms_bar_images->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
-    forms_bar_mdi->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
-    bars_bar_menu_2->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     sizer_bar_basic->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
-    other_bar_editors->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
+    bars_bar_other->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     sizer_bar_grids->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     sizer_bar_other->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     common_bar_controls->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
-    other_bar_ctrls->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
+    other_bar_editors->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     common_bar_choices->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
-    other_bar_html->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
+    other_bar_ctrls->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     common_bar_pickers->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     common_bar_other->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     container_bar_windows->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
+    other_bar_html->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     container_bar_books->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     container_bar_page->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     data_bar_grid->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
@@ -522,14 +491,13 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
     bars_bar_menu->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     bars_bar_tool->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     bars_bar_ribbon->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
-    bars_bar_other->Bind(wxEVT_RIBBONTOOLBAR_CLICKED, &RibbonPanelBase::OnToolClick, this);
     sizer_bar_basic->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
     common_bar_controls->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
     common_bar_choices->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
-    data_bar_dataview->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
     bars_bar_tool->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
-    container_bar_windows->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
+    data_bar_dataview->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
     bars_bar_ribbon->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
+    container_bar_windows->Bind(wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED, &RibbonPanelBase::OnDropDown, this);
 
     return true;
 }
@@ -1543,20 +1511,6 @@ namespace wxue_img
         156,97,136,2,25,20,8,64,10,8,160,164,64,202,239,46,89,76,124,10,200,141,128,193,182,51,83,17,161,30,0,36,9,
         219,190,175,83,189,108,123,211,58,143,12,122,73,197,21,87,92,113,197,63,143,3,96,90,14,235,43,30,175,247,19,
         231,168,234,87,216,0,0,0,0,73,69,78,68,174,66,96,130
-    };
-
-    const unsigned char wxPopupTransientWindow_png[358] {
-        137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,22,0,0,0,22,8,6,0,0,0,196,180,108,59,0,0,0,9,112,72,89,
-        115,0,0,11,19,0,0,11,19,1,0,154,156,24,0,0,1,24,73,68,65,84,56,203,237,149,189,138,132,48,20,133,207,13,130,
-        96,33,40,216,45,83,41,104,97,163,190,129,236,83,216,249,168,218,216,40,22,118,106,101,43,164,17,219,76,179,
-        186,235,223,56,178,59,197,194,28,8,9,132,124,220,123,110,114,3,188,245,37,2,128,170,170,196,111,32,66,44,143,
-        187,174,75,211,198,159,41,73,18,1,0,236,85,86,72,211,162,239,123,112,206,49,12,195,156,154,16,98,30,11,255,
-        136,64,68,243,90,85,85,152,166,185,15,38,34,140,227,8,206,249,67,240,79,224,52,75,146,116,28,49,0,24,134,1,
-        203,178,158,78,87,81,148,115,43,136,8,93,215,33,203,178,77,165,215,86,0,128,166,105,8,195,240,28,204,24,131,
-        109,219,112,28,103,99,193,30,88,215,245,231,138,71,68,40,203,18,109,219,30,194,54,143,128,8,66,136,217,239,
-        56,142,247,35,246,60,15,190,239,47,10,183,150,170,170,215,174,27,17,161,40,10,52,77,51,71,178,150,44,203,136,
-        162,232,58,56,8,2,4,65,112,90,184,75,96,198,24,242,60,71,93,215,15,123,193,119,54,4,34,32,12,63,113,187,125,
-        28,54,145,127,214,43,210,52,125,127,32,175,211,29,234,70,24,38,1,20,79,179,0,0,0,0,73,69,78,68,174,66,96,130
     };
 
     const unsigned char wxPropertyGridManager_png[225] {

--- a/src/wxui/ribbonpanel_base.h
+++ b/src/wxui/ribbonpanel_base.h
@@ -109,7 +109,6 @@ namespace wxue_img
     extern const unsigned char wxListbook_png[357];
     extern const unsigned char wxMenuBar_png[490];
     extern const unsigned char wxPanel_png[156];
-    extern const unsigned char wxPopupTransientWindow_png[358];
     extern const unsigned char wxPropertyGridManager_png[225];
     extern const unsigned char wxPropertyGrid_png[212];
     extern const unsigned char wxToolBar_png[554];

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -1023,67 +1023,6 @@
             </node>
             <node
               class="wxRibbonPage"
-              label="MDI">
-              <node
-                class="wxRibbonPanel"
-                label="MDI"
-                var_name="panel_mmdi">
-                <node
-                  class="wxRibbonToolBar"
-                  var_name="forms_bar_mdi"
-                  wxEVT_RIBBONTOOLBAR_CLICKED="OnToolClick">
-                  <node
-                    class="ribbonTool"
-                    bitmap="Embed;wxFrame.png"
-                    help="Creates MDI Frame and wxDocTemplate"
-                    id="CreateMdiFrame" />
-                  <node
-                    class="ribbonTool"
-                    bitmap="Embed;wxPopupTransientWindow.png"
-                    help="Creates a wxDocChildFrame view"
-                    id="CreateView"
-                    kind="wxRIBBON_BUTTON_DROPDOWN" />
-                </node>
-              </node>
-              <node
-                class="wxRibbonPanel"
-                label="Menu"
-                var_name="panel_bars_menu_2">
-                <node
-                  class="wxRibbonToolBar"
-                  var_name="bars_bar_menu_2"
-                  wxEVT_RIBBONTOOLBAR_CLICKED="OnToolClick">
-                  <node
-                    class="ribbonTool"
-                    bitmap="Embed;wxmenuBar.png"
-                    help="Creates a frame or child window menu bar"
-                    id="MdiMenuBar"
-                    kind="wxRIBBON_BUTTON_DROPDOWN" />
-                  <node
-                    class="ribbonTool"
-                    bitmap="Embed;menu.png"
-                    help="wxMenu"
-                    id="gen_wxMenu" />
-                  <node
-                    class="ribbonTool"
-                    bitmap="Embed;menuitem.png"
-                    help="wxMenuItem"
-                    id="gen_wxMenuItem" />
-                  <node
-                    class="ribbonTool"
-                    bitmap="Embed;submenu.png"
-                    help="submenu"
-                    id="gen_submenu" />
-                  <node
-                    class="ribbonTool"
-                    bitmap="Embed;separator.png"
-                    help="separator"
-                    id="gen_separator" />
-                </node>
-              </node>
-            </node>
-            <node
-              class="wxRibbonPage"
               label="Sizers"
               var_name="pg_sizer">
               <node

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -279,13 +279,6 @@
                 wxEVT_MENU="OnAppendSmith" />
               <node
                 class="wxMenuItem"
-                help="Append DialogBlocks project into current project"
-                id="id_AppendDialogBlocks"
-                label="DialogBlocks Project..."
-                var_name="menu_item_8"
-                wxEVT_MENU="OnAppendDialogBlocks" />
-              <node
-                class="wxMenuItem"
                 help="Append Windows Resource into current project"
                 id="id_AppendWinRes"
                 label="Windows Resource..."
@@ -3453,6 +3446,7 @@
               class="wxRadioButton"
               label="&amp;DialogBlocks File(s)"
               var_name="m_radio_DialogBlocks"
+              hidden="1"
               column="1"
               row="1"
               wxEVT_RADIOBUTTON="OnDialogBlocks" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR does a triage on two of the features that still need a _lot_ of work. Finishing these would significantly delay the release of 1.1.2, so work on them is being postponed. The underlying code is in place, but the UI to get at the new features is either hidden or removed.