### PR TITLE
Add additional controls to SDI test

### DIFF
--- a/src/generate/gen_prop_item.cpp
+++ b/src/generate/gen_prop_item.cpp
@@ -15,7 +15,14 @@
 
 bool PropertyGridItemGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().Str(" = ").ValidParentName();
+    auto parent = code.node()->get_parent();
+    if (parent->isGen(gen_propGridCategory))
+    {
+        parent = parent->get_parent();
+    }
+
+    code.AddAuto().NodeName().Str(" = ");
+    code.NodeName(parent);
     // .Function("Append(new wx").PropAs(prop_type).Str("Property(");
 
     if (code.view(prop_type) == "Category")

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -21,7 +21,13 @@ wxObject* StaticCheckboxBoxSizerGenerator::CreateMockup(Node* node, wxObject* pa
 {
     wxStaticBoxSizer* sizer;
 
+    // When testing, always display the checkbox, otherwise if Python is preferred, then don't
+    // display the checkbox since Python doesn't support it.
+#if defined(INTERNAL_TESTING)
+    if (Project.HasValue(prop_code_preference))
+#else
     if (Project.value(prop_code_preference) != "Python")
+#endif
     {
         long style_value = 0;
         if (node->as_string(prop_style).contains("wxALIGN_RIGHT"))

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -21,7 +21,13 @@ wxObject* StaticRadioBtnBoxSizerGenerator::CreateMockup(Node* node, wxObject* pa
 {
     wxStaticBoxSizer* sizer;
 
+    // When testing, always display the checkbox, otherwise if Python is preferred, then don't
+    // display the checkbox since Python doesn't support it.
+#if defined(INTERNAL_TESTING)
+    if (Project.HasValue(prop_code_preference))
+#else
     if (Project.value(prop_code_preference) != "Python")
+#endif
     {
         m_radiobtn = new wxRadioButton(wxStaticCast(parent, wxWindow), wxID_ANY, node->as_wxString(prop_label));
         if (node->as_bool(prop_checked))

--- a/tests/sdi/cpp/commonctrls.cpp
+++ b/tests/sdi/cpp/commonctrls.cpp
@@ -73,7 +73,7 @@ bool CommonCtrls::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     m_staticText = new wxStaticText(this, wxID_ANY, "Text:");
     box_sizer->Add(m_staticText, wxSizerFlags().Center().Border(wxLEFT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
-    m_textCtrl = new wxTextCtrl(this, wxID_ANY, "Text \"ctrl\"", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+    m_textCtrl = new wxTextCtrl(this, TXT_CTRL, "Text \"ctrl\"", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
     {
         wxArrayString tmp_array;
         tmp_array.Add("foo");

--- a/tests/sdi/cpp/commonctrls.h
+++ b/tests/sdi/cpp/commonctrls.h
@@ -53,6 +53,11 @@ public:
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr);
 
+    enum
+    {
+        TXT_CTRL = wxID_HIGHEST + 1
+    };
+
 public:
     ~CommonCtrls();
 

--- a/tests/sdi/cpp/maintestdialog.cpp
+++ b/tests/sdi/cpp/maintestdialog.cpp
@@ -667,6 +667,22 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     page_sizer->Add(box_sizer_18, wxSizerFlags().Border(wxALL));
     page_7->SetSizerAndFit(page_sizer);
 
+    auto* page_8 = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(page_8, "Data");
+    page_8->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+
+    auto* page_sizer_4 = new wxBoxSizer(wxVERTICAL);
+
+    propertyGrid = new wxPropertyGrid(page_8, wxID_ANY);
+    page_sizer_4->Add(propertyGrid, wxSizerFlags().Expand().Border(wxALL));
+
+    propertyGridItem = propertyGrid->Append(new wxPropertyCategory("CategoryName", "CategoryName"));
+
+    propertyGridItem_2 = propertyGrid->Append(new wxStringProperty("String", wxEmptyString));
+
+    propertyGridItem_3 = propertyGrid->Append(new wxIntProperty("Integer", wxEmptyString));
+    page_8->SetSizerAndFit(page_sizer_4);
+
     auto* box_sizer_14 = new wxBoxSizer(wxHORIZONTAL);
 
     auto* staticText_4 = new wxStaticText(this, wxID_ANY, "Events:");
@@ -688,11 +704,21 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     Centre(wxBOTH);
 
     // Event handlers
-    btn->Bind(wxEVT_BUTTON, &MainTestDialog::OnClearList, this);
     m_btn->Bind(wxEVT_BUTTON,
         [this](wxCommandEvent&)
         {
             OnEventName("Button: wxEVT_BUTTON");
+        });
+    m_btn_3->Bind(wxEVT_BUTTON,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("Button: wxEVT_BUTTON");
+        });
+    btn2->Bind(wxEVT_BUTTON, &MainTestDialog::OnPopupBtn, this);
+    m_btn_7->Bind(wxEVT_BUTTON,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("Ceci est une phrase en français.");
         });
     m_btn_2->Bind(wxEVT_BUTTON,
         [this](wxCommandEvent&)
@@ -709,28 +735,17 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
         {
             OnEventName("Button: wxEVT_BUTTON");
         });
-    m_btn_5->Bind(wxEVT_BUTTON,
-        [this](wxCommandEvent&)
-        {
-            OnEventName("CmdLinkBtn: wxEVT_BUTTON");
-        });
-    m_btn_3->Bind(wxEVT_BUTTON,
-        [this](wxCommandEvent&)
-        {
-            OnEventName("Button: wxEVT_BUTTON");
-        });
-    btn2->Bind(wxEVT_BUTTON, &MainTestDialog::OnPopupBtn, this);
     m_btn_6->Bind(wxEVT_BUTTON,
         [this](wxCommandEvent&)
         {
             OnEventName("This is a sentence in English.");
         });
-    m_btn_7->Bind(wxEVT_BUTTON,
+    btn->Bind(wxEVT_BUTTON, &MainTestDialog::OnClearList, this);
+    m_btn_5->Bind(wxEVT_BUTTON,
         [this](wxCommandEvent&)
         {
-            OnEventName("Ceci est une phrase en français.");
+            OnEventName("CmdLinkBtn: wxEVT_BUTTON");
         });
-    disable_bitmaps->Bind(wxEVT_CHECKBOX, &MainTestDialog::OnDisableBitmapsBtn, this);
     m_checkPlayAnimation->Bind(wxEVT_CHECKBOX,
         [this](wxCommandEvent&)
         {
@@ -743,6 +758,7 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
                 m_animation_ctrl->Stop();
             }
         });
+    disable_bitmaps->Bind(wxEVT_CHECKBOX, &MainTestDialog::OnDisableBitmapsBtn, this);
     m_checkList2->Bind(wxEVT_CHECKLISTBOX,
         [this](wxCommandEvent&)
         {
@@ -753,12 +769,12 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
         {
             OnEventName("CheckListBox1: wx.EVT_CHECKLISTBOX");
         });
-    m_choice2->Bind(wxEVT_CHOICE,
+    m_choice->Bind(wxEVT_CHOICE,
         [this](wxCommandEvent&)
         {
             OnEventName("Choice: wx.EVT_CHOICE");
         });
-    m_choice->Bind(wxEVT_CHOICE,
+    m_choice2->Bind(wxEVT_CHOICE,
         [this](wxCommandEvent&)
         {
             OnEventName("Choice: wx.EVT_CHOICE");
@@ -768,12 +784,12 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
         {
             OnEventName("ColourPicker: wxEVT_COLOURPICKER_CHANGED");
         });
-    m_comboBox2->Bind(wxEVT_COMBOBOX,
+    m_comboBox->Bind(wxEVT_COMBOBOX,
         [this](wxCommandEvent&)
         {
             OnEventName("Combobox: wxEVT_COMBOBOX");
         });
-    m_comboBox->Bind(wxEVT_COMBOBOX,
+    m_comboBox2->Bind(wxEVT_COMBOBOX,
         [this](wxCommandEvent&)
         {
             OnEventName("Combobox: wxEVT_COMBOBOX");
@@ -799,15 +815,15 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
             OnEventName("FontPicker: wx.OnFontChanged");
         });
     Bind(wxEVT_INIT_DIALOG, &MainTestDialog::OnInit, this);
-    m_listBox2->Bind(wxEVT_LISTBOX,
-        [this](wxCommandEvent&)
-        {
-            OnEventName("ListBox2: wxEVT_LISTBOX");
-        });
     m_listbox->Bind(wxEVT_LISTBOX,
         [this](wxCommandEvent&)
         {
             OnEventName("ListBox1: wxEVT_LISTBOX");
+        });
+    m_listBox2->Bind(wxEVT_LISTBOX,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("ListBox2: wxEVT_LISTBOX");
         });
     m_notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &MainTestDialog::OnPageChanged, this);
     radioBox->Bind(wxEVT_RADIOBOX,
@@ -815,30 +831,60 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
         {
             OnEventName("RadioBox: wxEVT_RADIOBOX");
         });
-    m_radioBtn2->Bind(wxEVT_RADIOBUTTON,
+    m_radioBtn_4->Bind(wxEVT_RADIOBUTTON,
         [this](wxCommandEvent&)
         {
-            OnEventName("RadioButton: wxEVT_RADIOBUTTON");
+            OnEventName("wxRadioButton: wxEVT_RADIOBUTTON");
+        });
+    m_radioBtn_2->Bind(wxEVT_RADIOBUTTON,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("wxRadioButton: wxEVT_RADIOBUTTON");
+        });
+    m_radioBtn_7->Bind(wxEVT_RADIOBUTTON,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("wxRadioButton: wxEVT_RADIOBUTTON");
         });
     m_radioBtn->Bind(wxEVT_RADIOBUTTON,
         [this](wxCommandEvent&)
         {
             OnEventName("RadioButton: wxEVT_RADIOBUTTON");
         });
+    m_radioBtn_6->Bind(wxEVT_RADIOBUTTON,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("wxRadioButton: wxEVT_RADIOBUTTON");
+        });
+    m_radioBtn2->Bind(wxEVT_RADIOBUTTON,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("RadioButton: wxEVT_RADIOBUTTON");
+        });
+    m_radioBtn_5->Bind(wxEVT_RADIOBUTTON,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("wxRadioButton: wxEVT_RADIOBUTTON");
+        });
+    m_radioBtn_3->Bind(wxEVT_RADIOBUTTON,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("wxRadioButton: wxEVT_RADIOBUTTON");
+        });
     m_scintilla->Bind(wxEVT_STC_CHANGE,
         [this](wxStyledTextEvent&)
         {
             OnEventName("wxStyledTextCtrl: wxEVT_STC_CHANGE");
         });
-    m_richText->Bind(wxEVT_TEXT,
-        [this](wxCommandEvent&)
-        {
-            OnEventName("wxRichTextCtrl: wxEVT_TEXT");
-        });
     m_text_ctrl->Bind(wxEVT_TEXT,
         [this](wxCommandEvent&)
         {
             OnEventName("wxTextCtrl: wxEVT_TEXT");
+        });
+    m_richText->Bind(wxEVT_TEXT,
+        [this](wxCommandEvent&)
+        {
+            OnEventName("wxRichTextCtrl: wxEVT_TEXT");
         });
     m_timePicker->Bind(wxEVT_TIME_CHANGED,
         [this](wxDateEvent&)

--- a/tests/sdi/cpp/maintestdialog.cpp
+++ b/tests/sdi/cpp/maintestdialog.cpp
@@ -443,6 +443,21 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     static_box->Add(box_sizer3, wxSizerFlags().Expand().Border(wxALL));
 
     page_sizer_2->Add(static_box, wxSizerFlags().Expand().Border(wxALL));
+
+    auto* box_sizer_20 = new wxBoxSizer(wxVERTICAL);
+
+    collapsible_pane = new wxCollapsiblePane(page_3, wxID_ANY, "Collapsible Pane");
+    collapsible_pane->Expand();
+    box_sizer_20->Add(collapsible_pane, wxSizerFlags().Expand().Border(wxALL));
+
+    auto* box_sizer_21 = new wxBoxSizer(wxHORIZONTAL);
+
+    staticText_5 = new wxStaticText(collapsible_pane->GetPane(), wxID_ANY,
+        "This text will be hidden if the Pane is collapsed.");
+    box_sizer_21->Add(staticText_5, wxSizerFlags().Border(wxALL));
+    collapsible_pane->GetPane()->SetSizerAndFit(box_sizer_21);
+
+    page_sizer_2->Add(box_sizer_20, wxSizerFlags().Border(wxALL));
     page_3->SetSizerAndFit(page_sizer_2);
 
     auto* page_6 = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_THEME|wxTAB_TRAVERSAL);

--- a/tests/sdi/cpp/maintestdialog.cpp
+++ b/tests/sdi/cpp/maintestdialog.cpp
@@ -70,7 +70,7 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     auto* page_sizer_1 = new wxBoxSizer(wxVERTICAL);
 
-    m_text_ctrl = new wxTextCtrl(page_2, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_RICH2);
+    m_text_ctrl = new wxTextCtrl(page_2, TXT_CTRL, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_RICH2);
     m_text_ctrl->SetHint("wxTextCtrl");
     page_sizer_1->Add(m_text_ctrl, wxSizerFlags().Expand().Border(wxALL));
 
@@ -174,6 +174,48 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     radioBox->SetSelection(1);
     radioBox->SetValidator(wxGenericValidator(&m_valRadio));
     box_sizer_7->Add(radioBox, wxSizerFlags().Border(wxALL));
+
+    m_checkBox_sizer = new wxCheckBox(page_4, wxID_ANY, "Checkbox");
+    auto* static_box_4 = new wxStaticBoxSizer(new wxStaticBox(page_4, wxID_ANY,
+#if wxCHECK_VERSION(3, 1, 1)
+        m_checkBox_sizer),
+#else
+        wxEmptyString),
+#endif
+    wxVERTICAL);
+
+    m_radioBtn_4 = new wxRadioButton(static_box_4->GetStaticBox(), wxID_ANY, "First button");
+    static_box_4->Add(m_radioBtn_4, wxSizerFlags().Border(wxALL));
+
+    m_radioBtn_2 = new wxRadioButton(static_box_4->GetStaticBox(), wxID_ANY, "Second button");
+    m_radioBtn_2->SetValue(true);
+    static_box_4->Add(m_radioBtn_2, wxSizerFlags().Border(wxALL));
+
+    m_radioBtn_3 = new wxRadioButton(static_box_4->GetStaticBox(), wxID_ANY, "Third button");
+    static_box_4->Add(m_radioBtn_3, wxSizerFlags().Border(wxALL));
+
+    box_sizer_7->Add(static_box_4, wxSizerFlags().Border(wxALL));
+
+    m_radioBtn__sizer = new wxRadioButton(page_4, wxID_ANY, "Radio");
+    auto* static_box_5 = new wxStaticBoxSizer(new wxStaticBox(page_4, wxID_ANY,
+#if wxCHECK_VERSION(3, 1, 1)
+        m_radioBtn__sizer),
+#else
+        wxEmptyString),
+#endif
+    wxVERTICAL);
+
+    m_radioBtn_5 = new wxRadioButton(static_box_5->GetStaticBox(), wxID_ANY, "First button");
+    static_box_5->Add(m_radioBtn_5, wxSizerFlags().Border(wxALL));
+
+    m_radioBtn_6 = new wxRadioButton(static_box_5->GetStaticBox(), wxID_ANY, "Second button");
+    m_radioBtn_6->SetValue(true);
+    static_box_5->Add(m_radioBtn_6, wxSizerFlags().Border(wxALL));
+
+    m_radioBtn_7 = new wxRadioButton(static_box_5->GetStaticBox(), wxID_ANY, "Third button");
+    static_box_5->Add(m_radioBtn_7, wxSizerFlags().Border(wxALL));
+
+    box_sizer_7->Add(static_box_5, wxSizerFlags().Border(wxALL));
 
     box_sizer_3->Add(box_sizer_7, wxSizerFlags().Border(wxALL));
 

--- a/tests/sdi/cpp/maintestdialog.h
+++ b/tests/sdi/cpp/maintestdialog.h
@@ -72,6 +72,11 @@ public:
     static const int DLG_MAINTEST = wxID_HIGHEST + 100;
     static const int ID_RICHTEXT = 100;
 
+    enum
+    {
+        TXT_CTRL = wxID_HIGHEST + 1
+    };
+
     void OnEventName(const std::string& event_name)
     {
         m_events_list->Select(m_events_list->Append(wxString().FromUTF8(event_name)));
@@ -107,6 +112,7 @@ protected:
     wxButton* m_btn_7;
     wxButton* m_btn_bitmaps;
     wxCheckBox* m_checkBox;
+    wxCheckBox* m_checkBox_sizer;
     wxCheckBox* m_checkPlayAnimation;
     wxCheckListBox* m_checkList2;
     wxCheckListBox* m_checkList;
@@ -130,6 +136,13 @@ protected:
     wxNotebook* m_notebook;
     wxRadioButton* m_radioBtn2;
     wxRadioButton* m_radioBtn;
+    wxRadioButton* m_radioBtn_2;
+    wxRadioButton* m_radioBtn_3;
+    wxRadioButton* m_radioBtn_4;
+    wxRadioButton* m_radioBtn_5;
+    wxRadioButton* m_radioBtn_6;
+    wxRadioButton* m_radioBtn_7;
+    wxRadioButton* m_radioBtn__sizer;
     wxRearrangeCtrl* m_rearrange;
     wxRibbonBar* m_rbnBar;
     wxRichTextCtrl* m_richText;

--- a/tests/sdi/cpp/maintestdialog.h
+++ b/tests/sdi/cpp/maintestdialog.h
@@ -18,6 +18,7 @@
 #include <wx/checklst.h>
 #include <wx/choice.h>
 #include <wx/clrpicker.h>
+#include <wx/collpane.h>
 #include <wx/colour.h>
 #include <wx/combobox.h>
 #include <wx/commandlinkbutton.h>
@@ -119,6 +120,7 @@ protected:
     wxCheckListBox* m_checkList_2;
     wxChoice* m_choice2;
     wxChoice* m_choice;
+    wxCollapsiblePane* collapsible_pane;
     wxColourPickerCtrl* m_colourPicker;
     wxComboBox* m_comboBox2;
     wxComboBox* m_comboBox;
@@ -158,6 +160,7 @@ protected:
     wxStaticText* m_staticText_2;
     wxStaticText* m_staticText_3;
     wxStaticText* m_staticText_4;
+    wxStaticText* staticText_5;
     wxStyledTextCtrl* m_scintilla;
     wxTextCtrl* m_text_ctrl;
     wxTimePickerCtrl* m_timePicker;

--- a/tests/sdi/cpp/maintestdialog.h
+++ b/tests/sdi/cpp/maintestdialog.h
@@ -39,6 +39,7 @@
 #include <wx/listbox.h>
 #include <wx/listctrl.h>
 #include <wx/notebook.h>
+#include <wx/propgrid/propgrid.h>
 #include <wx/radiobut.h>
 #include <wx/rearrangectrl.h>
 #include <wx/ribbon/art.h>
@@ -136,6 +137,10 @@ protected:
     wxListBox* m_listbox;
     wxListView* m_listview;
     wxNotebook* m_notebook;
+    wxPGProperty* propertyGridItem;
+    wxPGProperty* propertyGridItem_2;
+    wxPGProperty* propertyGridItem_3;
+    wxPropertyGrid* propertyGrid;
     wxRadioButton* m_radioBtn2;
     wxRadioButton* m_radioBtn;
     wxRadioButton* m_radioBtn_2;

--- a/tests/sdi/python/main_test_dlg.py
+++ b/tests/sdi/python/main_test_dlg.py
@@ -11,6 +11,7 @@ import wx.html
 import wx.ribbon
 import wx.richtext
 import wx.stc
+TXT_CTRL = wx.ID_HIGHEST + 1
 DLG_MAINTEST = wx.ID_HIGHEST + 100
 ID_RICHTEXT = 100
 
@@ -76,7 +77,7 @@ class MainTestDialog(wx.Dialog):
 
         page_sizer_1 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_text_ctrl = wx.TextCtrl(page_2, wx.ID_ANY, "", wx.DefaultPosition,
+        self.m_text_ctrl = wx.TextCtrl(page_2, TXT_CTRL, "", wx.DefaultPosition,
             wx.DefaultSize, wx.TE_RICH2)
         self.m_text_ctrl.SetHint("wxTextCtrl")
         page_sizer_1.Add(self.m_text_ctrl, wx.SizerFlags().Expand().Border(wx.ALL))
@@ -171,6 +172,42 @@ class MainTestDialog(wx.Dialog):
             wx.RA_SPECIFY_ROWS)
         radioBox.SetSelection(1)
         box_sizer_7.Add(radioBox, wx.SizerFlags().Border(wx.ALL))
+
+        # wxPython currently does not support a checkbox as a static box label
+        static_box_4 = wx.StaticBoxSizer(wx.VERTICAL, page_4, "Checkbox")
+
+        self.m_radioBtn_4 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
+            "First button")
+        static_box_4.Add(self.m_radioBtn_4, wx.SizerFlags().Border(wx.ALL))
+
+        self.m_radioBtn_2 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
+            "Second button")
+        self.m_radioBtn_2.SetValue(True)
+        static_box_4.Add(self.m_radioBtn_2, wx.SizerFlags().Border(wx.ALL))
+
+        self.m_radioBtn_3 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
+            "Third button")
+        static_box_4.Add(self.m_radioBtn_3, wx.SizerFlags().Border(wx.ALL))
+
+        box_sizer_7.Add(static_box_4, wx.SizerFlags().Border(wx.ALL))
+
+        # wxPython currently does not support a radio button as a static box label
+        static_box_5 = wx.StaticBoxSizer(wx.VERTICAL, page_4, "Radio")
+
+        self.m_radioBtn_5 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
+            "First button")
+        static_box_5.Add(self.m_radioBtn_5, wx.SizerFlags().Border(wx.ALL))
+
+        self.m_radioBtn_6 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
+            "Second button")
+        self.m_radioBtn_6.SetValue(True)
+        static_box_5.Add(self.m_radioBtn_6, wx.SizerFlags().Border(wx.ALL))
+
+        self.m_radioBtn_7 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
+            "Third button")
+        static_box_5.Add(self.m_radioBtn_7, wx.SizerFlags().Border(wx.ALL))
+
+        box_sizer_7.Add(static_box_5, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_3.Add(box_sizer_7, wx.SizerFlags().Border(wx.ALL))
 

--- a/tests/sdi/python/main_test_dlg.py
+++ b/tests/sdi/python/main_test_dlg.py
@@ -449,6 +449,21 @@ class MainTestDialog(wx.Dialog):
         static_box.Add(box_sizer3, wx.SizerFlags().Expand().Border(wx.ALL))
 
         page_sizer_2.Add(static_box, wx.SizerFlags().Expand().Border(wx.ALL))
+
+        box_sizer_20 = wx.BoxSizer(wx.VERTICAL)
+
+        self.collapsible_pane = wx.CollapsiblePane(page_3, wx.ID_ANY, "Collapsible Pane")
+        self.collapsible_pane.Expand()
+        box_sizer_20.Add(self.collapsible_pane, wx.SizerFlags().Expand().Border(wx.ALL))
+
+        box_sizer_21 = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.staticText_5 = wx.StaticText(self.collapsible_pane.GetPane(), wx.ID_ANY,
+            "This text will be hidden if the Pane is collapsed.")
+        box_sizer_21.Add(self.staticText_5, wx.SizerFlags().Border(wx.ALL))
+        self.collapsible_pane.GetPane().SetSizerAndFit(box_sizer_21)
+
+        page_sizer_2.Add(box_sizer_20, wx.SizerFlags().Border(wx.ALL))
         page_3.SetSizerAndFit(page_sizer_2)
 
         page_6 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,

--- a/tests/sdi/python/main_test_dlg.py
+++ b/tests/sdi/python/main_test_dlg.py
@@ -8,6 +8,7 @@
 import wx
 import wx.adv
 import wx.html
+import wx.propgrid
 import wx.ribbon
 import wx.richtext
 import wx.stc
@@ -676,6 +677,26 @@ class MainTestDialog(wx.Dialog):
         page_sizer.Add(box_sizer_18, wx.SizerFlags().Border(wx.ALL))
         page_7.SetSizerAndFit(page_sizer)
 
+        page_8 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+            wx.TAB_TRAVERSAL)
+        self.m_notebook.AddPage(page_8, "Data")
+        page_8.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
+
+        page_sizer_4 = wx.BoxSizer(wx.VERTICAL)
+
+        self.propertyGrid = wx.propgrid.PropertyGrid(page_8, wx.ID_ANY)
+        page_sizer_4.Add(self.propertyGrid, wx.SizerFlags().Expand().Border(wx.ALL))
+
+        self.propertyGridItem = self.propertyGrid.Append(wx.propgrid.PropertyCategory(
+        "CategoryName", "CategoryName"))
+
+        self.propertyGridItem_2 = self.propertyGrid.Append(wx.propgrid.StringProperty(
+        "String", ""))
+
+        self.propertyGridItem_3 = self.propertyGrid.Append(wx.propgrid.IntProperty(
+        "Integer", ""))
+        page_8.SetSizerAndFit(page_sizer_4)
+
         box_sizer_14 = wx.BoxSizer(wx.HORIZONTAL)
 
         staticText_4 = wx.StaticText(self, wx.ID_ANY, "Events:")
