### PR TITLE
Add C++ Header Settings and new no_closing_brace property

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -303,6 +303,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_namespace, "namespace" },
     { prop_native_col_header, "native_col_header" },
     { prop_native_col_labels, "native_col_labels" },
+    { prop_no_closing_brace, "no_closing_brace" },
     { prop_non_flexible_grow_mode, "non_flexible_grow_mode" },
     { prop_normal_color, "normal_color" },
     { prop_note, "note" },
@@ -562,6 +563,7 @@ std::map<GenEnum::GenName, const char*> GenEnum::map_GenNames = {
 
     { gen_Bitmaps, "Bitmaps" },
     { gen_Boolean_Validator, "Boolean Validator" },
+    { gen_CPlusHeaderSettings, "C++ Header Settings" },
     { gen_CPlusSettings, "C++ Settings" },
     { gen_Choice_Validator, "Choice Validator" },
     { gen_Code, "C++" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -321,6 +321,7 @@ namespace GenEnum
         prop_namespace,
         prop_native_col_header,
         prop_native_col_labels,
+        prop_no_closing_brace,
         prop_non_flexible_grow_mode,
         prop_normal_color,
         prop_note,
@@ -600,6 +601,7 @@ namespace GenEnum
 
         gen_Bitmaps,
         gen_Boolean_Validator,
+        gen_CPlusHeaderSettings,
         gen_CPlusSettings,
         gen_Choice_Validator,
         gen_Code,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -602,11 +602,6 @@ void BaseCodeGenerator::GenerateCppClass(Node* form_node, PANEL_PAGE panel_type)
         m_header->writeLine();
     }
 
-    if (m_panel_type != CPP_PANEL && m_embedded_images.size() && m_TranslationUnit)
-    {
-        WriteImagePostHeader();
-    }
-
     if (form_node->HasValue(prop_cpp_conditional) && m_TranslationUnit)
     {
         code.Eol().Str("#endif  // ").Str(form_node->value(prop_cpp_conditional));
@@ -1210,6 +1205,12 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, EventVector& events
     {
         m_header->writeLine(code);
         code.clear();
+    }
+
+    if (m_embedded_images.size() && m_TranslationUnit)
+    {
+        WriteImagePostHeader();
+        m_header->writeLine();
     }
 
     code.Str("class ");

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -1407,7 +1407,10 @@ void BaseCodeGenerator::GenerateClassHeader(Node* form_node, EventVector& events
     }
 
     m_header->Unindent();
-    m_header->writeLine("};");
+    if (not m_form_node->as_bool(prop_no_closing_brace))
+    {
+        m_header->writeLine("};");
+    }
 
     if (m_embedded_images.size() && !m_TranslationUnit)
     {

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -83,17 +83,17 @@ protected:
     // gen_Images node.
     //
     // This will call code.clear() before writing any code.
-    void WriteImagePreConstruction(Code& code);
+    void WriteImagePreConstruction(Code& code);  // declared in image_gen.cpp
 
-    // Generate code after the construcor for embedded images not defined in the gen_Images
+    // Generate code for embedded images not defined in the gen_Images
     // node.
     //
     // This will call code.clear() before writing any code.
-    void WriteImageConstruction(Code& code);
+    void WriteImageConstruction(Code& code);  // declared in image_gen.cpp
 
     // Generate extern statements after the header definition for embedded images not defined
     // in the gen_Images node.
-    void WriteImagePostHeader();
+    void WriteImagePostHeader();  // declared in image_gen.cpp
 
     void WritePropSourceCode(Node* node, GenEnum::PropName prop);
     void WritePropHdrCode(Node* node, GenEnum::PropName prop);
@@ -108,10 +108,10 @@ protected:
     void GenerateImagesForm();
 
     // This method is in image_gen.cpp, and handles Python code generation
-    void GeneratePythonImagesForm();
+    void GeneratePythonImagesForm();  // declared in image_gen.cpp
 
     // This method is in image_gen.cpp, and handles Ruby code generation
-    void GenerateRubyImagesForm();
+    void GenerateRubyImagesForm();  // declared in image_gen.cpp
 
     tt_string GetDeclaration(Node* node);
 

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -51,9 +51,8 @@ void BaseCodeGenerator::WriteImagePreConstruction(Code& code)
 
     if (code.is_cpp() && is_namespace_written)
     {
-        code.CloseBrace();
+        code.CloseBrace().Eol();
     }
-    // m_source->writeLine(code);
 }
 
 // Generate code after the construcor for embedded images not defined in the gen_Images node.

--- a/src/xml/aui_xml.xml
+++ b/src/xml/aui_xml.xml
@@ -52,6 +52,7 @@ inline const char* aui_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="AuiToolBar" image="auitoolbar" type="aui_toolbar_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />

--- a/src/xml/dialogs_xml.xml
+++ b/src/xml/dialogs_xml.xml
@@ -4,6 +4,7 @@ inline const char* dialogs_xml = R"===(<?xml version="1.0"?>
 	<gen class="wxDialog" image="wxDialog" type="form">
 		<inherits class="Dialog Window Settings" />
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />
@@ -70,6 +71,7 @@ inline const char* dialogs_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="PanelForm" image="wxPanel" type="form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />

--- a/src/xml/doc_view_app_xml.xml
+++ b/src/xml/doc_view_app_xml.xml
@@ -3,6 +3,7 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="DocViewApp" image="wxFrame" type="DocViewApp">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Frame Settings" />
 		<inherits class="wxRuby Frame Settings" />
@@ -65,6 +66,7 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="DocumentTextCtrl" image="wxTextCtrl" type="wx_document">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<property name="class_name" type="string"
 			help="The name of the class.">DocumentTextCtrlBase</property>
@@ -88,6 +90,7 @@ inline const char* doc_view_app_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="ViewTextCtrl" image="wxTextCtrl" type="wx_view">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxMdiWindow" />
 		<property name="class_name" type="string"

--- a/src/xml/forms_xml.xml
+++ b/src/xml/forms_xml.xml
@@ -3,6 +3,7 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="wxFrame" image="wxFrame" type="frame_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Frame Settings" />
 		<inherits class="wxRuby Frame Settings" />
@@ -72,6 +73,7 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="wxPopupTransientWindow" image="wxPopupTransientWindow" type="form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />
@@ -111,6 +113,7 @@ inline const char* forms_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="RibbonBar" image="ribbon_bar" type="ribbonbar_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -13,23 +13,31 @@ inline const char* lang_settings_xml = R"===(<?xml version="1.0"?>
 			help="Lists one or more local header files to include in the generated header file." />
 		<property name="system_src_includes" type="include_files"
 			help="Lists one or more system header files to include in the generated header file." />
-		<property name="header_preamble" type="code_edit"
-			help="This preamble is placed unchanged in the generated header file after all wx/ include files. It is commonly used to add forward class names needed by methods and members you add to the Derived Class Settings." />
-		<property name="local_hdr_includes" type="include_files"
-			help="Lists one or more local header files to include in the generated header file." />
-		<property name="system_hdr_includes" type="include_files"
-			help="Lists one or more system header files to include in the generated header file." />
 		<property name="generate_ids" type="bool"
 			help="If checked, any non-wxWidgets ids will be created as an enumerated list unless you specically assign the value of the id (e.g., myid=100).">
 			1</property>
 		<property name="initial_enum_string" type="string"
 			help="The first id in a generated enum will be set to this value.">
 			wxID_HIGHEST + 1</property>
+		<property name="class_decoration" type="string"
+			help="This specifies the keyword or macro to add to the class declaration (such as __declspec(dllexport) )." />
+	</gen>
+
+	<gen class="C++ Header Settings" type="interface">
+		<property name="header_preamble" type="code_edit"
+			help="This preamble is placed unchanged in the generated header file after all wx/ include files. It is commonly used to add forward class names needed by methods and members you add to the Derived Class Settings." />
+		<property name="local_hdr_includes" type="include_files"
+			help="Lists one or more local header files to include in the generated header file." />
+		<property name="system_hdr_includes" type="include_files"
+			help="Lists one or more system header files to include in the generated header file." />
+		<property name="inserted_hdr_code" type="code_edit"
+			help="Specify code to insert into the header file at the end of the public: section. You may add protected: and private: sections as needed for additional methods and member variables." />
 		<property name="generate_const_values" type="bool"
 			help="If checked, each form's header file will have const values declared for some of the possible parameters. E.g., const int form_id = your_id. You can use this when creating multiple instances of a form with different construction parameters.">
 			0</property>
-		<property name="class_decoration" type="string"
-			help="This specifies the keyword or macro to add to the class declaration (such as __declspec(dllexport) )." />
+		<property name="no_closing_brace" type="bool"
+			help="If checked no closing brace (};) will be generated at the end of the header file. This allows you to extend the class definition after the generated code block.">
+			0</property>
 	</gen>
 
 	<gen class="C++ Derived Class Settings" type="interface">
@@ -46,8 +54,6 @@ inline const char* lang_settings_xml = R"===(<?xml version="1.0"?>
 			help="Additional class methods to add (useful if you are *not* using a derived class." />
 		<property name="class_members" type="stringlist_escapes"
 			help="Additional class variable members to add (useful if you are *not* using a derived class." />
-		<property name="inserted_hdr_code" type="code_edit"
-			help="Specify code to insert into the header file at the end of the public: section. You may add protected: and private: sections as needed for additional methods and member variables." />
 		<property name="private_members" type="bool"
 			help="Check this to make all protected: members private:. This can only be done if you are NOT creating a derived class (use_derived_class is unchecked)." />
 	</gen>

--- a/src/xml/menus_xml.xml
+++ b/src/xml/menus_xml.xml
@@ -3,6 +3,7 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="MenuBar" image="wxMenuBar" type="menubar_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />
@@ -23,6 +24,7 @@ inline const char* menus_xml = R"===(<?xml version="1.0"?>
 
 	<gen class="PopupMenu" image="menu" type="popup_menu">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />

--- a/src/xml/toolbars_xml.xml
+++ b/src/xml/toolbars_xml.xml
@@ -3,6 +3,7 @@ inline const char* toolbars_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="ToolBar" image="wxToolBar" type="toolbar_form">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />

--- a/src/xml/wizard_xml.xml
+++ b/src/xml/wizard_xml.xml
@@ -3,6 +3,7 @@ inline const char* wizard_xml = R"===(<?xml version="1.0"?>
 <GeneratorDefinitions>
 	<gen class="wxWizard" image="wxWizard" type="wizard">
 		<inherits class="C++ Settings" />
+		<inherits class="C++ Header Settings" />
 		<inherits class="C++ Derived Class Settings" />
 		<inherits class="wxPython Settings" />
 		<inherits class="wxRuby Settings" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR has several parts:

- The generated namespace extern images in the header file is now written _before_ the class definition instead of afterwards.
- A new `C++ Header Settings` category has been added, and properties specific to generating a header file have been moved into this category.
- A new `no_closing_brace` property has been added to the C++ Header Settings. When checked, no closing brace (`};`) is written to the header file so that the user can extend the header definition after the comment block.

Closes #1111
