### PR TITLE
Update Code Generation Dialog

### DIFF
--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -281,7 +281,7 @@ int ProjectHandler::get_PreferredLanguage()
         return GEN_LANG_CPLUSPLUS;
 }
 
-size_t ProjectHandler::GetOutputType()
+size_t ProjectHandler::GetOutputType() const
 {
     size_t result = OUTPUT_NONE;
 
@@ -318,6 +318,10 @@ size_t ProjectHandler::GetOutputType()
                 {
                     result |= OUTPUT_RUBY;
                 }
+                if (child->hasValue(prop_xrc_file))
+                {
+                    result |= OUTPUT_XRC;
+                }
             }
         }
     };
@@ -327,7 +331,7 @@ size_t ProjectHandler::GetOutputType()
     return result;
 }
 
-tt_string ProjectHandler::GetDerivedFilename(Node* form)
+tt_string ProjectHandler::GetDerivedFilename(Node* form) const
 {
     tt_string path;
 

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -29,6 +29,7 @@ enum : size_t
     OUTPUT_C_DERIVED = OUTPUT_CPLUS | OUTPUT_DERIVED,
     OUTPUT_PYTHON = 1 << 2,
     OUTPUT_RUBY = 1 << 3,
+    OUTPUT_XRC = 1 << 4,
 };
 
 class ProjectHandler
@@ -68,8 +69,10 @@ public:
     // Returns the full path to the directory the project file is in
     tt_string ProjectFile() const { return m_projectFile; }
 
-    // Get a bit flag indicating which output types are enabled
-    size_t GetOutputType();
+    // Get a bit flag indicating which output types are enabled.
+    //
+    // OUTPUT_DERIVED is only set if the file is specified and does *not* exist.
+    size_t GetOutputType() const;
 
     // Change to the project's directory
     bool ChangeDir() const { return m_projectPath.ChangeDir(); }
@@ -86,7 +89,7 @@ public:
 
     // Returns the full path to the derived filename or an empty string if no derived file
     // was specified.
-    tt_string GetDerivedFilename(Node*);
+    tt_string GetDerivedFilename(Node*) const;
 
     Node* ProjectNode() const { return m_project_node.get(); }
     auto& ChildNodePtrs() { return m_project_node->getChildNodePtrs(); }

--- a/src/tools/generate_dlg.cpp
+++ b/src/tools/generate_dlg.cpp
@@ -26,25 +26,26 @@ bool GenerateDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     auto* box_sizer = new wxBoxSizer(wxVERTICAL);
 
-    auto* checkBox = new wxCheckBox(this, wxID_ANY, "C++ &Base");
-    checkBox->SetValidator(wxGenericValidator(&m_gen_base_code));
-    box_sizer->Add(checkBox, wxSizerFlags().Border(wxALL));
+    m_checkBaseCode = new wxCheckBox(this, wxID_ANY, "C++ &Base");
+    m_checkBaseCode->SetValidator(wxGenericValidator(&m_gen_base_code));
+    box_sizer->Add(m_checkBaseCode, wxSizerFlags().Border(wxALL));
 
-    checkBox_6 = new wxCheckBox(this, wxID_ANY, "C++ &Inherited");
-    checkBox_6->SetValidator(wxGenericValidator(&m_gen_inherited_code));
-    box_sizer->Add(checkBox_6, wxSizerFlags().Border(wxALL));
+    m_checkDerived = new wxCheckBox(this, wxID_ANY, "C++ &Derived");
+    m_checkDerived->SetValidator(wxGenericValidator(&m_gen_inherited_code));
+    m_checkDerived->SetToolTip("Generate any derived files that don\'t currently exist");
+    box_sizer->Add(m_checkDerived, wxSizerFlags().Border(wxALL));
 
-    auto* checkBox_5 = new wxCheckBox(this, wxID_ANY, "&Python");
-    checkBox_5->SetValidator(wxGenericValidator(&m_gen_python_code));
-    box_sizer->Add(checkBox_5, wxSizerFlags().Border(wxALL));
+    m_checkPython = new wxCheckBox(this, wxID_ANY, "&Python");
+    m_checkPython->SetValidator(wxGenericValidator(&m_gen_python_code));
+    box_sizer->Add(m_checkPython, wxSizerFlags().Border(wxALL));
 
-    auto* checkBox_3 = new wxCheckBox(this, wxID_ANY, "&Ruby");
-    checkBox_3->SetValidator(wxGenericValidator(&m_gen_ruby_code));
-    box_sizer->Add(checkBox_3, wxSizerFlags().Border(wxALL));
+    m_checkRuby = new wxCheckBox(this, wxID_ANY, "&Ruby");
+    m_checkRuby->SetValidator(wxGenericValidator(&m_gen_ruby_code));
+    box_sizer->Add(m_checkRuby, wxSizerFlags().Border(wxALL));
 
