### PR TITLE
Fix additional DialogBlocks import problems

### DIFF
--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -367,11 +367,19 @@ void DialogBlocks::createChildNode(pugi::xml_node& child_xml, Node* parent)
         else
         {
             auto msg = GatherErrorDetails(child_xml, getGenName);
+            msg << ", Type: " << ExtractQuotedString(type);
             FAIL_MSG(tt_string() << "Unrecognized class in \"proxy-type\" property: " << ExtractQuotedString(type) << "\n"
                                  << msg)
             m_errors.emplace(tt_string("Unrecognized class in \"proxy-type\" property: ") << ExtractQuotedString(type));
         }
         return;
+    }
+
+    // DialogBlocks uses wbToolBarButtonProxy for all toolbar buttons, so MapClassName() always
+    // turns it into gen_tool.
+    if (getGenName == gen_tool && parent->isGen(gen_wxAuiToolBar))
+    {
+        getGenName = gen_auitool;
     }
 
     auto node = NodeCreation.createNode(getGenName, parent);
@@ -399,6 +407,7 @@ void DialogBlocks::createChildNode(pugi::xml_node& child_xml, Node* parent)
             add_buttons("proxy-wxID_SAVE", prop_Save);
             return;
         }
+
         if (parent->isSizer() && parent->getParent()->isForm())
         {
             node = NodeCreation.createNode(getGenName, parent->getParent());

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -362,6 +362,28 @@ void DialogBlocks::createChildNode(pugi::xml_node& child_xml, Node* parent)
     auto node = NodeCreation.createNode(getGenName, parent);
     if (!node)
     {
+        if (parent->isGen(gen_wxStdDialogButtonSizer) && getGenName == gen_wxButton)
+        {
+            auto add_buttons = [&](std::string_view id, GenEnum::PropName propname)
+            {
+                if (auto value = child_xml.find_child_by_attribute("bool", "name", id); value && value.text().as_bool())
+                {
+                    parent->set_value(propname, true);
+                }
+            };
+
+            // Note that DialogBlocks does not use wxID_CLOSE
+
+            add_buttons("proxy-wxID_APPLY", prop_Apply);
+            add_buttons("proxy-wxID_OK", prop_OK);
+            add_buttons("proxy-wxID_CANCEL", prop_Cancel);
+            add_buttons("proxy-wxID_YES", prop_Yes);
+            add_buttons("proxy-wxID_NO", prop_No);
+            add_buttons("proxy-wxID_CONTEXT_HELP", prop_ContextHelp);
+            add_buttons("proxy-wxID_HELP", prop_Help);
+            add_buttons("proxy-wxID_SAVE", prop_Save);
+            return;
+        }
         if (parent->isSizer() && parent->getParent()->isForm())
         {
             node = NodeCreation.createNode(getGenName, parent->getParent());

--- a/src/import/import_dialogblocks.h
+++ b/src/import/import_dialogblocks.h
@@ -60,6 +60,8 @@ protected:
     // the string without quotes.
     tt_string ExtractQuotedString(pugi::xml_node& str_node);
 
+    tt_string GatherErrorDetails(pugi::xml_node& xml_node, GenEnum::GenName getGenName);
+
 private:
     bool m_use_enums { true };
     bool m_class_uses_dlg_units { false };

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -85,6 +85,7 @@ std::map<std::string_view, GenEnum::PropName, std::less<>> import_PropNames = {
     { "wxBitmapButton", gen_wxButton },
     { "wxListCtrl", gen_wxListView },
     { "wxScintilla", gen_wxStyledTextCtrl },
+    { "wxSpacer", gen_spacer },
 
 };
 

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -85,7 +85,13 @@ std::map<std::string_view, GenEnum::PropName, std::less<>> import_PropNames = {
     { "wxBitmapButton", gen_wxButton },
     { "wxListCtrl", gen_wxListView },
     { "wxScintilla", gen_wxStyledTextCtrl },
+
+    // DialogBlocks proxy conversion
     { "wxSpacer", gen_spacer },
+    { "wxMenuSeparator", gen_separator },
+    { "wxSubmenu", gen_submenu },
+    { "wxToolBarSeparator", gen_toolSeparator },
+    { "wxToolBarButton", gen_tool },
 
 };
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds more information to the Asserts that can occur if we have a problem importing from DialogBlocks. That should make it easier to track down and fix any problems encountered.

The PR also fixes some of the bugs found when converting most of the sdi test dialogs into XRC files, importing them into DialogBlocks, saving them as a DialogBlocks project file and importing it back into wxUiEditor. Sounds complicated, but is actually a fairly efficient process, except that DialogBlocks doesn't understand many of the wxWidgets 3.1 controls that wxUiEditor created in the sdi tests.