### PR TITLE
Change UI layout

### DIFF
--- a/src/generate/gen_panel.cpp
+++ b/src/generate/gen_panel.cpp
@@ -27,10 +27,16 @@ wxObject* PanelGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool PanelGenerator::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(true);
-
+    code.AddAuto().NodeName().CreateClass().ValidParentName();
+    if (code.IsDefaultPosSizeFlags() && code.IsEqualTo(prop_id, "wxID_ANY"))
+    {
+        code.EndFunction();
+    }
+    else
+    {
+        code.Comma().as_string(prop_id);
+        code.PosSizeFlags(true);
+    }
     return true;
 }
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -72,7 +72,8 @@
 using namespace wxue_img;
 using namespace GenEnum;
 
-// #define NEW_LAYOUT 1
+// Comment out the following line to change the UI back to the way it was in 1.1.2 and all earlier versions.
+#define NEW_LAYOUT 1
 
 enum
 {
@@ -228,17 +229,19 @@ MainFrame::MainFrame() :
     CreateStatusBar(StatusPanels);
     SetStatusBarPane(1);  // specifies where menu and toolbar help content is displayed
 #if defined(NEW_LAYOUT)
-    auto* box_sizer = new wxBoxSizer(wxVERTICAL);
+    // auto* box_sizer = new wxBoxSizer(wxVERTICAL);
     m_ribbon_panel = new RibbonPanel(this);
-    box_sizer->Add(m_ribbon_panel, wxSizerFlags(0).Expand());
+    m_mainframe_sizer->Insert(0, m_ribbon_panel, wxSizerFlags(0).Expand());
 
     CreateSplitters();
 
-    box_sizer->Add(m_MainSplitter, wxSizerFlags(1).Expand());
-    SetSizer(box_sizer);
+    // box_sizer->Add(m_MainSplitter, wxSizerFlags(1).Expand());
+    // SetSizer(box_sizer);
 #else
     CreateSplitters();
 #endif
+
+    m_nav_panel->SetMainFrame(this);
 
     m_SecondarySplitter->Bind(wxEVT_COMMAND_SPLITTER_SASH_POS_CHANGED,
                               [this](wxSplitterEvent&)
@@ -1274,33 +1277,32 @@ void MainFrame::CreateSplitters()
     // containing the Ribbon toolbar at the top, and a splitter window containing the property grid and notebook with
     // mockup and code windows below it.
 
-    m_MainSplitter = new wxSplitterWindow(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE);
+    m_panel_right->SetWindowStyle(wxBORDER_RAISED);
 
-    m_nav_panel = new NavigationPanel(m_MainSplitter, this);
-    auto panel_right = new wxPanel(m_MainSplitter);
-    panel_right->SetWindowStyle(wxBORDER_RAISED);
-
-    auto parent_sizer = new wxBoxSizer(wxVERTICAL);
+    // auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
 #if !defined(NEW_LAYOUT)
-    m_ribbon_panel = new RibbonPanel(panel_right);
-    parent_sizer->Add(m_ribbon_panel, wxSizerFlags(0).Expand());
+    m_ribbon_panel = new RibbonPanel(m_panel_right);
+    m_right_panel_sizer->Add(m_ribbon_panel, wxSizerFlags(0).Expand());
+#else
+    // auto main_toolbar = new MainToolBar(m_panel_right);
+    // m_right_panel_sizer->Add(main_toolbar, wxSizerFlags(0).Expand());
 #endif
 
-    m_SecondarySplitter = new wxSplitterWindow(panel_right, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE);
-    parent_sizer->Add(m_SecondarySplitter, wxSizerFlags(1).Expand());
+    m_SecondarySplitter = new wxSplitterWindow(m_panel_right, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE);
+    m_right_panel_sizer->Add(m_SecondarySplitter, wxSizerFlags(1).Expand());
 
-    m_info_bar = new wxInfoBar(panel_right);
-    parent_sizer->Add(m_info_bar, wxSizerFlags().Expand());
+    m_info_bar = new wxInfoBar(m_panel_right);
+    m_right_panel_sizer->Add(m_info_bar, wxSizerFlags().Expand());
 
-    panel_right->SetSizer(parent_sizer);
+    // m_panel_right->SetSizer(parent_sizer);
 
     m_property_panel = new PropGridPanel(m_SecondarySplitter, this);
     auto notebook = CreateNoteBook(m_SecondarySplitter);
 
     m_SecondarySplitter->SplitVertically(m_property_panel, notebook, m_SecondarySashPosition);
 
-    m_MainSplitter->SplitVertically(m_nav_panel, panel_right);
+    m_MainSplitter->SplitVertically(m_nav_panel, m_panel_right);
     m_MainSplitter->SetName("Navigation");
     wxPersistenceManager::Get().RegisterAndRestore(m_MainSplitter);
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -257,6 +257,12 @@ public:
     void SetPreviewDlgPtr(wxDialog* dlg) { m_pxrc_dlg = dlg; }
     void SetPreviewWinPtr(wxFrame* frame) { m_pxrc_win = frame; }
 
+    void OnPreviewXrc(wxCommandEvent& event) override;
+
+    void OnOpenProject(wxCommandEvent& event) override;
+    void OnSaveProject(wxCommandEvent& event) override;
+    void OnGenerateCode(wxCommandEvent& event) override;
+
 protected:
     void OnAbout(wxCommandEvent& event) override;
     void OnAppendCrafter(wxCommandEvent& event) override;
@@ -277,19 +283,15 @@ protected:
     void OnDuplicate(wxCommandEvent& event) override;
     void OnEditCustomIds(wxCommandEvent& event) override;
     void OnFindDialog(wxCommandEvent& event) override;
-    void OnGenerateCode(wxCommandEvent& event) override;
     void OnImportProject(wxCommandEvent& event);
     void OnImportRecent(wxCommandEvent& event);
     void OnImportWindowsResource(wxCommandEvent& event) override;
     void OnInsertWidget(wxCommandEvent&) override;
     void OnNewProject(wxCommandEvent& event);
-    void OnOpenProject(wxCommandEvent& event) override;
     void OnOpenRecentProject(wxCommandEvent& event);
     void OnOptionsDlg(wxCommandEvent& event) override;
     void OnPaste(wxCommandEvent& event) override;
-    void OnPreviewXrc(wxCommandEvent& event) override;
     void OnSaveAsProject(wxCommandEvent& event) override;
-    void OnSaveProject(wxCommandEvent& event) override;
     void OnToggleExpandLayout(wxCommandEvent&) override;
     void OnUpdateBrowseDocs(wxUpdateUIEvent& event) override;
     void OnUpdateBrowsePython(wxUpdateUIEvent& event) override;
@@ -325,12 +327,10 @@ protected:
     void UpdateWakaTime(bool FileSavedEvent = false);
 
 private:
-    wxSplitterWindow* m_MainSplitter { nullptr };
     wxSplitterWindow* m_SecondarySplitter { nullptr };
 
     wxAuiNotebook* m_notebook;
     PropGridPanel* m_property_panel;
-    NavigationPanel* m_nav_panel;
     RibbonPanel* m_ribbon_panel;
     std::unique_ptr<WakaTime> m_wakatime { nullptr };
 

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -61,17 +61,15 @@ inline const std::vector<GenEnum::GenName> unsupported_gen_XRC = {
 };
 // clang-format on
 
-NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(parent)
+NavigationPanel::NavigationPanel(wxWindow* parent) : wxPanel(parent)
 {
-    m_pMainFrame = frame;
-
     SetWindowStyle(wxBORDER_RAISED);
 
     m_tree_ctrl = new wxTreeCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                  wxTR_HAS_BUTTONS | wxTR_LINES_AT_ROOT | wxTR_DEFAULT_STYLE | wxBORDER_SUNKEN);
+
     int index = 0;
     m_iconList = new wxImageList(GenImageSize, GenImageSize);
-
     for (auto iter: NodeCreation.GetNodeDeclarationArray())
     {
         if (!iter)
@@ -82,16 +80,13 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
         m_iconList->Add(iter->GetImage());
         m_iconIdx[iter->gen_name()] = index++;
     }
-
     m_tree_ctrl->AssignImageList(m_iconList);
 
-    auto toolbar = new NavToolbar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTB_NODIVIDER);
+    m_toolbar = new NavToolbar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTB_NODIVIDER);
+    m_toolbar->Realize();
 
