### PR TITLE
Improve accuracy of internal Undo info

### DIFF
--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -770,7 +770,7 @@ void SortProjectAction::Change()
 
     for (auto& iter: Project.ChildNodePtrs())
     {
-        if (iter->isGen(gen_folder))
+        if (iter->isGen(gen_folder) || iter->isGen(gen_sub_folder))
         {
             SortFolder(iter.get());
         }

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -765,8 +765,6 @@ SortProjectAction::SortProjectAction()
 
 void SortProjectAction::Change()
 {
-    m_old_project = NodeCreation.MakeCopy(Project.ProjectNode());
-
     auto& children = Project.ChildNodePtrs();
     std::sort(children.begin(), children.end(), CompareClassNames);
 

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -282,7 +282,6 @@ protected:
     void SortFolder(Node* folder);
 
 private:
-    std::vector<NodeSharedPtr> m_children;
     NodeSharedPtr m_old_project;
 };
 

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -191,7 +191,7 @@ public:
     void Change() override;
     void Revert() override;
 
-    Node* GetOldNode() { return m_old_node.get(); }
+    NodeSharedPtr GetOldNode() override { return m_old_node; }
     Node* GetNode() { return m_node.get(); }
 
     size_t GetMemorySize() override { return sizeof(*this); }
@@ -210,7 +210,7 @@ public:
     void Change() override;
     void Revert() override;
 
-    Node* GetOldNode() { return m_old_node.get(); }
+    NodeSharedPtr GetOldNode() override { return m_old_node; }
     Node* GetNode() { return m_node.get(); }
 
     size_t GetMemorySize() override { return sizeof(*this); }
@@ -276,11 +276,13 @@ public:
     void Revert() override;
 
     size_t GetMemorySize() override { return sizeof(*this); }
+    NodeSharedPtr GetOldNode() override { return m_old_project; }
 
 protected:
     void SortFolder(Node* folder);
 
 private:
+    std::vector<NodeSharedPtr> m_children;
     NodeSharedPtr m_old_project;
 };
 

--- a/src/undo_stack.h
+++ b/src/undo_stack.h
@@ -32,6 +32,7 @@ public:
 
     // Size of the UndoAction object itself, plus any additional memory it allocates.
     virtual size_t GetMemorySize() = 0;
+    virtual NodeSharedPtr GetOldNode() { return nullptr; }
 
     tt_string GetUndoString() { return m_undo_string; }
     void SetUndoString(tt_string_view str) { m_undo_string = str; }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR greatly improves the accuracy of the internal `Undo Stack Information` dialog. It also adds sub folders to the forms being sorted when Sort Project is requested.