### PR TITLE
Add new property type: type_stringlist_semi

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -40,6 +40,7 @@ std::unordered_map<std::string_view, PropType, str_view_hash, std::equal_to<>> G
     { "string_edit_single", type_string_edit_single },
     { "string_escapes", type_string_escapes },
     { "stringlist", type_stringlist },
+    { "stringlist_semi", type_stringlist_semi },
     { "stringlist_escapes", type_stringlist_escapes },
     { "uint", type_uint },
     { "uintpairlist", type_uintpairlist },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -37,13 +37,26 @@ namespace GenEnum
         type_radiobox_item,
         type_statbar_fields,
         type_string,
+
+        // "_escapes" makes it possible for the user to include \n, \t, \r, and "\" in the string
+
         type_string_code_single,   // includes single-line custom editor, does not process escapes
         type_string_edit,          // includes a button that triggers a small text editor dialog
         type_string_edit_escapes,  // includes editor dialog and also escapes characters
         type_string_edit_single,   // includes single-line text editor, does not process escapes
         type_string_escapes,       // doubles the backslash in escaped characters: \n, \t, \r, and "\""
-        type_stringlist,           // includes button to edit/move multiple choices
-        type_stringlist_escapes,   // includes button to edit/move multiple choices, and supports escapes characters
+
+        // All the stringlist variants use wxArrayStringProperty, but with different separators.
+        // All of them include a button to edit/move multiple choices.
+        //
+        // stringlist uses either quoted strings or strings separated by a semi-colon.
+        // stringlist_semi uses ';' as the separator.
+        // stringlist_escapes uses uses quoted strings.
+
+        type_stringlist,          // includes button to edit/move multiple choices
+        type_stringlist_semi,     // includes button to edit/move multiple choices
+        type_stringlist_escapes,  // includes button to edit/move multiple choices
+
         type_uint,
         type_uintpairlist,
         type_wxColour,

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -12,12 +12,13 @@
 #include <wx/animate.h>                // wxAnimation and wxAnimationCtrl
 #include <wx/propgrid/propgriddefs.h>  // wxPropertyGrid miscellaneous definitions
 
-#include "font_prop.h"      // FontProperty -- FontProperty class
-#include "image_handler.h"  // ImageHandler class
-#include "mainapp.h"        // App -- Main application class
-#include "node.h"           // Node -- Node class
-#include "node_creator.h"   // NodeCreator class
-#include "utils.h"          // Utility functions that work with properties
+#include "font_prop.h"        // FontProperty -- FontProperty class
+#include "image_handler.h"    // ImageHandler class
+#include "mainapp.h"          // App -- Main application class
+#include "node.h"             // Node -- Node class
+#include "node_creator.h"     // NodeCreator class
+#include "project_handler.h"  // ProjectHandler singleton class
+#include "utils.h"            // Utility functions that work with properties
 
 #include "node_prop.h"
 
@@ -427,24 +428,8 @@ wxArrayString NodeProperty::as_wxArrayString() const
 
     if (m_value.size())
     {
-#if 0
-        // REVIEW: [Randalphwa - 06-26-2023] This works, however in wxWidgets 3.2, it converts
-        // the entire string to unicode and does a unicode parsing of the string. Since the
-        // original string is utf8, that's not efficient.
-        if (m_value[0] == '"')
-            delimiter = '"';
-        else
-            delimiter = ';';
-        wxString str = m_value.make_wxString();
-        wxPGStringTokenizer tokenizer(str, delimiter);
-        while (tokenizer.HasMoreTokens())
+        if (m_value[0] == '"' && !(type() == type_stringlist_semi && Project.GetOriginalProjectVersion() >= 18))
         {
-            result.Add(tokenizer.GetNextToken());
-        }
-#else
-        if (m_value[0] == '"')
-        {
-            // REVIEW: [Randalphwa - 06-26-2023] This uses tt_string_view to parse the string.
             auto view = m_value.view_substr(0, '"', '"');
             while (view.size() > 0)
             {
@@ -462,7 +447,6 @@ wxArrayString NodeProperty::as_wxArrayString() const
                 result.Add(str.make_wxString());
             }
         }
-#endif
     }
 
     return result;

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -398,11 +398,15 @@ std::vector<tt_string> NodeProperty::as_vector() const
 
 std::vector<tt_string> NodeProperty::as_ArrayString() const
 {
-    std::vector<tt_string> result;
+    tt_string_vector result;
 
     if (m_value.size())
     {
-        if (m_value[0] == '"')
+        if (type() == type_stringlist_semi)
+        {
+            result.SetString(m_value, ";", tt::TRIM::both);
+        }
+        else if (type() == type_stringlist_escapes || m_value[0] == '"')
         {
             auto view = m_value.view_substr(0, '"', '"');
             while (view.size() > 0)
@@ -411,12 +415,6 @@ std::vector<tt_string> NodeProperty::as_ArrayString() const
                 view = tt::stepover(view.data() + view.size());
                 view = view.view_substr(0, '"', '"');
             }
-        }
-        else
-        {
-            tt_string_vector array;
-            array.SetString(m_value, ";", tt::TRIM::both);
-            result = array;
         }
     }
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -563,8 +563,8 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
     else if (type == type_stringlist_semi)
     {
         new_pg_property = new wxArrayStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxArrayString());