@@ -707,32 +728,32 @@ class MainTestDialog(wx.Dialog):
         self.Centre(wx.BOTH)
 
         # Bind Event handlers
-        btn.Bind(wx.EVT_BUTTON, self.OnClearList)
         self.m_btn.Bind(wx.EVT_BUTTON, lambda event:
             self.m_events_list.Select(self.m_events_list.Append("Button: wx.EVT_BUTTON")))
+        self.m_btn_3.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("Button: wx.EVT_BUTTON"))
+        btn2.Bind(wx.EVT_BUTTON, self.OnPopupBtn)
+        self.m_btn_7.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("Ceci est une phrase en français."))
         self.m_btn_2.Bind(wx.EVT_BUTTON, lambda event:
             self.m_events_list.Select(self.m_events_list.Append("Button: wx.EVT_BUTTON")))
         self.m_btn_bitmaps.Bind(wx.EVT_BUTTON, lambda event:
             self.m_events_list.Select(self.m_events_list.Append("Button: wx.EVT_BUTTON")))
         self.m_btn_4.Bind(wx.EVT_BUTTON, lambda event:
             self.m_events_list.Select(self.m_events_list.Append("Button: wx.EVT_BUTTON")))
+        self.m_btn_6.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("This is a sentence in English."))
+        btn.Bind(wx.EVT_BUTTON, self.OnClearList)
         self.m_btn_5.Bind(wx.EVT_BUTTON, lambda event:
             self.m_events_list.Select(self.m_events_list.Append("CmdLinkBtn: wx.EVT_BUTTON")))