-    toolbar->Realize();
-
-    auto toolbar_sizer = new wxBoxSizer(wxHORIZONTAL);
-    toolbar_sizer->AddSpacer(50);
-    toolbar_sizer->Add(toolbar, wxSizerFlags().Expand().Border(wxBOTTOM | wxTOP));
+    auto toolbar_sizer = new wxBoxSizer(wxVERTICAL);
+    toolbar_sizer->Add(m_toolbar, wxSizerFlags().Expand());
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
     parent_sizer->Add(toolbar_sizer, wxSizerFlags().Expand());
@@ -128,6 +123,13 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
     Bind(wxEVT_MENU, &NavigationPanel::OnCollapse, this, NavToolbar::id_NavCollapse);
     Bind(wxEVT_MENU, &NavigationPanel::OnCollExpand, this, NavToolbar::id_NavCollExpand);
 
+    Bind(wxEVT_UPDATE_UI, &NavigationPanel::OnUpdateEvent, this);
+}
+
+void NavigationPanel::SetMainFrame(MainFrame* frame)
+{
+    m_pMainFrame = frame;
+
     Bind(
         wxEVT_MENU,
         [this](wxCommandEvent&)
@@ -159,8 +161,6 @@ NavigationPanel::NavigationPanel(wxWindow* parent, MainFrame* frame) : wxPanel(p
             m_pMainFrame->MoveNode(MoveDirection::Up);
         },
         NavToolbar::id_NavMoveUp);
-
-    Bind(wxEVT_UPDATE_UI, &NavigationPanel::OnUpdateEvent, this);
 
     m_pMainFrame->AddCustomEventHandler(GetEventHandler());
 }

--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -22,11 +22,14 @@ using namespace GenEnum;
 
 class CustomEvent;
 class MainFrame;
+class NavToolbar;
 
 class NavigationPanel : public wxPanel
 {
 public:
-    NavigationPanel(wxWindow* parent, MainFrame* frame);
+    NavigationPanel(wxWindow* parent);
+
+    void SetMainFrame(MainFrame* frame);
 
     void ChangeExpansion(Node* node, bool include_children, bool expand);
 
@@ -43,6 +46,8 @@ public:
 
     void InsertNode(Node* node);
     void DeleteNode(Node* item);
+
+    NavToolbar* GetToolbar() { return m_toolbar; }
 
 protected:
     Node* GetNode(wxTreeItemId item);
@@ -93,6 +98,7 @@ private:
     wxTreeCtrl* m_tree_ctrl;
 
     wxTreeItemId m_drag_node;
+    NavToolbar* m_toolbar;
 
     bool m_isSelChangeSuspended { false };
 };

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -9,12 +9,13 @@
 
 #include <wx/artprov.h>
 
