### PR TITLE
Limit Event Handler Dialog to language(s) actually being generated

### DIFF
--- a/src/customprops/eventhandler_dlg.h
+++ b/src/customprops/eventhandler_dlg.h
@@ -58,6 +58,8 @@ public:
     // only value specified.
     static tt_string GetPythonValue(tt_string_view value);
 
+    static tt_string GetRubyValue(tt_string_view value);
+
 protected:
     // This is used to colorize member variables in the C++ lambda
     void CollectMemberVariables(Node* node, std::set<std::string>& variables);
@@ -83,7 +85,9 @@ protected:
 private:
     NodeEvent* m_event;
     bool m_is_python_code { false };
+    bool m_is_ruby_code { false };
 
     bool m_is_cpp_lambda { false };
     bool m_is_python_lambda { false };
+    bool m_is_ruby_lambda { false };
 };

--- a/src/customprops/eventhandler_dlg.h
+++ b/src/customprops/eventhandler_dlg.h
@@ -50,14 +50,19 @@ public:
 
     const wxString& GetResults() { return m_value; }
 
-    // Given a complete C++/wxPython value, this will return a string as if C++ was the only
-    // value specified.
+    // This will return a string as if C++ was the only value specified even if the original
+    // value had values for multiple languages. Note that this *will* return a value even if
+    // C++ is not enabled and another language specified a value.
     static tt_string GetCppValue(tt_string_view value);
 
-    // Given a complete C++/wxPython value, this will return a string as if wxPython was the
-    // only value specified.
+    // This will return a string as if Python was the only value specified even if the original
+    // value had values for multiple languages. Note that this *will* return a value even if
+    // Python is not enabled and another language specified a value.
     static tt_string GetPythonValue(tt_string_view value);
 
+    // This will return a string as if Ruby was the only value specified even if the original
+    // value had values for multiple languages. Note that this *will* return a value even if
+    // Ruby is not enabled and another language specified a value.
     static tt_string GetRubyValue(tt_string_view value);
 
 protected:
@@ -74,18 +79,28 @@ protected:
     void OnChange(wxCommandEvent& WXUNUSED(event)) override;
     void OnInit(wxInitDialogEvent& WXUNUSED(event)) override;
     void OnOK(wxCommandEvent& event) override;
-    void OnUseFunction(wxCommandEvent& WXUNUSED(event)) override;
-    void OnUseLambda(wxCommandEvent& WXUNUSED(event)) override;
+    void OnPageChanged(wxBookCtrlEvent& event) override;
+    void OnUseCppFunction(wxCommandEvent& WXUNUSED(event)) override;
+    void OnUseCppLambda(wxCommandEvent& WXUNUSED(event)) override;
     void OnUsePythonFunction(wxCommandEvent& event) override;
     void OnUsePythonLambda(wxCommandEvent& event) override;
-    void OnPageChanged(wxBookCtrlEvent& event) override;
+    void OnUseRubyFunction(wxCommandEvent& event) override;
+    void OnUseRubyLambda(wxCommandEvent& WXUNUSED(event)) override;
 
     wxString m_value;
 
 private:
     NodeEvent* m_event;
-    bool m_is_python_code { false };
-    bool m_is_ruby_code { false };
+
+    size_t m_python_page;
+    size_t m_ruby_page;
+
+    size_t m_output_type;   // see ../project/project_handler.h for OUTPUT_TYPE_ defines
+    int m_code_preference;  // This will be one of the GEN_LANG values
+
+    bool m_is_cpp_enabled { false };
+    bool m_is_python_enabled { false };
+    bool m_is_ruby_enabled { false };
 
     bool m_is_cpp_lambda { false };
     bool m_is_python_lambda { false };

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -7,8 +7,11 @@
 
 // clang-format off
 
+#include <wx/bitmap.h>
 #include <wx/button.h>
 #include <wx/colour.h>
+#include <wx/icon.h>
+#include <wx/image.h>
 #include <wx/panel.h>
 #include <wx/persist.h>
 #include <wx/persist/toplevel.h>
@@ -18,9 +21,26 @@
 
 #include "eventhandler_dlg_base.h"
 
