### PR TITLE
Improve getting a URL for a control to display in Doc Panel or Help Menu

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -262,8 +262,22 @@ tt_string getClassHelpName(Node* node)
             class_name = "wxToolBar";
         else if (class_name == "AuiToolBar")
             class_name = "wxAuiToolBar";
+        else if (class_name == "auitool")
+            class_name = "wxAuiToolBarItem";
         else if (class_name == "StaticCheckboxBoxSizer" || class_name == "StaticRadioBtnBoxSizer")
             class_name = "wxStaticBoxSizer";
+        else if (class_name == "Check3State")
+            class_name = "wxCheckBox";
+        else if (class_name == "MenuBar")
+            class_name = "wxMenuBar";
+        else if (class_name == "propGridCategory")
+            class_name = "wxPropertyCategory";
+        else if (class_name == "propGridItem")
+            class_name = "wxPGProperty";
+        else if (class_name == "propGridPage")
+            class_name = "wxPropertyGridPage";
+        else if (class_name == "submenu")
+            class_name = "wxMenu";
         else
             class_name.clear();  // Don't return a non-wxWidgets class name
     }
@@ -312,6 +326,15 @@ tt_string BaseGenerator::GetPythonURL(Node* node)
     tt_string url = GetPythonHelpText(node);
     if (url.empty())
     {
+        auto class_name = map_GenNames[node->getGenName()];
+        if (tt::is_sameas(class_name, "auitool_spacer"))
+        {
+            url = "wx.aui.AuiToolBar.html?highlight=addspacer#wx.aui.AuiToolBar.AddSpacer";
+        }
+        else if (tt::is_sameas(class_name, "auitool_label"))
+        {
+            url = "wx.aui.AuiToolBar.html?highlight=addlabel#wx.aui.AuiToolBar.AddLabel";
+        }
         return url;
     }
     url << ".html";
@@ -342,6 +365,15 @@ tt_string BaseGenerator::GetRubyURL(Node* node)
     tt_string url = GetRubyHelpText(node);
     if (url.empty())
     {
+        auto class_name = map_GenNames[node->getGenName()];
+        if (tt::is_sameas(class_name, "auitool_spacer"))
+        {
+            url = "Wx/AUI/AuiToolBar.html#add_spacer-instance_method";
+        }
+        else if (tt::is_sameas(class_name, "auitool_spacer"))
+        {
+            url = "Wx/AUI/AuiToolBar.html#add_label-instance_method";
+        }
         return url;
     }
     url.Replace("::", "/", true);

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -278,6 +278,8 @@ tt_string getClassHelpName(Node* node)
             class_name = "wxPropertyGridPage";
         else if (class_name == "submenu")
             class_name = "wxMenu";
+        else if (class_name == "tool" || class_name == "tool_dropdown")
+            class_name = "wxToolBarToolBase";
         else
             class_name.clear();  // Don't return a non-wxWidgets class name
     }
@@ -335,8 +337,37 @@ tt_string BaseGenerator::GetPythonURL(Node* node)
         {
             url = "wx.aui.AuiToolBar.html?highlight=addlabel#wx.aui.AuiToolBar.AddLabel";
         }
+        else if (tt::is_sameas(class_name, "spacer"))
+        {
+            url = "wx.Sizer.html?highlight=addspacer#wx.Sizer.AddSpacer";
+        }
         return url;
     }
+    url << ".html";
+    return url;
+}
+
+tt_string BaseGenerator::GetRubyURL(Node* node)
+{
+    tt_string url = GetRubyHelpText(node);
+    if (url.empty())
+    {
+        auto class_name = map_GenNames[node->getGenName()];
+        if (tt::is_sameas(class_name, "auitool_spacer"))
+        {
+            url = "Wx/AUI/AuiToolBar.html#add_spacer-instance_method";
+        }
+        else if (tt::is_sameas(class_name, "auitool_spacer"))
+        {
+            url = "Wx/AUI/AuiToolBar.html#add_label-instance_method";
+        }
+        else if (tt::is_sameas(class_name, "spacer"))
+        {
+            url = "Wx/Sizer.html#add_spacer-instance_method";
+        }
+        return url;
+    }
+    url.Replace("::", "/", true);
     url << ".html";
     return url;
 }
