### PR TITLE
Improve node selection handling in header panel

### DIFF
--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -28,13 +28,6 @@ namespace pugi
 
 using EventVector = std::vector<NodeEvent*>;
 
-enum PANEL_PAGE : size_t
-{
-    NOT_PANEL,
-    CPP_PANEL,
-    HDR_PANEL,
-};
-
 namespace result
 {
     // These enums are returned to indicate the result of generating a file

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -178,6 +178,22 @@ void BasePanel::OnFind(wxFindDialogEvent& event)
     }
 }
 
+PANEL_PAGE BasePanel::GetPanelPage() const
+{
+    if (auto page = m_notebook->GetCurrentPage(); page)
+    {
+        if (page == m_cppPanel)
+            return CPP_PANEL;
+        else if (page == m_hPanel)
+            return HDR_PANEL;
+        else if (page == m_derived_src_panel)
+            return DERIVED_SRC_PANEL;
+        else if (page == m_derived_hdr_panel)
+            return DERIVED_HDR_PANEL;
+    }
+    return CPP_PANEL;
+}
+
 void BasePanel::GenerateBaseClass()
 {
     if (!IsShown())

--- a/src/panels/base_panel.h
+++ b/src/panels/base_panel.h
@@ -19,6 +19,15 @@ class wxAuiNotebook;
 class wxFindDialogEvent;
 class wxStyledTextCtrl;
 
+enum PANEL_PAGE : size_t
+{
+    NOT_PANEL,
+    CPP_PANEL,
+    HDR_PANEL,
+    DERIVED_SRC_PANEL,
+    DERIVED_HDR_PANEL,
+};
+
 class BasePanel : public wxPanel
 {
 public:
@@ -26,6 +35,8 @@ public:
     ~BasePanel() override;
 
     void GenerateBaseClass();
+
+    PANEL_PAGE GetPanelPage() const;
 
     void OnFind(wxFindDialogEvent& event);
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR improves handling of node selection when a Header panel is being displayed. In particular, it handles non-translation_unit, event handler name if Event panel is displayed, and find the variable name if the node's variable is non-local.