### PR TITLE
Global Custom ID editor

### DIFF
--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -284,6 +284,14 @@ set (file_list
     utils/font_prop.cpp         # FontProperty class
     utils/utils.cpp             # Utility functions that work with properties
 
+    # Tools
+
+    # tools/global_ids_dlg_base.cpp # Base class for Global IDs dialog (generated)
+    # tools/generate_dlg.cpp        # Dialog for choosing and generating specific language file(s)
+    # tools/preview_settings.cpp    # Dialog for setting preview options
+
+    tools/global_ids_dlg.cpp  # Dialog to Globally edit Custom IDs
+
     # Windows resource importer
 
     winres/ctrl_utils.cpp       # resCtrl class utility functions
@@ -333,9 +341,11 @@ set (debug_files
     internal/unused_gen_dlg.cpp
     internal/xrcpreview.cpp
 
+    tools/generate_dlg.cpp
+    tools/preview_settings.cpp
+
     wxui/optionsdlg.cpp
     wxui/code_preference_dlg.cpp
-    wxui/preview_settings.cpp
     wxui/dlg_gen_results.cpp
 
     tests/test_xrc_import.cpp

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -274,6 +274,7 @@ protected:
     void OnCut(wxCommandEvent& event) override;
     void OnDelete(wxCommandEvent& event) override;
     void OnDuplicate(wxCommandEvent& event) override;
+    void OnEditCustomIds(wxCommandEvent& event) override;
     void OnFindDialog(wxCommandEvent& event) override;
     void OnGenerateCode(wxCommandEvent& event) override;
     void OnImportProject(wxCommandEvent& event);

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -65,22 +65,28 @@ int NodeProperty::as_id() const
     return NodeCreation.GetConstantAsInt(m_value, wxID_ANY);
 }
 
-tt_string NodeProperty::get_prop_id() const
+// Static class function
+tt_string NodeProperty::get_prop_id(const tt_string& complete_id)
 {
     tt_string id;
-    if (auto pos = m_value.find('='); pos != tt::npos)
+    if (auto pos = complete_id.find('='); pos != tt::npos)
     {
-        while (pos > 0 && tt::is_whitespace(m_value[pos - 1]))
+        while (pos > 0 && tt::is_whitespace(complete_id[pos - 1]))
         {
             --pos;
         }
-        id = m_value.substr(0, pos);
+        id = complete_id.substr(0, pos);
     }
     else
     {
-        id = m_value;
+        id = complete_id;
     }
     return id;
+}
+
+tt_string NodeProperty::get_prop_id() const
+{
+    return get_prop_id(m_value);
 }
 
 int NodeProperty::as_mockup(std::string_view prefix) const

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -85,6 +85,9 @@ public:
     // Returns string containing the property ID without any assignment if it is a custom id.
     tt_string get_prop_id() const;
 
+    // Returns a string containing the ID without any assignment if it is a custom id.
+    static tt_string get_prop_id(const tt_string& complete_id);
+
     const tt_string& value() const { return m_value; }
 
     int as_int() const;

--- a/src/tools/global_ids_dlg.cpp
+++ b/src/tools/global_ids_dlg.cpp
@@ -9,6 +9,7 @@
 
 #include "mainframe.h"        // MainFrame -- Main application window
 #include "project_handler.h"  // ProjectHandler class
+#include "undo_cmds.h"        // Undoable command classes derived from UndoAction
 
 void MainFrame::OnEditCustomIds(wxCommandEvent& WXUNUSED(event))
 {
@@ -18,60 +19,273 @@ void MainFrame::OnEditCustomIds(wxCommandEvent& WXUNUSED(event))
 
 void GlobalCustomIDS::OnInit(wxInitDialogEvent& event)
 {
+    m_lb_folders->Append("Project", Project.ProjectNode());
+    for (const auto& iter: Project.ProjectNode()->GetChildNodePtrs())
+    {
+        if (iter->isGen(gen_folder))
+        {
+            m_lb_folders->Append(iter->as_string(prop_label), iter.get());
+        }
+        else if (iter->IsForm() && iter->HasValue(prop_class_name))
+        {
+            m_lb_forms->Append(iter->as_string(prop_class_name), iter.get());
+        }
+    }
+
+    if (Project.ProjectNode()->HasValue(prop_id_prefixes))
+    {
+        for (auto& iter: Project.ProjectNode()->as_ArrayString(prop_id_prefixes))
+        {
+            m_combo_prefixes->Append(iter.make_wxString());
+        }
+    }
+
+    if (Project.ProjectNode()->HasValue(prop_id_suffixes))
+    {
+        for (auto& iter: Project.ProjectNode()->as_ArrayString(prop_id_suffixes))
+        {
+            m_combo_suffixes->Append(iter.make_wxString());
+        }
+    }
     event.Skip();  // transfer all validator data to their windows and update UI
 }
 
 void GlobalCustomIDS::OnSelectFolders(wxCommandEvent& WXUNUSED(event))
 {
-    // TODO: Implement OnSelectFolders
+    m_lb_forms->Clear();
+    wxArrayInt selections;
+
+    if (auto count = m_lb_folders->GetSelections(selections); count > 0)
+    {
+        for (auto& iter: selections)
+        {
+            auto* node = static_cast<Node*>(m_lb_folders->GetClientData(iter));
+            if (node)
+            {
+                for (const auto& form: node->GetChildNodePtrs())
+                {
+                    if (form->IsForm() && form->HasValue(prop_class_name))
+                    {
+                        m_lb_forms->Append(form->as_string(prop_class_name), form.get());
+                    }
+                    else if (form.get() == Project.ProjectNode())
+                    {
+                        m_lb_forms->Append("Project", form.get());
+                    }
+                }
+            }
+        }
+    }
 }
+
+const int min_rows = 10;
+
+struct NODE_IDS
+{
+    tt_string id_portion;
+    Node* node;
+};
 
 void GlobalCustomIDS::OnSelectForms(wxCommandEvent& WXUNUSED(event))
 {
-    // TODO: Implement OnSelectForms
+    m_grid->ClearGrid();
+    if (m_grid->GetNumberRows() > min_rows)
+    {
+        m_grid->DeleteRows(min_rows - 1, m_grid->GetNumberRows() - min_rows);
+    }
+
+    wxArrayInt selections;
+    std::vector<NODE_IDS> ids;
+
+    if (auto count = m_lb_forms->GetSelections(selections); count > 0)
+    {
+        // Collect all non "wx" IDs into the ids vector
+        auto CollectIDs = [&](Node* node, auto&& CollectIDs) -> void
+        {
+            if (node->HasValue(prop_id) && !node->as_string(prop_id).is_sameprefix("wx"))
+            {
+                NODE_IDS node_id;
+                node_id.id_portion = node->get_prop_id();
+                node_id.node = node;
+                ids.push_back(node_id);
+            }
+
+            for (const auto& iter: node->GetChildNodePtrs())
+            {
+                CollectIDs(iter.get(), CollectIDs);
+            }
+        };
+
+        for (auto& iter: selections)
+        {
+            auto* node = static_cast<Node*>(m_lb_forms->GetClientData(iter));
+            CollectIDs(node, CollectIDs);
+        }
+    }
+
+    // REVIEW: [Randalphwa - 07-10-2023] We could sort the ids vector here, but that could be
+    // confusing since that would result in ids from different forms being mixed together
+    // looking like they are duplicates.
+
+    if (ids.size())
+    {
+        if (ids.size() > min_rows)
+        {
+            m_grid->AppendRows((to_int) ids.size() - min_rows);
+        }
+
+        int pos = 0;
+        for (auto& iter: ids)
+        {
+            tt_string modified_id = iter.id_portion;
+            if (m_text_old_prefix->GetValue().length())
+            {
+                auto old_prefix = m_text_old_prefix->GetValue().utf8_string();
+                if (modified_id.starts_with(old_prefix))
+                {
+                    modified_id.erase(0, old_prefix.length());
+                }
+            }
+            if (m_text_old_suffix->GetValue().length())
+            {
+                auto old_suffix = m_text_old_suffix->GetValue().utf8_string();
+                if (modified_id.ends_with(old_suffix))
+                {
+                    modified_id.erase(modified_id.length() - old_suffix.length());
+                }
+            }
+            if (m_combo_prefixes->GetValue().length())
+            {
+                modified_id.insert(0, m_combo_prefixes->GetValue().utf8_string());
+            }
+            if (m_combo_suffixes->GetValue().length())
+            {
+                modified_id.append(m_combo_suffixes->GetValue().utf8_string());
+            }
+
+            if (modified_id != iter.id_portion)
+            {
+                m_grid->SetCellValue(pos, 1, modified_id);
+            }
+
+            m_grid->SetCellValue(pos++, 0, iter.id_portion);
+        }
+    }
 }
 
 void GlobalCustomIDS::OnSelectAllFolders(wxCommandEvent& WXUNUSED(event))
 {
-    // TODO: Implement OnSelectAllFolders
+    for (unsigned int idx = 0; idx < m_lb_folders->GetCount(); ++idx)
+    {
+        m_lb_folders->SetSelection(idx, true);
+    }
 }
 
 void GlobalCustomIDS::OnSelectNoFolders(wxCommandEvent& WXUNUSED(event))
 {
-    // TODO: Implement OnSelectNoFolders
+    m_lb_folders->DeselectAll();
 }
 
 void GlobalCustomIDS::OnSelectAllForms(wxCommandEvent& WXUNUSED(event))
 {
-    // TODO: Implement OnSelectAllForms
+    for (unsigned int idx = 0; idx < m_lb_folders->GetCount(); ++idx)
+    {
+        m_lb_forms->SetSelection(idx, true);
+    }
 }
 
 void GlobalCustomIDS::OnSelectNoForms(wxCommandEvent& WXUNUSED(event))
 {
-    // TODO: Implement OnSelectNoForms
+    m_lb_forms->DeselectAll();
 }
 
-void GlobalCustomIDS::OnRemovePrefix(wxCommandEvent& WXUNUSED(event))
+void GlobalCustomIDS::OnUpdate(wxCommandEvent& event)
 {
-    // TODO: Implement OnRemovePrefix
-}
-
-void GlobalCustomIDS::OnRemoveSuffix(wxCommandEvent& WXUNUSED(event))
-{
-    // TODO: Implement OnRemoveSuffix
-}
-
-void GlobalCustomIDS::OnAddPrefix(wxCommandEvent& WXUNUSED(event))
-{
-    // TODO: Implement OnAddPrefix
-}
-
-void GlobalCustomIDS::OnAddSuffix(wxCommandEvent& WXUNUSED(event))
-{
-    // TODO: Implement OnAddSuffix
+    OnSelectForms(event);
 }
 
 void GlobalCustomIDS::OnCommit(wxCommandEvent& WXUNUSED(event))
 {
-    // TODO: Implement OnCommit
+    wxArrayInt selections;
+    std::vector<NODE_IDS> ids;
+
+    if (auto count = m_lb_forms->GetSelections(selections); count > 0)
+    {
+        // Collect all non "wx" IDs into the ids vector
+        auto CollectIDs = [&](Node* node, auto&& CollectIDs) -> void
+        {
+            if (node->HasValue(prop_id) && !node->as_string(prop_id).is_sameprefix("wx"))
+            {
+                NODE_IDS node_id;
+                node_id.id_portion = node->get_prop_id();
+                node_id.node = node;
+                ids.push_back(node_id);
+            }
+
+            for (const auto& iter: node->GetChildNodePtrs())
+            {
+                CollectIDs(iter.get(), CollectIDs);
+            }
+        };
+
+        for (auto& iter: selections)
+        {
+            auto* node = static_cast<Node*>(m_lb_forms->GetClientData(iter));
+            CollectIDs(node, CollectIDs);
+        }
+    }
+
+    if (ids.empty())
+    {
+        wxMessageBox("No IDs to update", "Update IDs", wxOK | wxICON_INFORMATION);
+        return;
+    }
+
+    auto undo_ids = std::make_shared<ModifyProperties>("Change IDs");
+
+    for (auto& iter: ids)
+    {
+        tt_string modified_id = iter.id_portion;
+        if (m_text_old_prefix->GetValue().length())
+        {
+            auto old_prefix = m_text_old_prefix->GetValue().utf8_string();
+            if (modified_id.starts_with(old_prefix))
+            {
+                modified_id.erase(0, old_prefix.length());
+            }
+        }
+        if (m_text_old_suffix->GetValue().length())
+        {
+            auto old_suffix = m_text_old_suffix->GetValue().utf8_string();
+            if (modified_id.ends_with(old_suffix))
+            {
+                modified_id.erase(modified_id.length() - old_suffix.length());
+            }
+        }
+        if (m_combo_prefixes->GetValue().length())
+        {
+            modified_id.insert(0, m_combo_prefixes->GetValue().utf8_string());
+        }
+        if (m_combo_suffixes->GetValue().length())
+        {
+            modified_id.append(m_combo_suffixes->GetValue().utf8_string());
+        }
+
+        if (modified_id != iter.id_portion)
+        {
+            tt_string new_id = iter.node->as_string(prop_id);
+            new_id.Replace(iter.id_portion, modified_id);
+            undo_ids->AddProperty(iter.node->get_prop_ptr(prop_id), new_id);
+        }
+    }
+
+    wxGetFrame().PushUndoAction(undo_ids);
+
+    m_text_old_prefix->Clear();
+    m_text_old_suffix->Clear();
+    m_combo_prefixes->SetValue("");
+    m_combo_suffixes->SetValue("");
+
+    wxCommandEvent dummy;
+    OnUpdate(dummy);
 }

--- a/src/tools/global_ids_dlg.cpp
+++ b/src/tools/global_ids_dlg.cpp
@@ -1,0 +1,77 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Dialog to Globally edit Custom IDs
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "global_ids_dlg_base.h"  // Generated header
+
+#include "mainframe.h"        // MainFrame -- Main application window
+#include "project_handler.h"  // ProjectHandler class
+
+void MainFrame::OnEditCustomIds(wxCommandEvent& WXUNUSED(event))
+{
+    GlobalCustomIDS dlg(this);
+    dlg.ShowModal();
+}
+
+void GlobalCustomIDS::OnInit(wxInitDialogEvent& event)
+{
+    event.Skip();  // transfer all validator data to their windows and update UI
+}
+
+void GlobalCustomIDS::OnSelectFolders(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnSelectFolders
+}
+
+void GlobalCustomIDS::OnSelectForms(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnSelectForms
+}
+
+void GlobalCustomIDS::OnSelectAllFolders(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnSelectAllFolders
+}
+
+void GlobalCustomIDS::OnSelectNoFolders(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnSelectNoFolders
+}
+
+void GlobalCustomIDS::OnSelectAllForms(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnSelectAllForms
+}
+
+void GlobalCustomIDS::OnSelectNoForms(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnSelectNoForms
+}
+
+void GlobalCustomIDS::OnRemovePrefix(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnRemovePrefix
+}
+
+void GlobalCustomIDS::OnRemoveSuffix(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnRemoveSuffix
+}
+
+void GlobalCustomIDS::OnAddPrefix(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnAddPrefix
+}
+
+void GlobalCustomIDS::OnAddSuffix(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnAddSuffix
+}
+
+void GlobalCustomIDS::OnCommit(wxCommandEvent& WXUNUSED(event))
+{
+    // TODO: Implement OnCommit
+}

--- a/src/tools/global_ids_dlg_base.cpp
+++ b/src/tools/global_ids_dlg_base.cpp
@@ -15,7 +15,7 @@
 
 #include "global_ids_dlg_base.h"
 
-bool GlobalCustomIDSBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
+bool GlobalCustomIDS::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     const wxPoint& pos, const wxSize& size, long style, const wxString &name)
 {
     if (!wxDialog::Create(parent, id, title, pos, size, style, name))
@@ -172,21 +172,21 @@ bool GlobalCustomIDSBase::Create(wxWindow* parent, wxWindowID id, const wxString
     SetSizerAndFit(dlg_sizer);
     Centre(wxBOTH);
 
-    wxPersistentRegisterAndRestore(this, "GlobalCustomIDSBase");
+    wxPersistentRegisterAndRestore(this, "GlobalCustomIDS");
 
     // Event handlers
-    btn->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnSelectAllFolders, this);
-    btn_2->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnSelectNoFolders, this);
-    btn_3->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnSelectAllForms, this);
-    btn_4->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnSelectNoForms, this);
-    m_btn_remove_prefix->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnRemovePrefix, this);
-    m_btn_remove_old_suffix->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnRemoveSuffix, this);
-    m_btn_Add_new_prefix->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnAddPrefix, this);
-    m_btn_add_new_suffix_2->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnAddSuffix, this);
-    m_btn_commit->Bind(wxEVT_BUTTON, &GlobalCustomIDSBase::OnCommit, this);
-    Bind(wxEVT_INIT_DIALOG, &GlobalCustomIDSBase::OnInit, this);
-    m_lb_folders->Bind(wxEVT_LISTBOX, &GlobalCustomIDSBase::OnSelectFolders, this);
-    m_lb_forms->Bind(wxEVT_LISTBOX, &GlobalCustomIDSBase::OnSelectForms, this);
+    btn->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnSelectAllFolders, this);
+    btn_2->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnSelectNoFolders, this);
+    btn_3->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnSelectAllForms, this);
+    btn_4->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnSelectNoForms, this);
+    m_btn_remove_prefix->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnRemovePrefix, this);
+    m_btn_remove_old_suffix->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnRemoveSuffix, this);
+    m_btn_Add_new_prefix->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnAddPrefix, this);
+    m_btn_add_new_suffix_2->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnAddSuffix, this);
+    m_btn_commit->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnCommit, this);
+    Bind(wxEVT_INIT_DIALOG, &GlobalCustomIDS::OnInit, this);
+    m_lb_folders->Bind(wxEVT_LISTBOX, &GlobalCustomIDS::OnSelectFolders, this);
+    m_lb_forms->Bind(wxEVT_LISTBOX, &GlobalCustomIDS::OnSelectForms, this);
 
     return true;
 }