-            wxVariant delimiter(";");
-            new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, delimiter);
+        wxVariant delimiter(";");
+        new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, delimiter);
     }
     else if (type == type_stringlist_escapes)
     {

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -560,6 +560,12 @@ wxPGProperty* PropGridPanel::CreatePGProperty(NodeProperty* prop)
             new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, delimiter);
         }
     }
+    else if (type == type_stringlist_semi)
+    {
+        new_pg_property = new wxArrayStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxArrayString());
+            wxVariant delimiter(";");
+            new_pg_property->SetAttribute(wxPG_ARRAY_DELIMITER, delimiter);
+    }
     else if (type == type_stringlist_escapes)
     {
         new_pg_property = new wxArrayStringProperty(prop->DeclName().make_wxString(), wxPG_LABEL, prop->as_wxArrayString());
@@ -1078,6 +1084,10 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                 }
             }
 #endif  // _WIN32
+            modifyProperty(prop, property->GetValueAsString().utf8_string());
+            break;
+
+        case type_stringlist_semi:
             modifyProperty(prop, property->GetValueAsString().utf8_string());
             break;
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -142,7 +142,7 @@ constexpr const int minRequiredVer = 15;
 
 // 1.0.0 == version 15
 // 1.1.0 == version 16
-// 1.1.1 == version 17
+// 1.1.1 == version 18
 
 // Use when you need to return an empty const tt_string&
 extern tt_string tt_empty_cstr;

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -284,9 +284,11 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent, boo
                     }
 
                     prop->set_value(value);