+#include "../panels/nav_panel.h"
 #include "ui_images.h"
+
+#include "mainframe_base.h"
 
 #include "mainframe.h"
 #include "project_handler.h"
-
-#include "mainframe_base.h"
 
 #include <wx/mstream.h>  // memory stream classes
 #include <wx/zstream.h>  // zlib stream classes
@@ -53,6 +54,103 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     if (!wxFrame::Create(parent, id, title, pos, size, style, name))
         return false;
     SetMinSize(wxSize(800, 800));
+
+    m_mainframe_sizer = new wxBoxSizer(wxVERTICAL);
+
+    m_toolbar = new wxToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTB_FLAT|wxTB_HORIZONTAL|wxTB_NODIVIDER);
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(id_NewProject, "New", wxueBundleSVG(wxue_img::new_project_svg, 921, 2208, wxSize(24, 24)),
+        "New Project (Ctrl+N)");
+
+    m_toolbar->AddTool(id_OpenProject, "Open", wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN, wxART_TOOLBAR),
+        "Open Project (Ctrl+O)");
+
+    m_toolbar->AddTool(wxID_SAVE, "Save", wxueBundleSVG(wxue_img::save_svg, 717, 2603, wxSize(24, 24)),
+        "Save current project");
+
+    m_toolbar->AddTool(id_GenerateCode, wxEmptyString, wxueBundleSVG(wxue_img::generate_svg, 780, 2716, wxSize(24, 24)),
+        "Generate code");
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(wxID_UNDO, wxEmptyString, wxue_img::bundle_undo_svg(16, 16), "Undo");
+
+    m_toolbar->AddTool(wxID_REDO, wxEmptyString, wxue_img::bundle_redo_svg(16, 16), "Redo");
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(wxID_CUT, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_CUT, wxART_TOOLBAR), "Cut");
+
+    m_toolbar->AddTool(wxID_COPY, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_COPY, wxART_TOOLBAR), "Copy");
+
+    m_toolbar->AddTool(wxID_PASTE, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_PASTE, wxART_TOOLBAR), "Paste");
+
+    m_toolbar->AddTool(wxID_DELETE, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_DELETE, wxART_TOOLBAR),
+        "Delete selected object without using clipboard.");
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(id_AlignLeft, wxEmptyString, wxueBundleSVG(wxue_img::alignleft_svg, 688, 1442, wxSize(24, 24)),
+        "Align left", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_AlignCenterHorizontal, wxEmptyString,
+        wxueBundleSVG(wxue_img::aligncenter_svg, 898, 1976, wxSize(24, 24)), "Center horizontally", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_AlignRight, wxEmptyString, wxueBundleSVG(wxue_img::alignright_svg, 690, 1441, wxSize(24, 24)),
+        "Align right", wxITEM_CHECK);
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(id_AlignTop, wxEmptyString, wxueBundleSVG(wxue_img::aligntop_svg, 688, 1440, wxSize(24, 24)),
+        "Align top", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_AlignCenterVertical, wxEmptyString,
+        wxueBundleSVG(wxue_img::alignvertcenter_svg, 911, 2016, wxSize(24, 24)), "Center vertically", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_AlignBottom, wxEmptyString,
+        wxueBundleSVG(wxue_img::alignbottom_svg, 658, 1392, wxSize(24, 24)), "Align bottom", wxITEM_CHECK);
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(id_BorderLeft, wxEmptyString, wxueBundleSVG(wxue_img::left_svg, 585, 1857, wxSize(24, 24)),
+        "Left border", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_BorderRight, wxEmptyString, wxueBundleSVG(wxue_img::right_svg, 599, 1878, wxSize(24, 24)),
+        "Right border", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_BorderTop, wxEmptyString, wxueBundleSVG(wxue_img::top_svg, 586, 1859, wxSize(24, 24)),
+        "Top border", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_BorderBottom, wxEmptyString, wxueBundleSVG(wxue_img::bottom_svg, 585, 1859, wxSize(24, 24)),
+        "Bottom border", wxITEM_CHECK);
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(id_Expand, wxEmptyString, wxueBundleSVG(wxue_img::expand_svg, 819, 1685, wxSize(24, 24)),
+        "Expand to fill the space", wxITEM_CHECK);
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(id_ShowHidden, wxEmptyString, wxueBundleSVG(wxue_img::hidden_svg, 2111, 5129, wxSize(24, 24)),
+        "Show hidden controls in Mockup panel", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_Magnify, wxEmptyString, wxueBundleSVG(wxue_img::magnify_svg, 3953, 8849, wxSize(24, 24)),
+        "Magnify the size of the Mockup window", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_PreviewForm, "Preview Form...",
+        wxueBundleSVG(wxue_img::xrc_preview_svg, 469, 1326, wxSize(24, 24)), "Preview form using XRC and/or C++",
+        wxITEM_CHECK);
+
+    m_toolbar->Realize();
+    m_mainframe_sizer->Add(m_toolbar, wxSizerFlags().Expand());
+
+    m_MainSplitter = new wxSplitterWindow(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE);
+    m_MainSplitter->SetSashGravity(0.0);
+    m_MainSplitter->SetMinimumPaneSize(2);
+    m_mainframe_sizer->Add(m_MainSplitter, wxSizerFlags(1).Expand());
+
+    m_nav_panel = new NavigationPanel(m_MainSplitter);
+
+    m_panel_right = new wxPanel(m_MainSplitter);
+
+    m_right_panel_sizer = new wxBoxSizer(wxVERTICAL);
+    m_panel_right->SetSizerAndFit(m_right_panel_sizer);
+    m_MainSplitter->SplitVertically(m_nav_panel, m_panel_right);
+    SetSizerAndFit(m_mainframe_sizer);
 
     m_menubar = new wxMenuBar();
 