--- a/src/tools/global_ids_dlg_base.cpp
+++ b/src/tools/global_ids_dlg_base.cpp
@@ -7,8 +7,6 @@
 
 // clang-format off
 
-#include <wx/persist.h>
-#include <wx/persist/toplevel.h>
 #include <wx/sizer.h>
 #include <wx/statbox.h>
 #include <wx/stattext.h>
@@ -33,8 +31,6 @@ bool GlobalCustomIDS::Create(wxWindow* parent, wxWindowID id, const wxString& ti
 
     m_lb_folders = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_MULTIPLE);
     m_lb_folders->SetFocus();
-    m_lb_folders->Append("Project");
-    m_lb_folders->SetSelection(0);
     m_lb_folders->SetMinSize(ConvertDialogToPixels(wxSize(130, 80)));
     flex_grid_sizer->Add(m_lb_folders, wxSizerFlags().Border(wxALL));
 
@@ -66,77 +62,70 @@ bool GlobalCustomIDS::Create(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto* box_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
 
-    auto* static_box = new wxStaticBoxSizer(wxVERTICAL, this, "Remove");
+    auto* static_box = new wxStaticBoxSizer(wxHORIZONTAL, this, "Modifications");
+
+    auto* box_sizer_6 = new wxBoxSizer(wxVERTICAL);
 
     auto* box_sizer_3 = new wxBoxSizer(wxHORIZONTAL);
 
     auto* box_sizer_4 = new wxBoxSizer(wxVERTICAL);
 
-    auto* staticText_4 = new wxStaticText(static_box->GetStaticBox(), wxID_ANY, "Old Prefix");
-    box_sizer_4->Add(staticText_4, wxSizerFlags().Border(wxALL));
+    auto* staticText_4 = new wxStaticText(static_box->GetStaticBox(), wxID_ANY, "Remove Old Prefix");
+    box_sizer_4->Add(staticText_4, wxSizerFlags().Center().Border(wxALL));
 
-    m_text_old_prefix = new wxTextCtrl(static_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_text_old_prefix->SetHint("old prefix");
+    m_text_old_prefix = new wxTextCtrl(static_box->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
+        wxDefaultSize, wxTE_PROCESS_ENTER);
     box_sizer_4->Add(m_text_old_prefix, wxSizerFlags().Border(wxALL));
-
-    m_btn_remove_prefix = new wxButton(static_box->GetStaticBox(), wxID_ANY, "Remove");
-    box_sizer_4->Add(m_btn_remove_prefix, wxSizerFlags().Border(wxALL));
 
     box_sizer_3->Add(box_sizer_4, wxSizerFlags().Border(wxALL));
 
     auto* box_sizer_5 = new wxBoxSizer(wxVERTICAL);
 
-    auto* staticText_5 = new wxStaticText(static_box->GetStaticBox(), wxID_ANY, "Old Suffix");
-    box_sizer_5->Add(staticText_5, wxSizerFlags().Border(wxALL));
+    auto* staticText_5 = new wxStaticText(static_box->GetStaticBox(), wxID_ANY, "Remove Old Suffix");
+    box_sizer_5->Add(staticText_5, wxSizerFlags().Center().Border(wxALL));
 
-    m_text_old_suffix = new wxTextCtrl(static_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_text_old_suffix->SetHint("old suffix");
+    m_text_old_suffix = new wxTextCtrl(static_box->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
+        wxDefaultSize, wxTE_PROCESS_ENTER);
     box_sizer_5->Add(m_text_old_suffix, wxSizerFlags().Border(wxALL));
-
-    m_btn_remove_old_suffix = new wxButton(static_box->GetStaticBox(), wxID_ANY, "Remove");
-    box_sizer_5->Add(m_btn_remove_old_suffix, wxSizerFlags().Border(wxALL));
 
     box_sizer_3->Add(box_sizer_5, wxSizerFlags().Border(wxALL));
 
-    static_box->Add(box_sizer_3, wxSizerFlags().Expand().Border(wxALL));
-
-    box_sizer_2->Add(static_box, wxSizerFlags().Expand().Border(wxALL));
-
-    auto* static_box_2 = new wxStaticBoxSizer(wxVERTICAL, this, "Add");
-
-    auto* box_sizer_6 = new wxBoxSizer(wxHORIZONTAL);
-
     auto* box_sizer_7 = new wxBoxSizer(wxVERTICAL);
 
-    auto* staticText_6 = new wxStaticText(static_box_2->GetStaticBox(), wxID_ANY, "New Prefix:");
-    box_sizer_7->Add(staticText_6, wxSizerFlags().Border(wxALL));
+    auto* staticText_6 = new wxStaticText(static_box->GetStaticBox(), wxID_ANY, "Add New Prefix");
+    box_sizer_7->Add(staticText_6, wxSizerFlags().Center().Border(wxALL));
 
-    m_combo_prefixes = new wxComboBox(static_box_2->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
-        wxDefaultSize, 0, nullptr, wxCB_DROPDOWN|wxCB_SORT);
+    m_combo_prefixes = new wxComboBox(static_box->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
+        wxDefaultSize, 0, nullptr, wxCB_DROPDOWN|wxCB_SORT|wxTE_PROCESS_ENTER);
+    m_combo_prefixes->SetMinSize(ConvertDialogToPixels(wxSize(70, -1)));
     box_sizer_7->Add(m_combo_prefixes, wxSizerFlags().Border(wxALL));
 
-    m_btn_Add_new_prefix = new wxButton(static_box_2->GetStaticBox(), wxID_ANY, "Add");
-    box_sizer_7->Add(m_btn_Add_new_prefix, wxSizerFlags().Border(wxALL));
-
-    box_sizer_6->Add(box_sizer_7, wxSizerFlags().Border(wxALL));
+    box_sizer_3->Add(box_sizer_7, wxSizerFlags().Border(wxALL));
 
     auto* box_sizer_8 = new wxBoxSizer(wxVERTICAL);
 
-    auto* staticText_7 = new wxStaticText(static_box_2->GetStaticBox(), wxID_ANY, "New Suffix:");
-    box_sizer_8->Add(staticText_7, wxSizerFlags().Border(wxALL));
+    auto* staticText_7 = new wxStaticText(static_box->GetStaticBox(), wxID_ANY, "Add New Suffix");
+    box_sizer_8->Add(staticText_7, wxSizerFlags().Center().Border(wxALL));
 
-    m_combo_suffixes = new wxComboBox(static_box_2->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
-        wxDefaultSize, 0, nullptr, wxCB_DROPDOWN|wxCB_SORT);
+    m_combo_suffixes = new wxComboBox(static_box->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
+        wxDefaultSize, 0, nullptr, wxCB_DROPDOWN|wxCB_SORT|wxTE_PROCESS_ENTER);
+    m_combo_suffixes->SetMinSize(ConvertDialogToPixels(wxSize(70, -1)));
     box_sizer_8->Add(m_combo_suffixes, wxSizerFlags().Border(wxALL));
 
-    m_btn_add_new_suffix_2 = new wxButton(static_box_2->GetStaticBox(), wxID_ANY, "Add");
-    box_sizer_8->Add(m_btn_add_new_suffix_2, wxSizerFlags().Border(wxALL));
+    box_sizer_3->Add(box_sizer_8, wxSizerFlags().Border(wxALL));
 
-    box_sizer_6->Add(box_sizer_8, wxSizerFlags().Border(wxALL));
+    box_sizer_6->Add(box_sizer_3, wxSizerFlags().Expand().Border(wxALL));
 
-    static_box_2->Add(box_sizer_6, wxSizerFlags().Expand().Border(wxALL));
+    auto* box_sizer_11 = new wxBoxSizer(wxHORIZONTAL);
 
-    box_sizer_2->Add(static_box_2, wxSizerFlags().Expand().Border(wxALL));
+    auto* btn_5 = new wxButton(static_box->GetStaticBox(), wxID_ANY, "Preview Changes");
+    box_sizer_11->Add(btn_5, wxSizerFlags().Border(wxALL));
+
+    box_sizer_6->Add(box_sizer_11, wxSizerFlags().Center().Border(wxALL));
+
+    static_box->Add(box_sizer_6, wxSizerFlags().Expand().Border(wxALL));
+
+    box_sizer_2->Add(static_box, wxSizerFlags().Expand().Border(wxALL));
 
     dlg_sizer->Add(box_sizer_2, wxSizerFlags().Expand().Border(wxALL));
 
@@ -144,12 +133,14 @@ bool GlobalCustomIDS::Create(wxWindow* parent, wxWindowID id, const wxString& ti
 
     m_grid = new wxGrid(this, wxID_ANY);
     {
-        m_grid->CreateGrid(5, 2);
+        m_grid->CreateGrid(10, 2);
+        m_grid->EnableEditing(false);
         m_grid->EnableDragGridSize(false);
         m_grid->SetMargins(0, 0);
+        m_grid->SetDefaultCellFitMode(wxGridFitMode::Ellipsize());
         m_grid->SetSelectionMode(wxGrid::wxGridSelectNone);
         m_grid->SetDefaultCellAlignment(wxALIGN_LEFT, wxALIGN_TOP);
-        m_grid->SetDefaultColSize(200);
+        m_grid->SetDefaultColSize(250);
         m_grid->SetColLabelAlignment(wxALIGN_CENTER, wxALIGN_CENTER);
         m_grid->SetColLabelSize(wxGRID_AUTOSIZE);
         m_grid->SetColLabelValue(0, "Original");
@@ -159,7 +150,7 @@ bool GlobalCustomIDS::Create(wxWindow* parent, wxWindowID id, const wxString& ti
         m_grid->SetColLabelValue(0, "Original");
         m_grid->SetColLabelValue(1, "Modified");
     }
-    box_sizer->Add(m_grid, wxSizerFlags().Border(wxALL));
+    box_sizer->Add(m_grid, wxSizerFlags(1).Expand().Border(wxALL));
 
     m_btn_commit = new wxButton(this, wxID_ANY, "Commit change");
     box_sizer->Add(m_btn_commit, wxSizerFlags().Center().Border(wxALL));
@@ -172,21 +163,22 @@ bool GlobalCustomIDS::Create(wxWindow* parent, wxWindowID id, const wxString& ti
     SetSizerAndFit(dlg_sizer);
     Centre(wxBOTH);
 
-    wxPersistentRegisterAndRestore(this, "GlobalCustomIDS");
-
     // Event handlers
     btn->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnSelectAllFolders, this);
     btn_2->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnSelectNoFolders, this);
     btn_3->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnSelectAllForms, this);
     btn_4->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnSelectNoForms, this);
-    m_btn_remove_prefix->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnRemovePrefix, this);
-    m_btn_remove_old_suffix->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnRemoveSuffix, this);
-    m_btn_Add_new_prefix->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnAddPrefix, this);
-    m_btn_add_new_suffix_2->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnAddSuffix, this);
+    btn_5->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnUpdate, this);
     m_btn_commit->Bind(wxEVT_BUTTON, &GlobalCustomIDS::OnCommit, this);