-                    if (Project.GetProjectVersion() < minRequiredVer + 1)
+                    // Conversion from quoted items to semicolon separated items was introduced
+                    // in 1.1.1 (project version 18)
+                    if (Project.GetProjectVersion() < 18)
                     {
-                        Project.ForceProjectVersion(minRequiredVer + 1);
+                        Project.ForceProjectVersion(18);
                         Project.SetProjectUpdated();
                     }
                 };

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -263,6 +263,34 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent, boo
 
             if (prop)
             {
+                auto convert_quoted_array = [&]()
+                {
+                    // Convert old style wxCheckListBox contents in quotes to new style separated by semicolons
+                    std::vector<tt_string> items;
+                    auto view = iter.as_sview().view_substr(0, '"', '"');
+                    while (view.size() > 0)
+                    {
+                        items.emplace_back(view);
+                        view = tt::stepover(view.data() + view.size());
+                        view = view.view_substr(0, '"', '"');
+                    }
+
+                    tt_string value;
+                    for (auto& item: items)
+                    {
+                        if (value.size())
+                            value << ';';
+                        value << item;
+                    }
+
+                    prop->set_value(value);
+                    if (Project.GetProjectVersion() < minRequiredVer + 1)
+                    {
+                        Project.ForceProjectVersion(minRequiredVer + 1);
+                        Project.SetProjectUpdated();
+                    }
+                };
+
                 if (prop->type() == type_bool)
                 {
                     prop->set_value(iter.as_bool());
@@ -271,37 +299,24 @@ NodeSharedPtr NodeCreator::CreateNode(pugi::xml_node& xml_obj, Node* parent, boo
                 {
                     if (new_node->isGen(gen_wxCheckListBox) && iter.as_sview().size() && iter.as_sview()[0] == '"')
                     {
-                        // Convert old style wxCheckListBox contents in quotes to new style separated by semicolons
-                        std::vector<tt_string> items;
-                        auto view = iter.as_sview();
-                        while (view.size() > 0)
-                        {
-                            items.emplace_back(view);
-                            view = tt::stepover(view.data() + view.size());
-                            view = view.view_substr(0, '"', '"');
-                        }
-
-                        tt_string value;
-                        for (auto& item: items)
-                        {
-                            if (value.size())
-                                value << ';';
-                            value << item;
-                        }
-
-                        prop->set_value(value);
-                        if (Project.GetProjectVersion() < minRequiredVer + 1)
-                        {
-                            Project.ForceProjectVersion(minRequiredVer + 1);
-                            Project.SetProjectUpdated();
-                        }
+                        convert_quoted_array();
                     }
                     else
                     {
                         prop->set_value(iter.as_sview());
                     }
                 }
-
+                else if (prop->type() == type_stringlist_semi && Project.GetOriginalProjectVersion() < 18)
+                {
+                    if (iter.as_sview().size() && iter.as_sview()[0] == '"')
+                    {
+                        convert_quoted_array();
+                    }
+                    else
+                    {
+                        prop->set_value(iter.as_sview());
+                    }
+                }
                 // Imported projects will be set as version ImportProjectVersion to get the fixups of constant to
                 // friendly name, and bit flag conflict resolution.
 
@@ -564,6 +579,34 @@ NodeSharedPtr NodeCreator::CreateProjectNode(pugi::xml_node* xml_obj, bool allow
                 if (prop->type() == type_bool)
                 {
                     prop->set_value(iter.as_bool());
+                }
+                else if (prop->type() == type_stringlist_semi && Project.GetOriginalProjectVersion() < 18)
+                {
+                    auto view = iter.as_sview();
+                    if (view.size() > 0 && view[0] == '"')
+                    {
+                        std::vector<tt_string> items;
+                        view = view.view_substr(0, '"', '"');
+                        while (view.size() > 0)
+                        {
+                            items.emplace_back(view);
+                            view = tt::stepover(view.data() + view.size());
+                            view = view.view_substr(0, '"', '"');
+                        }
+
+                        tt_string value;
+                        for (auto& item: items)
+                        {
+                            if (value.size())
+                                value << ';';
+                            value << item;
+                        }
+                        prop->set_value(value);
+                    }
+                    else
+                    {
+                        prop->set_value(iter.value());
+                    }
                 }
                 else
                 {

--- a/src/wxui/id_editor_dlg.cpp
+++ b/src/wxui/id_editor_dlg.cpp
@@ -196,11 +196,8 @@ void IDEditorDlg::OnInit(wxInitDialogEvent& event)
 
     ASSERT_MSG(m_node, "You must call SetNode() before calling OnInit()")
 
-    tt_string_vector prefixes;
-    prefixes.SetString(Project.ProjectNode()->value(prop_id_prefixes), '"', tt::TRIM::both);
-
-    tt_string_vector suffixes;
-    suffixes.SetString(Project.ProjectNode()->value(prop_id_suffixes), '"', tt::TRIM::both);
+    auto prefixes = Project.ProjectNode()->as_ArrayString(prop_id_prefixes);
+    auto suffixes = Project.ProjectNode()->as_ArrayString(prop_id_suffixes);
 
     if (prefixes.size())
     {

--- a/src/xml/grid_xml.xml
+++ b/src/xml/grid_xml.xml
@@ -86,7 +86,7 @@ inline const char* grid_xml = R"===(<?xml version="1.0"?>
 		</category>
 
 		<category name="Columns">
-			<property name="col_label_values" type="stringlist"
+			<property name="col_label_values" type="stringlist_semi"
 				help="List of column labels." />
 			<property name="default_col_size" type="int"
 				help="Sets the default width for columns in the grid. Ignored unless a positive value is set.">-1</property>
@@ -121,7 +121,7 @@ inline const char* grid_xml = R"===(<?xml version="1.0"?>
 		</category>
 
 		<category name="Rows">
-			<property name="row_label_values" type="stringlist"
+			<property name="row_label_values" type="stringlist_semi"
 				help="List of row labels." />
 			<property name="default_row_size" type="int"
 				help="Sets the default height for rows in the grid. Ignored unless a positive value is set.">-1</property>

--- a/src/xml/listview_xml.xml
+++ b/src/xml/listview_xml.xml
@@ -6,7 +6,7 @@ inline const char* listview_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_listview</property>
-		<property name="column_labels" type="stringlist"
+		<property name="column_labels" type="stringlist_semi"
 			help="Labels to use as column headers. Only used if the mode is set to wxLC_REPORT." />
 		<property name="contents" type="stringlist"
 			help="Array of strings used to initialize the list view. Each string is a row, with text for individual columns separated by a ';' character. Only valid if column_labels has been initialized and the mode is set to wxLC_REPORT." />

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -94,9 +94,9 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 				help="Use wxHelpControllerHelpProvider to provide context-sensitive help." />
 			none
 		</property>
-		<property name="id_prefixes" type="stringlist_escapes"
+		<property name="id_prefixes" type="stringlist_semi"
 			help="Optional prefixes to apply before a custom id. These can be added in the ID Editor dialog." />
-		<property name="id_suffixes" type="stringlist_escapes"
+		<property name="id_suffixes" type="stringlist_semi"
 			help="Optional suffixes to apply after a custom id. These can be added in the ID Editor dialog." />
 	</gen>
 

--- a/src/xml/textctrls_xml.xml
+++ b/src/xml/textctrls_xml.xml
@@ -41,7 +41,7 @@ inline const char* textctrls_xml = R"===(<?xml version="1.0"?>
 			help="Sets a hint to be shown when the control is empty and does not have the focus." />
 		<property name="maxlength" type="string"
 			help="The maximum length of user-entered text. 0 means no limit. Note that in wxGTK this function may only be used with single line text controls." />
-		<property name="auto_complete" type="stringlist"
+		<property name="auto_complete" type="stringlist_semi"
 			help="If one or more strings are entered, they will be used to initialize autocomplete." />
 		<property name="spellcheck" type="bitlist">
 			<option name="enabled"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new property type which is designed to seperate items using a semi-colon instead of double quotes. Initially this was just for the new id_prefix and id_suffix properties, but I extended it to some other properties as well. Use of quotes is harder for the user to just type in without using the editor button, it takes up more space in the project file (have to use an HTML escape sequence for each quote), and it slightly slower to parse into an array.