-        self.m_btn_3.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("Button: wx.EVT_BUTTON"))
-        btn2.Bind(wx.EVT_BUTTON, self.OnPopupBtn)
-        self.m_btn_6.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("This is a sentence in English."))
-        self.m_btn_7.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("Ceci est une phrase en français."))
         disable_bitmaps.Bind(wx.EVT_CHECKBOX, self.OnDisableBitmapsBtn)
         self.m_checkList2.Bind(wx.EVT_CHECKLISTBOX, lambda event:
             self.OnEventName("CheckListBox2: wx.EVT_CHECKLISTBOX"))
         self.m_checkList_2.Bind(wx.EVT_CHECKLISTBOX, lambda event:
             self.OnEventName("CheckListBox1: wx.EVT_CHECKLISTBOX"))
-        self.m_choice2.Bind(wx.EVT_CHOICE, lambda event:self.OnEventName("OnChoice: wx.EVT_CHOICE"))
         self.m_choice.Bind(wx.EVT_CHOICE, lambda event:self.OnEventName("Choice: wx.EVT_CHOICE"))
+        self.m_choice2.Bind(wx.EVT_CHOICE, lambda event:self.OnEventName("OnChoice: wx.EVT_CHOICE"))
         self.m_colourPicker.Bind(wx.EVT_COLOURPICKER_CHANGED, lambda event:
             self.OnEventName("ColourPicker: wx.EVT_COLOURPICKER_CHANGED"))
