### PR TITLE
Fix Python variable names

### DIFF
--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -39,17 +39,17 @@ Note: Ruby uses a leading `_` for an unused parameter, e.g. `_event`.
 #### none
 
 - C++: no prefix
-- Python: `_` as a prefix
+- Python: no prefix
 - Ruby: no prefix
 
 #### protected
 
 - C++: `m_`
-- Python: no prefix
+- Python: self. if not a form
 - Ruby: `@`
 
 #### public
 
 - C++: `m_`
-- Python: no prefix
+- Python: self. if not a form
 - Ruby: `@`

--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -548,7 +548,7 @@ void EventHandlerDlg::FormatBindText()
         if (m_event->getNode()->as_string(prop_id) != "wxID_ANY")
             code.as_string(prop_id).EndFunction();
         else
-            code.Add(m_event->getNode()->getNodeName()).Function("GetId()").EndFunction();
+            code.NodeName(m_event->getNode()).Function("GetId()").EndFunction();
     }
     else if (m_event->getNode()->isGen(gen_ribbonTool))
     {
@@ -563,7 +563,7 @@ void EventHandlerDlg::FormatBindText()
     }
     else
     {
-        code.Add(m_event->getNode()->getNodeName()).Function("Bind(").Add(handler).EndFunction();
+        code.NodeName(m_event->getNode()).Function("Bind(").Add(handler).EndFunction();
     }
 
     m_static_bind_text->SetLabel(code.make_wxString());

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -694,10 +694,9 @@ Code& Code::NodeName(Node* node)
     if (!node)
         node = m_node;
     auto& node_name = node->getNodeName();