-    auto* checkBox_2 = new wxCheckBox(this, wxID_ANY, "&XRC");
-    checkBox_2->SetValidator(wxGenericValidator(&m_gen_xrc_code));
-    box_sizer->Add(checkBox_2, wxSizerFlags().Border(wxALL));
+    m_checkXRC = new wxCheckBox(this, wxID_ANY, "&XRC");
+    m_checkXRC->SetValidator(wxGenericValidator(&m_gen_xrc_code));
+    box_sizer->Add(m_checkXRC, wxSizerFlags().Border(wxALL));
 
     dlg_sizer->Add(box_sizer, wxSizerFlags().Border(wxALL));
 
@@ -84,47 +85,80 @@ bool GenerateDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
 #include "../wxui/dlg_gen_results.h"
 
-enum
-{
-    GEN_BASE_CODE = 1 << 0,
-    GEN_INHERITED_CODE = 1 << 1,
-    GEN_PYTHON_CODE = 1 << 2,
-    GEN_XRC_CODE = 1 << 3
-};
-
 // This generates the base class files. For the derived class files, see OnGenInhertedClass()
 // in generate/gen_codefiles.cpp
 void MainFrame::OnGenerateCode(wxCommandEvent&)
 {
     ProjectImages.UpdateEmbedNodes();
-    ProjectImages.UpdateEmbedNodes();
+    bool code_generated = false;
+    GenResults results;
+    auto output_type = Project.GetOutputType();
 
-    GenerateDlg dlg(this);
-    if (dlg.ShowModal() == wxID_OK)
+    // First check to see if there is only one code output type. If so, then we can skip the
+    // dialog.
+
+    if (output_type == OUTPUT_CPLUS)
     {
-        GenResults results;
+        GenerateCodeFiles(results);
+        code_generated = true;
+    }
+    else if (output_type == OUTPUT_DERIVED)
+    {
+        GenInhertedClass(results);
+        code_generated = true;
+    }
+    else if (output_type == OUTPUT_PYTHON)
+    {
+        GeneratePythonFiles(results);
+        code_generated = true;
+    }
+    else if (output_type == OUTPUT_RUBY)
+    {
+        GenerateRubyFiles(results);
+        code_generated = true;
+    }
+    else if (output_type == OUTPUT_XRC)
+    {
+        GenerateXrcFiles(results);
+        code_generated = true;
+    }
 
-        if (dlg.is_gen_base())
-        {
-            GenerateCodeFiles(results);
-        }
-        if (dlg.is_gen_inherited())
-        {
-            GenInhertedClass(results);
-        }
-        if (dlg.is_gen_python())
-        {
-            GeneratePythonFiles(results);
-        }
-        if (dlg.is_gen_ruby())
-        {
-            GenerateRubyFiles(results);
-        }
-        if (dlg.is_gen_xrc())
-        {
-            GenerateXrcFiles(results);
-        }
 
+    if (!code_generated)
+    {
+        GenerateDlg dlg(this);
+        if (dlg.ShowModal() == wxID_OK)
+        {
+            if (dlg.is_gen_base())
+            {
+                GenerateCodeFiles(results);
+                code_generated = true;
+            }
+            if (dlg.is_gen_inherited())
+            {
+                GenInhertedClass(results);
+                code_generated = true;
+            }
+            if (dlg.is_gen_python())
+            {
+                GeneratePythonFiles(results);
+                code_generated = true;
+            }
+            if (dlg.is_gen_ruby())
+            {
+                GenerateRubyFiles(results);
+                code_generated = true;
+            }
+            if (dlg.is_gen_xrc())
+            {
+                GenerateXrcFiles(results);
+                code_generated = true;
+            }
+        }
+    }
+
+    if (code_generated)
+    {
         if ((results.updated_files.size() || results.msgs.size()))
         {
             GeneratedResultsDlg results_dlg;
@@ -153,19 +187,34 @@ void MainFrame::OnGenerateCode(wxCommandEvent&)
             msg << '\n' << "All " << results.file_count << " generated files are current";
             wxMessageBox(msg, "Code Generation", wxOK, this);
         }
-
-        UpdateWakaTime();
     }
+
+    UpdateWakaTime();
 }
 
 void GenerateDlg::OnInit(wxInitDialogEvent& event)
 {
+    auto output_type = Project.GetOutputType();
+
     if (Project.as_string(prop_code_preference) == "C++")
     {
         m_gen_python_code = false;
         m_gen_ruby_code = false;
         m_gen_base_code = true;
         m_gen_xrc_code = false;
+
+        if (not (output_type & OUTPUT_XRC))
+        {
+            m_checkXRC->Hide();
+        }
+        if (not (output_type & OUTPUT_PYTHON))
+        {
+            m_checkPython->Hide();
+        }
+        if (not (output_type & OUTPUT_RUBY))
+        {
+            m_checkRuby->Hide();
+        }
     }
     else if (Project.as_string(prop_code_preference) == "Python")
     {
@@ -173,6 +222,23 @@ void GenerateDlg::OnInit(wxInitDialogEvent& event)
         m_gen_ruby_code = false;
         m_gen_base_code = false;
         m_gen_xrc_code = false;
+
+        if (not (output_type & OUTPUT_XRC))
+        {
+            m_checkXRC->Hide();
+        }
+        if (not (output_type & OUTPUT_CPLUS))
+        {
+            m_checkBaseCode->Hide();
+        }
+        if (not (output_type & OUTPUT_DERIVED))
+        {
+            m_checkDerived->Hide();
+        }
+        if (not (output_type & OUTPUT_RUBY))
+        {
+            m_checkRuby->Hide();
+        }
     }
     else if (Project.as_string(prop_code_preference) == "Ruby")
     {
@@ -180,6 +246,23 @@ void GenerateDlg::OnInit(wxInitDialogEvent& event)
         m_gen_ruby_code = true;
         m_gen_base_code = false;
         m_gen_xrc_code = false;
+
+        if (not (output_type & OUTPUT_XRC))
+        {
+            m_checkXRC->Hide();
+        }
+        if (not (output_type & OUTPUT_CPLUS))
+        {
+            m_checkBaseCode->Hide();
+        }
+        if (not (output_type & OUTPUT_DERIVED))
+        {
+            m_checkDerived->Hide();
+        }
+        if (not (output_type & OUTPUT_PYTHON))
+        {
+            m_checkPython->Hide();
+        }
     }
     else if (Project.as_string(prop_code_preference) == "XRC")
     {
@@ -187,13 +270,26 @@ void GenerateDlg::OnInit(wxInitDialogEvent& event)
         m_gen_ruby_code = false;
         m_gen_base_code = false;
         m_gen_xrc_code = true;
+
+        // For XRC preferred files, we still display all the other languages in case the user
+        // is combining XRC with one of those languages.
     }
     else
     {
         m_gen_python_code = false;
         m_gen_ruby_code = false;
-        m_gen_base_code = true;
+        m_gen_base_code = false;
         m_gen_xrc_code = false;
+
+        // We get here if a new language preference has been added but we haven't updated this
+        // dialog to support it yet.
     }
+
+    // Some checkboxes may be hidden at this point, so we need to resize the dialog to fit.
+
+    // You have to reset minimum size to allow the window to shrink
+    SetMinSize(wxSize(-1, -1));
+    Fit();
+
     event.Skip();
 }