-        self.m_comboBox2.Bind(wx.EVT_COMBOBOX, lambda event:self.OnEventName("OnCombobox: wx.EVT_COMBOBOX"))
         self.m_comboBox.Bind(wx.EVT_COMBOBOX, lambda event:self.OnEventName("Combobox: wx.EVT_COMBOBOX"))
+        self.m_comboBox2.Bind(wx.EVT_COMBOBOX, lambda event:self.OnEventName("OnCombobox: wx.EVT_COMBOBOX"))
         self.m_datePicker.Bind(wx.adv.EVT_DATE_CHANGED, lambda event:
             self.OnEventName("DatePicker: wx.EVT_DATE_CHANGED"))
         self.m_dirPicker.Bind(wx.EVT_DIRPICKER_CHANGED, lambda event:
@@ -742,18 +763,30 @@ class MainTestDialog(wx.Dialog):
         self.m_fontPicker.Bind(wx.EVT_FONTPICKER_CHANGED, lambda event:
             self.OnEventName("FontPicker: wx.OnFontChanged"))
         self.Bind(wx.EVT_INIT_DIALOG, self.OnInit)
-        self.m_listBox2.Bind(wx.EVT_LISTBOX, lambda event:self.OnEventName("ListBox2: wx.EVT_LISTBOX"))
         self.m_listbox.Bind(wx.EVT_LISTBOX, lambda event:self.OnEventName("ListBox1: wx.EVT_LISTBOX"))
+        self.m_listBox2.Bind(wx.EVT_LISTBOX, lambda event:self.OnEventName("ListBox2: wx.EVT_LISTBOX"))
         self.m_notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self.OnPageChanged)
         radioBox.Bind(wx.EVT_RADIOBOX, lambda event:self.OnEventName("RadioBox: wx.EVT_RADIOBOX"))