+#include <wx/mstream.h>  // memory stream classes
+#include <wx/zstream.h>  // zlib stream classes
+
+#include <memory>  // for std::make_unique
+
+// Convert compressed SVG string into a wxBitmapBundle
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+{
+    auto str = std::make_unique<char[]>(size_svg);
+    wxMemoryInputStream stream_in(data, size_data);
+    wxZlibInputStream zlib_strm(stream_in);
+    zlib_strm.Read(str.get(), size_svg);
+    return wxBitmapBundle::FromSVG(str.get(), def_size);
+};
+
 namespace wxue_img
 {
     extern const unsigned char cpp_logo_svg[587];
+    extern const unsigned char ruby_logo_svg[1853];
     extern const unsigned char wxPython_1_5x_png[765];
     extern const unsigned char wxPython_2x_png[251];
     extern const unsigned char wxPython_png[399];
@@ -47,6 +67,7 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
         wxBookCtrlBase::Images bundle_list;
         bundle_list.push_back(wxue_img::bundle_cpp_logo_svg(16, 16));
         bundle_list.push_back(wxue_img::bundle_wxPython_png());
+        bundle_list.push_back(wxueBundleSVG(wxue_img::ruby_logo_svg, 1853, 10034, wxSize(16, 16)));
         m_notebook->SetImages(bundle_list);
     }
     box_sizer->Add(m_notebook, wxSizerFlags().Expand().Border(wxALL));
@@ -140,6 +161,63 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     page_sizer_2->Add(m_py_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
     python_page->SetSizerAndFit(page_sizer_2);
 
+    auto* ruby_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(ruby_page, "Ruby", false, 2);
+    ruby_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+
+    auto* page_sizer_3 = new wxBoxSizer(wxVERTICAL);
+
+    m_ruby_radio_use_function = new wxRadioButton(ruby_page, wxID_ANY, "Use function");
+    m_ruby_function_box = new wxStaticBoxSizer(new wxStaticBox(ruby_page, wxID_ANY, m_ruby_radio_use_function),
+        wxVERTICAL);
+
+    m_ruby_text_function = new wxTextCtrl(m_ruby_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
+    m_ruby_function_box->Add(m_ruby_text_function, wxSizerFlags().Expand().Border(wxALL));
+
+    m_ruby_radio_use_lambda = new wxRadioButton(m_ruby_function_box->GetStaticBox(), wxID_ANY, "Use lambda");
+    m_ruby_lambda_box = new wxStaticBoxSizer(new wxStaticBox(m_ruby_function_box->GetStaticBox(), wxID_ANY,
+        m_ruby_radio_use_lambda), wxVERTICAL);
+
+    auto* box_sizer_3 = new wxBoxSizer(wxHORIZONTAL);
+
+    m_ruby_lambda_box->Add(box_sizer_3, wxSizerFlags().Border(wxALL));
+
+    auto* staticText_3 = new wxStaticText(m_ruby_lambda_box->GetStaticBox(), wxID_ANY, "Lambda body:");
+    m_ruby_lambda_box->Add(staticText_3, wxSizerFlags().Border(wxALL));
+
+    m_ruby_stc_lambda = new wxStyledTextCtrl(m_ruby_lambda_box->GetStaticBox());
+    {
+        m_ruby_stc_lambda->SetLexer(wxSTC_LEX_RUBY);
+        m_ruby_stc_lambda->SetEOLMode(wxSTC_EOL_LF);
+        m_ruby_stc_lambda->SetWrapMode(wxSTC_WRAP_WORD);
+        m_ruby_stc_lambda->SetWrapVisualFlags(wxSTC_WRAPVISUALFLAG_END);
+        m_ruby_stc_lambda->SetWrapIndentMode(wxSTC_WRAPINDENT_INDENT);
+        m_ruby_stc_lambda->SetMultipleSelection(wxSTC_MULTIPASTE_EACH);
+        m_ruby_stc_lambda->SetMultiPaste(wxSTC_MULTIPASTE_EACH);
+        m_ruby_stc_lambda->SetAdditionalSelectionTyping(true);
+        m_ruby_stc_lambda->SetAdditionalCaretsBlink(true);
+        // Sets text margin scaled appropriately for the current DPI on Windows,
+        // 5 on wxGTK or wxOSX
+        m_ruby_stc_lambda->SetMarginLeft(wxSizerFlags::GetDefaultBorder());
+        m_ruby_stc_lambda->SetMarginRight(wxSizerFlags::GetDefaultBorder());
+        m_ruby_stc_lambda->SetMarginWidth(1, 0); // Remove default margin
+        m_ruby_stc_lambda->SetMarginWidth(0, 16);
+        m_ruby_stc_lambda->SetMarginType(0, wxSTC_MARGIN_SYMBOL);
+        m_ruby_stc_lambda->SetMarginMask(0, ~wxSTC_MASK_FOLDERS);
+        m_ruby_stc_lambda->SetMarginSensitive(0, false);
+        m_ruby_stc_lambda->SetIndentationGuides(wxSTC_IV_LOOKFORWARD);
+        m_ruby_stc_lambda->SetUseTabs(false);
+        m_ruby_stc_lambda->SetTabWidth(4);
+        m_ruby_stc_lambda->SetBackSpaceUnIndents(true);
+    }
+    m_ruby_stc_lambda->SetMinSize(ConvertDialogToPixels(wxSize(200, -1)));
+    m_ruby_lambda_box->Add(m_ruby_stc_lambda, wxSizerFlags(1).Expand().DoubleBorder(wxALL));
+
+    m_ruby_function_box->Add(m_ruby_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
+
+    page_sizer_3->Add(m_ruby_function_box, wxSizerFlags().Expand().Border(wxALL));
+    ruby_page->SetSizerAndFit(page_sizer_3);
+
     parent_sizer->Add(box_sizer, wxSizerFlags(1).Expand().Border(wxALL));
 
     parent_sizer->AddSpacer(10 + wxSizerFlags::GetDefaultBorder());
@@ -162,9 +240,12 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_cpp_radio_use_lambda->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseLambda, this);
     m_py_radio_use_function->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUsePythonFunction, this);
     m_py_radio_use_lambda->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUsePythonLambda, this);