@@ -288,88 +386,12 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
 
     SetMenuBar(m_menubar);
 
-    m_toolbar = CreateToolBar(wxTB_FLAT|wxTB_HORIZONTAL);
-    m_toolbar->AddTool(id_NewProject, "New", wxueBundleSVG(wxue_img::new_project_svg, 921, 2208, wxSize(24, 24)),
-        "New Project (Ctrl+N)");
-
-    m_toolbar->AddTool(id_OpenProject, "Open", wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN, wxART_TOOLBAR),
-        "Open Project (Ctrl+O)");
-
-    m_toolbar->AddTool(wxID_SAVE, "Save", wxueBundleSVG(wxue_img::save_svg, 717, 2603, wxSize(24, 24)),
-        "Save current project");
-
-    m_toolbar->AddTool(id_GenerateCode, wxEmptyString, wxueBundleSVG(wxue_img::generate_svg, 780, 2716, wxSize(24, 24)),
-        "Generate code");
-
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(wxID_UNDO, wxEmptyString, wxue_img::bundle_undo_svg(16, 16), "Undo");
-
-    m_toolbar->AddTool(wxID_REDO, wxEmptyString, wxue_img::bundle_redo_svg(16, 16), "Redo");
-
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(wxID_CUT, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_CUT, wxART_TOOLBAR), "Cut");
-
-    m_toolbar->AddTool(wxID_COPY, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_COPY, wxART_TOOLBAR), "Copy");
-
-    m_toolbar->AddTool(wxID_PASTE, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_PASTE, wxART_TOOLBAR), "Paste");
-
-    m_toolbar->AddTool(wxID_DELETE, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_DELETE, wxART_TOOLBAR),
-        "Delete selected object without using clipboard.");
-
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_AlignLeft, wxEmptyString, wxueBundleSVG(wxue_img::alignleft_svg, 688, 1442, wxSize(24, 24)),
-        "Align left", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_AlignCenterHorizontal, wxEmptyString,
-        wxueBundleSVG(wxue_img::aligncenter_svg, 898, 1976, wxSize(24, 24)), "Center horizontally", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_AlignRight, wxEmptyString, wxueBundleSVG(wxue_img::alignright_svg, 690, 1441, wxSize(24, 24)),
-        "Align right", wxITEM_CHECK);
-
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_AlignTop, wxEmptyString, wxueBundleSVG(wxue_img::aligntop_svg, 688, 1440, wxSize(24, 24)),
-        "Align top", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_AlignCenterVertical, wxEmptyString,
-        wxueBundleSVG(wxue_img::alignvertcenter_svg, 911, 2016, wxSize(24, 24)), "Center vertically", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_AlignBottom, wxEmptyString,
-        wxueBundleSVG(wxue_img::alignbottom_svg, 658, 1392, wxSize(24, 24)), "Align bottom", wxITEM_CHECK);
-
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_BorderLeft, wxEmptyString, wxueBundleSVG(wxue_img::left_svg, 585, 1857, wxSize(24, 24)),
-        "Left border", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_BorderRight, wxEmptyString, wxueBundleSVG(wxue_img::right_svg, 599, 1878, wxSize(24, 24)),
-        "Right border", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_BorderTop, wxEmptyString, wxueBundleSVG(wxue_img::top_svg, 586, 1859, wxSize(24, 24)),
-        "Top border", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_BorderBottom, wxEmptyString, wxueBundleSVG(wxue_img::bottom_svg, 585, 1859, wxSize(24, 24)),
-        "Bottom border", wxITEM_CHECK);
-
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_Expand, wxEmptyString, wxueBundleSVG(wxue_img::expand_svg, 819, 1685, wxSize(24, 24)),
-        "Expand to fill the space", wxITEM_CHECK);
-
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_ShowHidden, wxEmptyString, wxueBundleSVG(wxue_img::hidden_svg, 2111, 5129, wxSize(24, 24)),
-        "Show hidden controls in Mockup panel", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_Magnify, wxEmptyString, wxueBundleSVG(wxue_img::magnify_svg, 3953, 8849, wxSize(24, 24)),
-        "Magnify the size of the Mockup window", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_PreviewForm, "Preview Form...",
-        wxueBundleSVG(wxue_img::xrc_preview_svg, 469, 1326, wxSize(24, 24)), "Preview form using XRC and/or C++",
-        wxITEM_CHECK);
-
-    m_toolbar->Realize();
-
     Centre(wxBOTH);
 
     // Event handlers
     Bind(wxEVT_CLOSE_WINDOW, &MainFrameBase::OnClose, this);
+    Bind(wxEVT_MENU, &MainFrameBase::OnToggleExpandLayout, this, id_Expand);
+    Bind(wxEVT_MENU, &MainFrameBase::OnGenerateCode, this, id_GenerateCode);
     Bind(wxEVT_MENU,
         [](wxCommandEvent&)
         {
@@ -385,14 +407,14 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
         },
         menu_import->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveProject, this, wxID_SAVE);
-    Bind(wxEVT_MENU, &MainFrameBase::OnGenerateCode, this, id_GenerateCode);
+    Bind(wxEVT_MENU, &MainFrameBase::OnAppendXRC, this, id_AppendXRC);
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveAsProject, this, id_SaveProjectAs);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendCrafter, this, id_AppendCrafter);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendFormBuilder, this, id_AppendFormBuilder);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendGlade, this, id_AppendGlade);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendSmith, this, id_AppendSmith);
     Bind(wxEVT_MENU, &MainFrameBase::OnImportWindowsResource, this, id_AppendWinRes);