-        self.m_radioBtn2.Bind(wx.EVT_RADIOBUTTON, lambda event:
-            self.OnEventName("RadioButton: wx.EVT_RADIOBUTTON"))
+        self.m_radioBtn_4.Bind(wx.EVT_RADIOBUTTON, lambda event:
+            self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
+        self.m_radioBtn_2.Bind(wx.EVT_RADIOBUTTON, lambda event:
+            self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
+        self.m_radioBtn_7.Bind(wx.EVT_RADIOBUTTON, lambda event:
+            self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
         self.m_radioBtn.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("RadioButton: wx.EVT_RADIOBUTTON"))
+        self.m_radioBtn_6.Bind(wx.EVT_RADIOBUTTON, lambda event:
+            self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
+        self.m_radioBtn2.Bind(wx.EVT_RADIOBUTTON, lambda event:
+            self.OnEventName("RadioButton: wx.EVT_RADIOBUTTON"))
+        self.m_radioBtn_5.Bind(wx.EVT_RADIOBUTTON, lambda event:
+            self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
+        self.m_radioBtn_3.Bind(wx.EVT_RADIOBUTTON, lambda event:
+            self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
         self.m_scintilla.Bind(wx.stc.EVT_STC_CHANGE, lambda event:
             self.OnEventName("wx.StyledTextCtrl: wx.EVT_STC_CHANGE"))
-        self.m_richText.Bind(wx.EVT_TEXT, lambda event:self.OnEventName("wx.RichTextCtrl: wx.EVT_TEXT"))
         self.m_text_ctrl.Bind(wx.EVT_TEXT, lambda event:self.OnEventName("wx.TextCtrl: wx.EVT_TEXT"))
+        self.m_richText.Bind(wx.EVT_TEXT, lambda event:self.OnEventName("wx.RichTextCtrl: wx.EVT_TEXT"))
         self.m_timePicker.Bind(wx.adv.EVT_TIME_CHANGED, lambda event:
             self.OnEventName("TimePicker: wx.EVT_TIME_CHANGED"))
         self.m_toggleBtn.Bind(wx.EVT_TOGGLEBUTTON, lambda event:self.OnEventName("OnToggle: wx.EVT_BUTTON"))

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -445,16 +445,19 @@
                   <node
                     class="wxRadioButton"
                     label="First button"
-                    var_name="m_radioBtn_4" />
+                    var_name="m_radioBtn_4"
+                    wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;wxRadioButton: wxEVT_RADIOBUTTON&quot;);@@}[python:lambda]self.OnEventName(&quot;wx.RadioButton: wx.EVT_RADIOBUTTON&quot;)" />
                   <node
                     class="wxRadioButton"
                     checked="1"
                     label="Second button"
-                    var_name="m_radioBtn_2" />
+                    var_name="m_radioBtn_2"
+                    wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;wxRadioButton: wxEVT_RADIOBUTTON&quot;);@@}[python:lambda]self.OnEventName(&quot;wx.RadioButton: wx.EVT_RADIOBUTTON&quot;)" />
                   <node
                     class="wxRadioButton"
                     label="Third button"
-                    var_name="m_radioBtn_3" />
+                    var_name="m_radioBtn_3"
+                    wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;wxRadioButton: wxEVT_RADIOBUTTON&quot;);@@}[python:lambda]self.OnEventName(&quot;wx.RadioButton: wx.EVT_RADIOBUTTON&quot;)" />
                 </node>
                 <node
                   class="StaticRadioBtnBoxSizer"
