### PR TITLE
Additional Ruby property support

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -319,6 +319,12 @@ Code& Code::Add(tt_string_view text)
     }
     else
     {
+        if (is_ruby() && text == "wxEmptyString")
+        {
+            *this += "('')";
+            return *this;
+        }
+
         std::string_view wx_prefix = m_lang_wxPrefix;
         // Python has different prefixes based on the library being used. E.g., wxBoolProperty
         // has a prefix of wx.propgrid. rather than wx.
@@ -871,6 +877,8 @@ Code& Code::QuotedString(tt_string_view text)
             *this += "wxString::FromUTF8(";
         }
     }
+
+    // bool text_has_single_quote = (text.find('\'') != tt::npos);
 
     if (is_ruby())
         *this += '\'';

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -221,7 +221,7 @@ public:
     Code& AddConstant(GenEnum::PropName prop_name, tt_string_view short_name);
 
     // Adds "true" for C++ or "True" for Python
-    Code& AddTrue() { return Str(is_cpp() ? "true" : "True"); }
+    Code& AddTrue() { return Str(is_cpp() || is_ruby() ? "true" : "True"); }
 
     // Adds "true" for C++ or "True" for Python
     Code& True() { return AddTrue(); }
@@ -230,7 +230,7 @@ public:
     Code& TrueFalseIf(GenEnum::PropName prop_name);
 
     // Adds "false" for C++ or "False" for Python
-    Code& AddFalse() { return Str(is_cpp() ? "false" : "False"); }
+    Code& AddFalse() { return Str(is_cpp() || is_ruby() ? "false" : "False"); }
 
     // Adds "false" for C++ or "False" for Python
     Code& False() { return AddFalse(); }

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -172,7 +172,7 @@ bool TextCtrlGenerator::SettingsCode(Code& code)
         {
             if (Project.as_string(prop_wxWidgets_version) == "3.1")
             {
-                code.Eol() << "#if wxCHECK_VERSION(3, 1, 6)";
+                code.Eol(eol_if_needed) << "#if wxCHECK_VERSION(3, 1, 6)";
                 code.Eol().Tab().NodeName() << "->EnableProofCheck(wxTextProofOptions::Default()";
                 if (code.PropContains(prop_spellcheck, "grammar"))
                     code << ".GrammarCheck()";
@@ -181,15 +181,29 @@ bool TextCtrlGenerator::SettingsCode(Code& code)
             }
             else
             {
-                code.NodeName() << "->EnableProofCheck(wxTextProofOptions::Default()";
+                code.Eol(eol_if_needed).NodeName() << "->EnableProofCheck(wxTextProofOptions::Default()";
                 if (code.PropContains(prop_spellcheck, "grammar"))
                     code << ".GrammarCheck()";
-                code << ");";
+                code.EndFunction();
             }
+        }
+        else if (code.is_python())
+        {
+            code.Eol(eol_if_needed).Add("# wxPython 4.2.0 does not support wxTextProofOptions").Eol();
+        }
+        else if (code.is_ruby())
+        {
+            // REVIEW: [Randalphwa - 08-05-2023] The code is correct, but spell-checking does
+            // not work as of wxRuby3 rc3
+            code.Eol(eol_if_needed).NodeName().Function("EnableProofCheck(");
+            code.Add("wxTextProofOptions").ClassMethod("Default");
+            if (code.PropContains(prop_spellcheck, "grammar"))
+                code.Function("GrammarCheck");
+            code << ')';
         }
         else
         {
-            code.Eol().Add("# wxPython 4.2.0 does not support wxTextProofOptions").Eol();
+            code.Eol(eol_if_needed).Str("# unknown language in TextCtrlGenerator::SettingsCode");
         }
     }
 

--- a/tests/SUPPORTED.md
+++ b/tests/SUPPORTED.md
@@ -1,6 +1,6 @@
 # Contents
 
-The following tables indicate whether or not code is being generated in a specific language. A "???" or "---" indicates it has not been verified. "no" indcates that the language doesn't support it.
+The following tables indicate whether or not code is being generated in a specific language. A "???" or "---" indicates it has not been verified. "no" indcates that the language doesn't support it. `partial` means that not all properties for the control are supported.
 
 This does _not_ mean that the class is fully supported in every language -- this is just a guide to indicate whether or not it is at least partially implemented in the various languages.
 
@@ -67,7 +67,7 @@ This does _not_ mean that the class is fully supported in every language -- this
 | wxAuiToolBar | yes | ??? | --- | --- | ../src/generate/gen_aui_toolbar.cpp |
 | wxBannerWindow | yes | yes | --- | --- | ../src/generate/gen_banner_window.cpp |
 | wxBitmapComboBox | yes | ??? | --- | --- | ../src/generate/gen_bitmap_combo.cpp |
-| wxButton | yes | ??? | --- | --- | ../src/generate/gen_button.cpp |
+| wxButton | yes | yes | yes | partial | ../src/generate/gen_button.cpp |
 | wxCalendarCtrl | yes | yes | --- | --- | ../src/generate/gen_calendar_ctrl.cpp |
 | wxCheckBox | yes | yes | yes | yes | ../src/generate/gen_checkbox.cpp |
 | wxCheckListBox | yes | yes | --- | --- | ../src/generate/gen_check_listbox.cpp |
@@ -120,7 +120,7 @@ This does _not_ mean that the class is fully supported in every language -- this
 | wxStatusBar | yes | yes | --- | --- | ../src/generate/gen_status_bar.cpp |
 | wxStyledTextCtrl | yes | yes | --- | --- | ../src/generate/styled_text.cpp |
 | wxTextCtrl | yes | yes | yes | yes | ../src/generate/gen_text_ctrl.cpp |
-| wxToggleButton | yes | yes | --- | --- | ../src/generate/gen_toggle_btn.cpp |
+| wxToggleButton | yes | yes | yes | partial | ../src/generate/gen_toggle_btn.cpp |
 | wxToolBar | yes | yes | yes | --- | ../src/generate/gen_toolbar.cpp |
 | wxTreeCtrl | yes | ??? | --- | --- | ../src/generate/gen_tree_ctrl.cpp |
 | wxTreeListCtrl | yes | ??? | --- | no | ../src/generate/gen_tree_list.cpp |


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds additional Ruby support for properties in wxTextCtrl and wxButton.