-    Bind(wxEVT_MENU, &MainFrameBase::OnAppendXRC, this, id_AppendXRC);
+    Bind(wxEVT_MENU, &MainFrameBase::OnPreviewXrc, this, id_PreviewForm);
     Bind(wxEVT_MENU, &MainFrameBase::OnOptionsDlg, this, id_OptionsDlg);
     Bind(wxEVT_MENU,
         [](wxCommandEvent&)
@@ -400,23 +422,23 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
             wxGetFrame().Undo();
         },
         wxID_UNDO);
-    Bind(wxEVT_MENU, &MainFrameBase::OnPreviewXrc, this, id_PreviewForm);
+    Bind(wxEVT_MENU, &MainFrameBase::OnAbout, this, wxID_ABOUT);
     Bind(wxEVT_MENU,
         [](wxCommandEvent&)
         {
             wxGetFrame().Redo();
         },
         wxID_REDO);
-    Bind(wxEVT_MENU, &MainFrameBase::OnEditCustomIds, this, menu_item_8->GetId());
+    Bind(wxEVT_MENU, &MainFrameBase::OnBrowseDocs, this, menu_item_6->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnCut, this, wxID_CUT);
-    Bind(wxEVT_MENU, &MainFrameBase::OnAbout, this, wxID_ABOUT);
+    Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignLeft);
     Bind(wxEVT_MENU, &MainFrameBase::OnCopy, this, wxID_COPY);
     Bind(wxEVT_MENU, &MainFrameBase::OnPaste, this, wxID_PASTE);
-    Bind(wxEVT_MENU, &MainFrameBase::OnBrowseDocs, this, menu_item_6->GetId());
-    Bind(wxEVT_MENU, &MainFrameBase::OnDelete, this, wxID_DELETE);
     Bind(wxEVT_MENU, &MainFrameBase::OnBrowsePython, this, menu_item_9->GetId());
-    Bind(wxEVT_MENU, &MainFrameBase::OnDuplicate, this, menu_duplicate->GetId());
+    Bind(wxEVT_MENU, &MainFrameBase::OnDelete, this, wxID_DELETE);
     Bind(wxEVT_MENU, &MainFrameBase::OnBrowseRuby, this, menu_item_10->GetId());
+    Bind(wxEVT_MENU, &MainFrameBase::OnDuplicate, this, menu_duplicate->GetId());
+    Bind(wxEVT_MENU, &MainFrameBase::OnEditCustomIds, this, menu_item_8->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnFindDialog, this, wxID_FIND);
     Bind(wxEVT_MENU, &MainFrameBase::OnInsertWidget, this, id_insert_widget);
     Bind(wxEVT_MENU,
@@ -443,7 +465,6 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
             wxGetFrame().MoveNode(MoveDirection::Right);
         },
         id_MoveRight);
-    Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignLeft);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignCenterHorizontal);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignRight);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeAlignment, this, id_AlignTop);
@@ -453,7 +474,6 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeBorder, this, id_BorderRight);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeBorder, this, id_BorderTop);
     Bind(wxEVT_MENU, &MainFrameBase::OnChangeBorder, this, id_BorderBottom);
-    Bind(wxEVT_MENU, &MainFrameBase::OnToggleExpandLayout, this, id_Expand);
     Bind(wxEVT_TOOL, &MainFrameBase::OnGenerateCode, this, id_GenerateCode);
     Bind(wxEVT_TOOL, &MainFrameBase::OnPreviewXrc, this, id_PreviewForm);
     Bind(wxEVT_UPDATE_UI,
@@ -477,12 +497,6 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     Bind(wxEVT_UPDATE_UI,
         [](wxUpdateUIEvent& event)
         {
-            event.Enable(wxGetFrame().CanCopyNode());
-        },
-        wxID_CUT);
-    Bind(wxEVT_UPDATE_UI,
-        [](wxUpdateUIEvent& event)
-        {
             event.Enable(wxGetFrame().CanPasteNode());
         },
         wxID_PASTE);
@@ -492,6 +506,7 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
             event.Enable(wxGetFrame().CanCopyNode());
         },
         wxID_DELETE);
+    Bind(wxEVT_UPDATE_UI, &MainFrameBase::OnUpdateBrowseDocs, this, menu_item_6->GetId());
     Bind(wxEVT_UPDATE_UI,
         [](wxUpdateUIEvent& event)
         {
@@ -499,7 +514,12 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
         },
         menu_duplicate->GetId());
     Bind(wxEVT_UPDATE_UI, &MainFrameBase::OnUpdateBrowsePython, this, menu_item_9->GetId());
-    Bind(wxEVT_UPDATE_UI, &MainFrameBase::OnUpdateBrowseDocs, this, menu_item_6->GetId());
+    Bind(wxEVT_UPDATE_UI,
+        [](wxUpdateUIEvent& event)
+        {
+            event.Enable(wxGetFrame().CanCopyNode());
+        },
+        wxID_CUT);
     Bind(wxEVT_UPDATE_UI, &MainFrameBase::OnUpdateBrowseRuby, this, menu_item_10->GetId());
 
     return true;

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -16,7 +16,12 @@
 #include <wx/icon.h>
 #include <wx/image.h>
 #include <wx/menu.h>
+#include <wx/panel.h>
+#include <wx/sizer.h>
+#include <wx/splitter.h>
 #include <wx/toolbar.h>
