### PR TITLE
Importing validator check

### DIFF
--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -709,7 +709,8 @@ void FormBuilder::ProcessPropValue(pugi::xml_node& xml_prop, tt_string_view prop
     // wxGenericValidator
     else if (prop_name == "validator_type")
     {
-        // BUGBUG: [KeyWorks - 11-07-2020] This IS valid for text controls, so we need to process it
+        // wxUiEditor automatically switches validator type based on the data type used, so we
+        // ignore this property.
         return;
     }
 

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -581,7 +581,9 @@ void WxCrafter::ProcessStyles(Node* node, const Value& array)
 
     if (style)
     {
-        if (!node->isGen(gen_wxButton))  // if this was a wxBitmapButton, then wxBU_EXACTFIT will have been set
+        // Some styles will have been specifically set when other properties were processed, so
+        // we need to be careful about clearing all styles.
+        if (!node->isGen(gen_wxButton) && !node->isGen(gen_wxTextCtrl))
         {
             style->set_value("");
         }
@@ -987,6 +989,21 @@ GenEnum::PropName WxCrafter::UnknownProperty(Node* node, const Value& value, tt_
             return prop_processed;  // this doesn't apply to wxUiEditor
         else if (name.is_sameas("null page"))
             return prop_processed;  // unused
+        else if (name.is_sameas("enable spell checking") && node->hasProp(prop_spellcheck))
+        {
+            node->set_value(prop_spellcheck, "enabled");
+            tt_string style = node->as_string(prop_style);
+            if (style.size() && !style.contains("wxTE_RICH2"))
+                style << "|wxTE_RICH2";
+            else
+                style << "wxTE_RICH2";
+            node->set_value(prop_style, style);
+        }
+        else if (name.is_sameas("keep as a class member"))
+        {
+            if (node->as_string(prop_class_access) == "none")
+                node->set_value(prop_class_access, "protected:");
+        }
         else
         {
             if (!node->isGen(gen_propGridItem))


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR was initially planned to be a check that importing validators still works. wxFormBuilder and DialogBlocks still work fine, and wxCrafter doesn't support validators. I did update a comment about validators in wxFormBuilder, and added support for spellcheck in an edit control supported by wxCrafter.