@@ -464,16 +467,19 @@
                   <node
                     class="wxRadioButton"
                     label="First button"
-                    var_name="m_radioBtn_5" />
+                    var_name="m_radioBtn_5"
+                    wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;wxRadioButton: wxEVT_RADIOBUTTON&quot;);@@}[python:lambda]self.OnEventName(&quot;wx.RadioButton: wx.EVT_RADIOBUTTON&quot;)" />
                   <node
                     class="wxRadioButton"
                     checked="1"
                     label="Second button"
-                    var_name="m_radioBtn_6" />
+                    var_name="m_radioBtn_6"
+                    wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;wxRadioButton: wxEVT_RADIOBUTTON&quot;);@@}[python:lambda]self.OnEventName(&quot;wx.RadioButton: wx.EVT_RADIOBUTTON&quot;)" />
                   <node
                     class="wxRadioButton"
                     label="Third button"
-                    var_name="m_radioBtn_7" />
+                    var_name="m_radioBtn_7"
+                    wxEVT_RADIOBUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;wxRadioButton: wxEVT_RADIOBUTTON&quot;);@@}[python:lambda]self.OnEventName(&quot;wx.RadioButton: wx.EVT_RADIOBUTTON&quot;)" />
                 </node>
               </node>
               <node
@@ -1039,6 +1045,36 @@
                   bitmap="Embed;wiztest.png"
                   direction="wxLEFT"
                   title="This is a long title" />