+
+class NavigationPanel;
 
 class MainFrameBase : public wxFrame
 {
@@ -105,6 +110,9 @@ protected:
 
     // Class member variables
 
+    NavigationPanel* m_nav_panel;
+    wxBoxSizer* m_mainframe_sizer;
+    wxBoxSizer* m_right_panel_sizer;
     wxMenu* m_menuEdit;
     wxMenu* m_menuFile;
     wxMenu* m_menuHelp;
@@ -112,6 +120,8 @@ protected:
     wxMenu* m_submenu_recent;
     wxMenuBar* m_menubar;
     wxMenuItem* m_mi_preview;
+    wxPanel* m_panel_right;
+    wxSplitterWindow* m_MainSplitter;
     wxToolBar* m_toolbar;
 };
 

--- a/src/wxui/navtoolbar_base.cpp
+++ b/src/wxui/navtoolbar_base.cpp
@@ -14,6 +14,9 @@
 
 #include "navtoolbar_base.h"
 
+#include "mainframe.h"
+#include "project_handler.h"
+
 #include <wx/mstream.h>  // memory stream classes
 #include <wx/zstream.h>  // zlib stream classes
 
@@ -33,6 +36,8 @@ inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
 NavToolbar::NavToolbar(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style,
     const wxString& name) : wxToolBar(parent, id, pos, size, style, name)
 {
+
+    AddStretchableSpace();
 
     AddTool(id_NavCollExpand, wxEmptyString, wxueBundleSVG(wxue_img::nav_coll_expand_svg, 249, 482, wxSize(16, 16)),
         wxNullBitmap, wxITEM_NORMAL, "Collapse siblings, expand children",
@@ -56,6 +61,8 @@ NavToolbar::NavToolbar(wxWindow* parent, wxWindowID id, const wxPoint& pos, cons
 
     AddTool(id_NavMoveRight, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_GO_FORWARD, wxART_OTHER), wxNullBitmap,
         wxITEM_NORMAL, "Move Right", "Move the selected item right");
+
+    AddStretchableSpace();
 
     Realize();
 }

--- a/src/wxui/navtoolbar_base.h
+++ b/src/wxui/navtoolbar_base.h
@@ -16,7 +16,7 @@ class NavToolbar : public wxToolBar
 {
 public:
     NavToolbar(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size =
-        wxDefaultSize, long style = wxTB_NODIVIDER, const wxString &name = wxPanelNameStr);
+        wxDefaultSize, long style = wxTB_FLAT|wxTB_HORIZONTAL, const wxString &name = wxPanelNameStr);
 
     enum
     {

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -186,12 +186,253 @@
         class="wxFrame"
         class_name="MainFrameBase"
         base_file="mainframe_base"
-        source_preamble="#include &quot;mainframe.h&quot;@@#include &quot;project_handler.h&quot;"
+        local_src_includes="mainframe.h;project_handler.h"
         derived_class_name="MainFrame"
         minimum_size="800,800"
         size="1000,1000"
         window_style="wxTAB_TRAVERSAL"
         wxEVT_CLOSE_WINDOW="OnClose">
+        <node
+          class="wxBoxSizer"
+          class_access="protected:"
+          orientation="wxVERTICAL"
+          var_name="m_mainframe_sizer">
+          <node
+            class="wxToolBar"
+            style="wxTB_FLAT|wxTB_HORIZONTAL|wxTB_NODIVIDER"
+            var_name="m_toolbar"
+            borders=""
+            flags="wxEXPAND">
+            <node
+              class="toolSeparator" />
+            <node
+              class="tool"
+              bitmap="SVG;new-project.svg;[24,24]"
+              id="id_NewProject"
+              label="New"
+              tooltip="New Project (Ctrl+N)" />
+            <node
+              class="tool"
+              bitmap="Art;wxART_FILE_OPEN|wxART_TOOLBAR"
+              id="id_OpenProject"
+              label="Open"
+              tooltip="Open Project (Ctrl+O)"
+              var_name="tool2" />
+            <node
+              class="tool"
+              bitmap="SVG;save.svg;[24,24]"
+              id="wxID_SAVE"
+              label="Save"
+              tooltip="Save current project"
+              var_name="tool3" />
+            <node
+              class="tool"
+              bitmap="SVG;generate.svg;[24,24]"
+              id="id_GenerateCode"
+              label=""
+              tooltip="Generate code"
+              var_name="Generate"
+              wxEVT_TOOL="OnGenerateCode" />
+            <node
+              class="toolSeparator" />
+            <node
+              class="tool"
+              bitmap="SVG;undo.svg;[16,16]"
+              id="wxID_UNDO"
+              label=""
+              tooltip="Undo"
+              var_name="Undo" />
+            <node
+              class="tool"
+              bitmap="SVG;redo.svg;[16,16]"
+              id="wxID_REDO"
+              label=""
+              tooltip="Redo"
+              var_name="Redo" />
+            <node
+              class="toolSeparator" />
+            <node
+              class="tool"
+              bitmap="Art;wxART_CUT|wxART_TOOLBAR"
+              id="wxID_CUT"
+              label=""
+              tooltip="Cut"
+              var_name="Cut" />
+            <node
+              class="tool"
+              bitmap="Art;wxART_COPY|wxART_TOOLBAR"
+              id="wxID_COPY"
+              label=""
+              tooltip="Copy"
+              var_name="Copy" />
+            <node
+              class="tool"
+              bitmap="Art;wxART_PASTE|wxART_TOOLBAR"
+              id="wxID_PASTE"
+              label=""
+              tooltip="Paste"
+              var_name="Paste" />
+            <node
+              class="tool"
+              bitmap="Art;wxART_DELETE|wxART_TOOLBAR"
+              id="wxID_DELETE"
+              label=""
+              tooltip="Delete selected object without using clipboard."
+              var_name="Delete" />
+            <node
+              class="toolSeparator" />
+            <node
+              class="tool"
+              bitmap="SVG;alignleft.svg;[24,24]"
+              id="id_AlignLeft"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Align left"
+              var_name="AlignLeft" />
+            <node
+              class="tool"
+              bitmap="SVG;aligncenter.svg;[24,24]"
+              id="id_AlignCenterHorizontal"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Center horizontally"
+              var_name="AlignCenterH" />
+            <node
+              class="tool"
+              bitmap="SVG;alignright.svg;[24,24]"
+              id="id_AlignRight"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Align right"
+              var_name="AlignRight" />
+            <node
+              class="toolSeparator" />
+            <node
+              class="tool"
+              bitmap="SVG;aligntop.svg;[24,24]"
+              id="id_AlignTop"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Align top"
+              var_name="AlignTop" />
+            <node
+              class="tool"
+              bitmap="SVG;alignvertcenter.svg;[24,24]"
+              id="id_AlignCenterVertical"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Center vertically"
+              var_name="AlignCenterV" />
+            <node
+              class="tool"
+              bitmap="SVG;alignbottom.svg;[24,24]"
+              id="id_AlignBottom"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Align bottom"
+              var_name="AlignBottom" />
+            <node
+              class="toolSeparator" />
+            <node
+              class="tool"
+              bitmap="SVG;left.svg;[24,24]"
+              id="id_BorderLeft"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Left border"
+              var_name="BorderLeft" />
+            <node
+              class="tool"
+              bitmap="SVG;right.svg;[24,24]"
+              id="id_BorderRight"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Right border"
+              var_name="BorderRight" />
+            <node
+              class="tool"
+              bitmap="SVG;top.svg;[24,24]"
+              id="id_BorderTop"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Top border"
+              var_name="BorderTop" />
+            <node
+              class="tool"
+              bitmap="SVG;bottom.svg;[24,24]"
+              id="id_BorderBottom"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Bottom border"
+              var_name="BorderBottom" />
+            <node
+              class="toolSeparator" />
+            <node
+              class="tool"
+              bitmap="SVG;expand.svg;[24,24]"
+              id="id_Expand"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Expand to fill the space"
+              var_name="Expand" />
+            <node
+              class="toolSeparator" />
+            <node
+              class="tool"
+              bitmap="SVG;hidden.svg;[24,24]"
+              id="id_ShowHidden"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Show hidden controls in Mockup panel"
+              var_name="Spy" />
+            <node
+              class="tool"
+              bitmap="SVG;magnify.svg;[24,24]"
+              id="id_Magnify"
+              kind="wxITEM_CHECK"
+              label=""
+              tooltip="Magnify the size of the Mockup window"
+              var_name="Magnify" />
+            <node
+              class="tool"
+              bitmap="SVG;xrc_preview.svg;[24,24]"
+              id="id_PreviewForm"
+              kind="wxITEM_CHECK"
+              label="Preview Form..."
+              tooltip="Preview form using XRC and/or C++"
+              var_name="xrc_preview"
+              wxEVT_TOOL="OnPreviewXrc" />
+          </node>
+          <node
+            class="wxSplitterWindow"
+            min_pane_size="2"
+            style="wxSP_LIVE_UPDATE"
+            var_name="m_MainSplitter"
+            borders=""
+            flags="wxEXPAND"
+            proportion="1">
+            <node
+              class="wxPanel"
+              class_access="protected:"
+              var_name="m_nav_panel"
+              derived_class="NavigationPanel"
+              derived_header="../panels/nav_panel.h"
+              window_style="0"
+              flags="wxEXPAND" />
+            <node
+              class="wxPanel"
+              class_access="protected:"
+              var_name="m_panel_right"
+              window_style="0"
+              flags="wxEXPAND">
+              <node
+                class="wxBoxSizer"
+                class_access="protected:"
+                orientation="wxVERTICAL"
+                var_name="m_right_panel_sizer" />
+            </node>
+          </node>
+        </node>
         <node
           class="wxMenuBar">
           <node
@@ -623,214 +864,15 @@
               wxEVT_UPDATE_UI="OnUpdateBrowseRuby" />
           </node>
         </node>
-        <node
-          class="wxToolBar"
-          style="wxTB_FLAT|wxTB_HORIZONTAL"
-          var_name="m_toolbar">
-          <node
-            class="tool"
-            bitmap="SVG;new-project.svg;[24,24]"
-            id="id_NewProject"
-            label="New"
-            tooltip="New Project (Ctrl+N)" />
-          <node
-            class="tool"
-            bitmap="Art;wxART_FILE_OPEN|wxART_TOOLBAR"
-            id="id_OpenProject"
-            label="Open"
-            tooltip="Open Project (Ctrl+O)"
-            var_name="tool2" />
-          <node
-            class="tool"
-            bitmap="SVG;save.svg;[24,24]"
-            id="wxID_SAVE"
-            label="Save"
-            tooltip="Save current project"
-            var_name="tool3" />
-          <node
-            class="tool"
-            bitmap="SVG;generate.svg;[24,24]"
-            id="id_GenerateCode"
-            label=""
-            tooltip="Generate code"
-            var_name="Generate"
-            wxEVT_TOOL="OnGenerateCode" />
-          <node
-            class="toolSeparator" />
-          <node
-            class="tool"
-            bitmap="SVG;undo.svg;[16,16]"
-            id="wxID_UNDO"
-            label=""
-            tooltip="Undo"
-            var_name="Undo" />
-          <node
-            class="tool"
-            bitmap="SVG;redo.svg;[16,16]"
-            id="wxID_REDO"
-            label=""
-            tooltip="Redo"
-            var_name="Redo" />
-          <node
-            class="toolSeparator" />
-          <node
-            class="tool"
-            bitmap="Art;wxART_CUT|wxART_TOOLBAR"
-            id="wxID_CUT"
-            label=""
-            tooltip="Cut"
-            var_name="Cut" />
-          <node
-            class="tool"
-            bitmap="Art;wxART_COPY|wxART_TOOLBAR"
-            id="wxID_COPY"
-            label=""
-            tooltip="Copy"
-            var_name="Copy" />
-          <node
-            class="tool"
-            bitmap="Art;wxART_PASTE|wxART_TOOLBAR"
-            id="wxID_PASTE"
-            label=""
-            tooltip="Paste"
-            var_name="Paste" />
-          <node
-            class="tool"
-            bitmap="Art;wxART_DELETE|wxART_TOOLBAR"
-            id="wxID_DELETE"
-            label=""
-            tooltip="Delete selected object without using clipboard."
-            var_name="Delete" />
-          <node
-            class="toolSeparator" />
-          <node
-            class="tool"
-            bitmap="SVG;alignleft.svg;[24,24]"
-            id="id_AlignLeft"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Align left"
-            var_name="AlignLeft" />
-          <node
-            class="tool"
-            bitmap="SVG;aligncenter.svg;[24,24]"
-            id="id_AlignCenterHorizontal"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Center horizontally"
-            var_name="AlignCenterH" />
-          <node
-            class="tool"
-            bitmap="SVG;alignright.svg;[24,24]"
-            id="id_AlignRight"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Align right"
-            var_name="AlignRight" />
-          <node
-            class="toolSeparator" />
-          <node
-            class="tool"
-            bitmap="SVG;aligntop.svg;[24,24]"
-            id="id_AlignTop"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Align top"
-            var_name="AlignTop" />
-          <node
-            class="tool"
-            bitmap="SVG;alignvertcenter.svg;[24,24]"
-            id="id_AlignCenterVertical"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Center vertically"
-            var_name="AlignCenterV" />
-          <node
-            class="tool"
-            bitmap="SVG;alignbottom.svg;[24,24]"
-            id="id_AlignBottom"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Align bottom"
-            var_name="AlignBottom" />
-          <node
-            class="toolSeparator" />
-          <node
-            class="tool"
-            bitmap="SVG;left.svg;[24,24]"
-            id="id_BorderLeft"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Left border"
-            var_name="BorderLeft" />
-          <node
-            class="tool"
-            bitmap="SVG;right.svg;[24,24]"
-            id="id_BorderRight"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Right border"
-            var_name="BorderRight" />
-          <node
-            class="tool"
-            bitmap="SVG;top.svg;[24,24]"
-            id="id_BorderTop"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Top border"
-            var_name="BorderTop" />
-          <node
-            class="tool"
-            bitmap="SVG;bottom.svg;[24,24]"
-            id="id_BorderBottom"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Bottom border"
-            var_name="BorderBottom" />
-          <node
-            class="toolSeparator" />
-          <node
-            class="tool"
-            bitmap="SVG;expand.svg;[24,24]"
-            id="id_Expand"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Expand to fill the space"
-            var_name="Expand" />
-          <node
-            class="toolSeparator" />
-          <node
-            class="tool"
-            bitmap="SVG;hidden.svg;[24,24]"
-            id="id_ShowHidden"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Show hidden controls in Mockup panel"
-            var_name="Spy" />
-          <node
-            class="tool"
-            bitmap="SVG;magnify.svg;[24,24]"
-            id="id_Magnify"
-            kind="wxITEM_CHECK"
-            label=""
-            tooltip="Magnify the size of the Mockup window"
-            var_name="Magnify" />
-          <node
-            class="tool"
-            bitmap="SVG;xrc_preview.svg;[24,24]"
-            id="id_PreviewForm"
-            kind="wxITEM_CHECK"
-            label="Preview Form..."
-            tooltip="Preview form using XRC and/or C++"
-            var_name="xrc_preview"
-            wxEVT_TOOL="OnPreviewXrc" />
-        </node>
       </node>
       <node
         class="ToolBar"
         class_name="NavToolbar"
-        style="wxTB_NODIVIDER"
-        base_file="navtoolbar_base">
+        style="wxTB_FLAT|wxTB_HORIZONTAL"
+        base_file="navtoolbar_base"
+        local_src_includes="mainframe.h;project_handler.h">
+        <node
+          class="toolStretchable" />
         <node
           class="tool"
           bitmap="SVG;nav_coll_expand.svg;[16,16]"
@@ -889,6 +931,8 @@
           statusbar="Move the selected item right"
           tooltip="Move Right"
           var_name="move_right" />
+        <node
+          class="toolStretchable" />
       </node>
       <node
         class="PanelForm"


### PR DESCRIPTION
New layout is controlled by whether or not NEW_LAYOUT is defined. It places the Ribbon panel between the Menubar and the Toolbar.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the layout by moving the Ribbon panel between the Menubar and Toolbar, instead of just being above the Property Grid and Mockup/Code panels.

I also changed some of the underlying code to have wxUiEditor responsible for creating more of the UI -- in this case it creates the main splitter window and both of it's child windows including using the Derived class `NavigationPanel` for the left window.

Related to #1092