### PR TITLE
Change where/when wxWidgets validator files are included

### DIFF
--- a/src/generate/gen_bitmap_combo.cpp
+++ b/src/generate/gen_bitmap_combo.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxBitmapComboBox generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -160,7 +160,7 @@ bool BitmapComboBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set
 {
     InsertGeneratorInclude(node, "#include <wx/bmpcbox.h>", set_src, set_hdr);
     if (node->as_string(prop_validator_variable).size())
-        InsertGeneratorInclude(node, "#include <wx/valgen.h>", set_src, set_hdr);
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_button.cpp
+++ b/src/generate/gen_button.cpp
@@ -263,5 +263,7 @@ void ButtonGenerator::RequiredHandlers(Node* node, std::set<std::string>& handle
 bool ButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/button.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }

--- a/src/generate/gen_check_listbox.cpp
+++ b/src/generate/gen_check_listbox.cpp
@@ -152,6 +152,8 @@ int CheckListBoxGenerator::GetRequiredVersion(Node* node)
 bool CheckListBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/checklst.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_checkbox.cpp
+++ b/src/generate/gen_checkbox.cpp
@@ -72,7 +72,7 @@ bool CheckBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 {
     InsertGeneratorInclude(node, "#include <wx/checkbox.h>", set_src, set_hdr);
     if (node->as_string(prop_validator_variable).size())
-        InsertGeneratorInclude(node, "#include <wx/valgen.h>", set_src, set_hdr);
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 
@@ -175,6 +175,7 @@ bool Check3StateGenerator::SettingsCode(Code& code)
 bool Check3StateGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/checkbox.h>", set_src, set_hdr);
+    // 3-state checkboxes don't support validators
     return true;
 }
 

--- a/src/generate/gen_choice.cpp
+++ b/src/generate/gen_choice.cpp
@@ -141,6 +141,8 @@ bool ChoiceGenerator::SettingsCode(Code& code)
 bool ChoiceGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/choice.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_combobox.cpp
+++ b/src/generate/gen_combobox.cpp
@@ -144,6 +144,8 @@ bool ComboBoxGenerator::SettingsCode(Code& code)
 bool ComboBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/combobox.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_date_picker.cpp
+++ b/src/generate/gen_date_picker.cpp
@@ -52,6 +52,10 @@ bool DatePickerCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set
 {
     InsertGeneratorInclude(node, "#include <wx/datectrl.h>", set_src, set_hdr);
     InsertGeneratorInclude(node, "#include <wx/dateevt.h>", set_src, set_hdr);
+#if 0  // See issue #1144 -- wxDatePickerCtrl doesn't support validators
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
+#endif
     return true;
 }
 

--- a/src/generate/gen_gauge.cpp
+++ b/src/generate/gen_gauge.cpp
@@ -60,7 +60,7 @@ bool GaugeGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std
 {
     InsertGeneratorInclude(node, "#include <wx/gauge.h>", set_src, set_hdr);
     if (node->as_string(prop_validator_variable).size())
-        InsertGeneratorInclude(node, "#include <wx/valgen.h>", set_src, set_hdr);
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_listbox.cpp
+++ b/src/generate/gen_listbox.cpp
@@ -105,6 +105,8 @@ bool ListBoxGenerator::SettingsCode(Code& code)
 bool ListBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/listbox.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_radio_box.cpp
+++ b/src/generate/gen_radio_box.cpp
@@ -128,7 +128,7 @@ bool RadioBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 {
     InsertGeneratorInclude(node, "#include <wx/radiobox.h>", set_src, set_hdr);
     if (node->as_string(prop_validator_variable).size())
-        InsertGeneratorInclude(node, "#include <wx/valgen.h>", set_src, set_hdr);
+        set_src.insert("#include <wx/valgen.h>");
 
     return true;
 }

--- a/src/generate/gen_radio_btn.cpp
+++ b/src/generate/gen_radio_btn.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxRadioButton generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -96,7 +96,7 @@ bool RadioButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
 {
     InsertGeneratorInclude(node, "#include <wx/radiobut.h>", set_src, set_hdr);
     if (node->as_string(prop_validator_variable).size())
-        InsertGeneratorInclude(node, "#include <wx/valgen.h>", set_src, set_hdr);
+        set_src.insert("#include <wx/valgen.h>");
 
     return true;
 }

--- a/src/generate/gen_scrollbar.cpp
+++ b/src/generate/gen_scrollbar.cpp
@@ -74,5 +74,7 @@ void ScrollBarGenerator::RequiredHandlers(Node* /* node */, std::set<std::string
 bool ScrollBarGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/scrolbar.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }

--- a/src/generate/gen_slider.cpp
+++ b/src/generate/gen_slider.cpp
@@ -136,7 +136,7 @@ bool SliderGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, st
 {
     InsertGeneratorInclude(node, "#include <wx/slider.h>", set_src, set_hdr);
     if (node->as_string(prop_validator_variable).size())
-        InsertGeneratorInclude(node, "#include <wx/valgen.h>", set_src, set_hdr);
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_spin_btn.cpp
+++ b/src/generate/gen_spin_btn.cpp
@@ -67,6 +67,8 @@ bool SpinButtonGenerator::SettingsCode(Code& code)
 bool SpinButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/spinbutt.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_spin_ctrl.cpp
+++ b/src/generate/gen_spin_ctrl.cpp
@@ -134,6 +134,8 @@ void SpinCtrlGenerator::RequiredHandlers(Node* /* node */, std::set<std::string>
 bool SpinCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/spinctrl.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 
@@ -232,6 +234,8 @@ void SpinCtrlDoubleGenerator::RequiredHandlers(Node* /* node */, std::set<std::s
 bool SpinCtrlDoubleGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/spinctrl.h>", set_src, set_hdr);
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxStaticBoxSizer with wxCheckBox generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -219,6 +219,8 @@ bool StaticCheckboxBoxSizerGenerator::GetIncludes(Node* node, std::set<std::stri
 
     // The checkbox is always a class member, so we need to force it to be added to the header set
     set_hdr.insert("#include <wx/checkbox.h>");
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_static_text.cpp
+++ b/src/generate/gen_static_text.cpp
@@ -164,7 +164,7 @@ bool StaticTextGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 {
     InsertGeneratorInclude(node, "#include <wx/stattext.h>", set_src, set_hdr);
     if (node->as_string(prop_validator_variable).size())
-        InsertGeneratorInclude(node, "#include <wx/valgen.h>", set_src, set_hdr);
+        set_src.insert("#include <wx/valgen.h>");
 
     return true;
 }

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxStaticBoxSizer with wxRadioButton generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -210,6 +210,8 @@ bool StaticRadioBtnBoxSizerGenerator::GetIncludes(Node* node, std::set<std::stri
 
     // The radiobtn is always a class member, so we need to force it to be added to the header set
     set_hdr.insert("#include <wx/radiobut.h>");
+    if (node->hasValue(prop_validator_variable))
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -224,14 +224,20 @@ void TextCtrlGenerator::ChangeEnableState(wxPropertyGridManager* prop_grid, Node
 bool TextCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/textctrl.h>", set_src, set_hdr);
-    if (auto val_type = node->getValidatorType(); val_type.size())
+
+    // Only insert validator header files if the validator is being used (which requires a
+    // variable name).
+    if (node->hasValue(prop_validator_variable))
     {
-        if (val_type == "wxGenericValidator")
-            InsertGeneratorInclude(node, "#include <wx/valgen.h>", set_src, set_hdr);
-        else if (val_type == "wxTextValidator")
-            InsertGeneratorInclude(node, "#include <wx/valtext.h>", set_src, set_hdr);
-        else if (val_type == "wxIntegerValidator" || val_type == "wxFloatingPointValidator")
-            InsertGeneratorInclude(node, "#include <wx/valnum.h>", set_src, set_hdr);
+        if (auto val_type = node->getValidatorType(); val_type.size())
+        {
+            if (val_type == "wxGenericValidator")
+                set_src.insert("#include <wx/valgen.h>");
+            else if (val_type == "wxTextValidator")
+                set_src.insert("#include <wx/valtext.h>");
+            else if (val_type == "wxIntegerValidator" || val_type == "wxFloatingPointValidator")
+                set_src.insert("#include <wx/valnum.h>");
+        }
     }
     return true;
 }

--- a/src/generate/gen_toggle_btn.cpp
+++ b/src/generate/gen_toggle_btn.cpp
@@ -150,6 +150,8 @@ bool ToggleButtonGenerator::SettingsCode(Code& code)
 bool ToggleButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr)
 {
     InsertGeneratorInclude(node, "#include <wx/tglbtn.h>", set_src, set_hdr);
+    if (node->as_string(prop_validator_variable).size())
+        set_src.insert("#include <wx/valgen.h>");
     return true;
 }
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -1205,7 +1205,7 @@ static std::unordered_set<GenEnum::GenName> s_int_validators = {
 static std::unordered_set<GenEnum::GenName> s_read_only_validators = {
 
     gen_wxButton,
-    gen_wxComboBox,
+    gen_wxComboBox,  // get should still work, unlike button and static text
     gen_wxStaticText,
     gen_wxTextCtrl,
 

--- a/src/wxui/editstringdialog_base.cpp
+++ b/src/wxui/editstringdialog_base.cpp
@@ -9,7 +9,6 @@
 
 #include <wx/button.h>
 #include <wx/sizer.h>
-#include <wx/valgen.h>
 #include <wx/valtext.h>
 
 #include "editstringdialog_base.h"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how any necessary wxWidgets validator files get included. It's now the responsibility of each generator to determine whether or not to add a validator file to the include list for the generated source file. All the code that added these files to the include list for the generated header file has been removed.

This fixes some cases where a validator would be specified, but not header file added resulting in non-compilable code. This was the reason the old code often added wx/valgen.h to the header file whether it was really needed or not.