+    m_combo_prefixes->Bind(wxEVT_COMBOBOX_CLOSEUP, &GlobalCustomIDS::OnUpdate, this);
+    m_combo_suffixes->Bind(wxEVT_COMBOBOX_CLOSEUP, &GlobalCustomIDS::OnUpdate, this);
     Bind(wxEVT_INIT_DIALOG, &GlobalCustomIDS::OnInit, this);
     m_lb_folders->Bind(wxEVT_LISTBOX, &GlobalCustomIDS::OnSelectFolders, this);
     m_lb_forms->Bind(wxEVT_LISTBOX, &GlobalCustomIDS::OnSelectForms, this);
+    m_text_old_prefix->Bind(wxEVT_TEXT_ENTER, &GlobalCustomIDS::OnUpdate, this);
+    m_text_old_suffix->Bind(wxEVT_TEXT_ENTER, &GlobalCustomIDS::OnUpdate, this);
+    m_combo_prefixes->Bind(wxEVT_TEXT_ENTER, &GlobalCustomIDS::OnUpdate, this);
+    m_combo_suffixes->Bind(wxEVT_TEXT_ENTER, &GlobalCustomIDS::OnUpdate, this);
 
     return true;
 }

--- a/src/tools/global_ids_dlg_base.h
+++ b/src/tools/global_ids_dlg_base.h
@@ -18,11 +18,11 @@
 #include <wx/listbox.h>
 #include <wx/textctrl.h>
 