@@ -358,27 +389,6 @@ tt_string BaseGenerator::GetRubyHelpText(Node* node)
     help_text << prefix << class_name.subview(2);
 
     return help_text;
-}
-
-tt_string BaseGenerator::GetRubyURL(Node* node)
-{
-    tt_string url = GetRubyHelpText(node);
-    if (url.empty())
-    {
-        auto class_name = map_GenNames[node->getGenName()];
-        if (tt::is_sameas(class_name, "auitool_spacer"))
-        {
-            url = "Wx/AUI/AuiToolBar.html#add_spacer-instance_method";
-        }
-        else if (tt::is_sameas(class_name, "auitool_spacer"))
-        {
-            url = "Wx/AUI/AuiToolBar.html#add_label-instance_method";
-        }
-        return url;
-    }
-    url.Replace("::", "/", true);
-    url << ".html";
-    return url;
 }
 
 bool BaseGenerator::GetPythonImports(Node* node, std::set<std::string>& set_imports)
@@ -606,6 +616,10 @@ tt_string BaseGenerator::GetHelpURL(Node* node)
         {
             class_name = "simple_html_list_box";
         }
+        else if (class_name == "toolbartoolbase")
+        {
+            class_name = "tool_bar_tool_base";
+        }
         else
         {
             for (const auto& [key, value]: prefix_pair)
@@ -654,6 +668,10 @@ tt_string BaseGenerator::GetHelpURL(Node* node)
     else if (class_name == "RibbonToolBar")
     {
         return tt_string("wx_ribbon_tool_bar.html");
+    }
+    else if (class_name == "spacer")
+    {
+        return tt_string("wx_sizer.html");
     }
     else if (class_name == "StaticCheckboxBoxSizer" || class_name == "StaticRadioBtnBoxSizer")
     {

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -249,7 +249,9 @@ tt_string getClassHelpName(Node* node)
     if (!class_name.starts_with("wx"))
     {
         if (class_name == "BookPage")
-            class_name = "wxBookCtrl";
+        {
+            class_name = map_GenNames[node->getParent()->getGenName()];
+        }
         else if (class_name == "PanelForm")
             class_name = "wxPanel";
         else if (class_name == "RibbonBar")
@@ -283,7 +285,8 @@ tt_string BaseGenerator::GetHelpText(Node* node)
     return class_name;
 }
 
-extern std::map<std::string_view, std::string_view, std::less<>> g_map_class_prefix;
+extern std::map<std::string_view, std::string_view, std::less<>> g_map_python_prefix;
+extern std::map<std::string_view, std::string_view, std::less<>> g_map_ruby_prefix;
 
 tt_string BaseGenerator::GetPythonHelpText(Node* node)
 {
@@ -294,7 +297,7 @@ tt_string BaseGenerator::GetPythonHelpText(Node* node)
     }
 
     std::string_view prefix = "wx.";
-    if (auto wx_iter = g_map_class_prefix.find(class_name); wx_iter != g_map_class_prefix.end())
+    if (auto wx_iter = g_map_python_prefix.find(class_name); wx_iter != g_map_python_prefix.end())
     {
         prefix = wx_iter->second;
     }
@@ -324,6 +327,10 @@ tt_string BaseGenerator::GetRubyHelpText(Node* node)
     }
 
     std::string_view prefix = "Wx::";
+    if (auto wx_iter = g_map_ruby_prefix.find(class_name); wx_iter != g_map_ruby_prefix.end())
+    {
+        prefix = wx_iter->second;
+    }
     tt_string help_text;
     help_text << prefix << class_name.subview(2);
 
@@ -337,7 +344,7 @@ tt_string BaseGenerator::GetRubyURL(Node* node)
     {
         return url;
     }
-    url.Replace("::", "/");
+    url.Replace("::", "/", true);
     url << ".html";
     return url;
 }