+              </node>
+            </node>
+          </node>
+          <node
+            class="BookPage"
+            label="Data"
+            var_name="page_8"
+            background_colour="wxSYS_COLOUR_BTNFACE"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="page_sizer_4">
+              <node
+                class="wxPropertyGrid"
+                var_name="propertyGrid"
+                flags="wxEXPAND">
+                <node
+                  class="propGridCategory"
+                  var_name="propertyGridItem">
+                  <node
+                    class="propGridItem"
+                    label="String"
+                    var_name="propertyGridItem_2" />
+                  <node
+                    class="propGridItem"
+                    label="Integer"
+                    type="Int"
+                    var_name="propertyGridItem_3" />
+                </node>
               </node>
             </node>
           </node>

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -20,7 +20,6 @@
     xrc_directory="sdi/xrc">
     <node
       class="Images"
-      auto_update="1"
       base_file="images">
       <node
         class="embedded_image"
@@ -438,6 +437,44 @@
                   var_name="radioBox"
                   validator_variable="m_valRadio"
                   wxEVT_RADIOBOX="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;RadioBox: wxEVT_RADIOBOX&quot;);@@}[python:lambda]self.OnEventName(&quot;RadioBox: wx.EVT_RADIOBOX&quot;)" />
+                <node
+                  class="StaticCheckboxBoxSizer"
+                  checkbox_var_name="m_checkBox_sizer"
+                  label="Checkbox"
+                  var_name="static_box_4">
+                  <node
+                    class="wxRadioButton"
+                    label="First button"
+                    var_name="m_radioBtn_4" />
+                  <node
+                    class="wxRadioButton"
+                    checked="1"
+                    label="Second button"
+                    var_name="m_radioBtn_2" />
+                  <node
+                    class="wxRadioButton"
+                    label="Third button"
+                    var_name="m_radioBtn_3" />
+                </node>
+                <node
+                  class="StaticRadioBtnBoxSizer"
+                  label="Radio"
+                  radiobtn_var_name="m_radioBtn__sizer"
+                  var_name="static_box_5">
+                  <node
+                    class="wxRadioButton"
+                    label="First button"
+                    var_name="m_radioBtn_5" />
+                  <node
+                    class="wxRadioButton"
+                    checked="1"
+                    label="Second button"
+                    var_name="m_radioBtn_6" />
+                  <node
+                    class="wxRadioButton"
+                    label="Third button"
+                    var_name="m_radioBtn_7" />
+                </node>
               </node>
               <node
                 class="wxStaticLine"

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -611,7 +611,8 @@
             <node
               class="wxBoxSizer"
               orientation="wxVERTICAL"
-              var_name="page_sizer_2">
+              var_name="page_sizer_2"
+              flags="wxEXPAND">
               <node
                 class="wxStaticBoxSizer"
                 label="Combos and Choices"
@@ -727,6 +728,25 @@
                       style="wxLB_SORT"
                       var_name="m_checkList2"
                       wxEVT_CHECKLISTBOX="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;CheckListBox2: wx.EVT_CHECKLISTBOX&quot;);@@}[python:lambda]self.OnEventName(&quot;CheckListBox2: wx.EVT_CHECKLISTBOX&quot;)" />
+                  </node>
+                </node>
+              </node>
+              <node
+                class="wxBoxSizer"
+                orientation="wxVERTICAL"
+                var_name="box_sizer_20">
+                <node
+                  class="wxCollapsiblePane"
+                  label="Collapsible Pane"
+                  var_name="collapsible_pane"
+                  flags="wxEXPAND">
+                  <node
+                    class="wxBoxSizer"
+                    var_name="box_sizer_21">
+                    <node
+                      class="wxStaticText"
+                      label="This text will be hidden if the Pane is collapsed."
+                      var_name="staticText_5" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds more controls to the C++ and Python SDI tests, and fixes a bug found in wxPropertyGrid as a result of the additional testing.