-class GlobalCustomIDSBase : public wxDialog
+class GlobalCustomIDS : public wxDialog
 {
 public:
-    GlobalCustomIDSBase() {}
-    GlobalCustomIDSBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title =
+    GlobalCustomIDS() {}
+    GlobalCustomIDS(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title =
         "Globally Add Prefix/Suffix to Custom IDs", const wxPoint& pos = wxDefaultPosition, const wxSize& size =
         wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr)
@@ -37,20 +37,20 @@ public:
 
 protected:
 
-    // Virtual event handlers -- override them in your derived class
+    // Event handlers
 
-    virtual void OnAddPrefix(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnAddSuffix(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnCommit(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnInit(wxInitDialogEvent& event) { event.Skip(); }
-    virtual void OnRemovePrefix(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnRemoveSuffix(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnSelectAllFolders(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnSelectAllForms(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnSelectFolders(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnSelectForms(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnSelectNoFolders(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnSelectNoForms(wxCommandEvent& event) { event.Skip(); }
+    void OnAddPrefix(wxCommandEvent& event);
+    void OnAddSuffix(wxCommandEvent& event);
+    void OnCommit(wxCommandEvent& event);
+    void OnInit(wxInitDialogEvent& event);
+    void OnRemovePrefix(wxCommandEvent& event);
+    void OnRemoveSuffix(wxCommandEvent& event);
+    void OnSelectAllFolders(wxCommandEvent& event);
+    void OnSelectAllForms(wxCommandEvent& event);
+    void OnSelectFolders(wxCommandEvent& event);
+    void OnSelectForms(wxCommandEvent& event);
+    void OnSelectNoFolders(wxCommandEvent& event);
+    void OnSelectNoForms(wxCommandEvent& event);
 
     // Class member variables
 

--- a/src/tools/global_ids_dlg_base.h
+++ b/src/tools/global_ids_dlg_base.h
@@ -18,6 +18,8 @@
 #include <wx/listbox.h>
 #include <wx/textctrl.h>
 
+#include <map>
+
 class GlobalCustomIDS : public wxDialog
 {
 public:
@@ -25,7 +27,7 @@ public:
     GlobalCustomIDS(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title =
         "Globally Add Prefix/Suffix to Custom IDs", const wxPoint& pos = wxDefaultPosition, const wxSize& size =
         wxDefaultSize,
-        long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr)
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
     {
         Create(parent, id, title, pos, size, style, name);
     }
@@ -33,32 +35,25 @@ public:
     bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title =
         "Globally Add Prefix/Suffix to Custom IDs", const wxPoint& pos = wxDefaultPosition, const wxSize& size =
         wxDefaultSize,
-        long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr);
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 
     // Event handlers
 
-    void OnAddPrefix(wxCommandEvent& event);
-    void OnAddSuffix(wxCommandEvent& event);
     void OnCommit(wxCommandEvent& event);
     void OnInit(wxInitDialogEvent& event);
-    void OnRemovePrefix(wxCommandEvent& event);
-    void OnRemoveSuffix(wxCommandEvent& event);
     void OnSelectAllFolders(wxCommandEvent& event);
     void OnSelectAllForms(wxCommandEvent& event);
     void OnSelectFolders(wxCommandEvent& event);
     void OnSelectForms(wxCommandEvent& event);
     void OnSelectNoFolders(wxCommandEvent& event);
     void OnSelectNoForms(wxCommandEvent& event);
+    void OnUpdate(wxCommandEvent& event);
 
     // Class member variables
 
-    wxButton* m_btn_Add_new_prefix;
-    wxButton* m_btn_add_new_suffix_2;
     wxButton* m_btn_commit;
-    wxButton* m_btn_remove_old_suffix;
-    wxButton* m_btn_remove_prefix;
     wxComboBox* m_combo_prefixes;
     wxComboBox* m_combo_suffixes;
     wxGrid* m_grid;

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -254,6 +254,8 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     m_mi_preview->SetBitmap(wxueBundleSVG(wxue_img::xrc_preview_svg, 469, 1326, wxSize(16, 16)));
 
     m_menuTools->Append(m_mi_preview);
+    auto* menu_item_8 = new wxMenuItem(m_menuTools, wxID_ANY, "&Global Edit Custom IDs...");
+    m_menuTools->Append(menu_item_8);
     m_menubar->Append(m_menuTools, "&Tools");
 
     m_menuHelp = new wxMenu();
@@ -403,19 +405,14 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
         wxID_REDO);
     Bind(wxEVT_MENU, &MainFrameBase::OnPreviewXrc, this, id_PreviewForm);
     Bind(wxEVT_MENU, &MainFrameBase::OnCut, this, wxID_CUT);
-    Bind(wxEVT_MENU, &MainFrameBase::OnAbout, this, wxID_ABOUT);
+    Bind(wxEVT_MENU, &MainFrameBase::OnEditCustomIds, this, menu_item_8->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnCopy, this, wxID_COPY);
     Bind(wxEVT_MENU, &MainFrameBase::OnPaste, this, wxID_PASTE);
-    Bind(wxEVT_MENU, &MainFrameBase::OnBrowseDocs, this, menu_item_6->GetId());
+    Bind(wxEVT_MENU, &MainFrameBase::OnAbout, this, wxID_ABOUT);
     Bind(wxEVT_MENU, &MainFrameBase::OnDelete, this, wxID_DELETE);
-    Bind(wxEVT_MENU, &MainFrameBase::OnBrowsePython, this, menu_item_9->GetId());
+    Bind(wxEVT_MENU, &MainFrameBase::OnBrowseDocs, this, menu_item_6->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnDuplicate, this, menu_duplicate->GetId());
-    Bind(wxEVT_MENU,
-        [](wxCommandEvent&)
-        {
-            wxGetFrame().MoveNode(MoveDirection::Right);
-        },
-        id_MoveRight);
+    Bind(wxEVT_MENU, &MainFrameBase::OnBrowsePython, this, menu_item_9->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnFindDialog, this, wxID_FIND);
     Bind(wxEVT_MENU, &MainFrameBase::OnInsertWidget, this, id_insert_widget);
     Bind(wxEVT_MENU,
@@ -436,6 +433,12 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
             wxGetFrame().MoveNode(MoveDirection::Left);
         },
         id_MoveLeft);
+    Bind(wxEVT_MENU,
+        [](wxCommandEvent&)
+        {
+            wxGetFrame().MoveNode(MoveDirection::Right);
+        },
+        id_MoveRight);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignLeft);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignCenterHorizontal);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignRight);
@@ -484,13 +487,13 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
             event.Enable(wxGetFrame().CanCopyNode());
         },
         wxID_DELETE);
-    Bind(wxEVT_UPDATE_UI, &MainFrameBase::OnUpdateBrowseDocs, this, menu_item_6->GetId());
     Bind(wxEVT_UPDATE_UI,
         [](wxUpdateUIEvent& event)
         {
             event.Enable(wxGetFrame().CanCopyNode());
         },
         menu_duplicate->GetId());
+    Bind(wxEVT_UPDATE_UI, &MainFrameBase::OnUpdateBrowseDocs, this, menu_item_6->GetId());
     Bind(wxEVT_UPDATE_UI, &MainFrameBase::OnUpdateBrowsePython, this, menu_item_9->GetId());
 
     return true;

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -86,6 +86,7 @@ protected:
     virtual void OnCut(wxCommandEvent& event) { event.Skip(); }
     virtual void OnDelete(wxCommandEvent& event) { event.Skip(); }
     virtual void OnDuplicate(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnEditCustomIds(wxCommandEvent& event) { event.Skip(); }
     virtual void OnFindDialog(wxCommandEvent& event) { event.Skip(); }
     virtual void OnGenerateCode(wxCommandEvent& event) { event.Skip(); }
     virtual void OnImportWindowsResource(wxCommandEvent& event) { event.Skip(); }

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -580,6 +580,11 @@
               shortcut="F5"
               var_name="m_mi_preview"
               wxEVT_MENU="OnPreviewXrc" />
+            <node
+              class="wxMenuItem"
+              label="&amp;Global Edit Custom IDs..."
+              var_name="menu_item_8"
+              wxEVT_MENU="OnEditCustomIds" />
           </node>
           <node
             class="wxMenu"
@@ -1823,13 +1828,14 @@
       </node>
       <node
         class="wxDialog"
-        class_name="GlobalCustomIDSBase"
+        class_name="GlobalCustomIDS"
         persist="1"
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Globally Add Prefix/Suffix to Custom IDs"
         base_file="..\tools\global_ids_dlg_base"
-        derived_class_name="GlobalCustomIDSBase"
+        derived_class_name="GlobalCustomIDS"
         derived_file="../tools/global_ids_dlg"
+        use_derived_class="0"
         wxEVT_INIT_DIALOG="OnInit[python:OnInit]">
         <node
           class="wxBoxSizer"

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -1829,10 +1829,9 @@
       <node
         class="wxDialog"
         class_name="GlobalCustomIDS"
-        persist="1"
-        style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Globally Add Prefix/Suffix to Custom IDs"
         base_file="..\tools\global_ids_dlg_base"
+        system_hdr_includes="map"
         derived_class_name="GlobalCustomIDS"
         derived_file="../tools/global_ids_dlg"
         use_derived_class="0"
@@ -1858,9 +1857,7 @@
               var_name="staticText_2" />
             <node
               class="wxListBox"
-              contents="&quot;Project&quot;"
               focus="1"
-              selection_int="0"
               type="wxLB_MULTIPLE"
               var_name="m_lb_folders"
               maximum_size="-1,-1d"
@@ -1912,98 +1909,97 @@
             flags="wxEXPAND">
             <node
               class="wxStaticBoxSizer"
-              label="Remove"
+              label="Modifications"
+              orientation="wxHORIZONTAL"
               flags="wxEXPAND">
               <node
                 class="wxBoxSizer"
-                var_name="box_sizer_3"
-                flags="wxEXPAND">
-                <node
-                  class="wxBoxSizer"
-                  orientation="wxVERTICAL"
-                  var_name="box_sizer_4">
-                  <node
-                    class="wxStaticText"
-                    class_access="none"
-                    label="Old Prefix"
-                    var_name="staticText_4" />
-                  <node
-                    class="wxTextCtrl"
-                    hint="old prefix"
-                    var_name="m_text_old_prefix" />
-                  <node
-                    class="wxButton"
-                    label="Remove"
-                    var_name="m_btn_remove_prefix"
-                    wxEVT_BUTTON="OnRemovePrefix" />
-                </node>
-                <node
-                  class="wxBoxSizer"
-                  orientation="wxVERTICAL"
-                  var_name="box_sizer_5">
-                  <node
-                    class="wxStaticText"
-                    class_access="none"
-                    label="Old Suffix"
-                    var_name="staticText_5" />
-                  <node
-                    class="wxTextCtrl"
-                    hint="old suffix"
-                    var_name="m_text_old_suffix" />
-                  <node
-                    class="wxButton"
-                    label="Remove"
-                    var_name="m_btn_remove_old_suffix"
-                    wxEVT_BUTTON="OnRemoveSuffix" />
-                </node>
-              </node>
-            </node>
-            <node
-              class="wxStaticBoxSizer"
-              label="Add"
-              var_name="static_box_2"
-              flags="wxEXPAND">
-              <node
-                class="wxBoxSizer"
+                orientation="wxVERTICAL"
                 var_name="box_sizer_6"
                 flags="wxEXPAND">
                 <node
                   class="wxBoxSizer"
-                  orientation="wxVERTICAL"
-                  var_name="box_sizer_7">
+                  var_name="box_sizer_3"
+                  flags="wxEXPAND">
                   <node
-                    class="wxStaticText"
-                    class_access="none"
-                    label="New Prefix:"
-                    var_name="staticText_6" />
+                    class="wxBoxSizer"
+                    orientation="wxVERTICAL"
+                    var_name="box_sizer_4">
+                    <node
+                      class="wxStaticText"
+                      class_access="none"
+                      label="Remove Old Prefix"
+                      var_name="staticText_4"
+                      alignment="wxALIGN_CENTER_HORIZONTAL" />
+                    <node
+                      class="wxTextCtrl"
+                      style="wxTE_PROCESS_ENTER"
+                      var_name="m_text_old_prefix"
+                      wxEVT_TEXT_ENTER="OnUpdate" />
+                  </node>
                   <node
-                    class="wxComboBox"
-                    style="wxCB_DROPDOWN|wxCB_SORT"
-                    var_name="m_combo_prefixes" />
+                    class="wxBoxSizer"
+                    orientation="wxVERTICAL"
+                    var_name="box_sizer_5">
+                    <node
+                      class="wxStaticText"
+                      class_access="none"
+                      label="Remove Old Suffix"
+                      var_name="staticText_5"
+                      alignment="wxALIGN_CENTER_HORIZONTAL" />
+                    <node
+                      class="wxTextCtrl"
+                      style="wxTE_PROCESS_ENTER"
+                      var_name="m_text_old_suffix"
+                      wxEVT_TEXT_ENTER="OnUpdate" />
+                  </node>
                   <node
-                    class="wxButton"
-                    label="Add"
-                    var_name="m_btn_Add_new_prefix"
-                    wxEVT_BUTTON="OnAddPrefix" />
+                    class="wxBoxSizer"
+                    orientation="wxVERTICAL"
+                    var_name="box_sizer_7">
+                    <node
+                      class="wxStaticText"
+                      class_access="none"
+                      label="Add New Prefix"
+                      var_name="staticText_6"
+                      alignment="wxALIGN_CENTER_HORIZONTAL" />
+                    <node
+                      class="wxComboBox"
+                      style="wxCB_DROPDOWN|wxCB_SORT|wxTE_PROCESS_ENTER"
+                      var_name="m_combo_prefixes"
+                      minimum_size="70,-1d"
+                      wxEVT_COMBOBOX_CLOSEUP="OnUpdate"
+                      wxEVT_TEXT_ENTER="OnUpdate" />
+                  </node>
+                  <node
+                    class="wxBoxSizer"
+                    orientation="wxVERTICAL"
+                    var_name="box_sizer_8">
+                    <node
+                      class="wxStaticText"
+                      class_access="none"
+                      label="Add New Suffix"
+                      var_name="staticText_7"
+                      alignment="wxALIGN_CENTER_HORIZONTAL" />
+                    <node
+                      class="wxComboBox"
+                      style="wxCB_DROPDOWN|wxCB_SORT|wxTE_PROCESS_ENTER"
+                      var_name="m_combo_suffixes"
+                      minimum_size="70,-1d"
+                      wxEVT_COMBOBOX_CLOSEUP="OnUpdate"
+                      wxEVT_TEXT_ENTER="OnUpdate" />
+                  </node>
                 </node>
                 <node
                   class="wxBoxSizer"
-                  orientation="wxVERTICAL"
-                  var_name="box_sizer_8">
-                  <node
-                    class="wxStaticText"
-                    class_access="none"
-                    label="New Suffix:"
-                    var_name="staticText_7" />
-                  <node
-                    class="wxComboBox"
-                    style="wxCB_DROPDOWN|wxCB_SORT"
-                    var_name="m_combo_suffixes" />
+                  var_name="box_sizer_11"
+                  alignment="wxALIGN_CENTER_HORIZONTAL">
                   <node
                     class="wxButton"
-                    label="Add"
-                    var_name="m_btn_add_new_suffix_2"
-                    wxEVT_BUTTON="OnAddSuffix" />
+                    class_access="none"
+                    label="Preview Changes"
+                    var_name="btn_5"
+                    wxEVT_BUTTON="OnUpdate" />
                 </node>
               </node>
             </node>
@@ -2012,12 +2008,16 @@
             class="wxBoxSizer">
             <node
               class="wxGrid"
-              autosize_cols="1"
+              cell_fit="ellipsize"
               col_label_values="&quot;Original&quot; &quot;Modified&quot;"
               cols="2"
-              default_col_size="200"
+              default_col_size="250"
+              editing="0"
               row_label_size="0"
-              selection_mode="wxGridSelectNone" />
+              rows="10"
+              selection_mode="wxGridSelectNone"
+              flags="wxEXPAND"
+              proportion="1" />
             <node
               class="wxButton"
               label="Commit change"
@@ -5513,7 +5513,7 @@
         local_hdr_includes="gen_enums.h"
         local_src_includes="../panels/nav_panel.h;mainframe.h;node.h;project_handler.h;unused_gen_dlg.h"
         system_hdr_includes="map;set"
-        class_members="&quot;std::string m_name;  // could be gen_name, var_name or label&quot; &quot;Node* m_form = nullptr;&quot; &quot;std::map&lt;std::string, std::set&lt;Node*>> m_map_found;&quot;"
+        class_members="&quot;std::string m_name;  // could be gen_name, var_name, label or ID&quot; &quot;Node* m_form = nullptr;&quot; &quot;std::map&lt;std::string, std::set&lt;Node*>> m_map_found;&quot;"
         class_methods="&quot;std::string&amp; GetNameChoice() { return m_name; }&quot; &quot;Node* GetForm() { return m_form; }&quot; &quot;void FindGenerators(Node* node);&quot; &quot;void FindVariables(Node* node);&quot; &quot;void FindLabels(Node* node);&quot;"
         derived_class_name="NodeSearchDlg"
         inserted_hdr_code="struct FoundInfo@@{@@    const char* name;@@    std::vector&lt;Node*> forms;@@};"

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -2009,7 +2009,7 @@
             <node
               class="wxGrid"
               cell_fit="ellipsize"
-              col_label_values="&quot;Original&quot; &quot;Modified&quot;"
+              col_label_values="Original;Modified"
               cols="2"
               default_col_size="250"
               editing="0"
@@ -3316,7 +3316,7 @@
         <node
           class="wxGrid"
           cell_vert_alignment="wxALIGN_CENTER"
-          col_label_values="&quot;name&quot; &quot;value&quot;"
+          col_label_values="name;value"
           cols="2"
           drag_row_size="0"
           rows="1"

--- a/src/wxui/wxui_code.cmake
+++ b/src/wxui/wxui_code.cmake
@@ -14,6 +14,7 @@ set (wxue_generated_code
     ${CMAKE_CURRENT_LIST_DIR}/../internal/unused_gen_dlg.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../internal/xrcpreview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../tools/generate_dlg.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../tools/global_ids_dlg_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../tools/preview_settings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/code_preference_dlg.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dlg_gen_results.cpp
@@ -43,7 +44,6 @@ set (wxue_generated_code
     # Base classes
     ${CMAKE_CURRENT_LIST_DIR}/../internal/convert_img_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../internal/msgframe_base.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/../tools/global_ids_dlg_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/artpropdlg_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/codedisplay_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/colourprop_base.cpp

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -5,6 +5,8 @@
     class="Project"
     art_directory="art"
     code_preference="Python"
+    id_prefixes="ISSUE_"
+    id_suffixes="_TEST; _PYTHON"
     base_directory="sdi/cpp"
     cmake_file="sdi/cpp/wxui_code.cmake"
     cmake_varname="sdi_generated_code"
@@ -328,6 +330,7 @@
                 hint="wxTextCtrl"
                 style="wxTE_RICH2"
                 var_name="m_text_ctrl"
+                id="TXT_CTRL"
                 flags="wxEXPAND"
                 wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;wxTextCtrl: wxEVT_TEXT&quot;);@@}[python:lambda]self.OnEventName(&quot;wx.TextCtrl: wx.EVT_TEXT&quot;)" />
               <node
@@ -549,7 +552,7 @@
                     var_name="m_staticText_4" />
                   <node
                     class="wxListView"
-                    column_labels="&quot;name&quot; &quot;value&quot;"
+                    column_labels="name;value"
                     contents="&quot;meaning ; 42 &quot;"
                     style="wxLC_SINGLE_SEL"
                     tooltip="Separate content columns with a semi-colon (;)" />
@@ -674,7 +677,7 @@
                       var_name="m_staticText9" />
                     <node
                       class="wxCheckListBox"
-                      contents="&quot;item #1&quot; &quot;item #2&quot; &quot;item #0&quot;"
+                      contents="item #1;item #2;item #0"
                       var_name="m_checkList_2"
                       wxEVT_CHECKLISTBOX="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;CheckListBox1: wx.EVT_CHECKLISTBOX&quot;);@@}[python:lambda]self.OnEventName(&quot;CheckListBox1: wx.EVT_CHECKLISTBOX&quot;)" />
                     <node
@@ -683,7 +686,7 @@
                       var_name="m_staticText10" />
                     <node
                       class="wxCheckListBox"
-                      contents="&quot;item #1&quot; &quot;item #2&quot; &quot;item #0&quot;"
+                      contents="item #1;item #2;item #0"
                       style="wxLB_SORT"
                       var_name="m_checkList2"
                       wxEVT_CHECKLISTBOX="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;CheckListBox2: wx.EVT_CHECKLISTBOX&quot;);@@}[python:lambda]self.OnEventName(&quot;CheckListBox2: wx.EVT_CHECKLISTBOX&quot;)" />
@@ -1790,10 +1793,11 @@
               borders="wxLEFT|wxTOP|wxBOTTOM" />
             <node
               class="wxTextCtrl"
-              auto_complete="&quot;foo&quot; &quot;bar&quot;"
+              auto_complete="foo;bar"
               style="wxTE_PROCESS_ENTER"
               value="Text &quot;ctrl&quot;"
               validator_variable="m_textCtrlValidate"
+              id="TXT_CTRL"
               tooltip="Auto-complete contains &quot;foo&quot; and &quot;bar&quot;"
               wxEVT_TEXT_ENTER="[this](wxCommandEvent&amp;)@@{@@m_infoBar->ShowMessage(&quot;wxEVT_TEXT_ENTER event&quot;);@@Fit();@@}" />
             <node
@@ -1949,7 +1953,7 @@
                   var_name="m_staticText9" />
                 <node
                   class="wxCheckListBox"
-                  contents="&quot;item #1&quot; &quot;item #2&quot; &quot;item #0&quot;"
+                  contents="item #1;item #2;item #0"
                   wxEVT_CHECKLISTBOX="OnListChecked" />
                 <node
                   class="wxStaticText"
@@ -1957,7 +1961,7 @@
                   var_name="m_staticText10" />
                 <node
                   class="wxCheckListBox"
-                  contents="&quot;item #1&quot; &quot;item #2&quot; &quot;item #0&quot;"
+                  contents="item #1;item #2;item #0"
                   style="wxLB_SORT"
                   var_name="m_checkList2" />
               </node>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new Global Edit Custom IDs menu item to the tools menu that can be used to modify multiple custom IDs at once. Modifications can be limited to a single form, every form in the project, or just multiply selected forms. Old prefixes and suffixes can be removed and new prefixes and suffixes can be added in a single operation.

Closes #1017
