### PR TITLE
Refactor variable naming conventions based on class access

### DIFF
--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -29,3 +29,27 @@ If you are adding a comment to a function or variable in a header file, please w
 Prior to AI being available to generate code, comments in the code explained _why_ the code was written not _what_ the code did. The reasoning is that _what_ the code did should be obvious just by reading the code, but _why_ the code was written in a specific way might not be obvious.
 
 With AI, prefixing code with a comment that says _what_ the code should do will help the AI generate more accurate code. In addition, a comment that explains _what_ the code is doing can help AI training making the code more likely to be generated for someone else. This project is Open Source, and uses an Apache License, so there are no restrictions on how a section of the code is used in other projects.
+
+## Default variable names
+
+A variable's class access (public, protected or none) determines it's default prefix, which differs based on the Preferred language.
+
+Note: Ruby uses a leading `_` for an unused parameter, e.g. `_event`.
+
+#### none
+
+- C++: no prefix
+- Python: `_` as a prefix
+- Ruby: no prefix
+
+#### protected
+
+- C++: `m_`
+- Python: no prefix
+- Ruby: `@`
+
+#### public
+
+- C++: `m_`
+- Python: no prefix
+- Ruby: `@`

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -20,6 +20,7 @@
 #include "preferences.h"      // Preferences -- Stores user preferences
 #include "project_handler.h"  // ProjectHandler class
 #include "undo_cmds.h"        // InsertNodeAction -- Undoable command classes derived from UndoAction
+#include "utils.h"            // WXDLLIMPEXP_BASE -- Miscellaneous utilities
 
 using namespace GenEnum;
 
@@ -703,9 +704,18 @@ Node* Node::createChildNode(GenName name)
 
     if (new_node)
     {
+        bool is_name_changed = false;
+
         if (Project.getCodePreference() != GEN_LANG_CPLUSPLUS)
         {
             tt_string member_name = new_node->as_string(prop_var_name);
+            if (Project.getCodePreference() == GEN_LANG_RUBY)
+            {
+                member_name = ConvertToSnakeCase(member_name);
+                if (member_name != new_node->as_string(prop_var_name))
+                    is_name_changed = true;
+            }
+
             if (member_name.starts_with("m_"))
             {
                 member_name.erase(0, 2);
@@ -717,6 +727,12 @@ Node* Node::createChildNode(GenName name)
                     // prefix is unlikely.
                     member_name.erase(member_name.size() - 2);
                 }
+
+                is_name_changed = true;
+            }
+
+            if (is_name_changed)
+            {
                 new_node->set_value(prop_var_name, member_name);
                 new_node->fixDuplicateName();
             }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -709,7 +709,7 @@ Node* Node::createChildNode(GenName name)
         if (Project.getCodePreference() != GEN_LANG_CPLUSPLUS)
         {
             tt_string member_name = new_node->as_string(prop_var_name);
-            if (Project.getCodePreference() == GEN_LANG_RUBY)
+            if (Project.getCodePreference() == GEN_LANG_RUBY || Project.getCodePreference() == GEN_LANG_PYTHON)
             {
                 member_name = ConvertToSnakeCase(member_name);
                 if (member_name != new_node->as_string(prop_var_name))

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -718,7 +718,17 @@ Node* Node::createChildNode(GenName name)
 
             if (member_name.starts_with("m_"))
             {
-                member_name.erase(0, 2);
+                if (Project.getCodePreference() == GEN_LANG_PYTHON)
+                {
+                    // Python public names don't have a prefix
+                    member_name.erase(0, 2);
+                }
+                else if (Project.getCodePreference() == GEN_LANG_RUBY)
+                {
+                    member_name.erase(0, 2);
+                    member_name.insert(0, "@");
+                }
+
                 if (member_name.ends_with("_2"))
                 {
                     // This is unlikely, but the previous check for duplication assumed a m_
@@ -728,6 +738,12 @@ Node* Node::createChildNode(GenName name)
                     member_name.erase(member_name.size() - 2);
                 }
 
+                is_name_changed = true;
+            }
+            else if (Project.getCodePreference() == GEN_LANG_PYTHON)
+            {
+                // Python private names have '_' as a prefix
+                member_name.insert(0, "_");
                 is_name_changed = true;
             }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates and refactors handling of variable names in the various languages based on what kind of class access they have. This includes adding a section in Dev notes explaining the differences between the three languages.

This affects both the initial default variable name as well as changing the class access in the Property Grid.