@@ -351,7 +358,7 @@ bool BaseGenerator::GetPythonImports(Node* node, std::set<std::string>& set_impo
     }
 
     std::string_view prefix = "wx.";
-    if (auto wx_iter = g_map_class_prefix.find(class_name); wx_iter != g_map_class_prefix.end())
+    if (auto wx_iter = g_map_python_prefix.find(class_name); wx_iter != g_map_python_prefix.end())
     {
         prefix = wx_iter->second;
         tt_string import_lib("import ");
@@ -548,7 +555,8 @@ static std::vector<std::pair<const char*, const char*>> prefix_pair = {
 
 tt_string BaseGenerator::GetHelpURL(Node* node)
 {
-    tt_string class_name(map_GenNames[node->getGenName()]);
+    tt_string class_name = getClassHelpName(node);
+
     if (class_name.starts_with("wx"))
     {
         class_name.erase(0, 2);
@@ -579,6 +587,10 @@ tt_string BaseGenerator::GetHelpURL(Node* node)
         url << class_name << ".html";
         return url;
     }
+
+    // REVIEW: [Randalphwa - 07-23-2023] some of these are now being handled by getClassHelpName()
+    // and will therefore never make it this far.
+
     else if (class_name == "BookPage")
     {
         return tt_string("wx_book_ctrl_base.html");

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -243,7 +243,7 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
     return true;
 }
 
-tt_string BaseGenerator::GetHelpText(Node* node)
+tt_string getClassHelpName(Node* node)
 {
     tt_string class_name(map_GenNames[node->getGenName()]);
     if (!class_name.starts_with("wx"))
@@ -266,6 +266,13 @@ tt_string BaseGenerator::GetHelpText(Node* node)
             class_name.clear();  // Don't return a non-wxWidgets class name
     }
 
+    return class_name;
+}
+
+tt_string BaseGenerator::GetHelpText(Node* node)
+{
+    tt_string class_name = getClassHelpName(node);
+
 #if defined(_DEBUG)
     if (class_name.size())
     {
@@ -280,25 +287,10 @@ extern std::map<std::string_view, std::string_view, std::less<>> g_map_class_pre
 
 tt_string BaseGenerator::GetPythonHelpText(Node* node)
 {
-    auto class_name = node->declName();
-    if (!class_name.starts_with("wx"))
+    tt_string class_name = getClassHelpName(node);
+    if (class_name.empty())
     {
-        if (class_name == "BookPage")
-            class_name = "wxBookCtrl";
-        else if (class_name == "PanelForm")
-            class_name = "wxPanel";
-        else if (class_name == "RibbonBar")
-            class_name = "wxRibbonBar";
-        else if (class_name == "PopupMenu")
-            class_name = "wxMenu";
-        else if (class_name == "ToolBar")
-            class_name = "wxToolBar";
-        else if (class_name == "AuiToolBar")
-            class_name = "wxAuiToolBar";
-        else if (class_name == "StaticCheckboxBoxSizer" || class_name == "StaticRadioBtnBoxSizer")
-            class_name = "wxStaticBoxSizer";
-        else
-            return {};
+        return class_name;
     }
 
     std::string_view prefix = "wx.";
@@ -325,25 +317,10 @@ tt_string BaseGenerator::GetPythonURL(Node* node)
 
 tt_string BaseGenerator::GetRubyHelpText(Node* node)
 {
-    auto class_name = node->declName();
-    if (!class_name.starts_with("wx"))
+    tt_string class_name = getClassHelpName(node);
+    if (class_name.empty())
     {
-        if (class_name == "BookPage")
-            class_name = "wxBookCtrl";
-        else if (class_name == "PanelForm")
-            class_name = "wxPanel";
-        else if (class_name == "RibbonBar")
-            class_name = "wxRibbonBar";
-        else if (class_name == "PopupMenu")
-            class_name = "wxMenu";
-        else if (class_name == "ToolBar")
-            class_name = "wxToolBar";
-        else if (class_name == "AuiToolBar")
-            class_name = "wxAuiToolBar";
-        else if (class_name == "StaticCheckboxBoxSizer" || class_name == "StaticRadioBtnBoxSizer")
-            class_name = "wxStaticBoxSizer";
-        else
-            return {};
+        return class_name;
     }
 
     std::string_view prefix = "Wx::";

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -93,7 +93,7 @@ static const std::map<std::string_view, std::string_view, std::less<>> map_pytho
     { "wxWebViewBackendDefault", "wx.html2."},
 };
 
-std::map<std::string_view, std::string_view, std::less<>> g_map_class_prefix
+std::map<std::string_view, std::string_view, std::less<>> g_map_python_prefix
 {
     { "wxAnimationCtrl", "wx.adv."},
     { "wxAuiNotebook", "wx.aui."},
@@ -128,6 +128,13 @@ std::map<std::string_view, std::string_view, std::less<>> g_map_class_prefix
     { "wxPropertyGrid", "wx.propgrid."},
 
 };
+
+std::map<std::string_view, std::string_view, std::less<>> g_map_ruby_prefix
+{
+    { "wxAuiNotebook", "Wx::AUI::" },
+    { "wxAuiToolBar", "Wx::AUI::" },
+};
+
 // clang-format on
 
 Code::Code(Node* node, int language)
@@ -577,7 +584,14 @@ Code& Code::CreateClass(bool use_generic, tt_string_view override_name)
         std::string_view prefix = m_lang_wxPrefix;
         if (is_python())
         {
-            if (auto wx_iter = g_map_class_prefix.find(class_name); wx_iter != g_map_class_prefix.end())
+            if (auto wx_iter = g_map_python_prefix.find(class_name); wx_iter != g_map_python_prefix.end())
+            {
+                prefix = wx_iter->second;
+            }
+        }
+        else if (is_ruby())
+        {
+            if (auto wx_iter = g_map_ruby_prefix.find(class_name); wx_iter != g_map_ruby_prefix.end())
             {
                 prefix = wx_iter->second;
             }

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -98,6 +98,7 @@ std::map<std::string_view, std::string_view, std::less<>> g_map_python_prefix
     { "wxAnimationCtrl", "wx.adv."},
     { "wxAuiNotebook", "wx.aui."},
     { "wxAuiToolBar", "wx.aui."},
+    { "wxAuiToolBarItem", "wx.aui."},
     { "wxBannerWindow", "wx.adv."},
     { "wxCalendarCtrl", "wx.adv."},
     { "wxCommandLinkButton", "wx.adv."},
@@ -133,6 +134,7 @@ std::map<std::string_view, std::string_view, std::less<>> g_map_ruby_prefix
 {
     { "wxAuiNotebook", "Wx::AUI::" },
     { "wxAuiToolBar", "Wx::AUI::" },
+    { "wxAuiToolBarItem", "Wx::AUI::" },
 };
 
 // clang-format on

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -548,26 +548,6 @@ int ToolGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_f
     return BaseGenerator::xrc_updated;
 }
 
-tt_string ToolGenerator::GetHelpURL(Node*)
-{
-    return "wx_tool_bar.html";
-}
-
-tt_string ToolGenerator::GetHelpText(Node*)
-{
-    return "wxToolBar";
-}
-
-tt_string ToolGenerator::GetPythonURL(Node*)
-{
-    return "wx.ToolBar.html";
-}
-
-tt_string ToolGenerator::GetPythonHelpText(Node*)
-{
-    return "wx.ToolBar";
-}
-
 //////////////////////////////////////////  ToolDropDownGenerator  //////////////////////////////////////////
 
 bool ToolDropDownGenerator::ConstructionCode(Code& code)
@@ -732,26 +712,6 @@ int ToolDropDownGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size
     return BaseGenerator::xrc_updated;
 }
 
-tt_string ToolDropDownGenerator::GetHelpURL(Node*)
-{
-    return "wx_tool_bar.html";
-}
-
-tt_string ToolDropDownGenerator::GetHelpText(Node*)
-{
-    return "wxToolBar";
-}
-
-tt_string ToolDropDownGenerator::GetPythonURL(Node*)
-{
-    return "wx.ToolBar.html";
-}
-
-tt_string ToolDropDownGenerator::GetPythonHelpText(Node*)
-{
-    return "wx.ToolBar";
-}
-
 //////////////////////////////////////////  ToolSeparatorGenerator  //////////////////////////////////////////
 
 bool ToolSeparatorGenerator::ConstructionCode(Code& code)
@@ -788,12 +748,22 @@ tt_string ToolSeparatorGenerator::GetHelpText(Node*)
 
 tt_string ToolSeparatorGenerator::GetPythonURL(Node*)
 {
-    return "wx.ToolBar.html";
+    return "wx.ToolBar.html?highlight=addseparator#wx.ToolBar.AddSeparator";
 }
 
 tt_string ToolSeparatorGenerator::GetPythonHelpText(Node*)
 {
     return "wx.ToolBar";
+}
+
+tt_string ToolSeparatorGenerator::GetRubyURL(Node*)
+{
+    return "Wx/ToolBar.html#add_separator-instance_method";
+}
+
+tt_string ToolSeparatorGenerator::GetRubyHelpText(Node*)
+{
+    return "Wx/ToolBar.html";
 }
 
 //////////////////////////////////////////  ToolStretchableGenerator  //////////////////////////////////////////
@@ -841,10 +811,20 @@ tt_string ToolStretchableGenerator::GetHelpText(Node*)
 
 tt_string ToolStretchableGenerator::GetPythonURL(Node*)
 {
-    return "wx.ToolBar.html";
+    return "wx.ToolBar.html?highlight=addstretchablespace#wx.ToolBar.AddStretchableSpace";
 }
 
 tt_string ToolStretchableGenerator::GetPythonHelpText(Node*)
 {
     return "wx.ToolBar";
+}
+
+tt_string ToolStretchableGenerator::GetRubyURL(Node*)
+{
+    return "Wx/ToolBar.html#add_stretchable_space-instance_method";
+}
+
+tt_string ToolStretchableGenerator::GetRubyHelpText(Node*)
+{
+    return "Wx/ToolBar.html";
 }

--- a/src/generate/gen_toolbar.h
+++ b/src/generate/gen_toolbar.h
@@ -58,10 +58,6 @@ public:
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     int GetRequiredVersion(Node* /*node*/) override;
-    tt_string GetHelpText(Node*) override;
-    tt_string GetHelpURL(Node*) override;
-    tt_string GetPythonHelpText(Node*) override;
-    tt_string GetPythonURL(Node*) override;
 };
 
 class ToolDropDownGenerator : public BaseGenerator
@@ -72,10 +68,6 @@ public:
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     int GetRequiredVersion(Node* /*node*/) override { return minRequiredVer + 1; }
-    tt_string GetHelpText(Node*) override;
-    tt_string GetHelpURL(Node*) override;
-    tt_string GetPythonHelpText(Node*) override;
-    tt_string GetPythonURL(Node*) override;
 };
 
 class ToolSeparatorGenerator : public BaseGenerator
@@ -88,6 +80,8 @@ public:
     tt_string GetHelpURL(Node*) override;
     tt_string GetPythonHelpText(Node*) override;
     tt_string GetPythonURL(Node*) override;
+    tt_string GetRubyHelpText(Node*) override;
+    tt_string GetRubyURL(Node*) override;
 };
 
 class ToolStretchableGenerator : public BaseGenerator
@@ -101,4 +95,6 @@ public:
     tt_string GetHelpURL(Node*) override;
     tt_string GetPythonHelpText(Node*) override;
     tt_string GetPythonURL(Node*) override;
+    tt_string GetRubyHelpText(Node*) override;
+    tt_string GetRubyURL(Node*) override;
 };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability to get a URL for more of the controls that use a class name that doesn't start with `wx` such as `spacer`. I consolidated code into one function for parsing out a class name that can potentially be used by C++, Python or Ruby to formulate a URL. Both GetPythonURL() and GetPythonURL() have a few special-cases added which can be a template for further additions.