### PR TITLE
Begin work on adding alternate_name property to bitmaps

### DIFF
--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -44,10 +44,12 @@ void ImageProperties::InitValues(tt_string_view value)
             }
         }
     }
+#if defined(INTERNAL_FEATURE1)
     if (mstr.size() > IndexAltName)
     {
         alt_name = mstr[IndexAltName];
     }
+#endif
 }
 
 tt_string ImageProperties::CombineValues()
@@ -63,10 +65,12 @@ tt_string ImageProperties::CombineValues()
             value << ';' << alt_name;
         }
     }
+#if defined(INTERNAL_FEATURE1)
     else if (alt_name.size())
     {
         value << ";;" << alt_name;
     }
+#endif
 
     return value;
 }

--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -44,6 +44,10 @@ void ImageProperties::InitValues(tt_string_view value)
             }
         }
     }
+    if (mstr.size() > IndexAltName)
+    {
+        alt_name = mstr[IndexAltName];
+    }
 }
 
 tt_string ImageProperties::CombineValues()
@@ -52,7 +56,18 @@ tt_string ImageProperties::CombineValues()
     image.backslashestoforward();
     value << type << ';' << image;
     if (type == "SVG")
+    {
         value << ";[" << m_size.x << ',' << m_size.y << "]";
+        if (alt_name.size())
+        {
+            value << ';' << alt_name;
+        }
+    }
+    else if (alt_name.size())
+    {
+        value << ";;" << alt_name;
+    }
+
     return value;
 }
 

--- a/src/customprops/img_props.h
+++ b/src/customprops/img_props.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Handles property grid image properties
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -20,6 +20,7 @@ struct ImageProperties
 public:
     tt_string type { s_type_names[1] };
     tt_string image;
+    tt_string alt_name;
 
     NodeProperty* node_property;
 

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -59,7 +59,7 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
     AddPrivateChild(new wxEnumProperty("type", wxPG_LABEL, types, 0));
     AddPrivateChild(new ImageStringProperty("image", m_img_props));
 
-    AddPrivateChild(new CustomPointProperty("Size", prop, CustomPointProperty::type_SVG));
+    AddPrivateChild(new CustomPointProperty("Original Size (ignored)", prop, CustomPointProperty::type_SVG));
     Item(IndexSize)->SetHelpString("Default size -- ignored unless it's a SVG file.");
 }
 
@@ -74,10 +74,17 @@ void PropertyGrid_Image::RefreshChildren()
         {
             Item(IndexImage)->SetLabel("id");
             Item(IndexImage)->SetHelpString("Specifies the art ID and optional Client (separated by a | character).");
+            Item(IndexSize)->SetLabel("Original Size (ignored)");
+        }
+        else if (m_img_props.type == "SVG")
+        {
+            Item(IndexImage)->SetLabel("image");
+            Item(IndexSize)->SetLabel("Size");
         }
         else
         {
             Item(IndexImage)->SetLabel("image");
+            Item(IndexSize)->SetLabel("Original Size (ignored)");
         }
 
         if (m_img_props.type == "Embed" || m_img_props.type == "SVG")

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -26,7 +26,6 @@ using namespace wxue_img;
 #include "node.h"             // Node -- Node class
 #include "pg_point.h"         // CustomPointProperty -- Custom property grid class for wxPoint
 #include "project_handler.h"  // ProjectHandler class
-#include "utils.h"            // Utility functions that work with properties
 
 #include "art_ids.cpp"  // wxART_ strings
 
@@ -274,7 +273,7 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
                         name.make_relative(Project.get_ProjectPath());
                         name.backslashestoforward();
                     }
-                    img_props.image.assign_wx(name);
+                    img_props.image = name;
                 }
             }
             break;
@@ -285,6 +284,12 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
                 tt_view_vector mstr(u8_value, ',');
                 img_props.SetWidth(mstr[0].atoi());
                 img_props.SetHeight(mstr[1].atoi());