+    m_ruby_radio_use_function->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUsePythonFunction, this);
+    m_ruby_radio_use_lambda->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseLambda, this);
     m_cpp_text_function->Bind(wxEVT_TEXT, &EventHandlerDlgBase::OnChange, this);
     m_py_text_function->Bind(wxEVT_TEXT, &EventHandlerDlgBase::OnChange, this);
     m_py_text_lambda->Bind(wxEVT_TEXT, &EventHandlerDlgBase::OnChange, this);
+    m_ruby_text_function->Bind(wxEVT_TEXT, &EventHandlerDlgBase::OnChange, this);
 
     return true;
 }

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -236,12 +236,12 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_check_include_event->Bind(wxEVT_CHECKBOX, &EventHandlerDlgBase::OnChange, this);
     Bind(wxEVT_INIT_DIALOG, &EventHandlerDlgBase::OnInit, this);
     m_notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &EventHandlerDlgBase::OnPageChanged, this);
-    m_cpp_radio_use_function->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseFunction, this);
-    m_cpp_radio_use_lambda->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseLambda, this);
+    m_cpp_radio_use_function->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseCppFunction, this);
+    m_cpp_radio_use_lambda->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseCppLambda, this);
     m_py_radio_use_function->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUsePythonFunction, this);
     m_py_radio_use_lambda->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUsePythonLambda, this);
-    m_ruby_radio_use_function->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUsePythonFunction, this);
-    m_ruby_radio_use_lambda->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseLambda, this);
+    m_ruby_radio_use_function->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseRubyFunction, this);
+    m_ruby_radio_use_lambda->Bind(wxEVT_RADIOBUTTON, &EventHandlerDlgBase::OnUseRubyLambda, this);
     m_cpp_text_function->Bind(wxEVT_TEXT, &EventHandlerDlgBase::OnChange, this);
     m_py_text_function->Bind(wxEVT_TEXT, &EventHandlerDlgBase::OnChange, this);
     m_py_text_lambda->Bind(wxEVT_TEXT, &EventHandlerDlgBase::OnChange, this);

--- a/src/wxui/eventhandler_dlg_base.h
+++ b/src/wxui/eventhandler_dlg_base.h
@@ -62,11 +62,17 @@ protected:
     wxStaticBoxSizer* m_py_function_box;
     wxRadioButton* m_py_radio_use_lambda;
     wxStaticBoxSizer* m_py_lambda_box;
+    wxRadioButton* m_ruby_radio_use_function;
+    wxStaticBoxSizer* m_ruby_function_box;
+    wxRadioButton* m_ruby_radio_use_lambda;
+    wxStaticBoxSizer* m_ruby_lambda_box;
     wxStaticText* m_static_bind_text;
     wxStyledTextCtrl* m_cpp_stc_lambda;
+    wxStyledTextCtrl* m_ruby_stc_lambda;
     wxTextCtrl* m_cpp_text_function;
     wxTextCtrl* m_py_text_function;
     wxTextCtrl* m_py_text_lambda;
+    wxTextCtrl* m_ruby_text_function;
 };
 
 // ************* End of generated code ***********

--- a/src/wxui/eventhandler_dlg_base.h
+++ b/src/wxui/eventhandler_dlg_base.h
@@ -44,10 +44,12 @@ protected:
     virtual void OnInit(wxInitDialogEvent& event) { event.Skip(); }
     virtual void OnOK(wxCommandEvent& event) { event.Skip(); }
     virtual void OnPageChanged(wxBookCtrlEvent& event) { event.Skip(); }
