### PR TITLE
Add Ruby code generation for StdDialogButtonSizerGenerator

### DIFF
--- a/src/generate/gen_std_dlgbtn_sizer.h
+++ b/src/generate/gen_std_dlgbtn_sizer.h
@@ -24,4 +24,5 @@ public:
 
 protected:
     void GenPythonConstruction(Code& code);
+    void GenRubyConstruction(Code& code);
 };

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -45,8 +45,28 @@ inline const GenType lst_form_types[] =
 };
 
 const std::vector<std::string> reserved_names = {
-    "bitmaps",  // used for wxBitmapBundle
-    "_svg_string_", // used for python SVG image processing
+    "bitmaps",       // used for wxBitmapBundle
+    "_svg_string_",  // used for python SVG image processing
+
+    // Python variables
+    "_OK",
+    "_Yes",
+    "_Save",
+    "_Cancel",
+    "_No",
+    "_Close",
+    "_Help",
+    "_ContextHelp",
+
+    // Ruby variables
+    "_ok_btn",
+    "_yes_btn",
+    "_save_btn",
+    "_cancel_btn",
+    "_no_btn",
+    "_close_btn",
+    "_help_btn",
+    "_context_help_btn",
 
     "bundle_list",  // used for wxBitmapBundle, primarily for books
 

--- a/tests/SUPPORTED.md
+++ b/tests/SUPPORTED.md
@@ -55,7 +55,7 @@ This does _not_ mean that the class is fully supported in every language -- this
 | wxRadioBoxSizer | yes | no | --- | --- | ../src/generate/gen_statradiobox_sizer.cpp |
 | wxRadioButtonSizer | yes | no | --- | --- | ../src/generate/gen_statradiobox_sizer.cpp |
 | wxStaticBoxSizer | yes | yes | --- | --- | ../src/generate/gen_staticbox_sizer.cpp |
-| wxStdDialogButtonSizer | yes | yes | --- | --- | ../src/generate/gen_std_dlgbtn_sizer.cpp |
+| wxStdDialogButtonSizer | yes | yes | yes | partial | ../src/generate/gen_std_dlgbtn_sizer.cpp |
 | wxWrapSizer | yes | yes | --- | --- | ../src/generate/gen_wrap_sizer.cpp |
 
 # Classes


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds Ruby code generation for `StdDialogButtonSizerGenerator`.