### PR TITLE
Support Ruby and Python load file lists

### DIFF
--- a/src/customprops/include_files_dlg.h
+++ b/src/customprops/include_files_dlg.h
@@ -65,7 +65,8 @@ private:
     wxStaticText* m_staticText;
 
     wxString m_value;
-    NodeProperty* m_prop;
+    NodeProperty* m_prop { nullptr };
+    int m_language = GEN_LANG_CPLUSPLUS;
 };
 
 // ************* End of generated code ***********

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -332,6 +332,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_pressed_bmp, "pressed_bmp" },
     { prop_private_members, "private_members" },
     { prop_proportion, "proportion" },
+    { prop_python_import_list, "python_import_list" },
     { prop_radiobtn_var_name, "radiobtn_var_name" },
     { prop_range, "range" },
     { prop_read_only, "read_only" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -350,6 +350,7 @@ namespace GenEnum
         prop_pressed_bmp,
         prop_private_members,
         prop_proportion,
+        prop_python_import_list,
         prop_radiobtn_var_name,
         prop_range,
         prop_read_only,

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -286,16 +286,18 @@ void BaseCodeGenerator::GeneratePythonClass(Node* form_node, PANEL_PAGE panel_ty
         m_header->writeLine(import);
     }
 
-    if (form_node->isGen(gen_wxFrame) && form_node->as_bool(prop_import_all_dialogs))
+    if (form_node->hasValue(prop_python_import_list))
     {
-        for (auto& form: forms)
+        tt_string_vector list;
+        list.SetString(form_node->as_string(prop_python_import_list));
+        for (auto& iter: list)
         {
-            if ((form->isGen(gen_wxDialog) || form->isGen(gen_wxWizard)) && form->hasValue(prop_python_file))
-            {
-                tt_string import_name(form->as_string(prop_python_file).filename());
-                import_name.remove_extension();
-                m_source->writeLine(tt_string("import ") << import_name);
-            }
+            iter.remove_extension();
+            m_source->writeLine(tt_string("import ") << iter);
+        }
+        if (list.size())
+        {
+            m_source->writeLine();
         }
     }
 

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -269,6 +269,21 @@ void BaseCodeGenerator::GenerateRubyClass(Node* form_node, PANEL_PAGE panel_type
     m_source->writeLine();
     m_header->writeLine();
 
+    if (form_node->hasValue(prop_relative_require_list))
+    {
+        tt_string_vector list;
+        list.SetString(form_node->as_string(prop_relative_require_list));
+        for (auto& iter: list)
+        {
+            iter.remove_extension();
+            m_source->writeLine(tt_string("require_relative '") << iter << '\'');
+        }
+        if (list.size())
+        {
+            m_source->writeLine();
+        }
+    }
+
     if (form_node->isGen(gen_wxFrame) && form_node->as_bool(prop_import_all_dialogs))
     {
         for (auto& form: forms)

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -281,11 +281,11 @@ void XrcPreview::OnInit(wxInitDialogEvent& event)
 void XrcPreview::OnExport(wxCommandEvent& WXUNUSED(event))
 {
     tt_string path = Project.getProjectPath();
-#if defined(_WIN32)
+    #if defined(_WIN32)
     path.forwardslashestoback();
-#endif  // _WIN32
-    wxFileDialog dialog(this, "Export Project As XRC", path.make_wxString(), "preview_test.xrc",
-                        "XRC File (*.xrc)|*.xrc", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+    #endif  // _WIN32
+    wxFileDialog dialog(this, "Export Project As XRC", path.make_wxString(), "preview_test.xrc", "XRC File (*.xrc)|*.xrc",
+                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 
     if (dialog.ShowModal() == wxID_OK)
     {

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -535,8 +535,8 @@ void MainFrame::OnAppendCrafter(wxCommandEvent&)
 #if defined(_WIN32)
     cwd.forwardslashestoback();
 #endif  // _WIN32
-    wxFileDialog dlg(this, "Open or Import Project", cwd.make_wxString(), wxEmptyString, "wxCrafter Project File (*.wxcp)|*.wxcp||",
-                     wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
+    wxFileDialog dlg(this, "Open or Import Project", cwd.make_wxString(), wxEmptyString,
+                     "wxCrafter Project File (*.wxcp)|*.wxcp||", wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
     if (dlg.ShowModal() == wxID_OK)
     {
         wxArrayString files;
@@ -566,8 +566,8 @@ void MainFrame::OnAppendFormBuilder(wxCommandEvent&)
 #if defined(_WIN32)
     cwd.forwardslashestoback();
 #endif  // _WIN32
-    wxFileDialog dlg(this, "Open or Import Project", cwd.make_wxString(), wxEmptyString, "wxFormBuilder Project File (*.fbp)|*.fbp||",
-                     wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
+    wxFileDialog dlg(this, "Open or Import Project", cwd.make_wxString(), wxEmptyString,
+                     "wxFormBuilder Project File (*.fbp)|*.fbp||", wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
     if (dlg.ShowModal() == wxID_OK)
     {
         wxArrayString files;
@@ -582,8 +582,8 @@ void MainFrame::OnAppendGlade(wxCommandEvent&)
 #if defined(_WIN32)
     cwd.forwardslashestoback();
 #endif  // _WIN32
-    wxFileDialog dlg(this, "Open or Import Project", cwd.make_wxString(), wxEmptyString, "wxGlade Project File (*.wxg)|*.wxg||",
-                     wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
+    wxFileDialog dlg(this, "Open or Import Project", cwd.make_wxString(), wxEmptyString,
+                     "wxGlade Project File (*.wxg)|*.wxg||", wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
     if (dlg.ShowModal() == wxID_OK)
     {
         wxArrayString files;

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -3178,7 +3178,7 @@
         local_src_includes="node.h;node_prop.h;project_handler.h"
         system_src_includes="wx/filedlg.h;wx/tokenzr.h"
         header_preamble="class NodeProperty;"
-        class_members="&quot;wxString m_value;&quot; &quot;NodeProperty* m_prop;&quot;"
+        class_members="&quot;wxString m_value;&quot; &quot;NodeProperty* m_prop { nullptr };&quot; &quot;int m_language = GEN_LANG_CPLUSPLUS;&quot;"
         class_methods="&quot;void Initialize(NodeProperty* prop);&quot; &quot;const wxString&amp; GetResults() { return m_value; }&quot; &quot;void SetButtonsEnableState();&quot;"
         private_members="1"
         use_derived_class="0"

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -63,6 +63,8 @@ inline const char* lang_settings_xml = R"===(<?xml version="1.0"?>
 			help="The filename to use if generating code for wxPython." />
 		<property name="insert_python_code" type="code_edit"
 			help="Specify the code to insert into the python file after the generated import statements. This is usually used to import addtional modules, but can be any valid python code for use before the class definition." />
+		<property name="python_import_list" type="include_files"
+			help="Specifies the python modules that should be imported. These will be added using the import command." />
 		<!-- <property name="python_variable_args" type="bool"
 			help="If checked, the form
 		parameters will be set to (*args, **kwargs) instead of listing all the parameters and their
@@ -85,11 +87,10 @@ inline const char* lang_settings_xml = R"===(<?xml version="1.0"?>
 	<gen class="wxPython Frame Settings" type="interface">
 		<property name="python_file" type="file"
 			help="The filename to use if generating code for wxPython." />
-		<property name="import_all_dialogs" type="bool"
-			help="If checked, every wxDialog or wxWizard in this project that has a python_file specified for it will be imported into this module.">
-			0</property>
 		<property name="insert_python_code" type="code_edit"
 			help="Specify the code to insert into the python file after the generated import statements. This is usually used to import addtional modules, but can be any valid python code for use before the class definition." />
+		<property name="python_import_list" type="include_files"
+			help="Specifies the python modules that should be imported. These will be added using the import command." />
 		<property name="python_inherit_name" type="string"
 			help="The name to use for an inherited class. If specified, the Inherit tab in the Python panel will include a sample for creating an inherited class." />
 	</gen>


### PR DESCRIPTION
For Ruby, this is the list of files to load using require_relative, and for Python this is the list of files to import.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes the Python property `import_all_dialogs` that only existed in wxFrame forms. Now that we have a `python_import_list` property I think it's better for the user to determine what modules actually need to be imported instead of grabbing everything.

The rest of the PR implements support for `python_import_list` in Python and `relative_require_list` in Ruby.