### PR TITLE
Add ability to search for IDs in Find Widget dialog

### DIFF
--- a/src/internal/node_search_dlg.h
+++ b/src/internal/node_search_dlg.h
@@ -13,7 +13,6 @@
 #include <wx/event.h>
 #include <wx/gdicmn.h>
 #include <wx/listbox.h>
-#include <wx/radiobut.h>
 
 class Node;
 
@@ -40,6 +39,7 @@ public:
     bool isSearchGenerators() const { return m_search_generators; }
     bool isSearchVarnames() const { return m_search_varnames; }
     bool isSearchLabels() const { return m_search_labels; }
+    bool isSearchIDs() const { return m_search_ids; }
 
     struct FoundInfo
     {
@@ -58,6 +58,7 @@ protected:
     // Event handlers
 
     void OnGenerators(wxCommandEvent& event);
+    void OnIDs(wxCommandEvent& event);
     void OnInit(wxInitDialogEvent& event);
     void OnLabels(wxCommandEvent& event);
     void OnOK(wxCommandEvent& event);
@@ -70,6 +71,7 @@ private:
     // Validator variables
 
     bool m_search_generators { true };
+    bool m_search_ids { false };
     bool m_search_labels { false };
     bool m_search_varnames { false };
 
@@ -77,11 +79,8 @@ private:
 
     wxListBox* m_listbox;
     wxListBox* m_listbox_forms;
-    wxRadioButton* m_radioBtn;
-    wxRadioButton* m_radioBtn_3;
-    wxRadioButton* m_radio_variables;
 
-    std::string m_name;  // could be gen_name, var_name or label
+    std::string m_name;  // could be gen_name, var_name, label or ID
     Node* m_form = nullptr;
     std::map<std::string, std::set<Node*>> m_map_found;
 };

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -99,6 +99,9 @@ public:
         return (GetParent() ? name == GetParent()->m_declaration->gen_name() : false);
     }
 
+    // Returns true if this node is a folder, subfolder, or Images List
+    bool IsNonWidget() const noexcept { return (isGen(gen_folder) || isGen(gen_sub_folder) || isGen(gen_Images)); }
+
     bool IsWidget() const noexcept { return isType(type_widget); }
     bool IsWizard() const noexcept { return isType(type_wizard); }
     bool IsMenuBar() const noexcept { return (isType(type_menubar_form) || isType(type_menubar)); }

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -5528,25 +5528,37 @@
             <node
               class="wxRadioButton"
               checked="1"
+              class_access="none"
               label="&amp;Generators"
               style="wxRB_GROUP"
+              var_name="radioBtn_Generators"
               get_function="isSearchGenerators"
               validator_variable="m_search_generators"
               wxEVT_RADIOBUTTON="OnGenerators" />
             <node
               class="wxRadioButton"
+              class_access="none"
               label="&amp;Variables"
-              var_name="m_radio_variables"
+              var_name="radio_variables"
               get_function="isSearchVarnames"
               validator_variable="m_search_varnames"
               wxEVT_RADIOBUTTON="OnVariables" />
             <node
               class="wxRadioButton"
+              class_access="none"
               label="&amp;Labels"
-              var_name="m_radioBtn_3"
+              var_name="radioBtn_Labels"
               get_function="isSearchLabels"
               validator_variable="m_search_labels"
               wxEVT_RADIOBUTTON="OnLabels" />
+            <node
+              class="wxRadioButton"
+              class_access="none"
+              label="&amp;IDs"
+              var_name="radioBtn_IDs"
+              get_function="isSearchIDs"
+              validator_variable="m_search_ids"
+              wxEVT_RADIOBUTTON="OnIDs" />
             <node
               class="wxButton"
               class_access="none"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR modifies the NodeSearchDlg dialog by adding a new IDs radio button making it possible to locate a node via it's ID. wxID_ANY is ignored, but all other ids are listed.

The second part of the PR is to replace individual functions that looked for a specific property string with a recursive lambda to search for any property string. Recursive lambdas have an unusual syntax (you have to pass the name of the lambda to all calls to the lambda) but allows you to keep the code close to where it is used making the code easier to understand.