--- a/src/tools/generate_dlg.h
+++ b/src/tools/generate_dlg.h
@@ -52,7 +52,11 @@ protected:
 
     // Class member variables
 
-    wxCheckBox* checkBox_6;
+    wxCheckBox* m_checkBaseCode;
+    wxCheckBox* m_checkDerived;
+    wxCheckBox* m_checkPython;
+    wxCheckBox* m_checkRuby;
+    wxCheckBox* m_checkXRC;
     wxStaticText* m_staticText;
 };
 

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -1885,36 +1885,33 @@
             orientation="wxVERTICAL">
             <node
               class="wxCheckBox"
-              class_access="none"
               label="C++ &amp;Base"
-              var_name="checkBox"
+              var_name="m_checkBaseCode"
               get_function="is_gen_base"
               validator_variable="m_gen_base_code" />
             <node
               class="wxCheckBox"
-              label="C++ &amp;Inherited"
-              var_name="checkBox_6"
+              label="C++ &amp;Derived"
+              var_name="m_checkDerived"
               get_function="is_gen_inherited"
-              validator_variable="m_gen_inherited_code" />
+              validator_variable="m_gen_inherited_code"
+              tooltip="Generate any derived files that don't currently exist" />
             <node
               class="wxCheckBox"
-              class_access="none"
               label="&amp;Python"
-              var_name="checkBox_5"
+              var_name="m_checkPython"
               get_function="is_gen_python"
               validator_variable="m_gen_python_code" />
             <node
               class="wxCheckBox"
-              class_access="none"
               label="&amp;Ruby"
-              var_name="checkBox_3"
+              var_name="m_checkRuby"
               get_function="is_gen_ruby"
               validator_variable="m_gen_ruby_code" />
             <node
               class="wxCheckBox"
-              class_access="none"
               label="&amp;XRC"
-              var_name="checkBox_2"
+              var_name="m_checkXRC"
               get_function="is_gen_xrc"
               validator_variable="m_gen_xrc_code" />
           </node>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the Generate Dialog. The dialog is no longer displayed at all if there is only one output file type. For example, if the preferred language is Python, and there are no output filenames specified for C++, Derived, Ruby or XRC, then the dialog is not displayed at all and the code is simply generated immediately.

If there _is_ more than one output file available then the dialog will always display a checkbox for the `prop_code_preference` language type, but will _only_ display check boxes for other output types that have files specified which could be generated.