+            }
+            break;
+
+        case IndexAltName:
+            {
+                img_props.alt_name = childValue.GetString().utf8_string();
             }
             break;
     }

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Custom property grid class for images
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -17,9 +17,11 @@ using namespace wxue_img;
 
 #include "pg_image.h"
 
+#include "img_string_prop.h"  // wxSingleChoiceDialogAdapter
+#include "txt_string_prop.h"  // EditStringDialogAdapter -- Derived wxStringProperty class for single-line text
+
 #include "bitmaps.h"          // Contains various images handling functions
 #include "image_handler.h"    // ImageHandler class
-#include "img_string_prop.h"  // wxSingleChoiceDialogAdapter
 #include "mainframe.h"        // MainFrame -- Main window frame
 #include "node.h"             // Node -- Node class
 #include "pg_point.h"         // CustomPointProperty -- Custom property grid class for wxPoint
@@ -63,6 +65,11 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
 
     AddPrivateChild(new CustomPointProperty("Original Size (ignored)", prop, CustomPointProperty::type_SVG));
     Item(IndexSize)->SetHelpString("Default size -- ignored unless it's a SVG file.");
+
+    AddPrivateChild(new EditStringProperty("Alternate name", prop));
+    Item(IndexAltName)
+        ->SetHelpString("Variable name to use for the image. If not specified, the filename portion of the image file is "
+                        "used as the variable name.");
 }
 
 void PropertyGrid_Image::RefreshChildren()
@@ -72,32 +79,40 @@ void PropertyGrid_Image::RefreshChildren()
     {
         m_img_props.InitValues(value.utf8_string());
 
-        if (m_img_props.type == "Art")
+        if (m_img_props.type == "SVG")
         {
-            Item(IndexImage)->SetLabel("id");
-            Item(IndexImage)->SetHelpString("Specifies the art ID and optional Client (separated by a | character).");
-            Item(IndexSize)->SetLabel("Original Size (ignored)");
-        }
-        else if (m_img_props.type == "SVG")
-        {
-            Item(IndexImage)->SetLabel("image");
             Item(IndexSize)->SetLabel("Size");
         }
         else
         {
-            Item(IndexImage)->SetLabel("image");
             Item(IndexSize)->SetLabel("Original Size (ignored)");
         }
 
-        if (m_img_props.type == "Embed" || m_img_props.type == "SVG")
+        if (m_img_props.type == "Art")
         {
+            Item(IndexImage)->SetLabel("id");
+            Item(IndexAltName)->SetLabel("Alternate name (ignored)");
+            Item(IndexImage)->SetHelpString("Specifies the art ID and optional Client (separated by a | character).");
+            Item(IndexAltName)->SetHelpString("Ignored when using Art images.");
+        }
+        else if (m_img_props.type == "Embed" || m_img_props.type == "SVG")
+        {
+            Item(IndexImage)->SetLabel("image");
+            Item(IndexAltName)->SetLabel("Alternate name");
             Item(IndexImage)
                 ->SetHelpString("Specifies the original image which will be embedded into a generated class source file as "
                                 "an unsigned char array.");
+            Item(IndexAltName)
+                ->SetHelpString(
+                    "Variable name to use for the image. If not specified, the filename portion of the image file is "
+                    "used as the variable name.");
         }
         else if (m_img_props.type == "XPM")
         {
+            Item(IndexImage)->SetLabel("image");
+            Item(IndexAltName)->SetLabel("Alternate name (ignored)");
             Item(IndexImage)->SetHelpString("Specifies the XPM file to include.");
+            Item(IndexAltName)->SetHelpString("Ignored when including XPM files.");
         }
 
         if (m_old_image != m_img_props.image || m_old_type != m_img_props.type)
@@ -157,6 +172,7 @@ void PropertyGrid_Image::RefreshChildren()
     Item(IndexType)->SetValue(m_img_props.type.make_wxString());
     Item(IndexImage)->SetValue(m_img_props.image.make_wxString());
     Item(IndexSize)->SetValue(m_img_props.CombineDefaultSize());
+    Item(IndexAltName)->SetValue(m_img_props.alt_name.make_wxString());
 }
 
 void PropertyGrid_Image::SetAutoComplete()

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -57,6 +57,8 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
     }
 
     AddPrivateChild(new wxEnumProperty("type", wxPG_LABEL, types, 0));