-    virtual void OnUseFunction(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnUseLambda(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnUseCppFunction(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnUseCppLambda(wxCommandEvent& event) { event.Skip(); }
     virtual void OnUsePythonFunction(wxCommandEvent& event) { event.Skip(); }
     virtual void OnUsePythonLambda(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnUseRubyFunction(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnUseRubyLambda(wxCommandEvent& event) { event.Skip(); }
 
     // Class member variables
 

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -2571,6 +2571,71 @@
                   </node>
                 </node>
               </node>
+              <node
+                class="BookPage"
+                bitmap="SVG;ruby_logo.svg;[16,16]"
+                label="Ruby"
+                var_name="ruby_page"
+                background_colour="wxSYS_COLOUR_BTNFACE"
+                window_style="wxTAB_TRAVERSAL">
+                <node
+                  class="wxBoxSizer"
+                  orientation="wxVERTICAL"
+                  var_name="page_sizer_3">
+                  <node
+                    class="StaticRadioBtnBoxSizer"
+                    checked="0"
+                    class_access="protected:"
+                    label="Use function"
+                    radiobtn_var_name="m_ruby_radio_use_function"
+                    var_name="m_ruby_function_box"
+                    flags="wxEXPAND"
+                    wxEVT_RADIOBUTTON="OnUsePythonFunction">
+                    <node
+                      class="wxTextCtrl"
+                      var_name="m_ruby_text_function"
+                      flags="wxEXPAND"
+                      wxEVT_TEXT="OnChange" />
+                    <node
+                      class="StaticRadioBtnBoxSizer"
+                      checked="0"
+                      class_access="protected:"
+                      label="Use lambda"
+                      radiobtn_var_name="m_ruby_radio_use_lambda"
+                      var_name="m_ruby_lambda_box"
+                      flags="wxEXPAND"
+                      proportion="1"
+                      wxEVT_RADIOBUTTON="OnUseLambda">
+                      <node
+                        class="wxBoxSizer"
+                        var_name="box_sizer_3" />
+                      <node
+                        class="wxStaticText"
+                        class_access="none"
+                        label="Lambda body:"
+                        var_name="staticText_3" />
+                      <node
+                        class="wxStyledTextCtrl"
+                        additional_carets_blink="1"
+                        indentation_guides="forward"
+                        lexer="RUBY"
+                        multiple_selection_typing="1"
+                        multiple_selections="1"
+                        paste_multiple="1"
+                        symbol_margin="0"
+                        use_tabs="0"
+                        var_name="m_ruby_stc_lambda"
+                        wrap_indent_mode="indent"
+                        wrap_mode="word"
+                        wrap_visual_flag="end"
+                        minimum_size="200,-1d"
+                        border_size="10"
+                        flags="wxEXPAND"
+                        proportion="1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
           <node

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -2465,7 +2465,7 @@
                     radiobtn_var_name="m_cpp_radio_use_function"
                     var_name="m_cpp_function_box"
                     flags="wxEXPAND"
-                    wxEVT_RADIOBUTTON="OnUseFunction">
+                    wxEVT_RADIOBUTTON="OnUseCppFunction">
                     <node
                       class="wxTextCtrl"
                       var_name="m_cpp_text_function"
@@ -2481,7 +2481,7 @@
                     var_name="m_cpp_lambda_box"
                     flags="wxEXPAND"
                     proportion="1"
-                    wxEVT_RADIOBUTTON="OnUseLambda">
+                    wxEVT_RADIOBUTTON="OnUseCppLambda">
                     <node
                       class="wxBoxSizer"
                       var_name="box_sizer_2">
@@ -2590,7 +2590,7 @@
                     radiobtn_var_name="m_ruby_radio_use_function"
                     var_name="m_ruby_function_box"
                     flags="wxEXPAND"
-                    wxEVT_RADIOBUTTON="OnUsePythonFunction">
+                    wxEVT_RADIOBUTTON="OnUseRubyFunction">
                     <node
                       class="wxTextCtrl"
                       var_name="m_ruby_text_function"
@@ -2605,7 +2605,7 @@
                       var_name="m_ruby_lambda_box"
                       flags="wxEXPAND"
                       proportion="1"
-                      wxEVT_RADIOBUTTON="OnUseLambda">
+                      wxEVT_RADIOBUTTON="OnUseRubyLambda">
                       <node
                         class="wxBoxSizer"
                         var_name="box_sizer_3" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the Event Dialog editor that is invoked if the button is clicked in an event property. Instead of showing a tab for every possible language, the dialog now only displays tabs based on what the preferred language is, and whether or not output filenames have been specified for other languages. For most users, this will mean only a single tab reflecting the preferred programming language they want the current project to generate.

This PR also changes the property string that is created when the editor returns a value. It now only returns a value reflecting what tabs were displayed. For example, if the user prefers C++ and there are no output filenames for python or ruby, then _only_ the C++ event string is returned. Previously, `[python:]` was always appended to the string even if there was nothing in the project to indicate the user intended to generate python content.

Note that when looking at the code display panels, an event will be hooked up even if the user indicated they weren't going to generate code in that language. If the language being used contains a lambda, the default for the unused language will be `OnEvent` since lambdas differ in every language.

Closes #1107