### PR TITLE
Improved toolbar UI support

### DIFF
--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -107,7 +107,8 @@ public:
     bool IsMenuBar() const noexcept { return (isType(type_menubar_form) || isType(type_menubar)); }
     bool IsToolBar() const noexcept
     {
-        return (isType(type_toolbar) || isType(type_toolbar_form) || isType(type_toolbar_form) || isType(type_aui_toolbar));
+        return (isType(type_toolbar) || isType(type_toolbar_form) || isType(type_aui_toolbar_form) ||
+                isType(type_aui_toolbar));
     }
     bool IsStatusBar() const noexcept { return isType(type_statusbar); }
     bool IsRibbonBar() const noexcept { return isType(type_ribbonbar); }

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -226,19 +226,30 @@ NodeSharedPtr NodeCreator::CreateNode(tt_string_view name, Node* parent)
 NodeSharedPtr NodeCreator::MakeCopy(Node* node, Node* parent)
 {
     ASSERT(node);
+    NodeSharedPtr copyObj;
 
-    auto objInfo = node->GetNodeDeclaration();
+    // Sometimes we need to copy a similar node to a new node using the parent as the guide.
+    if (parent)
+    {
+        if (node->isGen(gen_tool) && (parent->isGen(gen_wxAuiToolBar) || parent->isGen(gen_AuiToolBar)))
+            copyObj = NewNode(gen_auitool);
+        else if (node->isGen(gen_auitool) && (parent->isGen(gen_wxToolBar) || parent->isGen(gen_ToolBar)))
+            copyObj = NewNode(gen_tool);
+    }
 
-    auto copyObj = NewNode(objInfo);
+    if (!copyObj)
+    {
+        copyObj = NewNode(node->GetNodeDeclaration());
+    }
+
     ASSERT(copyObj);
 
     for (auto& iter: node->get_props_vector())
     {
-        auto copyProp = copyObj->get_prop_ptr(iter.get_name());
-        ASSERT(copyProp);
-
-        if (copyProp)
+        if (auto copyProp = copyObj->get_prop_ptr(iter.get_name()); copyProp)
+        {
             copyProp->set_value(iter.as_string());
+        }
     }
 
     copyObj->CopyEventsFrom(node);

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -33,7 +33,7 @@ NavPopupMenu::NavPopupMenu(Node* node) : m_node(node)
         return;  // theoretically impossible, but don't crash if it happens
     }
 
-    if (node->GetParent() && (node->GetParent()->isGen(gen_wxToolBar) || node->GetParent()->isGen(gen_wxAuiToolBar)))
+    if (node->GetParent() && node->GetParent()->IsToolBar())
     {
         m_is_parent_toolbar = true;
     }
@@ -459,7 +459,7 @@ void NavPopupMenu::MenuAddCommands(Node* node)
 {
     if (node->IsForm() || node->isGen(gen_Images) || node->isGen(gen_embedded_image))
     {
-        if (!node->isGen(gen_wxWizard))
+        if (!node->isGen(gen_wxWizard) && !node->IsToolBar())
         {
             return;
         }
@@ -562,6 +562,7 @@ void NavPopupMenu::MenuAddCommands(Node* node)
             }
             break;
 
+        case gen_AuiToolBar:
         case gen_wxAuiToolBar:
         case gen_auitool:
             add_sizer = false;
@@ -1018,7 +1019,9 @@ void NavPopupMenu::AddToolbarCommands(Node* node)
     wxMenuItem* menu_item;
     AppendSubMenu(sub_menu, "Tools");
 
-    bool is_aui_toolbar = (node->gen_name() == gen_wxAuiToolBar || node->GetParent()->gen_name() == gen_wxAuiToolBar);
+    bool is_aui_toolbar =
+        (node->gen_name() == gen_wxAuiToolBar || node->gen_name() == gen_AuiToolBar ||
+         node->GetParent()->gen_name() == gen_wxAuiToolBar || node->GetParent()->gen_name() == gen_AuiToolBar);
 
     menu_item = sub_menu->Append(MenuADD_TOOL, "Tool (normal, check, radio)");
     menu_item->SetBitmap(GetInternalImage("tool"));


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes it possible to Copy and Paste either tools or entire toolbars into another toolbar. Copying between normal and form versions is supported, as well as copying between Aui and normal toolbars (and vice versa). When pasting one toolbar onto another, all of the children are added as a single undo action.

Note that problems _will_ occur if the user tries to paste a normal toolbar into a Aui toolbar when the normal toolbar contains a dropdown tool which is not supported in an Aui toolbar. The node will appear in the Navigation panel and the Property Grid panel, however it will not show up in Mockup, and no code will be generated for it.