+    Item(IndexType)->SetHelpString("The type of image to use.");
+
     AddPrivateChild(new ImageStringProperty("image", m_img_props));
 
     AddPrivateChild(new CustomPointProperty("Original Size (ignored)", prop, CustomPointProperty::type_SVG));

--- a/src/customprops/txt_string_prop.cpp
+++ b/src/customprops/txt_string_prop.cpp
@@ -9,7 +9,8 @@
 
 #include "txt_string_prop.h"
 
-#include "node_prop.h"  // NodeProperty class
+#include "image_handler.h"  // ImageHandler class
+#include "node_prop.h"      // NodeProperty class
 
 #include "wxui/editstringdialog_base.h"  // auto-generated: wxui/editstringdialog_base.cpp
 
@@ -24,7 +25,36 @@ public:
     EditStringDialog(wxWindow* parent, NodeProperty* prop) : EditStringDialogBase(parent)
     {
         SetTitle(tt_string() << prop->DeclName() << " property editor");
-        m_value = prop->as_wxString();
+        if (prop->isProp(prop_bitmap))
+        {
+            tt_view_vector mstr(prop->as_string(), ';', tt::TRIM::both);
+            if (mstr.size() > IndexAltName)
+            {
+                m_value = mstr[IndexAltName].make_wxString();
+            }
+            else
+            {
+                m_value.clear();
+                if (mstr.size() > IndexImage)
+                {
+                    if (auto result = ProjectImages.FileNameToVarName(mstr[IndexImage].filename()); result)
+                    {
+                        m_textCtrl->SetHint(result->make_wxString());
+                    }
+                }
+            }
+            m_static_hdr_text->SetLabel("&Alternate bitmap variable name:");
+            m_static_hdr_text->Show();
+            // With wxWidgets 3.2.0, calling m_textCtrl->SetFocus(); in
+            // EditStringDialogBase::Create() doesn't work, so we call it again here.
+            m_textCtrl->SetFocus();
+            // Now that m_static_hdr_text is visible, we need to fit the dialog to the new size
+            Fit();
+        }
+        else
+        {
+            m_value = prop->as_wxString();
+        }
     };
 };
 

--- a/src/wxui/editstringdialog_base.cpp
+++ b/src/wxui/editstringdialog_base.cpp
@@ -15,7 +15,7 @@
 #include "editstringdialog_base.h"
 
 bool EditStringDialogBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
-        const wxPoint& pos, const wxSize& size, long style, const wxString &name)
+    const wxPoint& pos, const wxSize& size, long style, const wxString &name)
 {
     if (!wxDialog::Create(parent, id, title, pos, size, style, name))
         return false;
@@ -27,6 +27,7 @@ bool EditStringDialogBase::Create(wxWindow* parent, wxWindowID id, const wxStrin
     parent_sizer->Add(m_static_hdr_text, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT|wxTOP, 15));
 
     m_textCtrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
+    m_textCtrl->SetFocus();
     m_textCtrl->SetValidator(wxTextValidator(wxFILTER_NONE, &m_value));
     m_textCtrl->SetMinSize(wxSize(500, -1));
     parent_sizer->Add(m_textCtrl, wxSizerFlags().Expand().TripleBorder(wxALL));

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -2575,6 +2575,7 @@
             flags="wxEXPAND" />
           <node
             class="wxTextCtrl"
+            focus="1"
             get_function="GetResults"
             validator_variable="m_value"
             minimum_size="500,-1"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR starts work on adding an alternate variable name to use for images. Currently the property is displayed, but any user-set value is not added.