-    if (is_python())
     if (is_python() && !node->isForm() && !node->isLocal())
     {
-        }
+        *this += "self.";
     }
     else if (is_ruby())
     {
@@ -720,9 +719,7 @@ Code& Code::NodeName(Node* node)
 
 Code& Code::ParentName()
 {
-    if (is_python() && !m_node->getParent()->isLocal() && !m_node->getParent()->isForm())
-        *this += "self.";
-    *this << m_node->getParent()->getNodeName();
+    NodeName(m_node->getParent());
     return *this;
 }
 
@@ -783,9 +780,7 @@ Code& Code::ValidParentName()
         {
             if (parent->isStaticBoxSizer())
             {
-                if (is_python() && !parent->isLocal() && !parent->isForm())
-                    *this += "self.";
-                *this += parent->getNodeName();
+                NodeName(parent);
                 Function("GetStaticBox()");
                 return *this;
             }
@@ -800,9 +795,7 @@ Code& Code::ValidParentName()
         {
             if (parent->isType(iter))
             {
-                if (is_python() && !parent->isLocal() && !parent->isForm())
-                    *this += "self.";
-                *this += parent->getNodeName();
+                NodeName(parent);
                 if (parent->isGen(gen_wxCollapsiblePane))
                 {
                     Function("GetPane()");

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -695,13 +695,8 @@ Code& Code::NodeName(Node* node)
         node = m_node;
     auto& node_name = node->getNodeName();
     if (is_python())
+    if (is_python() && !node->isForm() && !node->isLocal())
     {
-        if (!node->isForm())
-        {
-            if (!node->isLocal())
-                *this += "_";
-            else
-                *this += "self.";
         }
     }
     else if (is_ruby())

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -178,7 +178,7 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
             }
             else
             {
-                code.AddIfPython("id=").Add(event->getNode()->getNodeName()).Function("GetId()").EndFunction();
+                code.AddIfPython("id=").NodeName(event->getNode()).Function("GetId()").EndFunction();
             }
         }
         else if (code.is_ruby())
@@ -233,9 +233,7 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
     {
         if (code.is_cpp() || code.is_python())
         {
-            if (code.is_python() && !event->getNode()->isLocal())
-                code.Add("self.");
-            code.Add(event->getNode()->getNodeName()).Function("Bind(") << handler.GetCode();
+            code.NodeName(event->getNode()).Function("Bind(") << handler.GetCode();
             code.EndFunction();
         }
         else if (code.is_ruby())

--- a/tests/sdi/python/booktest_dlg.py
+++ b/tests/sdi/python/booktest_dlg.py
@@ -22,102 +22,102 @@ class BookTestDlg(wx.Dialog):
         dlg_sizer = wx.BoxSizer(wx.VERTICAL)
         dlg_sizer.SetMinSize(400, 400)
 
-        self.m_notebook = wx.aui.AuiNotebook(self, wx.ID_ANY, wx.DefaultPosition,
+        self.notebook = wx.aui.AuiNotebook(self, wx.ID_ANY, wx.DefaultPosition,
             wx.DefaultSize, wx.aui.AUI_NB_TOP|wx.aui.AUI_NB_TAB_SPLIT|
             wx.aui.AUI_NB_TAB_MOVE|wx.aui.AUI_NB_SCROLL_BUTTONS|
             wx.aui.AUI_NB_CLOSE_ON_ACTIVE_TAB|wx.aui.AUI_NB_MIDDLE_CLICK_CLOSE)
-        dlg_sizer.Add(self.m_notebook, wx.SizerFlags(1).Expand().Border(wx.ALL))
+        dlg_sizer.Add(self.notebook, wx.SizerFlags(1).Expand().Border(wx.ALL))
 
-        page_2 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_2 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_2, "ChoiceBook")
+        self.notebook.AddPage(page_2, "ChoiceBook")
 
         page_sizer_1 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_choicebook = wx.Choicebook(page_2, wx.ID_ANY)
-        self.m_choicebook.SetMinSize(wx.Size(400, 400))
-        page_sizer_1.Add(self.m_choicebook, wx.SizerFlags().Border(wx.ALL))
+        self.choicebook = wx.Choicebook(page_2, wx.ID_ANY)
+        self.choicebook.SetMinSize(wx.Size(400, 400))
+        page_sizer_1.Add(self.choicebook, wx.SizerFlags().Border(wx.ALL))
 
-        btn = wx.Button(self.m_choicebook, wx.ID_ANY, "First")
+        btn = wx.Button(self.choicebook, wx.ID_ANY, "First")
         # wxPython 4.2.0 does not support wx.Choicebook.GetControlSizer()
         # so btn cannot be added to the Choicebook.
 
-        btn_2 = wx.Button(self.m_choicebook, wx.ID_ANY, "Last")
+        btn_2 = wx.Button(self.choicebook, wx.ID_ANY, "Last")
         # wxPython 4.2.0 does not support wx.Choicebook.GetControlSizer()
         # so btn_2 cannot be added to the Choicebook.
 
-        page_20 = wx.Panel(self.m_choicebook, wx.ID_ANY, wx.DefaultPosition,
-            wx.DefaultSize, wx.TAB_TRAVERSAL)
-        self.m_choicebook.AddPage(page_20, "English")
+        page_20 = wx.Panel(self.choicebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+            wx.TAB_TRAVERSAL)
+        self.choicebook.AddPage(page_20, "English")
         page_20.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_13 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_16 = wx.StaticText(page_20, wx.ID_ANY,
+        self.staticText_16 = wx.StaticText(page_20, wx.ID_ANY,
             "This is a sentence in English.")
-        parent_sizer_13.Add(self.m_staticText_16, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_13.Add(self.staticText_16, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_2 = wx.StaticText(page_20, wx.ID_ANY,
+        self.staticText_2 = wx.StaticText(page_20, wx.ID_ANY,
             "The First and Last buttons above are children of the wcChoicebook. They are added using choicebook->GetControlSizer() which allows them to share the layout space for the wxChoice control.")
-        self.m_staticText_2.Wrap(380)
-        box_sizer.Add(self.m_staticText_2, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.staticText_2.Wrap(380)
+        box_sizer.Add(self.staticText_2, wx.SizerFlags().Expand().Border(wx.ALL))
 
         parent_sizer_13.Add(box_sizer, wx.SizerFlags().Border(wx.ALL))
         page_20.SetSizerAndFit(parent_sizer_13)
 
-        page_21 = wx.Panel(self.m_choicebook, wx.ID_ANY, wx.DefaultPosition,
-            wx.DefaultSize, wx.TAB_TRAVERSAL)
-        self.m_choicebook.AddPage(page_21, "Français")
+        page_21 = wx.Panel(self.choicebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+            wx.TAB_TRAVERSAL)
+        self.choicebook.AddPage(page_21, "Français")
         page_21.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer__2 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_17 = wx.StaticText(page_21, wx.ID_ANY,
+        self.staticText_17 = wx.StaticText(page_21, wx.ID_ANY,
             "Ceci est une phrase en français.")
-        parent_sizer__2.Add(self.m_staticText_17, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer__2.Add(self.staticText_17, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_3 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText__3 = wx.StaticText(page_21, wx.ID_ANY,
+        self.staticText__3 = wx.StaticText(page_21, wx.ID_ANY,
             "The First and Last buttons above are children of the wcChoicebook. They are added using choicebook->GetControlSizer() which allows them to share the layout space for the wxChoice control.")
-        self.m_staticText__3.Wrap(390)
-        box_sizer_3.Add(self.m_staticText__3, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.staticText__3.Wrap(390)
+        box_sizer_3.Add(self.staticText__3, wx.SizerFlags().Expand().Border(wx.ALL))
 
         parent_sizer__2.Add(box_sizer_3, wx.SizerFlags().Border(wx.ALL))
         page_21.SetSizerAndFit(parent_sizer__2)
 
-        page_22 = wx.Panel(self.m_choicebook, wx.ID_ANY, wx.DefaultPosition,
-            wx.DefaultSize, wx.TAB_TRAVERSAL)
-        self.m_choicebook.AddPage(page_22, "日本語")
+        page_22 = wx.Panel(self.choicebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+            wx.TAB_TRAVERSAL)
+        self.choicebook.AddPage(page_22, "日本語")
         page_22.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_14 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_18 = wx.StaticText(page_22, wx.ID_ANY,
+        self.staticText_18 = wx.StaticText(page_22, wx.ID_ANY,
             "これは日本語の文章です。")
-        parent_sizer_14.Add(self.m_staticText_18, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_14.Add(self.staticText_18, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_2 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText__2 = wx.StaticText(page_22, wx.ID_ANY,
+        self.staticText__2 = wx.StaticText(page_22, wx.ID_ANY,
             "The First and Last buttons above are children of the wcChoicebook. They are added using choicebook->GetControlSizer() which allows them to share the layout space for the wxChoice control.")
-        self.m_staticText__2.Wrap(390)
-        box_sizer_2.Add(self.m_staticText__2, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.staticText__2.Wrap(390)
+        box_sizer_2.Add(self.staticText__2, wx.SizerFlags().Expand().Border(wx.ALL))
 
         parent_sizer_14.Add(box_sizer_2, wx.SizerFlags().Border(wx.ALL))
         page_22.SetSizerAndFit(parent_sizer_14)
         page_2.SetSizerAndFit(page_sizer_1)
 
-        page_3 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_3 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_3, "ListBook")
+        self.notebook.AddPage(page_3, "ListBook")
 
         page_sizer_2 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_listbook = wx.Listbook(page_3, wx.ID_ANY, wx.DefaultPosition,
-            wx.DefaultSize, wx.LB_LEFT)
+        self.listbook = wx.Listbook(page_3, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+            wx.LB_LEFT)
 
         bundle_1 = wx.BitmapBundle.FromBitmap(images.english_png.Bitmap)
         bundle_2 = wx.BitmapBundle.FromBitmap(images.french_png.Bitmap)
@@ -127,55 +127,55 @@ class BookTestDlg(wx.Dialog):
             bundle_2,
             bundle_3
         ]
-        self.m_listbook.SetImages(bundle_list)
-        self.m_listbook.SetMinSize(wx.Size(400, 400))
-        page_sizer_2.Add(self.m_listbook, wx.SizerFlags().Border(wx.ALL))
+        self.listbook.SetImages(bundle_list)
+        self.listbook.SetMinSize(wx.Size(400, 400))
+        page_sizer_2.Add(self.listbook, wx.SizerFlags().Border(wx.ALL))
 
-        page_6 = wx.Panel(self.m_listbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_6 = wx.Panel(self.listbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_listbook.AddPage(page_6, "English", False, 0)
+        self.listbook.AddPage(page_6, "English", False, 0)
         page_6.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_6 = wx.StaticText(page_6, wx.ID_ANY,
+        self.staticText_6 = wx.StaticText(page_6, wx.ID_ANY,
             "This is a sentence in English.")
-        parent_sizer.Add(self.m_staticText_6, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer.Add(self.staticText_6, wx.SizerFlags().Border(wx.ALL))
         page_6.SetSizerAndFit(parent_sizer)
 
-        page_7 = wx.Panel(self.m_listbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_7 = wx.Panel(self.listbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_listbook.AddPage(page_7, "Français", False, 1)
+        self.listbook.AddPage(page_7, "Français", False, 1)
         page_7.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_2 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_3 = wx.StaticText(page_7, wx.ID_ANY,
+        self.staticText_3 = wx.StaticText(page_7, wx.ID_ANY,
             "Ceci est une phrase en français.")
-        parent_sizer_2.Add(self.m_staticText_3, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_2.Add(self.staticText_3, wx.SizerFlags().Border(wx.ALL))
         page_7.SetSizerAndFit(parent_sizer_2)
 
-        page_8 = wx.Panel(self.m_listbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_8 = wx.Panel(self.listbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_listbook.AddPage(page_8, "日本語", False, 2)
+        self.listbook.AddPage(page_8, "日本語", False, 2)
         page_8.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_3 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_7 = wx.StaticText(page_8, wx.ID_ANY,
+        self.staticText_7 = wx.StaticText(page_8, wx.ID_ANY,
             "これは日本語の文章です。")
-        parent_sizer_3.Add(self.m_staticText_7, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_3.Add(self.staticText_7, wx.SizerFlags().Border(wx.ALL))
         page_8.SetSizerAndFit(parent_sizer_3)
 
         page_3.SetSizerAndFit(page_sizer_2)
 
-        page_4 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_4 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_4, "NoteBook")
+        self.notebook.AddPage(page_4, "NoteBook")
 
         page_sizer_3 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_notebook_2 = wx.Notebook(page_4, wx.ID_ANY)
+        self.notebook_2 = wx.Notebook(page_4, wx.ID_ANY)
 
         bundle_1 = wx.BitmapBundle.FromBitmap(images.english_png.Bitmap)
         bundle_2 = wx.BitmapBundle.FromBitmap(images.french_png.Bitmap)
@@ -185,55 +185,55 @@ class BookTestDlg(wx.Dialog):
             bundle_2,
             bundle_3
         ]
-        self.m_notebook_2.SetImages(bundle_list)
-        self.m_notebook_2.SetMinSize(wx.Size(400, 400))
-        page_sizer_3.Add(self.m_notebook_2, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.notebook_2.SetImages(bundle_list)
+        self.notebook_2.SetMinSize(wx.Size(400, 400))
+        page_sizer_3.Add(self.notebook_2, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        page_9 = wx.Panel(self.m_notebook_2, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_9 = wx.Panel(self.notebook_2, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook_2.AddPage(page_9, "English", False, 0)
+        self.notebook_2.AddPage(page_9, "English", False, 0)
         page_9.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_4 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_4 = wx.StaticText(page_9, wx.ID_ANY,
+        self.staticText_4 = wx.StaticText(page_9, wx.ID_ANY,
             "This is a sentence in English.")
-        parent_sizer_4.Add(self.m_staticText_4, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_4.Add(self.staticText_4, wx.SizerFlags().Border(wx.ALL))
         page_9.SetSizerAndFit(parent_sizer_4)
 
-        page_10 = wx.Panel(self.m_notebook_2, wx.ID_ANY, wx.DefaultPosition,
-            wx.DefaultSize, wx.TAB_TRAVERSAL)
-        self.m_notebook_2.AddPage(page_10, "Français", False, 1)
+        page_10 = wx.Panel(self.notebook_2, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+            wx.TAB_TRAVERSAL)
+        self.notebook_2.AddPage(page_10, "Français", False, 1)
         page_10.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_5 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_8 = wx.StaticText(page_10, wx.ID_ANY,
+        self.staticText_8 = wx.StaticText(page_10, wx.ID_ANY,
             "Ceci est une phrase en français.")
-        parent_sizer_5.Add(self.m_staticText_8, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_5.Add(self.staticText_8, wx.SizerFlags().Border(wx.ALL))
         page_10.SetSizerAndFit(parent_sizer_5)
 
-        page_11 = wx.Panel(self.m_notebook_2, wx.ID_ANY, wx.DefaultPosition,
-            wx.DefaultSize, wx.TAB_TRAVERSAL)
-        self.m_notebook_2.AddPage(page_11, "日本語", False, 2)
+        page_11 = wx.Panel(self.notebook_2, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+            wx.TAB_TRAVERSAL)
+        self.notebook_2.AddPage(page_11, "日本語", False, 2)
         page_11.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_6 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_9 = wx.StaticText(page_11, wx.ID_ANY,
+        self.staticText_9 = wx.StaticText(page_11, wx.ID_ANY,
             "これは日本語の文章です。")
-        parent_sizer_6.Add(self.m_staticText_9, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_6.Add(self.staticText_9, wx.SizerFlags().Border(wx.ALL))
         page_11.SetSizerAndFit(parent_sizer_6)
 
         page_4.SetSizerAndFit(page_sizer_3)
 
-        page_5 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_5 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_5, "ToolBook")
+        self.notebook.AddPage(page_5, "ToolBook")
 
         page_sizer_4 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_toolbook = wx.Toolbook(page_5, wx.ID_ANY)
+        self.toolbook = wx.Toolbook(page_5, wx.ID_ANY)
 
         bundle_1 = wx.BitmapBundle.FromBitmap(images.english_png.Bitmap)
         bundle_2 = wx.BitmapBundle.FromBitmap(images.french_png.Bitmap)
@@ -243,55 +243,55 @@ class BookTestDlg(wx.Dialog):
             bundle_2,
             bundle_3
         ]
-        self.m_toolbook.SetImages(bundle_list)
-        self.m_toolbook.SetMinSize(wx.Size(400, 400))
-        page_sizer_4.Add(self.m_toolbook, wx.SizerFlags().Border(wx.ALL))
+        self.toolbook.SetImages(bundle_list)
+        self.toolbook.SetMinSize(wx.Size(400, 400))
+        page_sizer_4.Add(self.toolbook, wx.SizerFlags().Border(wx.ALL))
 
-        page_12 = wx.Panel(self.m_toolbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_12 = wx.Panel(self.toolbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_toolbook.AddPage(page_12, "English", False, 0)
+        self.toolbook.AddPage(page_12, "English", False, 0)
         page_12.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_7 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_5 = wx.StaticText(page_12, wx.ID_ANY,
+        self.staticText_5 = wx.StaticText(page_12, wx.ID_ANY,
             "This is a sentence in English.")
-        parent_sizer_7.Add(self.m_staticText_5, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_7.Add(self.staticText_5, wx.SizerFlags().Border(wx.ALL))
         page_12.SetSizerAndFit(parent_sizer_7)
 
-        page_13 = wx.Panel(self.m_toolbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_13 = wx.Panel(self.toolbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_toolbook.AddPage(page_13, "Français", False, 1)
+        self.toolbook.AddPage(page_13, "Français", False, 1)
         page_13.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_8 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_10 = wx.StaticText(page_13, wx.ID_ANY,
+        self.staticText_10 = wx.StaticText(page_13, wx.ID_ANY,
             "Ceci est une phrase en français.")
-        parent_sizer_8.Add(self.m_staticText_10, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_8.Add(self.staticText_10, wx.SizerFlags().Border(wx.ALL))
         page_13.SetSizerAndFit(parent_sizer_8)
 
-        page_14 = wx.Panel(self.m_toolbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_14 = wx.Panel(self.toolbook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_toolbook.AddPage(page_14, "日本語", False, 2)
+        self.toolbook.AddPage(page_14, "日本語", False, 2)
         page_14.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_9 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_11 = wx.StaticText(page_14, wx.ID_ANY,
+        self.staticText_11 = wx.StaticText(page_14, wx.ID_ANY,
             "これは日本語の文章です。")
-        parent_sizer_9.Add(self.m_staticText_11, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_9.Add(self.staticText_11, wx.SizerFlags().Border(wx.ALL))
         page_14.SetSizerAndFit(parent_sizer_9)
 
         page_5.SetSizerAndFit(page_sizer_4)
 
-        page = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page, "TreeBook")
+        self.notebook.AddPage(page, "TreeBook")
 
         page_sizer_5 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_treebook = wx.Treebook(page, wx.ID_ANY)
+        self.treebook = wx.Treebook(page, wx.ID_ANY)
 
         bundle_1 = wx.BitmapBundle.FromBitmap(images.english_png.Bitmap)
         bundle_2 = wx.BitmapBundle.FromBitmap(images.french_png.Bitmap)
@@ -301,66 +301,66 @@ class BookTestDlg(wx.Dialog):
             bundle_2,
             bundle_3
         ]
-        self.m_treebook.SetImages(bundle_list)
-        self.m_treebook.SetMinSize(wx.Size(400, 400))
-        page_sizer_5.Add(self.m_treebook, wx.SizerFlags().Border(wx.ALL))
+        self.treebook.SetImages(bundle_list)
+        self.treebook.SetMinSize(wx.Size(400, 400))
+        page_sizer_5.Add(self.treebook, wx.SizerFlags().Border(wx.ALL))
 
-        page_15 = wx.Panel(self.m_treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_15 = wx.Panel(self.treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_treebook.AddPage(page_15, "English", False, 0)
+        self.treebook.AddPage(page_15, "English", False, 0)
         page_15.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_10 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_12 = wx.StaticText(page_15, wx.ID_ANY,
+        self.staticText_12 = wx.StaticText(page_15, wx.ID_ANY,
             "This is a sentence in English.")
-        parent_sizer_10.Add(self.m_staticText_12, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_10.Add(self.staticText_12, wx.SizerFlags().Border(wx.ALL))
         page_15.SetSizerAndFit(parent_sizer_10)
 
-        page_16 = wx.Panel(self.m_treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_16 = wx.Panel(self.treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_treebook.AddSubPage(page_16, "British", False, 1)
+        self.treebook.AddSubPage(page_16, "British", False, 1)
         page_16.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         page_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_13 = wx.StaticText(page_16, wx.ID_ANY, "Theatre")
-        page_sizer.Add(self.m_staticText_13, wx.SizerFlags().Border(wx.ALL))
+        self.staticText_13 = wx.StaticText(page_16, wx.ID_ANY, "Theatre")
+        page_sizer.Add(self.staticText_13, wx.SizerFlags().Border(wx.ALL))
         page_16.SetSizerAndFit(page_sizer)
 
-        page_17 = wx.Panel(self.m_treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_17 = wx.Panel(self.treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_treebook.AddSubPage(page_17, "United States", False, 2)
+        self.treebook.AddSubPage(page_17, "United States", False, 2)
         page_17.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         page_sizer_6 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_14 = wx.StaticText(page_17, wx.ID_ANY, "Theater")
-        page_sizer_6.Add(self.m_staticText_14, wx.SizerFlags().Border(wx.ALL))
+        self.staticText_14 = wx.StaticText(page_17, wx.ID_ANY, "Theater")
+        page_sizer_6.Add(self.staticText_14, wx.SizerFlags().Border(wx.ALL))
         page_17.SetSizerAndFit(page_sizer_6)
 
-        page_18 = wx.Panel(self.m_treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_18 = wx.Panel(self.treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_treebook.AddPage(page_18, "Français", False, 3)
+        self.treebook.AddPage(page_18, "Français", False, 3)
         page_18.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_11 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_15 = wx.StaticText(page_18, wx.ID_ANY,
+        self.staticText_15 = wx.StaticText(page_18, wx.ID_ANY,
             "Ceci est une phrase en français.")
-        parent_sizer_11.Add(self.m_staticText_15, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_11.Add(self.staticText_15, wx.SizerFlags().Border(wx.ALL))
         page_18.SetSizerAndFit(parent_sizer_11)
 
-        page_19 = wx.Panel(self.m_treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_19 = wx.Panel(self.treebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_treebook.AddPage(page_19, "日本語", False, 4)
+        self.treebook.AddPage(page_19, "日本語", False, 4)
         page_19.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         parent_sizer_12 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText = wx.StaticText(page_19, wx.ID_ANY,
+        self.staticText = wx.StaticText(page_19, wx.ID_ANY,
             "これは日本語の文章です。")
-        parent_sizer_12.Add(self.m_staticText, wx.SizerFlags().Border(wx.ALL))
+        parent_sizer_12.Add(self.staticText, wx.SizerFlags().Border(wx.ALL))
         page_19.SetSizerAndFit(parent_sizer_12)
 
         page.SetSizerAndFit(page_sizer_5)

--- a/tests/sdi/python/dlgissue_956.py
+++ b/tests/sdi/python/dlgissue_956.py
@@ -24,36 +24,36 @@ class DlgIssue_956(wx.Dialog):
 
         grid_bag_sizer = wx.GridBagSizer()
 
-        self.m_staticText_4 = wx.StaticText(panel_2, wx.ID_ANY, "list test")
-        grid_bag_sizer.Add(self.m_staticText_4, wx.GBPosition(0, 0), wx.GBSpan(1, 1),
-            wx.ALL, 5)
+        self.staticText_4 = wx.StaticText(panel_2, wx.ID_ANY, "list test")
+        grid_bag_sizer.Add(self.staticText_4, wx.GBPosition(0, 0), wx.GBSpan(1, 1), wx.ALL,
+            5)
 
-        self.m_choice = wx.Choice(panel_2, wx.ID_ANY)
-        grid_bag_sizer.Add(self.m_choice, wx.GBPosition(0, 1), wx.GBSpan(1, 1),
+        self.choice = wx.Choice(panel_2, wx.ID_ANY)
+        grid_bag_sizer.Add(self.choice, wx.GBPosition(0, 1), wx.GBSpan(1, 1),
             wx.ALL|wx.EXPAND, 5)
 
-        self.m_btn = wx.Button(panel_2, wx.ID_ANY, wx.EmptyString)
-        self.m_btn.SetLabelMarkup("&Refresh")
-        grid_bag_sizer.Add(self.m_btn, wx.GBPosition(0, 2), wx.GBSpan(1, 1), wx.ALL, 5)
+        self.btn = wx.Button(panel_2, wx.ID_ANY, wx.EmptyString)
+        self.btn.SetLabelMarkup("&Refresh")
+        grid_bag_sizer.Add(self.btn, wx.GBPosition(0, 2), wx.GBSpan(1, 1), wx.ALL, 5)
 
-        self.m_btn_2 = wx.Button(panel_2, wx.ID_ANY, wx.EmptyString)
-        self.m_btn_2.SetLabelMarkup("&New")
-        grid_bag_sizer.Add(self.m_btn_2, wx.GBPosition(0, 3), wx.GBSpan(1, 1), wx.ALL, 5)
+        self.btn_2 = wx.Button(panel_2, wx.ID_ANY, wx.EmptyString)
+        self.btn_2.SetLabelMarkup("&New")
+        grid_bag_sizer.Add(self.btn_2, wx.GBPosition(0, 3), wx.GBSpan(1, 1), wx.ALL, 5)
 
-        self.m_btn_3 = wx.Button(panel_2, wx.ID_ANY, wx.EmptyString)
-        self.m_btn_3.SetLabelMarkup("&Edit")
-        grid_bag_sizer.Add(self.m_btn_3, wx.GBPosition(0, 4), wx.GBSpan(1, 1), wx.ALL, 5)
+        self.btn_3 = wx.Button(panel_2, wx.ID_ANY, wx.EmptyString)
+        self.btn_3.SetLabelMarkup("&Edit")
+        grid_bag_sizer.Add(self.btn_3, wx.GBPosition(0, 4), wx.GBSpan(1, 1), wx.ALL, 5)
 
-        self.m_btn_4 = wx.Button(panel_2, wx.ID_ANY, wx.EmptyString)
-        self.m_btn_4.SetLabelMarkup("&Delete")
-        grid_bag_sizer.Add(self.m_btn_4, wx.GBPosition(0, 5), wx.GBSpan(1, 1), wx.ALL, 5)
+        self.btn_4 = wx.Button(panel_2, wx.ID_ANY, wx.EmptyString)
+        self.btn_4.SetLabelMarkup("&Delete")
+        grid_bag_sizer.Add(self.btn_4, wx.GBPosition(0, 5), wx.GBSpan(1, 1), wx.ALL, 5)
 
-        self.m_staticText_5 = wx.StaticText(panel_2, wx.ID_ANY, "test type")
-        grid_bag_sizer.Add(self.m_staticText_5, wx.GBPosition(1, 0), wx.GBSpan(1, 1),
-            wx.ALL, 5)
+        self.staticText_5 = wx.StaticText(panel_2, wx.ID_ANY, "test type")
+        grid_bag_sizer.Add(self.staticText_5, wx.GBPosition(1, 0), wx.GBSpan(1, 1), wx.ALL,
+            5)
 
-        self.m_choice_2 = wx.Choice(panel_2, wx.ID_ANY)
-        grid_bag_sizer.Add(self.m_choice_2, wx.GBPosition(1, 1), wx.GBSpan(1, 5),
+        self.choice_2 = wx.Choice(panel_2, wx.ID_ANY)
+        grid_bag_sizer.Add(self.choice_2, wx.GBPosition(1, 1), wx.GBSpan(1, 5),
             wx.ALL|wx.EXPAND, 5)
 
         grid_bag_sizer.AddGrowableCol(1)

--- a/tests/sdi/python/main_test_dlg.py
+++ b/tests/sdi/python/main_test_dlg.py
@@ -68,87 +68,85 @@ class MainTestDialog(wx.Dialog):
 
         dlg_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_notebook = wx.Notebook(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        self.notebook = wx.Notebook(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.BK_TOP|wx.NB_MULTILINE)
-        dlg_sizer.Add(self.m_notebook, wx.SizerFlags().Expand().Border(wx.ALL))
+        dlg_sizer.Add(self.notebook, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        page_2 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_2 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_2, "Text")
+        self.notebook.AddPage(page_2, "Text")
 
         page_sizer_1 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_text_ctrl = wx.TextCtrl(page_2, TXT_CTRL, "", wx.DefaultPosition,
+        self.text_ctrl = wx.TextCtrl(page_2, TXT_CTRL, "", wx.DefaultPosition,
             wx.DefaultSize, wx.TE_RICH2)
-        self.m_text_ctrl.SetHint("wxTextCtrl")
-        page_sizer_1.Add(self.m_text_ctrl, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.text_ctrl.SetHint("wxTextCtrl")
+        page_sizer_1.Add(self.text_ctrl, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        self.m_richText = wx.richtext.RichTextCtrl(page_2, ID_RICHTEXT, "",
+        self.richText = wx.richtext.RichTextCtrl(page_2, ID_RICHTEXT, "",
             wx.DefaultPosition, wx.DefaultSize, wx.richtext.RE_MULTILINE|wx.VSCROLL|
             wx.HSCROLL|wx.NO_BORDER|wx.WANTS_CHARS)
-        self.m_richText.SetHint("wxRichTextCtrl")
-        self.m_richText.SetMinSize(self.ConvertDialogToPixels(wx.Size(150, 30)))
-        page_sizer_1.Add(self.m_richText, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.richText.SetHint("wxRichTextCtrl")
+        self.richText.SetMinSize(self.ConvertDialogToPixels(wx.Size(150, 30)))
+        page_sizer_1.Add(self.richText, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        self.m_scintilla = wx.stc.StyledTextCtrl(page_2, wx.ID_ANY)
-        self.m_scintilla.SetLexer(wx.stc.STC_LEX_CPP)
-        self.m_scintilla.SetEOLMode(wx.stc.STC_EOL_LF)
-        self.m_scintilla.SetViewWhiteSpace(wx.stc.STC_WS_VISIBLEALWAYS)
+        self.scintilla = wx.stc.StyledTextCtrl(page_2, wx.ID_ANY)
+        self.scintilla.SetLexer(wx.stc.STC_LEX_CPP)
+        self.scintilla.SetEOLMode(wx.stc.STC_EOL_LF)
+        self.scintilla.SetViewWhiteSpace(wx.stc.STC_WS_VISIBLEALWAYS)
         # Sets text margin scaled appropriately for the current DPI on Windows,
         # 5 on wxGTK or wxOSX
-        self.m_scintilla.SetMarginLeft(wx.SizerFlags.GetDefaultBorder())
-        self.m_scintilla.SetMarginRight(wx.SizerFlags.GetDefaultBorder())
-        self.m_scintilla.SetMarginWidth(1, 0) # Remove default margin
-        self.m_scintilla.SetBackSpaceUnIndents(True)
-        self.m_scintilla.SetMinSize(self.ConvertDialogToPixels(wx.Size(150, 60)))
-        page_sizer_1.Add(self.m_scintilla, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.scintilla.SetMarginLeft(wx.SizerFlags.GetDefaultBorder())
+        self.scintilla.SetMarginRight(wx.SizerFlags.GetDefaultBorder())
+        self.scintilla.SetMarginWidth(1, 0) # Remove default margin
+        self.scintilla.SetBackSpaceUnIndents(True)
+        self.scintilla.SetMinSize(self.ConvertDialogToPixels(wx.Size(150, 60)))
+        page_sizer_1.Add(self.scintilla, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        self.m_htmlWin = wx.html.HtmlWindow(page_2, wx.ID_ANY)
-        self.m_htmlWin.SetPage("This is an <b>HTML</b> window")
-        self.m_htmlWin.SetMinSize(self.ConvertDialogToPixels(wx.Size(100, 60)))
-        page_sizer_1.Add(self.m_htmlWin, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.htmlWin = wx.html.HtmlWindow(page_2, wx.ID_ANY)
+        self.htmlWin.SetPage("This is an <b>HTML</b> window")
+        self.htmlWin.SetMinSize(self.ConvertDialogToPixels(wx.Size(100, 60)))
+        page_sizer_1.Add(self.htmlWin, wx.SizerFlags().Expand().Border(wx.ALL))
         page_2.SetSizerAndFit(page_sizer_1)
 
-        page_4 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_4 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_4, "Buttons")
+        self.notebook.AddPage(page_4, "Buttons")
 
         box_sizer_3 = wx.BoxSizer(wx.VERTICAL)
 
         grid_bag_sizer = wx.GridBagSizer()
 
-        self.m_btn = wx.Button(page_4, wx.ID_ANY, "Normal")
-        self.m_btn.SetToolTip("A normal button")
-        grid_bag_sizer.Add(self.m_btn, wx.GBPosition(0, 0), wx.GBSpan(1, 1), wx.ALL, 5)
+        self.btn = wx.Button(page_4, wx.ID_ANY, "Normal")
+        self.btn.SetToolTip("A normal button")
+        grid_bag_sizer.Add(self.btn, wx.GBPosition(0, 0), wx.GBSpan(1, 1), wx.ALL, 5)
 
-        self.m_btn_2 = wx.Button(page_4, wx.ID_ANY, wx.EmptyString)
-        self.m_btn_2.SetLabelMarkup("<b><span foreground=\'red\'>Markup</span></b>")
-        self.m_btn_2.SetToolTip("Text should be Bold and Red.")
-        grid_bag_sizer.Add(self.m_btn_2, wx.GBPosition(0, 1), wx.GBSpan(1, 1), wx.ALL, 5)
+        self.btn_2 = wx.Button(page_4, wx.ID_ANY, wx.EmptyString)
+        self.btn_2.SetLabelMarkup("<b><span foreground=\'red\'>Markup</span></b>")
+        self.btn_2.SetToolTip("Text should be Bold and Red.")
+        grid_bag_sizer.Add(self.btn_2, wx.GBPosition(0, 1), wx.GBSpan(1, 1), wx.ALL, 5)
 
-        self.m_btn_bitmaps = wx.Button(page_4, wx.ID_ANY, "Bitmaps")
-        self.m_btn_bitmaps.SetBitmap(wx.BitmapBundle.FromBitmap(images.normal_png.Bitmap))
-        self.m_btn_bitmaps.SetBitmapDisabled(wx.BitmapBundle.FromBitmap(
-            images.no_hour_png.Bitmap))
-        self.m_btn_bitmaps.SetBitmapCurrent(wx.BitmapBundle.FromBitmap(images.focus_png.Bitmap))
-        self.m_btn_bitmaps.SetToolTip(
+        self.btn_bitmaps = wx.Button(page_4, wx.ID_ANY, "Bitmaps")
+        self.btn_bitmaps.SetBitmap(wx.BitmapBundle.FromBitmap(images.normal_png.Bitmap))
+        self.btn_bitmaps.SetBitmapDisabled(wx.BitmapBundle.FromBitmap(images.no_hour_png.Bitmap))
+        self.btn_bitmaps.SetBitmapCurrent(wx.BitmapBundle.FromBitmap(images.focus_png.Bitmap))
+        self.btn_bitmaps.SetToolTip(
         "Bitmap should change when mouse is over button, or button is disabled.")
-        grid_bag_sizer.Add(self.m_btn_bitmaps, wx.GBPosition(0, 2), wx.GBSpan(1, 1), wx.ALL,
+        grid_bag_sizer.Add(self.btn_bitmaps, wx.GBPosition(0, 2), wx.GBSpan(1, 1), wx.ALL,
             5)
 
-        self.m_btn_4 = wx.Button(page_4, wx.ID_ANY, "Right")
-        self.m_btn_4.SetBitmapPosition(wx.RIGHT)
-        self.m_btn_4.SetBitmap(wx.BitmapBundle.FromBitmap(images.normal_png.Bitmap))
-        self.m_btn_4.SetToolTip(
+        self.btn_4 = wx.Button(page_4, wx.ID_ANY, "Right")
+        self.btn_4.SetBitmapPosition(wx.RIGHT)
+        self.btn_4.SetBitmap(wx.BitmapBundle.FromBitmap(images.normal_png.Bitmap))
+        self.btn_4.SetToolTip(
         "Bitmap should be on the right side (fails in wxPython 4.2).")
-        grid_bag_sizer.Add(self.m_btn_4, wx.GBPosition(0, 3), wx.GBSpan(1, 1), wx.ALL, 5)
+        grid_bag_sizer.Add(self.btn_4, wx.GBPosition(0, 3), wx.GBSpan(1, 1), wx.ALL, 5)
 
-        self.m_toggleBtn = wx.ToggleButton(page_4, wx.ID_ANY, "Toggle", wx.DefaultPosition,
+        self.toggleBtn = wx.ToggleButton(page_4, wx.ID_ANY, "Toggle", wx.DefaultPosition,
             wx.DefaultSize, wx.BU_EXACTFIT)
-        self.m_toggleBtn.SetToolTip(
+        self.toggleBtn.SetToolTip(
         "Style set to exact fit, so it should be a bit smaller than usual.")
-        grid_bag_sizer.Add(self.m_toggleBtn, wx.GBPosition(0, 4), wx.GBSpan(1, 1), wx.ALL,
-            5)
+        grid_bag_sizer.Add(self.toggleBtn, wx.GBPosition(0, 4), wx.GBSpan(1, 1), wx.ALL, 5)
 
         disable_bitmaps = wx.CheckBox(page_4, wx.ID_ANY, "Disable")
         disable_bitmaps.SetToolTip(
@@ -160,12 +158,11 @@ class MainTestDialog(wx.Dialog):
 
         box_sizer_7 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.m_btn_5 = wx.adv.CommandLinkButton(page_4, wx.ID_ANY, "Command",
+        self.btn_5 = wx.adv.CommandLinkButton(page_4, wx.ID_ANY, "Command",
             "wxCommandLinkButton")
-        self.m_btn_5.SetBitmap(wx.ArtProvider.GetBitmapBundle(wx.ART_GO_FORWARD,
-            wx.ART_OTHER))
-        self.m_btn_5.SetToolTip("The bitmap for this is from Art Provider.")
-        box_sizer_7.Add(self.m_btn_5, wx.SizerFlags().Border(wx.ALL))
+        self.btn_5.SetBitmap(wx.ArtProvider.GetBitmapBundle(wx.ART_GO_FORWARD, wx.ART_OTHER))
+        self.btn_5.SetToolTip("The bitmap for this is from Art Provider.")
+        box_sizer_7.Add(self.btn_5, wx.SizerFlags().Border(wx.ALL))
 
         # Trailing spaces added to avoid clipping
         radioBox = wx.RadioBox(page_4, wx.ID_ANY, "Radio Box", wx.DefaultPosition,
@@ -177,36 +174,36 @@ class MainTestDialog(wx.Dialog):
         # wxPython currently does not support a checkbox as a static box label
         static_box_4 = wx.StaticBoxSizer(wx.VERTICAL, page_4, "Checkbox")
 
-        self.m_radioBtn_4 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
+        self.radioBtn_4 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
             "First button")
-        static_box_4.Add(self.m_radioBtn_4, wx.SizerFlags().Border(wx.ALL))
+        static_box_4.Add(self.radioBtn_4, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_radioBtn_2 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
+        self.radioBtn_2 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
             "Second button")
-        self.m_radioBtn_2.SetValue(True)
-        static_box_4.Add(self.m_radioBtn_2, wx.SizerFlags().Border(wx.ALL))
+        self.radioBtn_2.SetValue(True)
+        static_box_4.Add(self.radioBtn_2, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_radioBtn_3 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
+        self.radioBtn_3 = wx.RadioButton(static_box_4.GetStaticBox(), wx.ID_ANY,
             "Third button")
-        static_box_4.Add(self.m_radioBtn_3, wx.SizerFlags().Border(wx.ALL))
+        static_box_4.Add(self.radioBtn_3, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_7.Add(static_box_4, wx.SizerFlags().Border(wx.ALL))
 
         # wxPython currently does not support a radio button as a static box label
         static_box_5 = wx.StaticBoxSizer(wx.VERTICAL, page_4, "Radio")
 
-        self.m_radioBtn_5 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
+        self.radioBtn_5 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
             "First button")
-        static_box_5.Add(self.m_radioBtn_5, wx.SizerFlags().Border(wx.ALL))
+        static_box_5.Add(self.radioBtn_5, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_radioBtn_6 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
+        self.radioBtn_6 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
             "Second button")
-        self.m_radioBtn_6.SetValue(True)
-        static_box_5.Add(self.m_radioBtn_6, wx.SizerFlags().Border(wx.ALL))
+        self.radioBtn_6.SetValue(True)
+        static_box_5.Add(self.radioBtn_6, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_radioBtn_7 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
+        self.radioBtn_7 = wx.RadioButton(static_box_5.GetStaticBox(), wx.ID_ANY,
             "Third button")
-        static_box_5.Add(self.m_radioBtn_7, wx.SizerFlags().Border(wx.ALL))
+        static_box_5.Add(self.radioBtn_7, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_7.Add(static_box_5, wx.SizerFlags().Border(wx.ALL))
 
@@ -221,39 +218,39 @@ class MainTestDialog(wx.Dialog):
         wrap_sizer = wx.WrapSizer(wx.HORIZONTAL, wx.EXTEND_LAST_ON_EACH_LINE|
             wx.REMOVE_LEADING_SPACES)
 
-        self.m_btn_3 = wx.Button(page_4, wx.ID_ANY, "First btn")
-        wrap_sizer.Add(self.m_btn_3, wx.SizerFlags().Border(wx.ALL))
+        self.btn_3 = wx.Button(page_4, wx.ID_ANY, "First btn")
+        wrap_sizer.Add(self.btn_3, wx.SizerFlags().Border(wx.ALL))
 
         btn2 = wx.Button(page_4, wx.ID_ANY, "Popup")
         wrap_sizer.Add(btn2, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_radioBtn = wx.RadioButton(page_4, wx.ID_ANY, "First radio",
+        self.radioBtn = wx.RadioButton(page_4, wx.ID_ANY, "First radio",
             wx.DefaultPosition, wx.DefaultSize, wx.RB_GROUP)
-        wrap_sizer.Add(self.m_radioBtn, wx.SizerFlags().Center().Border(wx.ALL))
+        wrap_sizer.Add(self.radioBtn, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_radioBtn2 = wx.RadioButton(page_4, wx.ID_ANY, "Second radio")
-        wrap_sizer.Add(self.m_radioBtn2, wx.SizerFlags().Center().Border(wx.ALL))
+        self.radioBtn2 = wx.RadioButton(page_4, wx.ID_ANY, "Second radio")
+        wrap_sizer.Add(self.radioBtn2, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_checkBox = wx.CheckBox(page_4, wx.ID_ANY, "Checkbox", wx.DefaultPosition,
+        self.checkBox = wx.CheckBox(page_4, wx.ID_ANY, "Checkbox", wx.DefaultPosition,
             wx.DefaultSize, wx.CHK_3STATE)
-        self.m_checkBox.Set3StateValue(wx.CHK_UNDETERMINED)
-        wrap_sizer.Add(self.m_checkBox, wx.SizerFlags().Center().Border(wx.ALL))
+        self.checkBox.Set3StateValue(wx.CHK_UNDETERMINED)
+        wrap_sizer.Add(self.checkBox, wx.SizerFlags().Center().Border(wx.ALL))
 
         box_sizer_19.Add(wrap_sizer, wx.SizerFlags().Expand().Border(wx.ALL))
 
         # wxPython currently does not support a checkbox as a static box label
         static_box_3 = wx.StaticBoxSizer(wx.VERTICAL, page_4, "Play Animation")
 
-        self.m_toggleBtn_2 = wx.ToggleButton(static_box_3.GetStaticBox(), wx.ID_ANY,
+        self.toggleBtn_2 = wx.ToggleButton(static_box_3.GetStaticBox(), wx.ID_ANY,
             "Play Animation", wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT)
-        static_box_3.Add(self.m_toggleBtn_2, wx.SizerFlags().Border(wx.ALL))
+        static_box_3.Add(self.toggleBtn_2, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_animation_ctrl = wx.adv.AnimationCtrl(static_box_3.GetStaticBox(), wx.ID_ANY,
+        self.animation_ctrl = wx.adv.AnimationCtrl(static_box_3.GetStaticBox(), wx.ID_ANY,
             wx.adv.Animation("../../art/clr_hourglass.gif"), wx.DefaultPosition,
             wx.DefaultSize, wx.adv.AC_DEFAULT_STYLE)
-        self.m_animation_ctrl.SetInactiveBitmap(wx.BitmapBundle.FromBitmap(
+        self.animation_ctrl.SetInactiveBitmap(wx.BitmapBundle.FromBitmap(
             images.disabled_png.Bitmap))
-        static_box_3.Add(self.m_animation_ctrl, wx.SizerFlags().Border(wx.ALL))
+        static_box_3.Add(self.animation_ctrl, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_19.Add(static_box_3, wx.SizerFlags().Border(wx.ALL))
 
@@ -264,9 +261,9 @@ class MainTestDialog(wx.Dialog):
         box_sizer_3.Add(box_sizer_19, wx.SizerFlags().Expand().Border(wx.ALL))
         page_4.SetSizerAndFit(box_sizer_3)
 
-        page_5 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_5 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_5, "Lists")
+        self.notebook.AddPage(page_5, "Lists")
 
         box_sizer_5 = wx.BoxSizer(wx.VERTICAL)
 
@@ -274,12 +271,12 @@ class MainTestDialog(wx.Dialog):
 
         box_sizer_10 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_2 = wx.StaticText(page_5, wx.ID_ANY, "wxRearrangeCtrl")
-        box_sizer_10.Add(self.m_staticText_2, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.staticText_2 = wx.StaticText(page_5, wx.ID_ANY, "wxRearrangeCtrl")
+        box_sizer_10.Add(self.staticText_2, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        self.m_rearrange = wx.RearrangeCtrl(page_5, wx.ID_ANY, wx.DefaultPosition,
+        self.rearrange = wx.RearrangeCtrl(page_5, wx.ID_ANY, wx.DefaultPosition,
             wx.DefaultSize, [], [])
-        box_sizer_10.Add(self.m_rearrange, wx.SizerFlags().Border(wx.ALL))
+        box_sizer_10.Add(self.rearrange, wx.SizerFlags().Border(wx.ALL))
 
         flex_grid_sizer.Add(box_sizer_10, wx.SizerFlags().Border(wx.ALL))
 
@@ -288,46 +285,46 @@ class MainTestDialog(wx.Dialog):
         staticText_3 = wx.StaticText(page_5, wx.ID_ANY, "wxCheckListBox")
         box_sizer_11.Add(staticText_3, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        self.m_checkList = wx.CheckListBox(page_5, wx.ID_ANY)
-        box_sizer_11.Add(self.m_checkList, wx.SizerFlags().Border(wx.ALL))
+        self.checkList = wx.CheckListBox(page_5, wx.ID_ANY)
+        box_sizer_11.Add(self.checkList, wx.SizerFlags().Border(wx.ALL))
 
         flex_grid_sizer.Add(box_sizer_11, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_12 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_4 = wx.StaticText(page_5, wx.ID_ANY, "wxListView")
-        box_sizer_12.Add(self.m_staticText_4, wx.SizerFlags().Border(wx.ALL))
+        self.staticText_4 = wx.StaticText(page_5, wx.ID_ANY, "wxListView")
+        box_sizer_12.Add(self.staticText_4, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_listview = wx.ListView(page_5, wx.ID_ANY, wx.DefaultPosition,
-            wx.DefaultSize, wx.LC_SINGLE_SEL|wx.LC_REPORT)
-        self.m_listview.AppendColumn("name")
-        self.m_listview.AppendColumn("value")
+        self.listview = wx.ListView(page_5, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+            wx.LC_SINGLE_SEL|wx.LC_REPORT)
+        self.listview.AppendColumn("name")
+        self.listview.AppendColumn("value")
         info = wx.ListItem()
         info.Clear()
         info.SetId(0)
-        idx = self.m_listview.InsertItem(info)
-        self.m_listview.SetItem(idx, 0, "meaning")
-        self.m_listview.SetItem(idx, 1, "42")
-        self.m_listview.SetToolTip("Separate content columns with a semi-colon (;)")
-        box_sizer_12.Add(self.m_listview, wx.SizerFlags().Border(wx.ALL))
+        idx = self.listview.InsertItem(info)
+        self.listview.SetItem(idx, 0, "meaning")
+        self.listview.SetItem(idx, 1, "42")
+        self.listview.SetToolTip("Separate content columns with a semi-colon (;)")
+        box_sizer_12.Add(self.listview, wx.SizerFlags().Border(wx.ALL))
 
         flex_grid_sizer.Add(box_sizer_12, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_13 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.m_edit_listbox = wx.adv.EditableListBox(page_5, wx.ID_ANY,
+        self.edit_listbox = wx.adv.EditableListBox(page_5, wx.ID_ANY,
             "My Editable ListBox", wx.DefaultPosition, wx.DefaultSize, wx.adv.EL_ALLOW_NEW|
             wx.adv.EL_ALLOW_EDIT|wx.adv.EL_ALLOW_DELETE)
-        box_sizer_13.Add(self.m_edit_listbox, wx.SizerFlags().Border(wx.ALL))
+        box_sizer_13.Add(self.edit_listbox, wx.SizerFlags().Border(wx.ALL))
 
         flex_grid_sizer.Add(box_sizer_13, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_5.Add(flex_grid_sizer, wx.SizerFlags().Border(wx.ALL))
         page_5.SetSizerAndFit(box_sizer_5)
 
-        page_3 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_3 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_3, "Combos")
+        self.notebook.AddPage(page_3, "Combos")
 
         page_sizer_2 = wx.BoxSizer(wx.VERTICAL)
 
@@ -338,112 +335,112 @@ class MainTestDialog(wx.Dialog):
         static_box_sizer2 = wx.StaticBoxSizer(wx.VERTICAL, static_box.GetStaticBox(),
             "Combo")
 
-        self.m_staticText3 = wx.StaticText(static_box_sizer2.GetStaticBox(), wx.ID_ANY,
+        self.staticText3 = wx.StaticText(static_box_sizer2.GetStaticBox(), wx.ID_ANY,
             "Unsorted")
-        static_box_sizer2.Add(self.m_staticText3, wx.SizerFlags().Border(wx.ALL))
+        static_box_sizer2.Add(self.staticText3, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_comboBox = wx.ComboBox(static_box_sizer2.GetStaticBox(), wx.ID_ANY)
-        self.m_comboBox.Append("item #1")
-        self.m_comboBox.Append("item #2")
-        self.m_comboBox.Append("item #0")
-        self.m_comboBox.SetStringSelection("item #2")
-        self.m_comboBox.SetToolTip("Item #0 should be selected by default")
-        static_box_sizer2.Add(self.m_comboBox, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.comboBox = wx.ComboBox(static_box_sizer2.GetStaticBox(), wx.ID_ANY)
+        self.comboBox.Append("item #1")
+        self.comboBox.Append("item #2")
+        self.comboBox.Append("item #0")
+        self.comboBox.SetStringSelection("item #2")
+        self.comboBox.SetToolTip("Item #0 should be selected by default")
+        static_box_sizer2.Add(self.comboBox, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        self.m_staticText4 = wx.StaticText(static_box_sizer2.GetStaticBox(), wx.ID_ANY,
+        self.staticText4 = wx.StaticText(static_box_sizer2.GetStaticBox(), wx.ID_ANY,
             "Sorted")
-        static_box_sizer2.Add(self.m_staticText4, wx.SizerFlags().Border(wx.ALL))
+        static_box_sizer2.Add(self.staticText4, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_comboBox2 = wx.ComboBox(static_box_sizer2.GetStaticBox(), wx.ID_ANY,
+        self.comboBox2 = wx.ComboBox(static_box_sizer2.GetStaticBox(), wx.ID_ANY,
             wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, [], wx.CB_SORT)
-        self.m_comboBox2.Append("item #1")
-        self.m_comboBox2.Append("item #2")
-        self.m_comboBox2.Append("item #0")
-        self.m_comboBox2.SetStringSelection("item #2")
-        self.m_comboBox2.SetToolTip("Item #2 should be selected by default")
-        static_box_sizer2.Add(self.m_comboBox2, wx.SizerFlags().Border(wx.ALL))
+        self.comboBox2.Append("item #1")
+        self.comboBox2.Append("item #2")
+        self.comboBox2.Append("item #0")
+        self.comboBox2.SetStringSelection("item #2")
+        self.comboBox2.SetToolTip("Item #2 should be selected by default")
+        static_box_sizer2.Add(self.comboBox2, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer3.Add(static_box_sizer2, wx.SizerFlags().Expand().Border(wx.ALL))
 
         static_box_sizer3 = wx.StaticBoxSizer(wx.VERTICAL, static_box.GetStaticBox(),
             "Choice")
 
-        self.m_staticText5 = wx.StaticText(static_box_sizer3.GetStaticBox(), wx.ID_ANY,
+        self.staticText5 = wx.StaticText(static_box_sizer3.GetStaticBox(), wx.ID_ANY,
             "Unsorted")
-        static_box_sizer3.Add(self.m_staticText5, wx.SizerFlags().Border(wx.ALL))
+        static_box_sizer3.Add(self.staticText5, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_choice = wx.Choice(static_box_sizer3.GetStaticBox(), wx.ID_ANY)
-        self.m_choice.Append("item #1")
-        self.m_choice.Append("item #2")
-        self.m_choice.Append("item #0")
-        self.m_choice.SetSelection(2)
-        self.m_choice.SetToolTip("Item #0 should be selected by default")
-        static_box_sizer3.Add(self.m_choice, wx.SizerFlags().Border(wx.ALL))
+        self.choice = wx.Choice(static_box_sizer3.GetStaticBox(), wx.ID_ANY)
+        self.choice.Append("item #1")
+        self.choice.Append("item #2")
+        self.choice.Append("item #0")
+        self.choice.SetSelection(2)
+        self.choice.SetToolTip("Item #0 should be selected by default")
+        static_box_sizer3.Add(self.choice, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_staticText6 = wx.StaticText(static_box_sizer3.GetStaticBox(), wx.ID_ANY,
+        self.staticText6 = wx.StaticText(static_box_sizer3.GetStaticBox(), wx.ID_ANY,
             "Sorted")
-        static_box_sizer3.Add(self.m_staticText6, wx.SizerFlags().Border(wx.ALL))
+        static_box_sizer3.Add(self.staticText6, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_choice2 = wx.Choice(static_box_sizer3.GetStaticBox(), wx.ID_ANY,
+        self.choice2 = wx.Choice(static_box_sizer3.GetStaticBox(), wx.ID_ANY,
             wx.DefaultPosition, wx.DefaultSize, [], wx.CB_SORT)
-        self.m_choice2.Append("item #1")
-        self.m_choice2.Append("item #2")
-        self.m_choice2.Append("item #0")
-        self.m_choice2.SetSelection(2)
-        self.m_choice2.SetToolTip("Item #2 should be selected by default")
-        static_box_sizer3.Add(self.m_choice2, wx.SizerFlags().Border(wx.ALL))
+        self.choice2.Append("item #1")
+        self.choice2.Append("item #2")
+        self.choice2.Append("item #0")
+        self.choice2.SetSelection(2)
+        self.choice2.SetToolTip("Item #2 should be selected by default")
+        static_box_sizer3.Add(self.choice2, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer3.Add(static_box_sizer3, wx.SizerFlags().Expand().Border(wx.ALL))
 
         static_box_sizer4 = wx.StaticBoxSizer(wx.VERTICAL, static_box.GetStaticBox(),
             "List")
 
-        self.m_staticText7 = wx.StaticText(static_box_sizer4.GetStaticBox(), wx.ID_ANY,
+        self.staticText7 = wx.StaticText(static_box_sizer4.GetStaticBox(), wx.ID_ANY,
             "Unsorted")
-        static_box_sizer4.Add(self.m_staticText7, wx.SizerFlags().Border(wx.ALL))
+        static_box_sizer4.Add(self.staticText7, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_listbox = wx.ListBox(static_box_sizer4.GetStaticBox(), wx.ID_ANY)
-        self.m_listbox.Append("item #1")
-        self.m_listbox.Append("item #2")
-        self.m_listbox.Append("item #0")
-        static_box_sizer4.Add(self.m_listbox, wx.SizerFlags().Border(wx.ALL))
+        self.listbox = wx.ListBox(static_box_sizer4.GetStaticBox(), wx.ID_ANY)
+        self.listbox.Append("item #1")
+        self.listbox.Append("item #2")
+        self.listbox.Append("item #0")
+        static_box_sizer4.Add(self.listbox, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_staticText8 = wx.StaticText(static_box_sizer4.GetStaticBox(), wx.ID_ANY,
+        self.staticText8 = wx.StaticText(static_box_sizer4.GetStaticBox(), wx.ID_ANY,
             "Sorted")
-        static_box_sizer4.Add(self.m_staticText8, wx.SizerFlags().Border(wx.ALL))
+        static_box_sizer4.Add(self.staticText8, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_listBox2 = wx.ListBox(static_box_sizer4.GetStaticBox(), wx.ID_ANY,
+        self.listBox2 = wx.ListBox(static_box_sizer4.GetStaticBox(), wx.ID_ANY,
             wx.DefaultPosition, wx.DefaultSize, [], wx.LB_SINGLE|wx.LB_SORT)
-        self.m_listBox2.Append("item #1")
-        self.m_listBox2.Append("item #2")
-        self.m_listBox2.Append("item #0")
-        static_box_sizer4.Add(self.m_listBox2, wx.SizerFlags().Border(wx.ALL))
+        self.listBox2.Append("item #1")
+        self.listBox2.Append("item #2")
+        self.listBox2.Append("item #0")
+        static_box_sizer4.Add(self.listBox2, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer3.Add(static_box_sizer4, wx.SizerFlags().Expand().Border(wx.ALL))
 
         static_box_sizer5 = wx.StaticBoxSizer(wx.VERTICAL, static_box.GetStaticBox(),
             "Checked")
 
-        self.m_staticText9 = wx.StaticText(static_box_sizer5.GetStaticBox(), wx.ID_ANY,
+        self.staticText9 = wx.StaticText(static_box_sizer5.GetStaticBox(), wx.ID_ANY,
             "Unsorted")
-        static_box_sizer5.Add(self.m_staticText9, wx.SizerFlags().Border(wx.ALL))
+        static_box_sizer5.Add(self.staticText9, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_checkList_2 = wx.CheckListBox(static_box_sizer5.GetStaticBox(), wx.ID_ANY)
-        self.m_checkList_2.Append("item #1")
-        self.m_checkList_2.Append("item #2")
-        self.m_checkList_2.Append("item #0")
-        static_box_sizer5.Add(self.m_checkList_2, wx.SizerFlags().Border(wx.ALL))
+        self.checkList_2 = wx.CheckListBox(static_box_sizer5.GetStaticBox(), wx.ID_ANY)
+        self.checkList_2.Append("item #1")
+        self.checkList_2.Append("item #2")
+        self.checkList_2.Append("item #0")
+        static_box_sizer5.Add(self.checkList_2, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_staticText10 = wx.StaticText(static_box_sizer5.GetStaticBox(), wx.ID_ANY,
+        self.staticText10 = wx.StaticText(static_box_sizer5.GetStaticBox(), wx.ID_ANY,
             "Sorted")
-        static_box_sizer5.Add(self.m_staticText10, wx.SizerFlags().Border(wx.ALL))
+        static_box_sizer5.Add(self.staticText10, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_checkList2 = wx.CheckListBox(static_box_sizer5.GetStaticBox(), wx.ID_ANY,
+        self.checkList2 = wx.CheckListBox(static_box_sizer5.GetStaticBox(), wx.ID_ANY,
             wx.DefaultPosition, wx.DefaultSize, [], wx.LB_SINGLE|wx.LB_SORT)
-        self.m_checkList2.Append("item #1")
-        self.m_checkList2.Append("item #2")
-        self.m_checkList2.Append("item #0")
-        static_box_sizer5.Add(self.m_checkList2, wx.SizerFlags().Border(wx.ALL))
+        self.checkList2.Append("item #1")
+        self.checkList2.Append("item #2")
+        self.checkList2.Append("item #0")
+        static_box_sizer5.Add(self.checkList2, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer3.Add(static_box_sizer5, wx.SizerFlags().Expand().Border(wx.ALL))
 
@@ -467,9 +464,9 @@ class MainTestDialog(wx.Dialog):
         page_sizer_2.Add(box_sizer_20, wx.SizerFlags().Border(wx.ALL))
         page_3.SetSizerAndFit(page_sizer_2)
 
-        page_6 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_6 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.BORDER_THEME|wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_6, "Pickers")
+        self.notebook.AddPage(page_6, "Pickers")
 
         parent_sizer2 = wx.BoxSizer(wx.VERTICAL)
 
@@ -482,10 +479,10 @@ class MainTestDialog(wx.Dialog):
         staticText__2 = wx.StaticText(static_box_2.GetStaticBox(), wx.ID_ANY, "File:")
         box_sizer.Add(staticText__2, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_filePicker = wx.FilePickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
+        self.filePicker = wx.FilePickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
             wx.EmptyString, wx.FileSelectorPromptStr, "BMP files|*.bmp", wx.DefaultPosition,
             wx.DefaultSize, wx.FLP_USE_TEXTCTRL|wx.FLP_OPEN|wx.FLP_FILE_MUST_EXIST)
-        box_sizer.Add(self.m_filePicker, wx.SizerFlags().Border(wx.ALL))
+        box_sizer.Add(self.filePicker, wx.SizerFlags().Border(wx.ALL))
 
         grid_sizer.Add(box_sizer, wx.SizerFlags().Border(wx.ALL))
 
@@ -494,10 +491,10 @@ class MainTestDialog(wx.Dialog):
         staticText__3 = wx.StaticText(static_box_2.GetStaticBox(), wx.ID_ANY, "Directory:")
         box_sizer_2.Add(staticText__3, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_dirPicker = wx.DirPickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY, ".",
+        self.dirPicker = wx.DirPickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY, ".",
             wx.DirSelectorPromptStr, wx.DefaultPosition, wx.DefaultSize,
             wx.DIRP_DEFAULT_STYLE|wx.DIRP_SMALL)
-        box_sizer_2.Add(self.m_dirPicker, wx.SizerFlags().Border(wx.ALL))
+        box_sizer_2.Add(self.dirPicker, wx.SizerFlags().Border(wx.ALL))
 
         grid_sizer.Add(box_sizer_2, wx.SizerFlags().Border(wx.ALL))
 
@@ -506,9 +503,9 @@ class MainTestDialog(wx.Dialog):
         staticText__4 = wx.StaticText(static_box_2.GetStaticBox(), wx.ID_ANY, "Colour:")
         box_sizer_4.Add(staticText__4, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_colourPicker = wx.ColourPickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
+        self.colourPicker = wx.ColourPickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
             wx.BLACK)
-        box_sizer_4.Add(self.m_colourPicker, wx.SizerFlags().Border(wx.ALL))
+        box_sizer_4.Add(self.colourPicker, wx.SizerFlags().Border(wx.ALL))
 
         grid_sizer.Add(box_sizer_4, wx.SizerFlags().Border(wx.ALL))
 
@@ -517,11 +514,11 @@ class MainTestDialog(wx.Dialog):
         staticText__7 = wx.StaticText(static_box_2.GetStaticBox(), wx.ID_ANY, "Font:")
         box_sizer_9.Add(staticText__7, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_fontPicker = wx.FontPickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
+        self.fontPicker = wx.FontPickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
             wx.Font(wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL,
             wx.FONTWEIGHT_NORMAL, False, "Comic Sans MS"), wx.DefaultPosition, wx.DefaultSize,
             wx.FNTP_DEFAULT_STYLE|wx.FNTP_USE_TEXTCTRL)
-        box_sizer_9.Add(self.m_fontPicker, wx.SizerFlags().Border(wx.ALL))
+        box_sizer_9.Add(self.fontPicker, wx.SizerFlags().Border(wx.ALL))
 
         grid_sizer.Add(box_sizer_9, wx.SizerFlags().Border(wx.ALL))
 
@@ -530,9 +527,9 @@ class MainTestDialog(wx.Dialog):
         staticText__5 = wx.StaticText(static_box_2.GetStaticBox(), wx.ID_ANY, "Date:")
         box_sizer_6.Add(staticText__5, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_datePicker = wx.adv.DatePickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
+        self.datePicker = wx.adv.DatePickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
             wx.DefaultDateTime)
-        box_sizer_6.Add(self.m_datePicker, wx.SizerFlags().Border(wx.ALL))
+        box_sizer_6.Add(self.datePicker, wx.SizerFlags().Border(wx.ALL))
 
         grid_sizer.Add(box_sizer_6, wx.SizerFlags().Border(wx.ALL))
 
@@ -541,9 +538,9 @@ class MainTestDialog(wx.Dialog):
         staticText__6 = wx.StaticText(static_box_2.GetStaticBox(), wx.ID_ANY, "Time:")
         box_sizer_8.Add(staticText__6, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_timePicker = wx.adv.TimePickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
+        self.timePicker = wx.adv.TimePickerCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
             wx.DefaultDateTime)
-        box_sizer_8.Add(self.m_timePicker, wx.SizerFlags().Border(wx.ALL))
+        box_sizer_8.Add(self.timePicker, wx.SizerFlags().Border(wx.ALL))
 
         grid_sizer.Add(box_sizer_8, wx.SizerFlags().Border(wx.ALL))
 
@@ -556,21 +553,21 @@ class MainTestDialog(wx.Dialog):
         parent_sizer2.Add(self.fileCtrl, wx.SizerFlags().Border(wx.ALL))
         page_6.SetSizerAndFit(parent_sizer2)
 
-        page = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page, "RibbonBar")
+        self.notebook.AddPage(page, "RibbonBar")
 
         page_sizer_3 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_rbnBar = wx.ribbon.RibbonBar(page, wx.ID_ANY, wx.DefaultPosition,
+        self.rbnBar = wx.ribbon.RibbonBar(page, wx.ID_ANY, wx.DefaultPosition,
             wx.DefaultSize, wx.ribbon.RIBBON_BAR_SHOW_PAGE_LABELS|
             wx.ribbon.RIBBON_BAR_SHOW_PAGE_ICONS|wx.ribbon.RIBBON_BAR_FLOW_HORIZONTAL)
 
-        self.m_rbnBar.SetArtProvider(wx.ribbon.RibbonAUIArtProvider())
-        page_sizer_3.Add(self.m_rbnBar, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.rbnBar.SetArtProvider(wx.ribbon.RibbonAUIArtProvider())
+        page_sizer_3.Add(self.rbnBar, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        rbnPage = wx.ribbon.RibbonPage(self.m_rbnBar, wx.ID_ANY, "First")
-        self.m_rbnBar.SetActivePage(rbnPage)
+        rbnPage = wx.ribbon.RibbonPage(self.rbnBar, wx.ID_ANY, "First")
+        self.rbnBar.SetActivePage(rbnPage)
 
         rbnPanel = wx.ribbon.RibbonPanel(rbnPage, wx.ID_ANY, "English",
             images.english_png.Bitmap)
@@ -579,13 +576,13 @@ class MainTestDialog(wx.Dialog):
 
         box_sizer_15 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText = wx.StaticText(rbnPanel, wx.ID_ANY,
+        self.staticText = wx.StaticText(rbnPanel, wx.ID_ANY,
             "This is a sentence in English.")
-        self.m_staticText.Wrap(200)
-        box_sizer_15.Add(self.m_staticText, wx.SizerFlags().Border(wx.ALL))
+        self.staticText.Wrap(200)
+        box_sizer_15.Add(self.staticText, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_btn_6 = wx.Button(rbnPanel, wx.ID_ANY, "Switch")
-        box_sizer_15.Add(self.m_btn_6, wx.SizerFlags().Center().Border(wx.ALL))
+        self.btn_6 = wx.Button(rbnPanel, wx.ID_ANY, "Switch")
+        box_sizer_15.Add(self.btn_6, wx.SizerFlags().Center().Border(wx.ALL))
 
         first_parent_sizer.Add(box_sizer_15, wx.SizerFlags(1).Expand().Border(wx.ALL))
         rbnPanel.SetSizerAndFit(first_parent_sizer)
@@ -598,18 +595,18 @@ class MainTestDialog(wx.Dialog):
 
         box_sizer_16 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText_3 = wx.StaticText(rbnPanel_2, wx.ID_ANY,
+        self.staticText_3 = wx.StaticText(rbnPanel_2, wx.ID_ANY,
             "Ceci est une phrase en français.")
-        self.m_staticText_3.Wrap(200)
-        box_sizer_16.Add(self.m_staticText_3, wx.SizerFlags().Border(wx.ALL))
+        self.staticText_3.Wrap(200)
+        box_sizer_16.Add(self.staticText_3, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_btn_7 = wx.Button(rbnPanel_2, wx.ID_ANY, "Switch")
-        box_sizer_16.Add(self.m_btn_7, wx.SizerFlags().Center().Border(wx.ALL))
+        self.btn_7 = wx.Button(rbnPanel_2, wx.ID_ANY, "Switch")
+        box_sizer_16.Add(self.btn_7, wx.SizerFlags().Center().Border(wx.ALL))
 
         first_parent_sizer_2.Add(box_sizer_16, wx.SizerFlags(1).Expand().Border(wx.ALL))
         rbnPanel_2.SetSizerAndFit(first_parent_sizer_2)
 
-        ribbonPage2 = wx.ribbon.RibbonPage(self.m_rbnBar, wx.ID_ANY, "Second")
+        ribbonPage2 = wx.ribbon.RibbonPage(self.rbnBar, wx.ID_ANY, "Second")
 
         ribbonPanel2 = wx.ribbon.RibbonPanel(ribbonPage2, wx.ID_ANY, "Button Panel")
 
@@ -620,7 +617,7 @@ class MainTestDialog(wx.Dialog):
             wx.ribbon.RIBBON_BUTTON_NORMAL)
         rbnBtnBar.Realize()
 
-        ribbonPage_2 = wx.ribbon.RibbonPage(self.m_rbnBar, wx.ID_ANY, "Third")
+        ribbonPage_2 = wx.ribbon.RibbonPage(self.rbnBar, wx.ID_ANY, "Third")
 
         ribbonPanel_2 = wx.ribbon.RibbonPanel(ribbonPage_2, wx.ID_ANY, "Tool Panel")
 
@@ -632,7 +629,7 @@ class MainTestDialog(wx.Dialog):
             wx.ART_TOOLBAR), "", wx.ribbon.RIBBON_BUTTON_NORMAL)
         rbnToolBar.Realize()
 
-        ribbonPage_3 = wx.ribbon.RibbonPage(self.m_rbnBar, wx.ID_ANY, "Fourth")
+        ribbonPage_3 = wx.ribbon.RibbonPage(self.rbnBar, wx.ID_ANY, "Fourth")
 
         rbnPanel_3 = wx.ribbon.RibbonPanel(ribbonPage_3, wx.ID_ANY, "Gallery Panel")
 
@@ -641,45 +638,45 @@ class MainTestDialog(wx.Dialog):
         rbnGallery.Realize()
         page.SetSizerAndFit(page_sizer_3)
 
-        page_7 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_7 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_7, "Banners")
+        self.notebook.AddPage(page_7, "Banners")
         page_7.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         page_sizer = wx.BoxSizer(wx.VERTICAL)
 
         box_sizer_17 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.m_banner_left = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.LEFT)
-        self.m_banner_left.SetText("Left Banner", "")
-        box_sizer_17.Add(self.m_banner_left, wx.SizerFlags().Border(wx.ALL))
+        self.banner_left = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.LEFT)
+        self.banner_left.SetText("Left Banner", "")
+        box_sizer_17.Add(self.banner_left, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_banner_top = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.TOP)
-        self.m_banner_top.SetGradient(wx.SystemSettings.GetColour(
+        self.banner_top = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.TOP)
+        self.banner_top.SetGradient(wx.SystemSettings.GetColour(
             wx.SYS_COLOUR_INACTIVECAPTION),
             wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT))
-        self.m_banner_top.SetText("Top Banner", "This is the top banner message")
-        box_sizer_17.Add(self.m_banner_top, wx.SizerFlags().Border(wx.ALL))
+        self.banner_top.SetText("Top Banner", "This is the top banner message")
+        box_sizer_17.Add(self.banner_top, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_banner_right = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.RIGHT)
-        self.m_banner_right.SetText("Right Banner", "")
-        box_sizer_17.Add(self.m_banner_right, wx.SizerFlags().Border(wx.ALL))
+        self.banner_right = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.RIGHT)
+        self.banner_right.SetText("Right Banner", "")
+        box_sizer_17.Add(self.banner_right, wx.SizerFlags().Border(wx.ALL))
 
         page_sizer.Add(box_sizer_17, wx.SizerFlags(1).Border(wx.ALL))
 
         box_sizer_18 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.m_banner = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.LEFT)
-        self.m_banner.SetBitmap(wx.BitmapBundle.FromBitmap(images.wiztest_png.Bitmap))
-        self.m_banner.SetText("This is a long title", "")
-        box_sizer_18.Add(self.m_banner, wx.SizerFlags().Border(wx.ALL))
+        self.banner = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.LEFT)
+        self.banner.SetBitmap(wx.BitmapBundle.FromBitmap(images.wiztest_png.Bitmap))
+        self.banner.SetText("This is a long title", "")
+        box_sizer_18.Add(self.banner, wx.SizerFlags().Border(wx.ALL))
 
         page_sizer.Add(box_sizer_18, wx.SizerFlags().Border(wx.ALL))
         page_7.SetSizerAndFit(page_sizer)
 
-        page_8 = wx.Panel(self.m_notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        page_8 = wx.Panel(self.notebook, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
-        self.m_notebook.AddPage(page_8, "Data")
+        self.notebook.AddPage(page_8, "Data")
         page_8.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
         page_sizer_4 = wx.BoxSizer(wx.VERTICAL)
@@ -707,9 +704,9 @@ class MainTestDialog(wx.Dialog):
 
         dlg_sizer.Add(box_sizer_14, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_events_list = wx.ListBox(self, wx.ID_ANY)
-        self.m_events_list.SetMinSize(self.ConvertDialogToPixels(wx.Size(-1, 60)))
-        dlg_sizer.Add(self.m_events_list, wx.SizerFlags(1).Expand().Border(wx.ALL))
+        self.events_list = wx.ListBox(self, wx.ID_ANY)
+        self.events_list.SetMinSize(self.ConvertDialogToPixels(wx.Size(-1, 60)))
+        dlg_sizer.Add(self.events_list, wx.SizerFlags(1).Expand().Border(wx.ALL))
 
         if "wxMac" not in wx.PlatformInfo:
             stdBtn_line = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
@@ -728,69 +725,69 @@ class MainTestDialog(wx.Dialog):
         self.Centre(wx.BOTH)
 
         # Bind Event handlers
-        self.m_btn.Bind(wx.EVT_BUTTON, lambda event:
-            self.m_events_list.Select(self.m_events_list.Append("Button: wx.EVT_BUTTON")))
-        self.m_btn_3.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("Button: wx.EVT_BUTTON"))
+        self.btn.Bind(wx.EVT_BUTTON, lambda event:
+            self.events_list.Select(self.events_list.Append("Button: wx.EVT_BUTTON")))
+        self.btn_3.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("Button: wx.EVT_BUTTON"))
         btn2.Bind(wx.EVT_BUTTON, self.OnPopupBtn)
-        self.m_btn_7.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("Ceci est une phrase en français."))
-        self.m_btn_2.Bind(wx.EVT_BUTTON, lambda event:
-            self.m_events_list.Select(self.m_events_list.Append("Button: wx.EVT_BUTTON")))
-        self.m_btn_bitmaps.Bind(wx.EVT_BUTTON, lambda event:
-            self.m_events_list.Select(self.m_events_list.Append("Button: wx.EVT_BUTTON")))
-        self.m_btn_4.Bind(wx.EVT_BUTTON, lambda event:
-            self.m_events_list.Select(self.m_events_list.Append("Button: wx.EVT_BUTTON")))
-        self.m_btn_6.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("This is a sentence in English."))
+        self.btn_7.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("Ceci est une phrase en français."))
+        self.btn_2.Bind(wx.EVT_BUTTON, lambda event:
+            self.events_list.Select(self.events_list.Append("Button: wx.EVT_BUTTON")))
+        self.btn_bitmaps.Bind(wx.EVT_BUTTON, lambda event:
+            self.events_list.Select(self.events_list.Append("Button: wx.EVT_BUTTON")))
+        self.btn_4.Bind(wx.EVT_BUTTON, lambda event:
+            self.events_list.Select(self.events_list.Append("Button: wx.EVT_BUTTON")))
+        self.btn_6.Bind(wx.EVT_BUTTON, lambda event:self.OnEventName("This is a sentence in English."))
         btn.Bind(wx.EVT_BUTTON, self.OnClearList)
-        self.m_btn_5.Bind(wx.EVT_BUTTON, lambda event:
-            self.m_events_list.Select(self.m_events_list.Append("CmdLinkBtn: wx.EVT_BUTTON")))
+        self.btn_5.Bind(wx.EVT_BUTTON, lambda event:
+            self.events_list.Select(self.events_list.Append("CmdLinkBtn: wx.EVT_BUTTON")))
         disable_bitmaps.Bind(wx.EVT_CHECKBOX, self.OnDisableBitmapsBtn)
-        self.m_checkList2.Bind(wx.EVT_CHECKLISTBOX, lambda event:
+        self.checkList2.Bind(wx.EVT_CHECKLISTBOX, lambda event:
             self.OnEventName("CheckListBox2: wx.EVT_CHECKLISTBOX"))
-        self.m_checkList_2.Bind(wx.EVT_CHECKLISTBOX, lambda event:
+        self.checkList_2.Bind(wx.EVT_CHECKLISTBOX, lambda event:
             self.OnEventName("CheckListBox1: wx.EVT_CHECKLISTBOX"))
-        self.m_choice.Bind(wx.EVT_CHOICE, lambda event:self.OnEventName("Choice: wx.EVT_CHOICE"))
-        self.m_choice2.Bind(wx.EVT_CHOICE, lambda event:self.OnEventName("OnChoice: wx.EVT_CHOICE"))
-        self.m_colourPicker.Bind(wx.EVT_COLOURPICKER_CHANGED, lambda event:
+        self.choice.Bind(wx.EVT_CHOICE, lambda event:self.OnEventName("Choice: wx.EVT_CHOICE"))
+        self.choice2.Bind(wx.EVT_CHOICE, lambda event:self.OnEventName("OnChoice: wx.EVT_CHOICE"))
+        self.colourPicker.Bind(wx.EVT_COLOURPICKER_CHANGED, lambda event:
             self.OnEventName("ColourPicker: wx.EVT_COLOURPICKER_CHANGED"))
-        self.m_comboBox.Bind(wx.EVT_COMBOBOX, lambda event:self.OnEventName("Combobox: wx.EVT_COMBOBOX"))
-        self.m_comboBox2.Bind(wx.EVT_COMBOBOX, lambda event:self.OnEventName("OnCombobox: wx.EVT_COMBOBOX"))
-        self.m_datePicker.Bind(wx.adv.EVT_DATE_CHANGED, lambda event:
+        self.comboBox.Bind(wx.EVT_COMBOBOX, lambda event:self.OnEventName("Combobox: wx.EVT_COMBOBOX"))
+        self.comboBox2.Bind(wx.EVT_COMBOBOX, lambda event:self.OnEventName("OnCombobox: wx.EVT_COMBOBOX"))
+        self.datePicker.Bind(wx.adv.EVT_DATE_CHANGED, lambda event:
             self.OnEventName("DatePicker: wx.EVT_DATE_CHANGED"))
-        self.m_dirPicker.Bind(wx.EVT_DIRPICKER_CHANGED, lambda event:
+        self.dirPicker.Bind(wx.EVT_DIRPICKER_CHANGED, lambda event:
             self.OnEventName("DirPicker: wx.EVT_DIRPICKER_CHANGED"))
-        self.m_filePicker.Bind(wx.EVT_FILEPICKER_CHANGED, lambda event:
+        self.filePicker.Bind(wx.EVT_FILEPICKER_CHANGED, lambda event:
             self.OnEventName("FilePicker: wx.EVT_FILEPICKER_CHANGED"))
-        self.m_fontPicker.Bind(wx.EVT_FONTPICKER_CHANGED, lambda event:
+        self.fontPicker.Bind(wx.EVT_FONTPICKER_CHANGED, lambda event:
             self.OnEventName("FontPicker: wx.OnFontChanged"))
         self.Bind(wx.EVT_INIT_DIALOG, self.OnInit)
-        self.m_listbox.Bind(wx.EVT_LISTBOX, lambda event:self.OnEventName("ListBox1: wx.EVT_LISTBOX"))
-        self.m_listBox2.Bind(wx.EVT_LISTBOX, lambda event:self.OnEventName("ListBox2: wx.EVT_LISTBOX"))
-        self.m_notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self.OnPageChanged)
+        self.listbox.Bind(wx.EVT_LISTBOX, lambda event:self.OnEventName("ListBox1: wx.EVT_LISTBOX"))
+        self.listBox2.Bind(wx.EVT_LISTBOX, lambda event:self.OnEventName("ListBox2: wx.EVT_LISTBOX"))
+        self.notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self.OnPageChanged)
         radioBox.Bind(wx.EVT_RADIOBOX, lambda event:self.OnEventName("RadioBox: wx.EVT_RADIOBOX"))
-        self.m_radioBtn_4.Bind(wx.EVT_RADIOBUTTON, lambda event:
+        self.radioBtn_4.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
-        self.m_radioBtn_2.Bind(wx.EVT_RADIOBUTTON, lambda event:
+        self.radioBtn_2.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
-        self.m_radioBtn_7.Bind(wx.EVT_RADIOBUTTON, lambda event:
+        self.radioBtn_7.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
-        self.m_radioBtn.Bind(wx.EVT_RADIOBUTTON, lambda event:
+        self.radioBtn.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("RadioButton: wx.EVT_RADIOBUTTON"))
-        self.m_radioBtn_6.Bind(wx.EVT_RADIOBUTTON, lambda event:
+        self.radioBtn_6.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
-        self.m_radioBtn2.Bind(wx.EVT_RADIOBUTTON, lambda event:
+        self.radioBtn2.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("RadioButton: wx.EVT_RADIOBUTTON"))
-        self.m_radioBtn_5.Bind(wx.EVT_RADIOBUTTON, lambda event:
+        self.radioBtn_5.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
-        self.m_radioBtn_3.Bind(wx.EVT_RADIOBUTTON, lambda event:
+        self.radioBtn_3.Bind(wx.EVT_RADIOBUTTON, lambda event:
             self.OnEventName("wx.RadioButton: wx.EVT_RADIOBUTTON"))
-        self.m_scintilla.Bind(wx.stc.EVT_STC_CHANGE, lambda event:
+        self.scintilla.Bind(wx.stc.EVT_STC_CHANGE, lambda event:
             self.OnEventName("wx.StyledTextCtrl: wx.EVT_STC_CHANGE"))
-        self.m_text_ctrl.Bind(wx.EVT_TEXT, lambda event:self.OnEventName("wx.TextCtrl: wx.EVT_TEXT"))
-        self.m_richText.Bind(wx.EVT_TEXT, lambda event:self.OnEventName("wx.RichTextCtrl: wx.EVT_TEXT"))
-        self.m_timePicker.Bind(wx.adv.EVT_TIME_CHANGED, lambda event:
+        self.text_ctrl.Bind(wx.EVT_TEXT, lambda event:self.OnEventName("wx.TextCtrl: wx.EVT_TEXT"))
+        self.richText.Bind(wx.EVT_TEXT, lambda event:self.OnEventName("wx.RichTextCtrl: wx.EVT_TEXT"))
+        self.timePicker.Bind(wx.adv.EVT_TIME_CHANGED, lambda event:
             self.OnEventName("TimePicker: wx.EVT_TIME_CHANGED"))
-        self.m_toggleBtn.Bind(wx.EVT_TOGGLEBUTTON, lambda event:self.OnEventName("OnToggle: wx.EVT_BUTTON"))
-        self.m_toggleBtn_2.Bind(wx.EVT_TOGGLEBUTTON, self.OnToggleButton)
+        self.toggleBtn.Bind(wx.EVT_TOGGLEBUTTON, lambda event:self.OnEventName("OnToggle: wx.EVT_BUTTON"))
+        self.toggleBtn_2.Bind(wx.EVT_TOGGLEBUTTON, self.OnToggleButton)
 
     # Unimplemented Event handler functions
     # Copy any listed and paste them below the comment block, or to your inherited class.
@@ -811,13 +808,13 @@ class MainTestDialog(wx.Dialog):
         event.Skip()
 
     def OnClearList(self, event):
-        self.m_events_list.Clear()
+        self.events_list.Clear()
 
     def OnDisableBitmapsBtn(self, event):
         self.m_btn_bitmaps.Enable(not event.IsChecked())
 
     def OnPageChanged(self, event):
-        self.m_events_list.Clear()
+        self.events_list.Clear()
         event.Skip()
 
     def OnPopupBtn(self, event):
@@ -828,8 +825,8 @@ class MainTestDialog(wx.Dialog):
         self.popupwin.Show()
 
     def OnEventName(self, event_name):
-        pos = self.m_events_list.Append(event_name)
-        self.m_events_list.Select(pos)
+        pos = self.events_list.Append(event_name)
+        self.events_list.Select(pos)
 
     def OnToggleButton(self, event):
         if (self.m_toggleBtn_2.GetValue()):

--- a/tests/sdi/python/mainframe.py
+++ b/tests/sdi/python/mainframe.py
@@ -142,37 +142,35 @@ class MainFrame(wx.Frame):
 
         self.SetMenuBar(menubar)
 
-        self.m_toolBar = self.CreateToolBar()
+        self.toolBar = self.CreateToolBar()
 
-        tool_dropdown = self.m_toolBar.AddTool(wx.ID_ANY, "",
-            wx.ArtProvider.GetBitmapBundle(wx.ART_EXECUTABLE_FILE, wx.ART_MENU),
-            wx.EmptyString, wx.ITEM_DROPDOWN)
+        tool_dropdown = self.toolBar.AddTool(wx.ID_ANY, "", wx.ArtProvider.GetBitmapBundle(
+            wx.ART_EXECUTABLE_FILE, wx.ART_MENU), wx.EmptyString, wx.ITEM_DROPDOWN)
         tool_dropdown_menu = wx.Menu()
         menu_item = wx.MenuItem(tool_dropdown_menu, wx.ID_ANY, "Wizard...")
         menu_item.SetBitmap(wx.ArtProvider.GetBitmapBundle(wx.ART_FIND, wx.ART_MENU))
         tool_dropdown_menu.Append(menu_item)
         tool_dropdown.SetDropdownMenu(tool_dropdown_menu)
-        tool_4 = self.m_toolBar.AddTool(wx.ID_ANY, "MainTestDlg", wx.BitmapBundle.FromBitmap(
+        tool_4 = self.toolBar.AddTool(wx.ID_ANY, "MainTestDlg", wx.BitmapBundle.FromBitmap(
             images.debug_32_png.Bitmap))
 
-        tool_5 = self.m_toolBar.AddTool(wx.ID_ANY, "BookTestDlg", wx.BitmapBundle.FromBitmap(
+        tool_5 = self.toolBar.AddTool(wx.ID_ANY, "BookTestDlg", wx.BitmapBundle.FromBitmap(
             images.wxNotebook_png.Bitmap))
 
-        self.m_toolBar.AddSeparator()
-        tool_3 = self.m_toolBar.AddTool(wx.ID_ANY, "PythonDlg", wx.BitmapBundle.FromBitmap(
+        self.toolBar.AddSeparator()
+        tool_3 = self.toolBar.AddTool(wx.ID_ANY, "PythonDlg", wx.BitmapBundle.FromBitmap(
             images.wxPython_1_5x_png.Bitmap))
 
-        self.m_toolBar.AddStretchableSpace()
+        self.toolBar.AddStretchableSpace()
 
-        tool_2 = self.m_toolBar.AddTool(wx.ID_ANY, "Common Controls...",
+        tool_2 = self.toolBar.AddTool(wx.ID_ANY, "Common Controls...",
             wx.ArtProvider.GetBitmapBundle(wx.ART_TIP, wx.ART_TOOLBAR))
 
-        self.m_toolBar.Realize()
+        self.toolBar.Realize()
 
-        self.m_statusBar = self.CreateStatusBar(2)
-        self.m_statusBar.SetStatusWidths([100, -1])
-        self.m_statusBar.SetStatusStyles([wx.SB_FLAT, wx.SB_FLAT])
-
+        self.statusBar = self.CreateStatusBar(2)
+        self.statusBar.SetStatusWidths([100, -1])
+        self.statusBar.SetStatusStyles([wx.SB_FLAT, wx.SB_FLAT])
 
         self.Centre(wx.BOTH)
 

--- a/tests/sdi/python/popupwin.py
+++ b/tests/sdi/python/popupwin.py
@@ -15,10 +15,10 @@ class PopupWin(wx.PopupTransientWindow):
 
         parent_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText = wx.StaticText(self, wx.ID_ANY,
+        self.staticText = wx.StaticText(self, wx.ID_ANY,
             "This is a wxPopupTransientWindow set to use a raised border around it. Note that the default is to not have a border at all.\n\nBTW, right-click anywhere in the dialog to get a popup menu for changing some of the control values.\n\nClick outside this window to dismiss it.")
-        self.m_staticText.Wrap(250)
-        parent_sizer.Add(self.m_staticText, wx.SizerFlags().Border(wx.ALL))
+        self.staticText.Wrap(250)
+        parent_sizer.Add(self.staticText, wx.SizerFlags().Border(wx.ALL))
         self.SetSizerAndFit(parent_sizer)
 # ************* End of generated code ***********
 # DO NOT EDIT THIS COMMENT BLOCK!

--- a/tests/sdi/python/python_dlg.py
+++ b/tests/sdi/python/python_dlg.py
@@ -78,14 +78,14 @@ class PythonDlg(wx.Dialog):
         self.auiToolBar.Realize()
         box_sizer.Add(self.auiToolBar, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_staticText = wx.StaticText(self, wx.ID_ANY,
+        self.staticText = wx.StaticText(self, wx.ID_ANY,
             "wxPython est génial n\'est-ce pas?",
             self.ConvertDialogToPixels(wx.Point(50, 100)),
             self.ConvertDialogToPixels(wx.Size(150, 32)), wx.ALIGN_CENTER_HORIZONTAL,
             "my_text")
-        self.m_staticText.SetWindowVariant(wx.WINDOW_VARIANT_LARGE)
-        self.m_staticText.SetForegroundColour(wx.Colour(0, 128, 0))
-        box_sizer.Add(self.m_staticText, wx.SizerFlags().Center().Border(wx.ALL))
+        self.staticText.SetWindowVariant(wx.WINDOW_VARIANT_LARGE)
+        self.staticText.SetForegroundColour(wx.Colour(0, 128, 0))
+        box_sizer.Add(self.staticText, wx.SizerFlags().Center().Border(wx.ALL))
 
         _svg_string_ = zlib.decompress(base64.b64decode(images.face_smile_svg))
         bmp = wx.StaticBitmap(self, wx.ID_ANY, wx.BitmapBundle.FromSVG(_svg_string_,
@@ -95,16 +95,16 @@ class PythonDlg(wx.Dialog):
         # wxPython currently does not support a checkbox as a static box label
         static_box_2 = wx.StaticBoxSizer(wx.VERTICAL, self, "Play Animation")
 
-        self.m_toggleBtn = wx.ToggleButton(static_box_2.GetStaticBox(), wx.ID_ANY,
+        self.toggleBtn = wx.ToggleButton(static_box_2.GetStaticBox(), wx.ID_ANY,
             "Play Animation", wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT)
-        static_box_2.Add(self.m_toggleBtn, wx.SizerFlags().Border(wx.ALL))
+        static_box_2.Add(self.toggleBtn, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_animation_ctrl = wx.adv.AnimationCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
+        self.animation_ctrl = wx.adv.AnimationCtrl(static_box_2.GetStaticBox(), wx.ID_ANY,
             wx.adv.Animation("../../art/clr_hourglass.gif"), wx.DefaultPosition,
             wx.DefaultSize, wx.adv.AC_DEFAULT_STYLE)
-        self.m_animation_ctrl.SetInactiveBitmap(wx.BitmapBundle.FromBitmap(
+        self.animation_ctrl.SetInactiveBitmap(wx.BitmapBundle.FromBitmap(
             images.disabled_png.Bitmap))
-        static_box_2.Add(self.m_animation_ctrl, wx.SizerFlags().Border(wx.ALL))
+        static_box_2.Add(self.animation_ctrl, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer.Add(static_box_2, wx.SizerFlags().Border(wx.ALL))
 
@@ -128,7 +128,7 @@ class PythonDlg(wx.Dialog):
 
         # Bind Event handlers
         self.Bind(wx.EVT_INIT_DIALOG, self.OnInit)
-        self.m_toggleBtn.Bind(wx.EVT_TOGGLEBUTTON, lambda event:self.m_animation_ctrl.Play())
+        self.toggleBtn.Bind(wx.EVT_TOGGLEBUTTON, lambda event:self.m_animation_ctrl.Play())
 
     # Unimplemented Event handler functions
     # Copy any listed and paste them below the comment block, or to your inherited class.

--- a/tests/sdi/python/testformpanel.py
+++ b/tests/sdi/python/testformpanel.py
@@ -19,30 +19,30 @@ class TestFormPanel(wx.Panel):
 
         parent_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_splitter = wx.SplitterWindow(self, wx.ID_ANY, wx.DefaultPosition,
+        self.splitter = wx.SplitterWindow(self, wx.ID_ANY, wx.DefaultPosition,
             wx.DefaultSize, wx.SP_3D)
-        self.m_splitter.SetSashGravity(0.0)
-        self.m_splitter.SetMinimumPaneSize(150)
-        parent_sizer.Add(self.m_splitter, wx.SizerFlags(1).Expand().Border(wx.ALL))
+        self.splitter.SetSashGravity(0.0)
+        self.splitter.SetMinimumPaneSize(150)
+        parent_sizer.Add(self.splitter, wx.SizerFlags(1).Expand().Border(wx.ALL))
 
-        panel = wx.Panel(self.m_splitter, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        panel = wx.Panel(self.splitter, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
 
         parent_sizer2 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText = wx.StaticText(panel, wx.ID_ANY, "Left Panel")
-        parent_sizer2.Add(self.m_staticText, wx.SizerFlags().Border(wx.ALL))
+        self.staticText = wx.StaticText(panel, wx.ID_ANY, "Left Panel")
+        parent_sizer2.Add(self.staticText, wx.SizerFlags().Border(wx.ALL))
         panel.SetSizerAndFit(parent_sizer2)
 
-        m_panel2 = wx.Panel(self.m_splitter, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
+        panel2 = wx.Panel(self.splitter, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TAB_TRAVERSAL)
 
         parent_sizer3 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText2 = wx.StaticText(m_panel2, wx.ID_ANY, "Right Panel")
-        parent_sizer3.Add(self.m_staticText2, wx.SizerFlags().Border(wx.ALL))
-        m_panel2.SetSizerAndFit(parent_sizer3)
-        self.m_splitter.SplitVertically(panel, m_panel2)
+        self.staticText2 = wx.StaticText(panel2, wx.ID_ANY, "Right Panel")
+        parent_sizer3.Add(self.staticText2, wx.SizerFlags().Border(wx.ALL))
+        panel2.SetSizerAndFit(parent_sizer3)
+        self.splitter.SplitVertically(panel, panel2)
 
         self.SetSizerAndFit(parent_sizer)
         self.SetSize(wx.Size(500, 300))

--- a/tests/sdi/python/wizard.py
+++ b/tests/sdi/python/wizard.py
@@ -26,95 +26,95 @@ class Wizard(wx.adv.Wizard):
 
         box_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText = wx.StaticText(wizPage, wx.ID_ANY,
+        self.staticText = wx.StaticText(wizPage, wx.ID_ANY,
             "This is the first Wizard page")
-        box_sizer.Add(self.m_staticText, wx.SizerFlags().Border(wx.ALL))
+        box_sizer.Add(self.staticText, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_calendar = wx.adv.CalendarCtrl(wizPage, wx.ID_ANY, wx.DefaultDateTime,
+        self.calendar = wx.adv.CalendarCtrl(wizPage, wx.ID_ANY, wx.DefaultDateTime,
             wx.DefaultPosition, wx.DefaultSize, wx.adv.CAL_SHOW_HOLIDAYS)
-        box_sizer.Add(self.m_calendar, wx.SizerFlags().Border(wx.ALL))
+        box_sizer.Add(self.calendar, wx.SizerFlags().Border(wx.ALL))
         wizPage.SetSizerAndFit(box_sizer)
 
         m_wizPage2 = wx.adv.WizardPageSimple(self)
 
         box_sizer2 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText2 = wx.StaticText(m_wizPage2, wx.ID_ANY,
+        self.staticText2 = wx.StaticText(wizPage2, wx.ID_ANY,
             "This is the second Wizard page which is wider.")
-        box_sizer2.Add(self.m_staticText2, wx.SizerFlags().Border(wx.ALL))
+        box_sizer2.Add(self.staticText2, wx.SizerFlags().Border(wx.ALL))
 
         parent_sizer3 = wx.BoxSizer(wx.VERTICAL)
 
         box_sizer_2 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.staticText = wx.StaticText(m_wizPage2, wx.ID_ANY, "Scrollbar:")
+        self.staticText = wx.StaticText(wizPage2, wx.ID_ANY, "Scrollbar:")
         box_sizer_2.Add(self.staticText, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_scrollBar = wx.ScrollBar(m_wizPage2, wx.ID_ANY, wx.DefaultPosition,
+        self.scrollBar = wx.ScrollBar(wizPage2, wx.ID_ANY, wx.DefaultPosition,
             wx.DefaultSize, wx.SB_HORIZONTAL)
-        self.m_scrollBar.SetScrollbar(0, 1, 100, 1)
-        box_sizer_2.Add(self.m_scrollBar, wx.SizerFlags(1).Expand().Border(wx.ALL))
+        self.scrollBar.SetScrollbar(0, 1, 100, 1)
+        box_sizer_2.Add(self.scrollBar, wx.SizerFlags(1).Expand().Border(wx.ALL))
 
         parent_sizer3.Add(box_sizer_2, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_3 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.staticText_2 = wx.StaticText(m_wizPage2, wx.ID_ANY, "Normal SpinCtrl")
+        self.staticText_2 = wx.StaticText(wizPage2, wx.ID_ANY, "Normal SpinCtrl")
         box_sizer_3.Add(self.staticText_2, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_spinCtrl = wx.SpinCtrl(m_wizPage2, wx.ID_ANY, wx.EmptyString,
+        self.spinCtrl = wx.SpinCtrl(wizPage2, wx.ID_ANY, wx.EmptyString,
             wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 100, 4)
-        box_sizer_3.Add(self.m_spinCtrl, wx.SizerFlags().Border(wx.ALL))
+        box_sizer_3.Add(self.spinCtrl, wx.SizerFlags().Border(wx.ALL))
 
         parent_sizer3.Add(box_sizer_3, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_4 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.staticText_3 = wx.StaticText(m_wizPage2, wx.ID_ANY, "Double SpinCtrl")
+        self.staticText_3 = wx.StaticText(wizPage2, wx.ID_ANY, "Double SpinCtrl")
         box_sizer_4.Add(self.staticText_3, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_spinCtrlDouble = wx.SpinCtrlDouble(m_wizPage2)
-        box_sizer_4.Add(self.m_spinCtrlDouble, wx.SizerFlags().Border(wx.ALL))
+        self.spinCtrlDouble = wx.SpinCtrlDouble(wizPage2)
+        box_sizer_4.Add(self.spinCtrlDouble, wx.SizerFlags().Border(wx.ALL))
 
         parent_sizer3.Add(box_sizer_4, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_5 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.staticText_4 = wx.StaticText(m_wizPage2, wx.ID_ANY, "Spin Button")
+        self.staticText_4 = wx.StaticText(wizPage2, wx.ID_ANY, "Spin Button")
         box_sizer_5.Add(self.staticText_4, wx.SizerFlags().Border(wx.ALL))
 
-        self.m_spinBtn = wx.SpinButton(m_wizPage2, wx.ID_ANY)
-        self.m_spinBtn.SetRange(0, 10)
-        box_sizer_5.Add(self.m_spinBtn, wx.SizerFlags().Border(wx.ALL))
+        self.spinBtn = wx.SpinButton(wizPage2, wx.ID_ANY)
+        self.spinBtn.SetRange(0, 10)
+        box_sizer_5.Add(self.spinBtn, wx.SizerFlags().Border(wx.ALL))
 
         parent_sizer3.Add(box_sizer_5, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer2.Add(parent_sizer3, wx.SizerFlags().Border(wx.ALL))
-        m_wizPage2.SetSizerAndFit(box_sizer2)
+        wizPage2.SetSizerAndFit(box_sizer2)
 
         m_wizPage3 = wx.adv.WizardPageSimple(self, None, None, wx.BitmapBundle.FromBitmap(
             images.wiztest2_png.Bitmap))
 
         box_sizer3 = wx.BoxSizer(wx.VERTICAL)
 
-        self.m_staticText3 = wx.StaticText(m_wizPage3, wx.ID_ANY,
+        self.staticText3 = wx.StaticText(wizPage3, wx.ID_ANY,
             "This is the final Wizard page")
-        box_sizer3.Add(self.m_staticText3, wx.SizerFlags().Border(wx.ALL))
+        box_sizer3.Add(self.staticText3, wx.SizerFlags().Border(wx.ALL))
 
         box_sizer_6 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.m_hyperlink = wx.adv.HyperlinkCtrl(m_wizPage3, wx.ID_ANY, "Blank Page",
+        self.hyperlink = wx.adv.HyperlinkCtrl(wizPage3, wx.ID_ANY, "Blank Page",
             "https://blank.page/")
-        box_sizer_6.Add(self.m_hyperlink, wx.SizerFlags().Center().Border(wx.ALL))
+        box_sizer_6.Add(self.hyperlink, wx.SizerFlags().Center().Border(wx.ALL))
 
-        self.m_searchCtrl = wx.SearchCtrl(m_wizPage3, wx.ID_ANY, "")
-        self.m_searchCtrl.SetHint("Search for something...")
-        self.m_searchCtrl.ShowSearchButton(True)
-        self.m_searchCtrl.ShowCancelButton(True)
-        box_sizer_6.Add(self.m_searchCtrl, wx.SizerFlags(1).Border(wx.ALL))
+        self.searchCtrl = wx.SearchCtrl(wizPage3, wx.ID_ANY, "")
+        self.searchCtrl.SetHint("Search for something...")
+        self.searchCtrl.ShowSearchButton(True)
+        self.searchCtrl.ShowCancelButton(True)
+        box_sizer_6.Add(self.searchCtrl, wx.SizerFlags(1).Border(wx.ALL))
 
         box_sizer3.Add(box_sizer_6, wx.SizerFlags().Expand().Border(wx.ALL))
-        m_wizPage3.SetSizerAndFit(box_sizer3)
+        wizPage3.SetSizerAndFit(box_sizer3)
 
         wizPage.Chain(m_wizPage2).Chain(m_wizPage3)
         self.GetPageAreaSizer().Add(wizPage)

--- a/tests/sdi_test.wxui
+++ b/tests/sdi_test.wxui
@@ -370,7 +370,7 @@
                   class="wxButton"
                   label="Normal"
                   tooltip="A normal button"
-                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;Button: wxEVT_BUTTON&quot;);@@}[python:lambda]self.m_events_list.Select(self.m_events_list.Append(&quot;Button: wx.EVT_BUTTON&quot;))" />
+                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;Button: wxEVT_BUTTON&quot;);@@}[python:lambda]self.events_list.Select(self.events_list.Append(&quot;Button: wx.EVT_BUTTON&quot;))" />
                 <node
                   class="wxButton"
                   label="&lt;b>&lt;span foreground='red'>Markup&lt;/span>&lt;/b>"
@@ -378,7 +378,7 @@
                   var_name="m_btn_2"
                   tooltip="Text should be Bold and Red."
                   column="1"
-                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;Button: wxEVT_BUTTON&quot;);@@}[python:lambda]self.m_events_list.Select(self.m_events_list.Append(&quot;Button: wx.EVT_BUTTON&quot;))" />
+                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;Button: wxEVT_BUTTON&quot;);@@}[python:lambda]self.events_list.Select(self.events_list.Append(&quot;Button: wx.EVT_BUTTON&quot;))" />
                 <node
                   class="wxButton"
                   label="Bitmaps"
@@ -388,7 +388,7 @@
                   disabled_bmp="Embed;no_hour.png"
                   tooltip="Bitmap should change when mouse is over button, or button is disabled."
                   column="2"
-                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;Button: wxEVT_BUTTON&quot;);@@}[python:lambda]self.m_events_list.Select(self.m_events_list.Append(&quot;Button: wx.EVT_BUTTON&quot;))" />
+                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;Button: wxEVT_BUTTON&quot;);@@}[python:lambda]self.events_list.Select(self.events_list.Append(&quot;Button: wx.EVT_BUTTON&quot;))" />
                 <node
                   class="wxButton"
                   label="Right"
@@ -397,7 +397,7 @@
                   position="wxRIGHT"
                   tooltip="Bitmap should be on the right side (fails in wxPython 4.2)."
                   column="3"
-                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;Button: wxEVT_BUTTON&quot;);@@}[python:lambda]self.m_events_list.Select(self.m_events_list.Append(&quot;Button: wx.EVT_BUTTON&quot;))" />
+                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;Button: wxEVT_BUTTON&quot;);@@}[python:lambda]self.events_list.Select(self.events_list.Append(&quot;Button: wx.EVT_BUTTON&quot;))" />
                 <node
                   class="wxToggleButton"
                   label="Toggle"
@@ -426,7 +426,7 @@
                   bitmap="Art;wxART_GO_FORWARD|wxART_OTHER"
                   tooltip="The bitmap for this is from Art Provider."
                   row="1"
-                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;CmdLinkBtn: wxEVT_BUTTON&quot;);@@}[python:lambda]self.m_events_list.Select(self.m_events_list.Append(&quot;CmdLinkBtn: wx.EVT_BUTTON&quot;))" />
+                  wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;CmdLinkBtn: wxEVT_BUTTON&quot;);@@}[python:lambda]self.events_list.Select(self.events_list.Append(&quot;CmdLinkBtn: wx.EVT_BUTTON&quot;))" />
                 <node
                   class="wxRadioBox"
                   class_access="none"
@@ -1854,10 +1854,10 @@
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Common controls"
         base_file="commonctrls"
+        inserted_hdr_code="public:@@    ~CommonCtrls();@@@@private:@@    PopupWin* m_popup_win { nullptr };"
         local_hdr_includes="popupwin.h"
         derived_class_name="CommonCtrls"
         derived_file="../ui/commonctrls"
-        inserted_hdr_code="public:@@    ~CommonCtrls();@@@@private:@@    PopupWin* m_popup_win { nullptr };"
         use_derived_class="0"
         xrc_file="commonctrls"
         wxEVT_INIT_DIALOG="OnInit"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR reverts the change to Python variable names -- it no longer adds a '_' prefix to variables that don't have class access. The second part of the PR is to run all node names including parent nodes through `Code::NodeName()`. Without this change, the non-C++ variables can be named one way and generated elsewhere in a different way causing a variable name mismatch.

The final change was to regenerate all the Python code now that any `m_` prefix is automatically removed from Python and Ruby code.