### PR TITLE
Minor improvements to readability of gen_ Categories

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -12,7 +12,7 @@
 
 using namespace GenEnum;
 
-std::unordered_map<std::string_view, PropType, str_view_hash, std::equal_to<>> GenEnum::umap_PropTypes = {
+std::map<std::string_view, PropType, std::less<>> GenEnum::umap_PropTypes = {
 
     { "animation", type_animation },
     { "bitlist", type_bitlist },
@@ -728,7 +728,7 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_wxWrapSizer, "wxWrapSizer" },
 
 };
-std::unordered_map<tt_string_view, GenEnum::GenName, str_view_hash, std::equal_to<>> rmap_GenNames;
+std::map<std::string_view, GenEnum::GenName, std::less<>> rmap_GenNames;
 
 std::map<GenEnum::PropName, const char*> map_PropMacros = {
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -543,7 +543,11 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
 
     { gen_AUI, "AUI" },  // This is always the first one, set to a value of 0
 
-    // The following are categories (type="interface")
+    // If you add a category to the following list, be sure to also add it to
+    // unused_gen_dlg.cpp
+
+    // The following are categories (type="interface") -- these don't have an actual generator
+    // that implements them, but they do have a NodeDeclaration with the category name.
 
     { gen_Bitmaps, "Bitmaps" },
     { gen_Boolean_Validator, "Boolean Validator" },
@@ -572,6 +576,7 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_wxMdiWindow, "wxMdiWindow" },
     { gen_wxPython, "wxPython" },
     { gen_wxTopLevelWindow, "wxTopLevelWindow" },
+    { gen_wxTreeCtrlBase, "wxTreeCtrlBase" },
     { gen_wxWindow, "wxWindow" },
 
     // These are special purpose generators. gen_Images is used for code, but gen_folder is
@@ -719,7 +724,6 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
     { gen_wxToolBar, "wxToolBar" },
     { gen_wxToolbook, "wxToolbook" },
     { gen_wxTreeCtrl, "wxTreeCtrl" },
-    { gen_wxTreeCtrlBase, "wxTreeCtrlBase" },
     { gen_wxTreeListCtrl, "wxTreeListCtrl" },
     { gen_wxTreebook, "wxTreebook" },
     { gen_wxWebView, "wxWebView" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -67,7 +67,7 @@ namespace GenEnum
         type_unknown,
 
     };
-    extern std::unordered_map<std::string_view, PropType, str_view_hash, std::equal_to<>> umap_PropTypes;
+    extern std::map<std::string_view, PropType, std::less<>> umap_PropTypes;
 
     enum PropName : size_t
     {
@@ -779,4 +779,4 @@ namespace GenEnum
 
 extern std::map<GenEnum::PropName, const char*> map_PropMacros;
 extern std::map<std::string_view, GenEnum::PropName, std::less<>> map_MacroProps;
-extern std::unordered_map<tt_string_view, GenEnum::GenName, str_view_hash, std::equal_to<>> rmap_GenNames;
+extern std::map<std::string_view, GenEnum::GenName, std::less<>> rmap_GenNames;

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -613,6 +613,7 @@ namespace GenEnum
         gen_wxMdiWindow,
         gen_wxPython,
         gen_wxTopLevelWindow,
+        gen_wxTreeCtrlBase,
         gen_wxWindow,
 
         // These are special purpose generators. gen_Images is used for code, but gen_folder is
@@ -760,7 +761,6 @@ namespace GenEnum
         gen_wxToolBar,
         gen_wxToolbook,
         gen_wxTreeCtrl,
-        gen_wxTreeCtrlBase,
         gen_wxTreeListCtrl,
         gen_wxTreebook,
         gen_wxWebView,

--- a/src/internal/unused_gen_dlg.cpp
+++ b/src/internal/unused_gen_dlg.cpp
@@ -66,7 +66,7 @@ bool UnusedGenerators::Create(wxWindow* parent, wxWindowID id, const wxString& t
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-void FindGenerators(Node* node, std::unordered_set<std::string>& used)
+void FindGenerators(Node* node, std::unordered_set<std::string, str_view_hash, std::equal_to<>>& used)
 {
     if (node->isGen(gen_Images))
         return;
@@ -97,6 +97,40 @@ const auto gen_ignore_list = {
     gen_sizer_dimension,
     gen_sizeritem,
     gen_splitteritem,
+
+    // These are categories, not actual generators -- this should be kept in sync with the
+    // categories in gen_enums.cpp
+
+    gen_Bitmaps,
+    gen_Boolean_Validator,
+    gen_CPlusSettings,
+    gen_Choice_Validator,
+    gen_Code,
+    gen_Code_Generation,
+    gen_Command_Bitmaps,
+    gen_DerivedCPlusSettings,
+    gen_DlgWindowSettings,
+    gen_Integer_Validator,
+    gen_List_Validator,
+    gen_PythonFrameSettings,
+    gen_PythonSettings,
+    gen_String_Validator,
+    gen_Text_Validator,
+    gen_Window_Events,
+    gen_XRC,
+    gen_XrcSettings,
+    gen_flexgridsizerbase,
+    gen_folder_Code,
+    gen_folder_XRC,
+    gen_folder_wxPython,
+    gen_sizer_child,
+    gen_sizeritem_settings,
+    gen_wxMdiWindow,
+    gen_wxPython,
+    gen_wxTopLevelWindow,
+    gen_wxTreeCtrlBase,
+    gen_wxWindow,
+
     gen_unknown,
 
 };
@@ -105,7 +139,7 @@ const auto gen_ignore_list = {
 
 void UnusedGenerators::OnInit(wxInitDialogEvent& event)
 {
-    std::unordered_set<std::string> used;
+    std::unordered_set<std::string, str_view_hash, std::equal_to<>> used;
 
     for (const auto& child: Project.ProjectNode()->GetChildNodePtrs())
     {
@@ -141,9 +175,9 @@ void UnusedGenerators::OnInit(wxInitDialogEvent& event)
             }
         }
 
-        if (!used.contains(iter.first.as_str()))
+        if (!used.contains(iter.first))
         {
-            m_listbox->Append(iter.first.make_wxString());
+            m_listbox->Append(wxString::FromUTF8Unchecked(iter.first.data(), iter.first.size()));
         }
     }
 

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -1,4 +1,4 @@
-inline const char* language_xml = R"===(<?xml version="1.0"?>
+inline const char* lang_settings_xml = R"===(<?xml version="1.0"?>
 <!DOCTYPE GeneratorDefinitions SYSTEM "gen.dtd">
 <GeneratorDefinitions>
 	<gen class="C++ Settings" type="interface">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes some minor modifications to GenEnums. The main focus is to make the code a bit more understandable and therefore maintainable. I updated the comments about categories, optimized reading in the interface xml files which are all categories, and changed one of the unordered_maps to a regular map just to make it easier to debug.