### PR TITLE
Fix code generation for custom ids with an assignment

### DIFF
--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -350,7 +350,7 @@ void EventHandlerDlg::FormatBindText()
     {
         code << "Bind(" << handler << ", ";
         if (m_event->GetNode()->value(prop_id) != "wxID_ANY")
-            code.Add(prop_id).EndFunction();
+            code.as_string(prop_id).EndFunction();
         else
             code.Add(m_event->GetNode()->get_node_name()).Function("GetId()").EndFunction();
     }
@@ -362,7 +362,7 @@ void EventHandlerDlg::FormatBindText()
         }
         else
         {
-            code.Add("Bind(").Add(handler).Comma().Add(prop_id).EndFunction();
+            code.Add("Bind(").Add(handler).Comma().as_string(prop_id).EndFunction();
         }
     }
     else

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -503,6 +503,18 @@ Code& Code::EndFunction()
 
 Code& Code::as_string(PropName prop_name)
 {
+    if (prop_name == prop_id)
+    {
+        auto result = m_node->get_prop_id();
+        CheckLineLength(result.size());
+
+        if (is_python() && result._Starts_with("wx"))
+        {
+            result.insert(2, ".");
+        }
+        *this += result;
+        return *this;
+    }
     auto& str = m_node->as_string(prop_name);
     if (is_cpp())
     {

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -124,7 +124,7 @@ void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */, N
 
 bool DataViewCtrl::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 
     return true;
@@ -235,7 +235,7 @@ void DataViewListCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent *
 
 bool DataViewListCtrl::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 
     return true;
@@ -288,7 +288,7 @@ wxObject* DataViewTreeCtrl::CreateMockup(Node* node, wxObject* parent)
 
 bool DataViewTreeCtrl::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 
     return true;

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -111,7 +111,7 @@ bool AuiToolBarGenerator::ConstructionCode(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.ValidParentName().Comma().Add(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(false, "wxAUI_TB_DEFAULT_STYLE");
 
     return true;
@@ -283,7 +283,7 @@ bool AuiToolLabelGenerator::ConstructionCode(Code& code)
     {
         code.FormFunction("AddLabel(");
     }
-    code.Add(prop_id).Comma().QuotedString(prop_label);
+    code.as_string(prop_id).Comma().QuotedString(prop_label);
     if (code.IntValue(prop_width) >= 0)
         code.Comma().Str(prop_width);
     code.EndFunction();

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1260,7 +1260,7 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, EventVector& events
         {
             code.Eol(eol_if_needed).Str("const int form_id = ");
             if (form_node->value(prop_id).size())
-                code.Str(prop_id) += ";";
+                code.as_string(prop_id) += ";";
             else
                 code.Str("wxID_ANY;");
         }

--- a/src/generate/gen_book_page.cpp
+++ b/src/generate/gen_book_page.cpp
@@ -208,7 +208,7 @@ bool BookPageGenerator::ConstructionCode(Code& code)
             treebook = treebook->GetParent();
         }
 
-        code.NodeName(treebook).Comma().Add(prop_id);
+        code.NodeName(treebook).Comma().as_string(prop_id);
         code.PosSizeFlags();
 
         // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/generate/gen_date_picker.cpp
+++ b/src/generate/gen_date_picker.cpp
@@ -32,7 +32,7 @@ wxObject* DatePickerCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 bool DatePickerCtrlGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().Add(prop_id).Comma().Add("wxDefaultDateTime");
+    code.ValidParentName().Comma().as_string(prop_id).Comma().Add("wxDefaultDateTime");
     code.PosSizeFlags(true, "wxDP_DEFAULT|wxDP_SHOWCENTURY");
 
     return true;

--- a/src/generate/gen_dialog.cpp
+++ b/src/generate/gen_dialog.cpp
@@ -67,7 +67,7 @@ bool DialogFormGenerator::ConstructionCode(Code& code)
         // SettingsCode(). From the user's perspective, it looks like one-step creation, but
         // it's actually two steps.
         code.Add("class ").NodeName().Str("(wx.Dialog):");
-        code.Eol().Tab().Add("def __init__(self, parent, id=").Add(prop_id);
+        code.Eol().Tab().Add("def __init__(self, parent, id=").as_string(prop_id);
         code.Indent(3);
         code.Comma().Str("title=").QuotedString(prop_title).Comma().Add("pos=").Pos(prop_pos);
         code.Comma().Str("size=").WxSize(prop_size).Comma();
@@ -162,7 +162,7 @@ bool DialogFormGenerator::HeaderCode(Code& code)
     auto* node = code.node();
     code.NodeName() += "() {}";
     code.Eol().NodeName() += "(wxWindow *parent";
-    code.Comma().Str("wxWindowID id = ").Str(prop_id);
+    code.Comma().Str("wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxString& title = ").QuotedString(prop_title);
     code.Comma().Str("const wxPoint& pos = ");
 
@@ -195,7 +195,7 @@ bool DialogFormGenerator::HeaderCode(Code& code)
     code.Str(")").Eol().OpenBrace().Str("Create(parent, id, title, pos, size, style, name);").CloseBrace();
 
     code.Eol().Str("bool Create(wxWindow *parent");
-    code.Comma().Str("wxWindowID id = ").Str(prop_id);
+    code.Comma().Str("wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxString& title = ").QuotedString(prop_title);
     code.Comma().Str("const wxPoint& pos = ");
 

--- a/src/generate/gen_dir_ctrl.cpp
+++ b/src/generate/gen_dir_ctrl.cpp
@@ -32,7 +32,7 @@ wxObject* GenericDirCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool GenericDirCtrlGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id).Comma();
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
     if (code.HasValue(prop_defaultfolder))
         code.QuotedString(prop_defaultfolder);
     else

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -123,7 +123,8 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
         code << "Bind(" << handler.GetCode() << comma;
         if (event->GetNode()->value(prop_id) != "wxID_ANY")
         {
-            code.AddIfPython("id=").Add(event->GetNode()->value(prop_id)).EndFunction();
+            auto id = event->GetNode()->get_prop_id();
+            code.AddIfPython("id=").Add(id).EndFunction();
         }
         else
         {

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -37,7 +37,7 @@ bool FrameFormGenerator::ConstructionCode(Code& code)
     else
     {
         code.Add("class ").NodeName().Add("(wx.Frame):\n");
-        code.Eol().Tab().Add("def __init__(self, parent, id=").Add(prop_id);
+        code.Eol().Tab().Add("def __init__(self, parent, id=").as_string(prop_id);
         code.Indent(3);
         code.Comma().Str("title=").QuotedString(prop_title).Comma().Add("pos=").Pos(prop_pos);
         code.Comma().Add("size=").WxSize(prop_size);
@@ -125,7 +125,7 @@ bool FrameFormGenerator::HeaderCode(Code& code)
 {
     auto* node = code.node();
     code.NodeName() += "() {}";
-    code.Eol().NodeName().Str("(wxWindow* parent, wxWindowID id = ").Str(prop_id);
+    code.Eol().NodeName().Str("(wxWindow* parent, wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxString& title = ");
     auto& title = node->as_string(prop_title);
     if (code.HasValue(prop_title))

--- a/src/generate/gen_grid.cpp
+++ b/src/generate/gen_grid.cpp
@@ -134,7 +134,7 @@ wxObject* GridGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool GridGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(false, "wxWANTS_CHARS");
 
     return true;

--- a/src/generate/gen_html_listbox.cpp
+++ b/src/generate/gen_html_listbox.cpp
@@ -47,7 +47,7 @@ wxObject* HtmlListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool HtmlListBoxGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     if (auto params_needed = code.WhatParamsNeeded("wxHLB_DEFAULT_STYLE"); params_needed != nothing_needed)
     {
         code.Comma().Pos().Comma().WxSize();

--- a/src/generate/gen_html_window.cpp
+++ b/src/generate/gen_html_window.cpp
@@ -59,7 +59,7 @@ bool HtmlWindowGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
-    code.NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true, "wxHW_SCROLLBAR_AUTO");
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/generate/gen_menuitem.cpp
+++ b/src/generate/gen_menuitem.cpp
@@ -61,7 +61,7 @@ bool MenuItemGenerator::ConstructionCode(Code& code)
         code.NodeName();
         code.AddIfCpp(" = Append(");
         code.AddIfPython(" = self.Append(");
-        code.Add(prop_id).Comma();
+        code.as_string(prop_id).Comma();
     }
     else
     {
@@ -71,7 +71,7 @@ bool MenuItemGenerator::ConstructionCode(Code& code)
             code.Add(prop_stock_id).EndFunction();
             return true;
         }
-        code.Add(prop_id).Comma();
+        code.as_string(prop_id).Comma();
     }
 
     auto& label = node->value(prop_label);

--- a/src/generate/gen_panel_form.cpp
+++ b/src/generate/gen_panel_form.cpp
@@ -53,7 +53,7 @@ bool PanelFormGenerator::ConstructionCode(Code& code)
     else
     {
         code.Add("class ").NodeName().Add("(wx.Panel):\n");
-        code.Eol().Tab().Add("def __init__(self, parent, id=").Add(prop_id);
+        code.Eol().Tab().Add("def __init__(self, parent, id=").as_string(prop_id);
         code.Indent(3);
         code.Comma().Add("pos=").Pos(prop_pos);
         code.Comma().Add("size=").WxSize(prop_size);
@@ -140,7 +140,7 @@ bool PanelFormGenerator::HeaderCode(Code& code)
     auto* node = code.node();
 
     code.NodeName() += "() {}";
-    code.Eol().NodeName().Str("(wxWindow* parent, wxWindowID id = ").Str(prop_id);
+    code.Eol().NodeName().Str("(wxWindow* parent, wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxPoint& pos = ");
 
     auto position = node->as_wxPoint(prop_pos);
@@ -193,7 +193,7 @@ bool PanelFormGenerator::HeaderCode(Code& code)
     code.Str(")").Eol().OpenBrace().Str("Create(parent, id, pos, size, style, name);").CloseBrace();
 
     code.Eol().Str("bool Create(wxWindow *parent");
-    code.Comma().Str("wxWindowID id = ").Str(prop_id);
+    code.Comma().Str("wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxPoint& pos = ");
 
     if (position == wxDefaultPosition)

--- a/src/generate/gen_prop_grid.cpp
+++ b/src/generate/gen_prop_grid.cpp
@@ -38,7 +38,7 @@ void PropertyGridGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
 
 bool PropertyGridGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(false, "wxPG_DEFAULT_STYLE");
 
     if (code.HasValue(prop_extra_style))

--- a/src/generate/gen_prop_grid_mgr.cpp
+++ b/src/generate/gen_prop_grid_mgr.cpp
@@ -86,7 +86,7 @@ void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /
 
 bool PropertyGridManagerGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(false, "wxPGMAN_DEFAULT_STYLE");
 
     if (code.HasValue(prop_extra_style))

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -305,14 +305,23 @@ void BaseCodeGenerator::GeneratePythonClass(Node* form_node, PANEL_PAGE panel_ty
     {
         if (!iter.starts_with("self."))
         {
-            m_source->writeLine(tt_string() << iter << " = wxID_HIGHEST + " << id_value++);
+            m_source->writeLine(tt_string() << iter << " = wx.ID_HIGHEST + " << id_value++);
         }
     }
     for (auto& iter: m_set_const_ids)
     {
         if (!iter.starts_with("self."))
         {
-            m_source->writeLine(iter);
+            if (tt::contains(iter, " wx"))
+            {
+                tt_string id = iter;
+                id.Replace(" wx", " wx.", true, tt::CASE::exact);
+                m_source->writeLine(id);
+            }
+            else
+            {
+                m_source->writeLine(iter);
+            }
         }
     }
 

--- a/src/generate/gen_ribbon_bar.cpp
+++ b/src/generate/gen_ribbon_bar.cpp
@@ -63,7 +63,7 @@ bool RibbonBarFormGenerator::ConstructionCode(Code& code)
     else
     {
         code.Add("class ").NodeName().Add("(wx.RibbonBar):\n");
-        code.Eol().Tab().Add("def __init__(self, parent, id=").Add(prop_id);
+        code.Eol().Tab().Add("def __init__(self, parent, id=").as_string(prop_id);
         code.Indent(3);
         code.Comma().Add("pos=").Pos(prop_pos);
         code.Comma().Add("size=").WxSize(prop_size);
@@ -90,7 +90,7 @@ bool RibbonBarFormGenerator::HeaderCode(Code& code)
 {
     auto* node = code.node();
 
-    code.NodeName().Str("(wxWindow* parent, wxWindowID id = ").Str(prop_id);
+    code.NodeName().Str("(wxWindow* parent, wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxPoint& pos = ");
 
     auto position = node->as_wxPoint(prop_pos);
@@ -230,7 +230,7 @@ void RibbonBarGenerator::OnPageChanged(wxRibbonBarEvent& event)
 bool RibbonBarGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName();
-    code.CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(false, "wxRIBBON_BAR_DEFAULT_STYLE");
 
     return true;

--- a/src/generate/gen_ribbon_button.cpp
+++ b/src/generate/gen_ribbon_button.cpp
@@ -45,7 +45,7 @@ void RibbonButtonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxp
 bool RibbonButtonBarGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName();
-    code.CreateClass().ParentName().Comma().Add(prop_id).PosSizeFlags();
+    code.CreateClass().ParentName().Comma().as_string(prop_id).PosSizeFlags();
 
     return true;
 }
@@ -69,7 +69,7 @@ int RibbonButtonBarGenerator::GenXrcObject(Node* node, pugi::xml_node& object, s
 
 bool RibbonButtonGenerator::ConstructionCode(Code& code)
 {
-    code.ParentName().Function("AddButton(").Add(prop_id).Comma().QuotedString(prop_label);
+    code.ParentName().Function("AddButton(").as_string(prop_id).Comma().QuotedString(prop_label);
     code.Comma();
     GenerateSingleBitmapCode(code, code.node()->as_string(prop_bitmap));
     code.Comma().QuotedString(prop_help).Comma().Add(prop_kind).EndFunction();

--- a/src/generate/gen_ribbon_gallery.cpp
+++ b/src/generate/gen_ribbon_gallery.cpp
@@ -48,7 +48,7 @@ void RibbonGalleryGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpar
 bool RibbonGalleryGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName();
-    code.CreateClass().ParentName().Comma().Add(prop_id).PosSizeFlags();
+    code.CreateClass().ParentName().Comma().as_string(prop_id).PosSizeFlags();
 
     return true;
 }

--- a/src/generate/gen_ribbon_page.cpp
+++ b/src/generate/gen_ribbon_page.cpp
@@ -32,7 +32,7 @@ wxObject* RibbonPageGenerator::CreateMockup(Node* node, wxObject* parent)
 bool RibbonPageGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName();
-    code.CreateClass().ParentName().Comma().Add(prop_id);
+    code.CreateClass().ParentName().Comma().as_string(prop_id);
     code.Comma().QuotedString(prop_label);
     if (code.HasValue(prop_bitmap))
     {
@@ -101,7 +101,7 @@ wxObject* RibbonPanelGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool RibbonPanelGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ParentName().Comma().Add(prop_id).Comma().QuotedString(prop_label);
+    code.AddAuto().NodeName().CreateClass().ParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     if (code.HasValue(prop_bitmap))
     {
         code.Comma();

--- a/src/generate/gen_ribbon_tool.cpp
+++ b/src/generate/gen_ribbon_tool.cpp
@@ -58,7 +58,7 @@ void RibbonToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpar
 bool RibbonToolBarGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName();
-    code.CreateClass().ParentName().Comma().Add(prop_id).PosSizeFlags();
+    code.CreateClass().ParentName().Comma().as_string(prop_id).PosSizeFlags();
 
     return true;
 }
@@ -98,7 +98,7 @@ int RibbonToolBarGenerator::GenXrcObject(Node* /* node */, pugi::xml_node& /* ob
 
 bool RibbonToolGenerator::ConstructionCode(Code& code)
 {
-    code.ParentName().Function("AddTool(").Add(prop_id);
+    code.ParentName().Function("AddTool(").as_string(prop_id);
     code.Comma();
     GenerateSingleBitmapCode(code, code.node()->as_string(prop_bitmap));
     code.Comma().QuotedString(prop_help).Comma().Add(prop_kind).EndFunction();

--- a/src/generate/gen_scrollbar.cpp
+++ b/src/generate/gen_scrollbar.cpp
@@ -30,7 +30,7 @@ wxObject* ScrollBarGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool ScrollBarGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags();
 
     return true;

--- a/src/generate/gen_spin_btn.cpp
+++ b/src/generate/gen_spin_btn.cpp
@@ -37,7 +37,7 @@ bool SpinButtonGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
-    code.NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(false, "wxSP_VERTICAL");
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/generate/gen_static_box.cpp
+++ b/src/generate/gen_static_box.cpp
@@ -31,7 +31,7 @@ bool StaticBoxGenerator::ConstructionCode(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.ValidParentName().Comma().Add(prop_id).Comma().QuotedString(prop_label);
+    code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true);
 
     return true;

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -115,7 +115,7 @@ bool ToolBarFormGenerator::ConstructionCode(Code& code)
     else
     {
         code.Add("class ").NodeName().Add("(wx.ToolBar):\n");
-        code.Eol().Tab().Add("def __init__(self, parent, id=").Add(prop_id);
+        code.Eol().Tab().Add("def __init__(self, parent, id=").as_string(prop_id);
         code.Indent(3);
         code.Comma().Add("pos=").Pos(prop_pos);
         code.Comma().Add("size=").WxSize(prop_size);
@@ -179,7 +179,7 @@ bool ToolBarFormGenerator::HeaderCode(Code& code)
 {
     auto* node = code.node();
 
-    code.NodeName().Str("(wxWindow* parent, wxWindowID id = ").Str(prop_id);
+    code.NodeName().Str("(wxWindow* parent, wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxPoint& pos = ");
 
     auto position = node->as_wxPoint(prop_pos);

--- a/src/generate/gen_tree_ctrl.cpp
+++ b/src/generate/gen_tree_ctrl.cpp
@@ -27,7 +27,7 @@ wxObject* TreeCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool TreeCtrlGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true, "wxTR_DEFAULT_STYLE");
 
     return true;

--- a/src/generate/gen_tree_list.cpp
+++ b/src/generate/gen_tree_list.cpp
@@ -36,7 +36,7 @@ void TreeListCtrlGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
 
 bool TreeListCtrlGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().Add(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true, "wxTL_DEFAULT_STYLE");
 
     return true;

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -479,7 +479,7 @@ bool StyledTextGenerator::ConstructionCode(Code& code)
     if (code.is_cpp() && code.is_local_var())
         code << "auto* ";
     code.NodeName().CreateClass();
-    code.ValidParentName().Comma().Add(prop_id);
+    code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -410,6 +410,14 @@ tt_string* Node::prop_as_raw_ptr(PropName name)
         return nullptr;
 }
 
+tt_string Node::get_prop_id() const
+{
+    tt_string id;
+    if (auto result = m_prop_indices.find(prop_id); result != m_prop_indices.end())
+        id = m_properties[result->second].get_prop_id();
+    return id;
+}
+
 std::vector<NODEPROP_STATUSBAR_FIELD> Node::as_statusbar_fields(PropName name)
 {
     if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -201,6 +201,9 @@ public:
         }
     }
 
+    // Returns string containing the property ID without any assignment if it is a custom id.
+    tt_string get_prop_id() const;
+
     const tt_string& value(PropName name) const { return as_string(name); }
 
     const tt_string_view view(PropName name) const { return as_string(name); }

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -64,6 +64,24 @@ int NodeProperty::as_id() const
     return NodeCreation.GetConstantAsInt(m_value, wxID_ANY);
 }
 
+tt_string NodeProperty::get_prop_id() const
+{
+    tt_string id;
+    if (auto pos = m_value.find('='); pos != tt::npos)
+    {
+        while (pos > 0 && tt::is_whitespace(m_value[pos - 1]))
+        {
+            --pos;
+        }
+        id = m_value.substr(0, pos);
+    }
+    else
+    {
+        id = m_value;
+    }
+    return id;
+}
+
 int NodeProperty::as_mockup(std::string_view prefix) const
 {
     switch (type())

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -82,6 +82,9 @@ public:
     // NodeProperty.
     tt_string& get_value() { return m_value; }
 
+    // Returns string containing the property ID without any assignment if it is a custom id.
+    tt_string get_prop_id() const;
+
     const tt_string& value() const { return m_value; }
 
     int as_int() const;

--- a/tests/sdi/cpp/maintestdialog.cpp
+++ b/tests/sdi/cpp/maintestdialog.cpp
@@ -74,7 +74,7 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     m_text_ctrl->SetHint("wxTextCtrl");
     page_sizer_1->Add(m_text_ctrl, wxSizerFlags().Expand().Border(wxALL));
 
-    m_richText = new wxRichTextCtrl(page_2, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxRE_MULTILINE|
+    m_richText = new wxRichTextCtrl(page_2, ID_RICHTEXT, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxRE_MULTILINE|
         wxVSCROLL | wxHSCROLL | wxNO_BORDER | wxWANTS_CHARS);
     m_richText->SetHint("wxRichTextCtrl");
     m_richText->SetMinSize(ConvertDialogToPixels(wxSize(150, 30)));

--- a/tests/sdi/cpp/maintestdialog.h
+++ b/tests/sdi/cpp/maintestdialog.h
@@ -58,16 +58,19 @@ public:
     wxHtmlWindow* m_htmlWin;
 
     MainTestDialog() {}
-    MainTestDialog(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString,
+    MainTestDialog(wxWindow *parent, wxWindowID id = DLG_MAINTEST, const wxString& title = wxEmptyString,
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
     {
         Create(parent, id, title, pos, size, style, name);
     }
 
-    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos =
-        wxDefaultPosition, const wxSize& size = wxDefaultSize,
+    bool Create(wxWindow *parent, wxWindowID id = DLG_MAINTEST, const wxString& title = wxEmptyString,
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
+
+    static const int DLG_MAINTEST = wxID_HIGHEST + 100;
+    static const int ID_RICHTEXT = 100;
 
     void OnEventName(const std::string& event_name)
     {

--- a/tests/sdi/python/main_test_dlg.py
+++ b/tests/sdi/python/main_test_dlg.py
@@ -11,6 +11,8 @@ import wx.html
 import wx.ribbon
 import wx.richtext
 import wx.stc
+DLG_MAINTEST = wx.ID_HIGHEST + 100
+ID_RICHTEXT = 100
 
 import images
 from wx.lib.embeddedimage import PyEmbeddedImage
@@ -54,7 +56,7 @@ clr_hourglass_gif = PyEmbeddedImage(
 import popupwin
 
 class MainTestDialog(wx.Dialog):
-    def __init__(self, parent, id=wx.ID_ANY, title="", pos=
+    def __init__(self, parent, id=DLG_MAINTEST, title="", pos=
                 wx.DefaultPosition, size=wx.DefaultSize,
                 style=wx.DEFAULT_DIALOG_STYLE, name=wx.DialogNameStr):
         wx.Dialog.__init__(self)
@@ -79,7 +81,7 @@ class MainTestDialog(wx.Dialog):
         self.m_text_ctrl.SetHint("wxTextCtrl")
         page_sizer_1.Add(self.m_text_ctrl, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        self.m_richText = wx.richtext.RichTextCtrl(page_2, wx.ID_ANY, "",
+        self.m_richText = wx.richtext.RichTextCtrl(page_2, ID_RICHTEXT, "",
             wx.DefaultPosition, wx.DefaultSize, wx.richtext.RE_MULTILINE|wx.VSCROLL|wx.HSCROLL|
             wx.NO_BORDER|wx.WANTS_CHARS)
         self.m_richText.SetHint("wxRichTextCtrl")

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -296,6 +296,7 @@
     <node
       class="wxDialog"
       class_name="MainTestDialog"
+      id="DLG_MAINTEST = wxID_HIGHEST + 100"
       base_file="maintestdialog"
       inserted_hdr_code="void OnEventName(const std::string&amp; event_name)@@{@@    m_events_list->Select(m_events_list->Append(wxString().FromUTF8(event_name)));@@}"
       insert_python_code="import popupwin"
@@ -332,6 +333,7 @@
               <node
                 class="wxRichTextCtrl"
                 hint="wxRichTextCtrl"
+                id="ID_RICHTEXT = 100"
                 minimum_size="150,30d"
                 window_style="wxVSCROLL | wxHSCROLL | wxNO_BORDER | wxWANTS_CHARS"
                 flags="wxEXPAND"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how prop_id is retrieved and code for it generated in order to correctly strip out any assignments in the string before generating code that uses the ID as a parameter. It also fixes wxPython code generation where a custom id is defined as an offset from a wxWidgets id (typically wxID_HIGHEST).

Closes #1081