### PR TITLE
Code class

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -301,9 +301,6 @@ tt_string BaseGenerator::GetHelpText(Node* node)
     return class_name;
 }
 
-extern std::map<std::string_view, std::string_view, std::less<>> g_map_python_prefix;
-extern std::map<std::string_view, std::string_view, std::less<>> g_map_ruby_prefix;
-
 tt_string BaseGenerator::GetPythonHelpText(Node* node)
 {
     tt_string class_name = getClassHelpName(node);

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -19,7 +19,8 @@ using namespace code;
 
 // clang-format off
 
-static const std::map<tt_string_view, std::string_view, std::less<>> s_short_python_map
+// This maps just the prefix
+static const view_map s_short_python_map
 {
     { "wxAUI_", "wx.aui."},
     { "wxCAL_", "wx.adv."},
@@ -41,9 +42,41 @@ static const std::map<tt_string_view, std::string_view, std::less<>> s_short_pyt
 
 };
 
-static const std::map<std::string_view, std::string_view, std::less<>> map_python_wx_prefix
+const view_map g_map_python_prefix
 {
-    { "wxAC_DEFAULT_STYLE", "wx.adv."},
+    { "wxAnimationCtrl", "wx.adv."},
+    { "wxAuiNotebook", "wx.aui."},
+    { "wxAuiToolBar", "wx.aui."},
+    { "wxAuiToolBarItem", "wx.aui."},
+    { "wxBannerWindow", "wx.adv."},
+    { "wxCalendarCtrl", "wx.adv."},
+    { "wxCommandLinkButton", "wx.adv."},
+    { "wxDatePickerCtrl", "wx.adv."},
+    { "wxEditableListBox", "wx.adv."},
+    { "wxHtmlWindow", "wx.html."},
+    { "wxSimpleHtmlListBox", "wx.html."},
+    { "wxHyperlinkCtrl", "wx.adv."},
+    { "wxRichTextCtrl", "wx.richtext."},
+    { "wxStyledTextCtrl", "wx.stc."},
+    { "wxTimePickerCtrl", "wx.adv."},
+    { "wxStyledTextCtrl", "wx.stc."},
+    { "wxWebView", "wx.html2."},
+    { "wxWizard", "wx.adv."},
+    { "wxWizardPageSimple", "wx.adv."},
+    { "wxRibbonBar", "wx.ribbon."},
+    { "wxRibbonButtonBar", "wx.ribbon."},
+    { "wxRibbonPage", "wx.ribbon."},
+    { "wxRibbonPanel", "wx.ribbon."},
+    { "wxRibbonToolBar", "wx.ribbon."},
+    { "wxRibbonGallery", "wx.ribbon."},
+    { "wxBitmapComboBox", "wx.adv."},
+    { "wxDataViewCtrl", "wx.dataview."},
+    { "wxDataViewListCtrl", "wx.dataview."},
+    { "wxDataViewTreeCtrl", "wx.dataview."},
+    { "wxGrid", "wx.grid."},
+    { "wxPropertyGridManager", "wx.propgrid."},
+    { "wxPropertyGrid", "wx.propgrid."},
+        { "wxAC_DEFAULT_STYLE", "wx.adv."},
     { "wxAC_NO_AUTORESIZE", "wx.adv."},
     { "wxNullAnimation", "wx.adv."},
     { "wxEL_ALLOW_NEW", "wx.adv."},
@@ -92,53 +125,125 @@ static const std::map<std::string_view, std::string_view, std::less<>> map_pytho
     // This doesn't get created as a class, so we have to add it as if it was a constant.
     { "wxWebView", "wx.html2."},
     { "wxWebViewBackendDefault", "wx.html2."},
-};
 
-std::map<std::string_view, std::string_view, std::less<>> g_map_python_prefix
-{
-    { "wxAnimationCtrl", "wx.adv."},
-    { "wxAuiNotebook", "wx.aui."},
-    { "wxAuiToolBar", "wx.aui."},
-    { "wxAuiToolBarItem", "wx.aui."},
-    { "wxBannerWindow", "wx.adv."},
-    { "wxCalendarCtrl", "wx.adv."},
-    { "wxCommandLinkButton", "wx.adv."},
-    { "wxDatePickerCtrl", "wx.adv."},
-    { "wxEditableListBox", "wx.adv."},
-    { "wxHtmlWindow", "wx.html."},
-    { "wxSimpleHtmlListBox", "wx.html."},
-    { "wxHyperlinkCtrl", "wx.adv."},
-    { "wxRichTextCtrl", "wx.richtext."},
-    { "wxStyledTextCtrl", "wx.stc."},
-    { "wxTimePickerCtrl", "wx.adv."},
-    { "wxStyledTextCtrl", "wx.stc."},
-    { "wxWebView", "wx.html2."},
-    { "wxWizard", "wx.adv."},
-    { "wxWizardPageSimple", "wx.adv."},
-    { "wxRibbonBar", "wx.ribbon."},
-    { "wxRibbonButtonBar", "wx.ribbon."},
-    { "wxRibbonPage", "wx.ribbon."},
-    { "wxRibbonPanel", "wx.ribbon."},
-    { "wxRibbonToolBar", "wx.ribbon."},
-    { "wxRibbonGallery", "wx.ribbon."},
-    { "wxBitmapComboBox", "wx.adv."},
-    { "wxDataViewCtrl", "wx.dataview."},
-    { "wxDataViewListCtrl", "wx.dataview."},
-    { "wxDataViewTreeCtrl", "wx.dataview."},
-    { "wxGrid", "wx.grid."},
-    { "wxPropertyGridManager", "wx.propgrid."},
-    { "wxPropertyGrid", "wx.propgrid."},
 
 };
 
-std::map<std::string_view, std::string_view, std::less<>> g_map_ruby_prefix
+static const view_map s_short_ruby_map
 {
-    { "wxAuiNotebook", "Wx::AUI::" },
-    { "wxAuiToolBar", "Wx::AUI::" },
+    { "wxAUI_", "Wx::AUI::"},
+    { "wxPG_", "Wx::PG::"},
+    { "wxRE_", "Wx::RTC::"},
+    { "wxRIBBON", "Wx::RBN::"},
+    { "wxSTC_", "Wx::STC::"},
+    { "wxGRID_", "Wx::GRID::"},
+
+};
+
+const view_map g_map_ruby_prefix
+{
+    { "wxAuiNotebook",    "Wx::AUI::" },
+    { "wxAuiToolBar",     "Wx::AUI::" },
     { "wxAuiToolBarItem", "Wx::AUI::" },
+
+    { "wxGrid", "Wx::GRID::"},
+
+    { "wxSimpleHtmlListBox", "Wx::HTML::"},
+    { "wxHtmlWindow",        "Wx::HTML::"},
+
+    { "wxEVT_PG_CHANGED",       "Wx::PG::" },
+    { "wxEVT_PG_CHANGING",      "Wx::PG::" },
+    { "wxPropertyCategory",     "Wx::PG::" },
+    { "wxBoolProperty",         "Wx::PG::" },
+    { "wxColourProperty",       "Wx::PG::" },
+    { "wxCursorProperty",       "Wx::PG::" },
+    { "wxDateProperty",         "Wx::PG::" },
+    { "wxDirProperty",          "Wx::PG::" },
+    { "wxEditEnumProperty",     "Wx::PG::" },
+    { "wxEnumProperty",         "Wx::PG::" },
+    { "wxFileProperty",         "Wx::PG::" },
+    { "wxFlagsProperty",        "Wx::PG::" },
+    { "wxFloatProperty",        "Wx::PG::" },
+    { "wxFontProperty",         "Wx::PG::" },
+    { "wxImageFileProperty",    "Wx::PG::" },
+    { "wxIntProperty",          "Wx::PG::" },
+    { "wxLongStringProperty",   "Wx::PG::" },
+    { "wxMultiChoiceProperty",  "Wx::PG::" },
+    { "wxStringProperty",       "Wx::PG::" },
+    { "wxSystemColourProperty", "Wx::PG::" },
+    { "wxUIntProperty",         "Wx::PG::" },
+
+    { "wxRibbonBar",       "Wx::RBN::"},
+    { "wxRibbonButtonBar", "Wx::RBN::"},
+    { "wxRibbonPage",      "Wx::RBN::"},
+    { "wxRibbonPanel",     "Wx::RBN::"},
+    { "wxRibbonToolBar",   "Wx::RBN::"},
+    { "wxRibbonGallery",   "Wx::RBN::"},
+
+    { "wxRichTextCtrl", "Wx::RTC::"},
+    { "wxStyledTextCtrl", "Wx::STC::"},
+
 };
 
 // clang-format on
+
+std::string_view GetLanguagePrefix(tt_string_view candidate, int language)
+{
+    const view_map* prefix_list;
+    const view_map* global_list;
+
+    switch (language)
+    {
+        case GEN_LANG_PYTHON:
+            prefix_list = &s_short_python_map;
+            global_list = &g_map_python_prefix;
+            break;
+
+        case GEN_LANG_RUBY:
+            prefix_list = &s_short_ruby_map;
+            global_list = &g_map_ruby_prefix;
+            break;
+
+        case GEN_LANG_GOLANG:
+            // wxGo doesn't have modules
+            return {};
+
+        case GEN_LANG_LUA:
+            // wxLua doesn't have modules
+            return {};
+
+        case GEN_LANG_PERL:
+            // wxPerl doesn't appear to have modules, but needs verification
+            return {};
+
+        case GEN_LANG_RUST:
+            // wxRust doesn't appear to have modules, but needs verification
+            return {};
+
+        case GEN_LANG_CPLUSPLUS:
+            FAIL_MSG("Don't call GetLanguagePrefix() for C++ code!");
+            return {};
+
+        default:
+            FAIL_MSG("Unknown language");
+            return {};
+    }
+
+    for (auto& iter_prefix: *prefix_list)
+    {
+        if (candidate.starts_with(iter_prefix.first))
+        {
+            return iter_prefix.second;
+        }
+    }
+
+    if (auto result = global_list->find(candidate); result != global_list->end())
+    {
+        return result->second;
+    }
+
+    return {};
+}
 
 Code::Code(Node* node, int language)
 {
@@ -151,14 +256,14 @@ void Code::Init(Node* node, int language)
     m_language = language;
     if (language == GEN_LANG_CPLUSPLUS)
     {
-        m_lang_wxPrefix = "wx";
+        m_language_wxPrefix = "wx";
         m_break_length = Project.as_size_t(prop_cpp_line_length);
         // Always assume C++ code has one tab at the beginning of the line
         m_break_length -= m_indent_size;
     }
     else if (language == GEN_LANG_PYTHON)
     {
-        m_lang_wxPrefix = "wx.";
+        m_language_wxPrefix = "wx.";
         m_break_length = Project.as_size_t(prop_python_line_length);
         // Always assume Python code has two tabs at the beginning of the line
         m_break_length -= (m_indent_size * 2);
@@ -166,7 +271,7 @@ void Code::Init(Node* node, int language)
     else if (language == GEN_LANG_RUBY)
     {
         m_indent_size = 2;
-        m_lang_wxPrefix = "Wx::";
+        m_language_wxPrefix = "Wx::";
         m_lang_assignment = " = ";
         m_break_length = Project.as_size_t(prop_ruby_line_length);
         // Always assume Ruby code has two tabs at the beginning of the line
@@ -178,7 +283,7 @@ void Code::Init(Node* node, int language)
 
     else if (language == GEN_LANG_GOLANG)
     {
-        m_lang_wxPrefix = "wx.";
+        m_language_wxPrefix = "wx.";
         m_lang_assignment = " := ";
         m_break_length = Project.as_size_t(prop_golang_line_length);
         if (m_break_length < 80)
@@ -187,7 +292,7 @@ void Code::Init(Node* node, int language)
     }
     else if (language == GEN_LANG_LUA)
     {
-        m_lang_wxPrefix = "wx.";
+        m_language_wxPrefix = "wx.";
         m_break_length = Project.as_size_t(prop_lua_line_length);
         if (m_break_length < 80)
             m_break_length = 80;
@@ -195,7 +300,7 @@ void Code::Init(Node* node, int language)
     }
     else if (language == GEN_LANG_PERL)
     {
-        m_lang_wxPrefix = "Wx::";
+        m_language_wxPrefix = "Wx::";
         m_break_length = Project.as_size_t(prop_perl_line_length);
         if (m_break_length < 80)
             m_break_length = 80;
@@ -203,7 +308,7 @@ void Code::Init(Node* node, int language)
     }
     else if (language == GEN_LANG_RUST)
     {
-        m_lang_wxPrefix = "wx::";
+        m_language_wxPrefix = "wx::";
         m_break_length = Project.as_size_t(prop_rust_line_length);
         if (m_break_length < 80)
             m_break_length = 80;
@@ -213,7 +318,7 @@ void Code::Init(Node* node, int language)
     else
     {
         FAIL_MSG("Unknown language");
-        m_lang_wxPrefix = "wx";
+        m_language_wxPrefix = "wx";
         m_lang_assignment = " = ";
         m_break_length = 90;
         // Always assume code has one tab at the beginning of the line
@@ -350,81 +455,94 @@ Code& Code::Tab(int tabs)
     return *this;
 }
 
+Code& Code::as_string(PropName prop_name)
+{
+    if (prop_name == prop_id)
+    {
+        auto result = m_node->getPropId();
+        CheckLineLength(result.size());
+
+        if (!is_cpp())
+        {
+            result.Replace("wx", m_language_wxPrefix);
+        }
+        *this += result;
+        return *this;
+    }
+
+    return Add(m_node->as_string(prop_name));
+}
+
 Code& Code::Add(tt_string_view text)
 {
-    CheckLineLength(text.size());
-
     if (is_cpp() || text.size() < 3)
     {
+        CheckLineLength(text.size());
         *this += text;
     }
     else
     {
         if (is_ruby() && text == "wxEmptyString")
         {
+            // wxRuby prefers ('') for an empty string instead of the expected Wx::empty_string
             *this += "('')";
             return *this;
         }
 
-        std::string_view wx_prefix = m_lang_wxPrefix;
-        // Python has different prefixes based on the library being used. E.g., wxBoolProperty
-        // has a prefix of wx.propgrid. rather than wx.
-        auto GetPythonPrefix = [&](tt_string_view candidate)
-        {
-            // Note that you can *NOT* allocate anything on the stack and return a
-            // std::string_view to it!
-
-            for (auto& iter_prefix: s_short_python_map)
-            {
-                if (candidate.starts_with(iter_prefix.first))
-                {
-                    wx_prefix = iter_prefix.second;
-                    return;
-                }
-            }
-            if (auto wx_iter = map_python_wx_prefix.find(candidate); wx_iter != map_python_wx_prefix.end())
-            {
-                wx_prefix = wx_iter->second;
-            }
-        };
-
         if (text.find('|') != tt::npos)
         {
-            bool style_set = false;
+            bool initial_combined_value_set = false;
             tt_view_vector multistr(text, "|", tt::TRIM::both);
             for (auto& iter: multistr)
             {
                 if (iter.empty())
                     continue;
-                if (style_set)
+                if (initial_combined_value_set)
                     *this += '|';
-                if (iter.is_sameprefix("wx"))
+                if (iter.is_sameprefix("wx") && !is_cpp())
                 {
-                    if (is_python())
+                    if (std::string_view language_prefix = GetLanguagePrefix(text, m_language); language_prefix.size())
                     {
-                        GetPythonPrefix(iter);
+                        // Some languages will have a module added after their standard prefix.
+                        CheckLineLength(language_prefix.size() + iter.size() - 2);
+                        *this << language_prefix << iter.substr(2);
                     }
-                    *this << wx_prefix << iter.substr(2);
+                    else
+                    {
+                        // If there was no sub-language module added (e.g., wx.aui. for
+                        // Python), then use the default language prefix.
+                        CheckLineLength(m_language_wxPrefix.size() + iter.size() - 2);
+                        *this << m_language_wxPrefix << iter.substr(2);
+                    }
                 }
                 else
+                {
+                    CheckLineLength(iter.size());
                     *this += iter;
-                style_set = true;
+                }
+                initial_combined_value_set = true;
             }
         }
-        // text.size() has already been checked to be certain it is at least 3 characters
-        else if (text.is_sameprefix("wx") && text[2] != '.')
+        else if (text.is_sameprefix("wx") && !is_cpp())
         {
-            if (is_python())
+            if (std::string_view language_prefix = GetLanguagePrefix(text, m_language); language_prefix.size())
             {
-                GetPythonPrefix(text);
+                CheckLineLength(language_prefix.size() + text.size() - 2);
+                *this << language_prefix << text.substr(2);
             }
-            *this << wx_prefix << text.substr(2);
+            else
+            {
+                CheckLineLength(m_language_wxPrefix.size() + text.size() - 2);
+                *this << m_language_wxPrefix << text.substr(2);
+            }
         }
         else
         {
+            CheckLineLength(text.size());
             *this += text;
         }
     }
+
     return *this;
 }
 
@@ -452,7 +570,7 @@ Code& Code::Function(tt_string_view text)
         *this << '.';
         if (text.is_sameprefix("wx"))
         {
-            *this << m_lang_wxPrefix << text.substr(sizeof("wx") - 1);
+            *this << m_language_wxPrefix << text.substr(sizeof("wx") - 1);
         }
         else
         {
@@ -578,31 +696,39 @@ Code& Code::CreateClass(bool use_generic, tt_string_view override_name)
         class_name = "wxPanel";
     }
 
-    if (m_language == GEN_LANG_CPLUSPLUS)
+    if (is_cpp())
         *this += class_name;
     else
     {
-        std::string_view prefix = m_lang_wxPrefix;
-        if (is_python())
+        if (class_name.is_sameprefix("wx") && !is_cpp())
         {
-            if (auto wx_iter = g_map_python_prefix.find(class_name); wx_iter != g_map_python_prefix.end())
+            if (std::string_view language_prefix = GetLanguagePrefix(class_name, m_language); language_prefix.size())
             {
-                prefix = wx_iter->second;
+                *this << language_prefix << class_name.substr(2);
+            }
+            else if (is_golang())
+            {
+                *this << m_language_wxPrefix << "New" << class_name.substr(2);
+            }
+            else
+            {
+                *this << m_language_wxPrefix << class_name.substr(2);
             }
         }
-        else if (is_ruby())
+        else
         {
-            if (auto wx_iter = g_map_ruby_prefix.find(class_name); wx_iter != g_map_ruby_prefix.end())
-            {
-                prefix = wx_iter->second;
-            }
+            *this += class_name;
         }
-        *this << prefix << class_name.substr(2);
         if (is_ruby())
         {
             *this += ".new";
         }
+        else if (is_rust())
+        {
+            *this += "::new";
+        }
     }
+
     *this += '(';
     return *this;
 }
@@ -644,111 +770,6 @@ Code& Code::EndFunction()
     {
         *this += ';';
     }
-    return *this;
-}
-
-Code& Code::as_string(PropName prop_name)
-{
-    if (prop_name == prop_id)
-    {
-        auto result = m_node->getPropId();
-        CheckLineLength(result.size());
-
-        if (is_python() && result._Starts_with("wx"))
-        {
-            result.insert(2, ".");
-        }
-        else if (is_ruby() && result._Starts_with("wx"))
-        {
-            result.Replace("wx", "Wx::");
-        }
-        *this += result;
-        return *this;
-    }
-    auto& str = m_node->as_string(prop_name);
-    if (is_cpp())
-    {
-        CheckLineLength(str.size());
-        *this += str;
-        return *this;
-    }
-    std::string_view wx_prefix = m_lang_wxPrefix;
-    auto GetPythonPrefix = [&](tt_string_view candidate)
-    {
-        for (auto& iter_prefix: s_short_python_map)
-        {
-            if (candidate.starts_with(iter_prefix.first))
-            {
-                wx_prefix = iter_prefix.second;
-                return;
-            }
-        }
-        if (auto wx_iter = map_python_wx_prefix.find(candidate); wx_iter != map_python_wx_prefix.end())
-        {
-            wx_prefix = wx_iter->second;
-            return;
-        }
-    };
-
-    if (!tt::is_found(str.find('|')))
-    {
-        if (str == "wxEmptyString")
-        {
-            *this += "\"\"";
-        }
-        else
-        {
-            if (str.is_sameprefix("wx"))
-            {
-                if (is_python())
-                {
-                    GetPythonPrefix(str);
-                }
-                CheckLineLength(str.size() + wx_prefix.size());
-                *this << wx_prefix << str.substr(sizeof("wx") - 1);
-            }
-            else
-            {
-                CheckLineLength(str.size());
-                *this += str;
-            }
-            return *this;
-        }
-    }
-
-    auto cur_pos = size();
-
-    tt_view_vector multistr(str, "|", tt::TRIM::both);
-    bool first = true;
-    for (auto& iter: multistr)
-    {
-        if (iter.empty())
-            continue;
-        if (!first)
-            *this += '|';
-        else
-            first = false;
-
-        if (iter == "wxEmptyString")
-            *this += "\"\"";
-        else if (iter.is_sameprefix("wx"))
-        {
-            if (is_python())
-            {
-                GetPythonPrefix(iter);
-            }
-            CheckLineLength(iter.size() + wx_prefix.size());
-            *this << wx_prefix << iter.substr(sizeof("wx") - 1);
-        }
-        else
-            *this += iter;
-    }
-
-    if (m_auto_break && size() > m_break_at)
-    {
-        InsertLineBreak(cur_pos);
-    }
-
     return *this;
 }
 
@@ -1036,8 +1057,8 @@ Code& Code::WxSize(GenEnum::PropName prop_name, bool enable_dlg_units)
 
     if (m_node->as_wxSize(prop_name) == wxDefaultSize)
     {
-        CheckLineLength((sizeof("DefaultSize") - 1) + m_lang_wxPrefix.size());
-        *this << m_lang_wxPrefix << "DefaultSize";
+        CheckLineLength((sizeof("DefaultSize") - 1) + m_language_wxPrefix.size());
+        *this << m_language_wxPrefix << "DefaultSize";
         return *this;
     }
 
@@ -1118,8 +1139,8 @@ Code& Code::Pos(GenEnum::PropName prop_name, bool enable_dlg_units)
 
     if (m_node->as_wxPoint(prop_name) == wxDefaultPosition)
     {
-        CheckLineLength((sizeof("DefaultPosition") - 1) + m_lang_wxPrefix.size());
-        *this << m_lang_wxPrefix << "DefaultPosition";
+        CheckLineLength((sizeof("DefaultPosition") - 1) + m_language_wxPrefix.size());
+        *this << m_language_wxPrefix << "DefaultPosition";
         return *this;
     }
 
@@ -1194,27 +1215,6 @@ Code& Code::Style(const char* prefix, tt_string_view force_style)
             else
             {
                 tt_view_vector multistr(m_node->as_constant(prop_style, prefix), "|", tt::TRIM::both);
-                std::string_view wx_prefix = m_lang_wxPrefix;
-                auto map_python_wxWidget = [&](tt_string_view candidate)
-                {
-                    for (auto& iter_prefix: s_short_python_map)
-                    {
-                        if (candidate.starts_with(iter_prefix.first))
-                        {
-                            wx_prefix = iter_prefix.second;
-                            return;
-                        }
-                    }
-                    if (is_python())
-                    {
-                        if (auto wx_iter = map_python_wx_prefix.find(candidate); wx_iter != map_python_wx_prefix.end())
-                        {
-                            wx_prefix = wx_iter->second;
-                            return;
-                        }
-                    }
-                };
-
                 for (auto& iter: multistr)
                 {
                     if (iter.empty())
@@ -1223,11 +1223,19 @@ Code& Code::Style(const char* prefix, tt_string_view force_style)
                         *this += '|';
                     if (iter.is_sameprefix("wx"))
                     {
-                        if (is_python())
+                        if (std::string_view language_prefix = GetLanguagePrefix(iter, m_language); language_prefix.size())
                         {
-                            map_python_wxWidget(iter);
+                            // Some languages will have a module added after their standard prefix.
+                            CheckLineLength(language_prefix.size() + iter.size() - 2);
+                            *this << language_prefix << iter.substr(2);
                         }
-                        *this << wx_prefix << iter.substr(2);
+                        else
+                        {
+                            // If there was no sub-language module added (e.g., wx.aui. for
+                            // Python), then use the default language prefix.
+                            CheckLineLength(m_language_wxPrefix.size() + iter.size() - 2);
+                            *this << m_language_wxPrefix << iter.substr(2);
+                        }
                     }
                     else
                         *this += iter;
@@ -1535,25 +1543,25 @@ Code& Code::GenSizerFlags()
             {
                 if (border_flags.size())
                     border_flags << '|';
-                border_flags << m_lang_wxPrefix << "LEFT";
+                border_flags << m_language_wxPrefix << "LEFT";
             }
             if (prop.contains("wxRIGHT"))
             {
                 if (border_flags.size())
                     border_flags << '|';
-                border_flags << m_lang_wxPrefix << "RIGHT";
+                border_flags << m_language_wxPrefix << "RIGHT";
             }
             if (prop.contains("wxTOP"))
             {
                 if (border_flags.size())
                     border_flags << '|';
-                border_flags << m_lang_wxPrefix << "TOP";
+                border_flags << m_language_wxPrefix << "TOP";
             }
             if (prop.contains("wxBOTTOM"))
             {
                 if (border_flags.size())
                     border_flags << '|';
-                border_flags << m_lang_wxPrefix << "BOTTOM";
+                border_flags << m_language_wxPrefix << "BOTTOM";
             }
             if (border_flags.empty())
                 border_flags = "0";
@@ -1566,7 +1574,7 @@ Code& Code::GenSizerFlags()
                 else if (is_ruby())
                     *this += "Wx::SizerFlags.get_default_border)";
                 else
-                    *this << m_lang_wxPrefix << "SizerFlags.GetDefaultBorder())";
+                    *this << m_language_wxPrefix << "SizerFlags.GetDefaultBorder())";
             }
             else
             {

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -283,9 +283,6 @@ public:
         return *this;
     }
 
-    // Equivalent to calling as_string(prop_name)
-    Code& Str(GenEnum::PropName prop_name) { return as_string(prop_name); }
-
     // Adds -> or . to the string, then function (fixing wx prefix if needed)
     Code& Function(tt_string_view text);
 
@@ -326,7 +323,10 @@ public:
     // non-sizer parents.
     Code& ValidParentName();
 
-    // Handles regular or or'd styles for C++ or Python
+    // Handles regular or or'd properties.
+    //
+    // If the property value begins with wx and the language is not C++, this will change the
+    // prefix to match the language's prefix (e.g., wx. for wxPython).
     Code& as_string(GenEnum::PropName prop_name);
 
     Code& itoa(int val)
@@ -349,7 +349,7 @@ public:
 
     Code& itoa(GenEnum::PropName prop_name1, GenEnum::PropName prop_name2)
     {
-        Str(prop_name1).Comma().Str(prop_name2);
+        as_string(prop_name1).Comma().as_string(prop_name2);
         return *this;
     }
 
@@ -419,7 +419,7 @@ protected:
 
 private:
     // wx for C++, wx. for Python, Wx:: for Ruby
-    tt_string m_lang_wxPrefix { "wx" };
+    tt_string m_language_wxPrefix { "wx" };
     tt_string m_lang_assignment { " = " };  // " = " default, " := " for Go
 
     size_t m_break_length { 80 };

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -52,6 +52,9 @@ namespace code
 // Assume anyone including this header file needs access to the code namespace
 using namespace code;
 
+extern const view_map g_map_python_prefix;
+extern const view_map g_map_ruby_prefix;
+
 class Code : public tt_string
 {
 public:

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -333,8 +333,14 @@ void DataViewTreeCtrl::RequiredHandlers(Node* /* node */, std::set<std::string>&
 
 bool DataViewColumn::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().Str(" = ").ParentName().Function("Append").Str(prop_type).Str("Column(");
-    code.QuotedString(prop_label).Comma().Str(prop_model_column).Comma().Str(prop_mode).Comma().Str(prop_width);
+    code.AddAuto().NodeName().Str(" = ").ParentName().Function("Append").as_string(prop_type).Str("Column(");
+    code.QuotedString(prop_label)
+        .Comma()
+        .as_string(prop_model_column)
+        .Comma()
+        .as_string(prop_mode)
+        .Comma()
+        .as_string(prop_width);
     code.Comma();
     if (code.is_cpp())
         code.Str("static_cast<wxAlignment>(");
@@ -355,8 +361,8 @@ bool DataViewColumn::ConstructionCode(Code& code)
 
 bool DataViewListColumn::ConstructionCode(Code& code)
 {
-    code.AddAuto().NodeName().Str(" = ").ParentName().Function("Append").Str(prop_type).Str("Column(");
-    code.QuotedString(prop_label).Comma().Str(prop_mode).Comma().Str(prop_width);
+    code.AddAuto().NodeName().Str(" = ").ParentName().Function("Append").as_string(prop_type).Str("Column(");
+    code.QuotedString(prop_label).Comma().as_string(prop_mode).Comma().as_string(prop_width);
     code.Comma();
     if (code.is_cpp())
         code.Str("static_cast<wxAlignment>(");

--- a/src/generate/gen_aui_notebook.cpp
+++ b/src/generate/gen_aui_notebook.cpp
@@ -83,7 +83,7 @@ bool AuiNotebookGenerator::SettingsCode(Code& code)
 {
     if (code.IntValue(prop_tab_height) > 0)
     {
-        code.Eol().NodeName().Function("SetTabCtrlHeight(").Str(prop_tab_height).EndFunction();
+        code.Eol().NodeName().Function("SetTabCtrlHeight(").as_string(prop_tab_height).EndFunction();
     }
 
     return true;

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -111,7 +111,7 @@ bool AuiToolBarFormGenerator::ConstructionCode(Code& code)
     // Note: Form construction is called before any indentation is set
     if (code.is_cpp())
     {
-        code.Str((prop_class_name)).Str("::").Str(prop_class_name);
+        code.as_string(prop_class_name).Str("::").as_string(prop_class_name);
         code += "(wxWindow* parent, wxWindowID id";
         code.Comma().Str("const wxPoint& pos").Comma().Str("const wxSize& size");
         code.Comma().Str("long style)");
@@ -203,7 +203,7 @@ bool AuiToolBarFormGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {
@@ -227,17 +227,17 @@ bool AuiToolBarFormGenerator::SettingsCode(Code& code)
 
     if (!code.isPropValue(prop_separation, 5))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetToolSeparation(").Str(prop_separation).EndFunction();
+        code.Eol(eol_if_needed).NodeName().Function("SetToolSeparation(").as_string(prop_separation).EndFunction();
     }
 
     if (code.hasValue(prop_margins))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetMargins(").Str(prop_margins).EndFunction();
+        code.Eol(eol_if_needed).NodeName().Function("SetMargins(").as_string(prop_margins).EndFunction();
     }
 
     if (!code.isPropValue(prop_packing, 1))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetToolPacking(").Str(prop_packing).EndFunction();
+        code.Eol(eol_if_needed).NodeName().Function("SetToolPacking(").as_string(prop_packing).EndFunction();
     }
 
     return true;
@@ -418,17 +418,17 @@ bool AuiToolBarGenerator::SettingsCode(Code& code)
 
     if (!code.isPropValue(prop_separation, 5))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetToolSeparation(").Str(prop_separation).EndFunction();
+        code.Eol(eol_if_needed).NodeName().Function("SetToolSeparation(").as_string(prop_separation).EndFunction();
     }
 
     if (code.hasValue(prop_margins))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetMargins(").Str(prop_margins).EndFunction();
+        code.Eol(eol_if_needed).NodeName().Function("SetMargins(").as_string(prop_margins).EndFunction();
     }
 
     if (!code.isPropValue(prop_packing, 1))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetToolPacking(").Str(prop_packing).EndFunction();
+        code.Eol(eol_if_needed).NodeName().Function("SetToolPacking(").as_string(prop_packing).EndFunction();
     }
 
     return true;
@@ -524,7 +524,7 @@ bool AuiToolGenerator::ConstructionCode(Code& code)
 
     if (code.node()->as_string(prop_initial_state) != "wxAUI_BUTTON_STATE_NORMAL")
     {
-        code.Eol().NodeName().Function("SetState(").Str(prop_initial_state).EndFunction();
+        code.Eol().NodeName().Function("SetState(").as_string(prop_initial_state).EndFunction();
     }
 
     return true;
@@ -579,7 +579,7 @@ bool AuiToolLabelGenerator::ConstructionCode(Code& code)
     }
     code.as_string(prop_id).Comma().QuotedString(prop_label);
     if (code.IntValue(prop_width) >= 0)
-        code.Comma().Str(prop_width);
+        code.Comma().as_string(prop_width);
     code.EndFunction();
 
     return true;
@@ -606,7 +606,7 @@ bool AuiToolSpacerGenerator::ConstructionCode(Code& code)
     {
         code.FormFunction("AddSpacer(");
     }
-    code.ParentName().Function("FromDIP(").Str(prop_width).Str(")").EndFunction();
+    code.ParentName().Function("FromDIP(").as_string(prop_width).Str(")").EndFunction();
 
     return true;
 }
@@ -635,7 +635,7 @@ bool AuiToolStretchSpacerGenerator::ConstructionCode(Code& code)
 
     if (code.IntValue(prop_proportion) != 1)
     {
-        code.Str(prop_proportion);
+        code.as_string(prop_proportion);
     }
     code.EndFunction();
 

--- a/src/generate/gen_button.cpp
+++ b/src/generate/gen_button.cpp
@@ -185,7 +185,7 @@ bool ButtonGenerator::SettingsCode(Code& code)
     {
         if (code.hasValue(prop_position))
         {
-            code.Eol(eol_if_needed).NodeName().Function("SetBitmapPosition(").Str(prop_position).EndFunction();
+            code.Eol(eol_if_needed).NodeName().Function("SetBitmapPosition(").as_string(prop_position).EndFunction();
         }
 
         if (code.hasValue(prop_margins))

--- a/src/generate/gen_check_listbox.cpp
+++ b/src/generate/gen_check_listbox.cpp
@@ -132,7 +132,7 @@ bool CheckListBoxGenerator::SettingsCode(Code& code)
             int sel = node->as_int(prop_selection_int);
             if (sel > -1 && sel < (to_int) contents.size())
             {
-                code.Eol(eol_if_empty).NodeName().Function("SetSelection(").Str(prop_selection_int).EndFunction();
+                code.Eol(eol_if_empty).NodeName().Function("SetSelection(").as_string(prop_selection_int).EndFunction();
             }
         }
     }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -977,7 +977,7 @@ void GenValidatorSettings(Code& code)
         {
             if (node->hasValue(prop_minValue) && node->hasValue(prop_maxValue))
             {
-                code.Comma().Str(prop_minValue).Comma().Str(prop_maxValue);
+                code.Comma().as_string(prop_minValue).Comma().as_string(prop_maxValue);
             }
         }
 

--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -103,7 +103,7 @@ void BaseCodeGenerator::GenConstruction(Node* node)
         tt_string code;
         gen_code.clear();
         if (parent->isType(type_toolbar_form) || parent->isType(type_aui_toolbar_form))
-            gen_code.Str("AddControl(").Str(prop_var_name).EndFunction();
+            gen_code.Str("AddControl(").as_string(prop_var_name).EndFunction();
         else
             gen_code.ParentName().Function("AddControl(").NodeName().EndFunction();
         m_source->writeLine(gen_code);

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -689,8 +689,8 @@ void BaseCodeGenerator::GenerateCppClassHeader(Node* form_node, EventVector& eve
 
     code.Str("class ");
     if (form_node->hasValue(prop_class_decoration))
-        code.Str(prop_class_decoration) += " ";
-    code.Str(prop_class_name) += " : public ";
+        code.as_string(prop_class_decoration) += " ";
+    code.as_string(prop_class_name) += " : public ";
     if (generator->BaseClassNameCode(code))
     {
         if (m_form_node->hasValue(prop_additional_inheritance))
@@ -743,7 +743,7 @@ void BaseCodeGenerator::GenerateCppClassHeader(Node* form_node, EventVector& eve
         {
             code.Eol(eol_if_needed).Str("const int form_style = ");
             if (form_node->as_string(prop_style).size())
-                code.Str(prop_style) += ";";
+                code.as_string(prop_style) += ";";
             else
                 code.Str("0;");
         }
@@ -751,7 +751,7 @@ void BaseCodeGenerator::GenerateCppClassHeader(Node* form_node, EventVector& eve
         {
             code.Eol(eol_if_needed).Str("const int form_style = ");
             if (form_node->as_string(prop_window_style).size())
-                code.Str(prop_window_style) += ";";
+                code.as_string(prop_window_style) += ";";
             else
                 code.Str("0;");
         }
@@ -763,7 +763,7 @@ void BaseCodeGenerator::GenerateCppClassHeader(Node* form_node, EventVector& eve
         {
             code.Eol(eol_if_needed).Str("static const wxString form_title() { return ");
             if (form_node->hasValue(prop_title))
-                code.Str("wxString::FromUTF8(\"").Str(prop_title) += "\"); }";
+                code.Str("wxString::FromUTF8(\"").as_string(prop_title) += "\"); }";
             else
                 code.Str("wxEmptyString; }");
         }

--- a/src/generate/gen_ctx_menu.cpp
+++ b/src/generate/gen_ctx_menu.cpp
@@ -64,7 +64,7 @@ bool CtxMenuGenerator::AfterChildrenCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.Str("void ").Str(code.node()->getFormName()).Str("::").Str(prop_handler_name);
+        code.Str("void ").Str(code.node()->getFormName()).Str("::").as_string(prop_handler_name);
         code.Str("(wxContextMenuEvent& event)").OpenBrace();
     }
 

--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -34,7 +34,7 @@ bool CustomControl::ConstructionCode(Code& code)
     code.AddAuto().NodeName();
     code.Str(" = ").AddIfCpp("new ");
     if (code.hasValue(prop_namespace) && code.is_cpp())
-        code.Str(prop_namespace) += "::";
+        code.as_string(prop_namespace) += "::";
 
     tt_string parameters(code.view(prop_parameters));
     parameters.Replace("${parent}", code.node()->getParentName(), tt::REPLACE::all);
@@ -80,7 +80,7 @@ bool CustomControl::ConstructionCode(Code& code)
     if (parameters.back() != ')')
         parameters += ")";
 
-    code.Str(prop_class_name).Str(parameters).AddIfCpp(";");
+    code.as_string(prop_class_name).Str(parameters).AddIfCpp(";");
 
     return true;
 }

--- a/src/generate/gen_dialog.cpp
+++ b/src/generate/gen_dialog.cpp
@@ -46,7 +46,7 @@ bool DialogFormGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.Str("bool ").Str((prop_class_name));
+        code.Str("bool ").as_string(prop_class_name);
         code +=
             "::Create(wxWindow* parent, wxWindowID id, const wxString& title,\n\tconst wxPoint& pos, const wxSize& size, "
             "long style, const wxString &name)";
@@ -231,7 +231,7 @@ bool DialogFormGenerator::HeaderCode(Code& code)
 
     code.Comma().Eol().Tab().Str("long style = ");
     if (node->hasValue(prop_style))
-        code.Str(prop_style);
+        code.as_string(prop_style);
     else
         code.Str("wxDEFAULT_DIALOG_STYLE");
 
@@ -282,7 +282,7 @@ bool DialogFormGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {

--- a/src/generate/gen_file_ctrl.cpp
+++ b/src/generate/gen_file_ctrl.cpp
@@ -81,7 +81,7 @@ bool FileCtrlGenerator::SettingsCode(Code& code)
 
     if (code.IntValue(prop_filter_index) > 0)
     {
-        code.Eol(eol_if_empty).NodeName().Function("SetFilterIndex(").Str(prop_filter_index).EndFunction();
+        code.Eol(eol_if_empty).NodeName().Function("SetFilterIndex(").as_string(prop_filter_index).EndFunction();
     }
 
     if (code.IsTrue(prop_show_hidden))

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -22,7 +22,7 @@ bool FrameFormGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.Str("bool ").Str((prop_class_name));
+        code.Str("bool ").as_string(prop_class_name);
         code +=
             "::Create(wxWindow* parent, wxWindowID id, const wxString& title,\n\tconst wxPoint& pos, const wxSize& size, "
             "long style, const wxString &name)";
@@ -240,7 +240,7 @@ bool FrameFormGenerator::HeaderCode(Code& code)
     code.Str(")").Eol().OpenBrace().Str("Create(parent, id, title, pos, size, style, name);").CloseBrace();
 
     code.Eol().Str("bool Create(wxWindow *parent");
-    code.Comma().Str("wxWindowID id = ").Str(prop_id);
+    code.Comma().Str("wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxString& title = ").QuotedString(prop_title);
     code.Comma().Str("const wxPoint& pos = ");
 
@@ -294,7 +294,7 @@ bool FrameFormGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {

--- a/src/generate/gen_grid.cpp
+++ b/src/generate/gen_grid.cpp
@@ -142,7 +142,7 @@ bool GridGenerator::ConstructionCode(Code& code)
 
 bool GridGenerator::SettingsCode(Code& code)
 {
-    code.OpenBrace().NodeName().Function("CreateGrid(").Str(prop_rows).Comma().Str(prop_cols).EndFunction();
+    code.OpenBrace().NodeName().Function("CreateGrid(").as_string(prop_rows).Comma().as_string(prop_cols).EndFunction();
 
     if (code.IsFalse(prop_editing))
         code.Eol().NodeName().Function("EnableEditing(").False().EndFunction();
@@ -265,7 +265,7 @@ bool GridGenerator::SettingsCode(Code& code)
 
     if (code.IntValue(prop_default_col_size) > 0)
     {
-        code.Eol().NodeName().Function("SetDefaultColSize(").Str(prop_default_col_size).EndFunction();
+        code.Eol().NodeName().Function("SetDefaultColSize(").as_string(prop_default_col_size).EndFunction();
     }
     else if (code.IsTrue(prop_autosize_cols))
     {
@@ -286,7 +286,7 @@ bool GridGenerator::SettingsCode(Code& code)
     else if (code.IntValue(prop_col_label_size) == 0)
         code.Eol().NodeName().Function("HideColLabels(").EndFunction();
     else
-        code.Eol().NodeName().Function("SetColLabelSize(").Str(prop_col_label_size).EndFunction();
+        code.Eol().NodeName().Function("SetColLabelSize(").as_string(prop_col_label_size).EndFunction();
 
     if (code.hasValue(prop_col_label_values))
     {
@@ -303,7 +303,7 @@ bool GridGenerator::SettingsCode(Code& code)
 
     if (code.IntValue(prop_default_row_size) > 0)
     {
-        code.Eol().NodeName().Function("SetDefaultRowSize(").Str(prop_default_row_size).EndFunction();
+        code.Eol().NodeName().Function("SetDefaultRowSize(").as_string(prop_default_row_size).EndFunction();
     }
     else if (code.IsTrue(prop_autosize_rows))
     {
@@ -321,7 +321,7 @@ bool GridGenerator::SettingsCode(Code& code)
     else if (code.IntValue(prop_row_label_size) == 0)
         code.Eol().NodeName().Function("HideRowLabels(").EndFunction();
     else
-        code.Eol().NodeName().Function("SetRowLabelSize(").Str(prop_row_label_size).EndFunction();
+        code.Eol().NodeName().Function("SetRowLabelSize(").as_string(prop_row_label_size).EndFunction();
 
     if (code.hasValue(prop_col_label_values))
     {

--- a/src/generate/gen_grid_sizer.cpp
+++ b/src/generate/gen_grid_sizer.cpp
@@ -44,9 +44,9 @@ bool GridSizerGenerator::ConstructionCode(Code& code)
     code.AddAuto().NodeName().CreateClass();
     if (code.node()->as_int(prop_rows) != 0)
     {
-        code.Str(prop_rows).Comma();
+        code.as_string(prop_rows).Comma();
     }
-    code.Str(prop_cols).Comma().Str(prop_vgap).Comma().Str(prop_hgap).EndFunction();
+    code.as_string(prop_cols).Comma().as_string(prop_vgap).Comma().as_string(prop_hgap).EndFunction();
 
     if (code.hasValue(prop_minimum_size))
     {

--- a/src/generate/gen_gridbag_sizer.cpp
+++ b/src/generate/gen_gridbag_sizer.cpp
@@ -141,7 +141,7 @@ bool GridBagSizerGenerator::ConstructionCode(Code& code)
 
     if (code.node()->as_int(prop_vgap) != 0 || code.node()->as_int(prop_hgap) != 0)
     {
-        code.Str(prop_vgap).Comma().Str(prop_hgap);
+        code.as_string(prop_vgap).Comma().as_string(prop_hgap);
     }
     code.EndFunction();
 

--- a/src/generate/gen_html_window.cpp
+++ b/src/generate/gen_html_window.cpp
@@ -75,7 +75,7 @@ bool HtmlWindowGenerator::SettingsCode(Code& code)
     {
         code.Eol(eol_if_needed).NodeName().Function("SetBorders(");
         code += (code.is_cpp() ? "this->FromDIP(, " : "self.FromDIP(, ");
-        code.Str(prop_html_borders).Str(")").EndFunction();
+        code.as_string(prop_html_borders).Str(")").EndFunction();
     }
 
     if (code.hasValue(prop_html_content))

--- a/src/generate/gen_listbox.cpp
+++ b/src/generate/gen_listbox.cpp
@@ -95,7 +95,7 @@ bool ListBoxGenerator::SettingsCode(Code& code)
             int sel = code.IntValue(prop_selection_int);
             if (sel > -1 && sel < (to_int) array.size())
             {
-                code.Eol(eol_if_empty).NodeName().Function("SetSelection(").Str(prop_selection_int).EndFunction();
+                code.Eol(eol_if_empty).NodeName().Function("SetSelection(").as_string(prop_selection_int).EndFunction();
             }
         }
     }

--- a/src/generate/gen_panel_form.cpp
+++ b/src/generate/gen_panel_form.cpp
@@ -44,7 +44,7 @@ bool PanelFormGenerator::ConstructionCode(Code& code)
     // Note: Form construction is called before any indentation is set
     if (code.is_cpp())
     {
-        code.Str("bool ").Str((prop_class_name));
+        code.Str("bool ").as_string(prop_class_name);
         code += "::Create(wxWindow* parent, wxWindowID id";
         code.Comma().Str("const wxPoint& pos").Comma().Str("const wxSize& size");
         code.Comma().Str("long style").Comma().Str("const wxString& name)");
@@ -278,7 +278,7 @@ bool PanelFormGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {

--- a/src/generate/gen_popup_trans_win.cpp
+++ b/src/generate/gen_popup_trans_win.cpp
@@ -19,7 +19,7 @@ bool PopupWinGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.Str(prop_class_name).Str("::").Str(prop_class_name);
+        code.as_string(prop_class_name).Str("::").as_string(prop_class_name);
         code += "(wxWindow* parent, int style) : wxPopupTransientWindow(parent, style)\n{";
     }
     else
@@ -46,7 +46,7 @@ bool PopupWinGenerator::SettingsCode(Code& code)
 
 bool PopupWinGenerator::HeaderCode(Code& code)
 {
-    code.NodeName().Str("(wxWindow* parent, int style = ").Str(prop_border);
+    code.NodeName().Str("(wxWindow* parent, int style = ").as_string(prop_border);
     if (code.hasValue(prop_style))
     {
         code.Str(" | ").Add(prop_style);
@@ -60,7 +60,7 @@ bool PopupWinGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {

--- a/src/generate/gen_radio_box.cpp
+++ b/src/generate/gen_radio_box.cpp
@@ -103,7 +103,7 @@ bool RadioBoxGenerator::ConstructionCode(Code& code)
         code.GetCode().pop_back();  // remove the last comma
         code << "]";
     }
-    code.Comma().CheckLineLength(3).Str(prop_majorDimension);
+    code.Comma().CheckLineLength(3).as_string(prop_majorDimension);
     code.Comma().Style("rb_");
     if (code.hasValue(prop_window_name))
     {
@@ -118,7 +118,7 @@ bool RadioBoxGenerator::SettingsCode(Code& code)
 {
     if (auto sel = code.IntValue(prop_selection); sel > 0)
     {
-        code.NodeName().Function("SetSelection(").Str(prop_selection).EndFunction();
+        code.NodeName().Function("SetSelection(").as_string(prop_selection).EndFunction();
     }
 
     return true;

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -151,7 +151,7 @@ bool RearrangeCtrlGenerator::SettingsCode(Code& code)
                     .NodeName()
                     .Function("GetList()")
                     .Function("SetSelection(")
-                    .Str(prop_selection_int)
+                    .as_string(prop_selection_int)
                     .EndFunction();
             }
         }

--- a/src/generate/gen_ribbon_bar.cpp
+++ b/src/generate/gen_ribbon_bar.cpp
@@ -54,7 +54,7 @@ bool RibbonBarFormGenerator::ConstructionCode(Code& code)
     // Note: Form construction is called before any indentation is set
     if (code.is_cpp())
     {
-        code.Str((prop_class_name)).Str("::").Str(prop_class_name);
+        code.as_string(prop_class_name).Str("::").as_string(prop_class_name);
         code += "(wxWindow* parent, wxWindowID id";
         code.Comma().Str("const wxPoint& pos").Comma().Str("const wxSize& size");
         code.Comma().Str("long style)");
@@ -141,7 +141,7 @@ bool RibbonBarFormGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {

--- a/src/generate/gen_scrollbar.cpp
+++ b/src/generate/gen_scrollbar.cpp
@@ -38,8 +38,8 @@ bool ScrollBarGenerator::ConstructionCode(Code& code)
 
 bool ScrollBarGenerator::SettingsCode(Code& code)
 {
-    code.NodeName().Function("SetScrollbar(").Str(prop_position).Comma().Str(prop_thumbsize);
-    code.Comma().Str(prop_range).Comma().Str(prop_pagesize).EndFunction();
+    code.NodeName().Function("SetScrollbar(").as_string(prop_position).Comma().as_string(prop_thumbsize);
+    code.Comma().as_string(prop_range).Comma().as_string(prop_pagesize).EndFunction();
     return true;
 }
 

--- a/src/generate/gen_simplebook.cpp
+++ b/src/generate/gen_simplebook.cpp
@@ -62,7 +62,7 @@ bool SimplebookGenerator::SettingsCode(Code& code)
 
         if (code.IntValue(prop_duration) != 0)
         {
-            code.NodeName().Function("SetEffectTimeout(").Str(prop_duration).EndFunction();
+            code.NodeName().Function("SetEffectTimeout(").as_string(prop_duration).EndFunction();
         }
     }
     return true;

--- a/src/generate/gen_spacer_sizer.cpp
+++ b/src/generate/gen_spacer_sizer.cpp
@@ -24,10 +24,10 @@ bool SpacerGenerator::ConstructionCode(Code& code)
     {
         auto flags = node->getSizerFlags();
 
-        code.Function("Add(").Str(prop_width).Comma().Str(prop_height);
-        code.Comma().Add("wxGBPosition(").Str(prop_row).Comma().Str(prop_column) += ")";
-        code.Comma().Add("wxGBSpan(").Str(prop_rowspan).Comma().Str(prop_colspan) += ")";
-        code.Comma().itoa(flags.GetFlags()).Comma().Str(prop_border_size);
+        code.Function("Add(").as_string(prop_width).Comma().as_string(prop_height);
+        code.Comma().Add("wxGBPosition(").as_string(prop_row).Comma().as_string(prop_column) += ")";
+        code.Comma().Add("wxGBSpan(").as_string(prop_rowspan).Comma().as_string(prop_colspan) += ")";
+        code.Comma().itoa(flags.GetFlags()).Comma().as_string(prop_border_size);
         if (node->as_bool(prop_add_default_border))
         {
             code.Str(" + ").Add("wxSizerFlags").ClassMethod("GetDefaultBorder()");
@@ -44,29 +44,29 @@ bool SpacerGenerator::ConstructionCode(Code& code)
         {
             if (node->as_int(prop_width) == node->as_int(prop_height))
             {
-                code.Function("AddSpacer(").Str(prop_width);
+                code.Function("AddSpacer(").as_string(prop_width);
             }
             else if (node->getParent()->hasValue(prop_orientation))
             {
                 code.Function("AddSpacer(");
                 if (node->getParent()->as_string(prop_orientation) == "wxVERTICAL")
                 {
-                    code.Str(prop_height);
+                    code.as_string(prop_height);
                 }
                 else
                 {
-                    code.Str(prop_width);
+                    code.as_string(prop_width);
                 }
             }
 
             else
             {
-                code.Function("Add(").Str(prop_width);
+                code.Function("Add(").as_string(prop_width);
                 if (node->as_bool(prop_add_default_border))
                 {
                     code.Str(" + ").Add("wxSizerFlags").ClassMethod("GetDefaultBorder()");
                 }
-                code.Comma().Str(prop_height);
+                code.Comma().as_string(prop_height);
             }
 
             if (node->as_bool(prop_add_default_border))

--- a/src/generate/gen_spin_ctrl.cpp
+++ b/src/generate/gen_spin_ctrl.cpp
@@ -172,7 +172,7 @@ bool SpinCtrlDoubleGenerator::ConstructionCode(Code& code)
         return true;
     }
     code.Comma().as_string(prop_id).Comma().Add("wxEmptyString").Comma().Pos().Comma().WxSize().Comma().Style();
-    code.Comma().Str(prop_min).Comma().Str(prop_max).Comma().Str(prop_initial).Comma().Str(prop_inc);
+    code.Comma().as_string(prop_min).Comma().as_string(prop_max).Comma().as_string(prop_initial).Comma().as_string(prop_inc);
     if (needed_parms & window_name_needed)
         code.Comma().QuotedString(prop_window_name);
     code.EndFunction();
@@ -184,7 +184,7 @@ bool SpinCtrlDoubleGenerator::SettingsCode(Code& code)
 {
     if (code.IntValue(prop_digits) > 0)
     {
-        code.NodeName().Function("SetDigits(").Str(prop_digits).EndFunction();
+        code.NodeName().Function("SetDigits(").as_string(prop_digits).EndFunction();
     }
 
     return true;

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -148,7 +148,7 @@ bool StaticCheckboxBoxSizerGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.NodeName().CreateClass(false, "wxStaticBoxSizer").Str(prop_orientation).Comma().Str(parent_name);
+        code.NodeName().CreateClass(false, "wxStaticBoxSizer").as_string(prop_orientation).Comma().Str(parent_name);
         if (code.hasValue(prop_label))
         {
             code.Comma().QuotedString(prop_label);
@@ -173,7 +173,7 @@ bool StaticCheckboxBoxSizerGenerator::SettingsCode(Code& code)
 
     if (code.hasValue(prop_tooltip) && code.is_cpp())
     {
-        code.Eol(eol_if_needed).Str(prop_checkbox_var_name).Function("SetToolTip(");
+        code.Eol(eol_if_needed).as_string(prop_checkbox_var_name).Function("SetToolTip(");
         code.QuotedString(prop_tooltip).EndFunction();
     }
 

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -131,7 +131,7 @@ bool StaticRadioBtnBoxSizerGenerator::ConstructionCode(Code& code)
             code.as_string(prop_radiobtn_var_name) << "),";
             code.Eol().Str("#else").Eol().Tab().Str("wxEmptyString),");
             code.Eol().Str("#endif").Eol();
-            code.Str(prop_orientation).EndFunction();
+            code.as_string(prop_orientation).EndFunction();
         }
         else
         {
@@ -140,7 +140,7 @@ bool StaticRadioBtnBoxSizerGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.NodeName().CreateClass(false, "wxStaticBoxSizer").Str(prop_orientation).Comma().Str(parent_name);
+        code.NodeName().CreateClass(false, "wxStaticBoxSizer").as_string(prop_orientation).Comma().Str(parent_name);
         if (code.hasValue(prop_label))
         {
             code.Comma().QuotedString(prop_label);

--- a/src/generate/gen_text_sizer.cpp
+++ b/src/generate/gen_text_sizer.cpp
@@ -39,7 +39,7 @@ bool TextSizerGenerator::ConstructionCode(Code& code)
         code << " = wxTextSizerWrapper(" << parent->getNodeName() << ").CreateSizer(";
     }
 
-    code.QuotedString(prop_text).Comma().Str(prop_width).EndFunction();
+    code.QuotedString(prop_text).Comma().as_string(prop_width).EndFunction();
 
     return true;
 }

--- a/src/generate/gen_toggle_btn.cpp
+++ b/src/generate/gen_toggle_btn.cpp
@@ -128,7 +128,7 @@ bool ToggleButtonGenerator::SettingsCode(Code& code)
     {
         if (code.hasValue(prop_position))
         {
-            code.Eol(eol_if_needed).NodeName().Function("SetBitmapPosition(").Str(prop_position).EndFunction();
+            code.Eol(eol_if_needed).NodeName().Function("SetBitmapPosition(").as_string(prop_position).EndFunction();
         }
 
         if (code.hasValue(prop_margins))

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -106,7 +106,7 @@ bool ToolBarFormGenerator::ConstructionCode(Code& code)
     // Note: Form construction is called before any indentation is set
     if (code.is_cpp())
     {
-        code.Str((prop_class_name)).Str("::").Str(prop_class_name);
+        code.as_string(prop_class_name).Str("::").as_string(prop_class_name);
         code += "(wxWindow* parent, wxWindowID id";
         code.Comma().Str("const wxPoint& pos").Comma().Str("const wxSize& size");
         code.Comma().Str("long style").Comma().Str("const wxString& name)");
@@ -239,7 +239,7 @@ bool ToolBarFormGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {
@@ -428,17 +428,17 @@ bool ToolBarGenerator::SettingsCode(Code& code)
 {
     if (code.node()->as_int(prop_separation) != 5)
     {
-        code.Eol().NodeName().Function("SetToolSeparation(").Str(prop_separation).EndFunction();
+        code.Eol().NodeName().Function("SetToolSeparation(").as_string(prop_separation).EndFunction();
     }
 
     if (code.hasValue(prop_margins))
     {
-        code.Eol().NodeName().Function("SetMargins(").Str(prop_margins).EndFunction();
+        code.Eol().NodeName().Function("SetMargins(").as_string(prop_margins).EndFunction();
     }
 
     if (code.node()->as_int(prop_packing) != 1)
     {
-        code.Eol().NodeName().Function("SetToolPacking(").Str(prop_packing).EndFunction();
+        code.Eol().NodeName().Function("SetToolPacking(").as_string(prop_packing).EndFunction();
     }
 
     return true;
@@ -780,7 +780,7 @@ bool ToolStretchableGenerator::ConstructionCode(Code& code)
         code.ParentName().Function("AddStretchSpacer(");
         if (code.IntValue(prop_proportion) != 1)
         {
-            code.Str(prop_proportion);
+            code.as_string(prop_proportion);
         }
         code.EndFunction();
     }

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -29,7 +29,7 @@ bool WizardFormGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.Str((prop_class_name)).Str("::").Str(prop_class_name);
+        code.as_string(prop_class_name).Str("::").as_string(prop_class_name);
         code += "(wxWindow* parent, wxWindowID id, const wxString& title";
         code.Comma().Str("const wxPoint& pos").Comma().Str("long style)");
         code.Str(" : wxWizard()").Eol() += "{";
@@ -73,15 +73,15 @@ bool WizardFormGenerator::SettingsCode(Code& code)
 
     if (!code.isPropValue(prop_border, 5))
     {
-        code.Eol(eol_if_needed).FormFunction("SetBorder(").Str(prop_border).EndFunction();
+        code.Eol(eol_if_needed).FormFunction("SetBorder(").as_string(prop_border).EndFunction();
     }
 
     if (code.IntValue(prop_bmp_placement))
     {
-        code.Eol(eol_if_needed).FormFunction("SetBitmapPlacement(").Str(prop_bmp_placement).EndFunction();
+        code.Eol(eol_if_needed).FormFunction("SetBitmapPlacement(").as_string(prop_bmp_placement).EndFunction();
         if (code.IntValue(prop_bmp_min_width) > 0)
         {
-            code.Eol().FormFunction("SetBitmapMinWidth(").Str(prop_bmp_min_width).EndFunction();
+            code.Eol().FormFunction("SetBitmapMinWidth(").as_string(prop_bmp_min_width).EndFunction();
         }
         if (code.hasValue(prop_bmp_background_colour))
         {
@@ -191,7 +191,7 @@ bool WizardFormGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {
@@ -203,7 +203,7 @@ bool WizardFormGenerator::HeaderCode(Code& code)
 {
     auto* node = code.node();
 
-    code.Str(prop_class_name).Str("(wxWindow* parent, wxWindowID id = ").Str(prop_id);
+    code.as_string(prop_class_name).Str("(wxWindow* parent, wxWindowID id = ").as_string(prop_id);
     code.Comma().Str("const wxString& title = ");
     auto& title = node->as_string(prop_title);
     if (code.hasValue(prop_title))
@@ -403,12 +403,12 @@ bool WizardPageGenerator::ConstructionCode(Code& code)
 {
     if (!code.hasValue(prop_bitmap))
     {
-        code.AddAuto().Str(prop_var_name).CreateClass().Str(code.is_cpp() ? "this" : "self").EndFunction();
+        code.AddAuto().as_string(prop_var_name).CreateClass().Str(code.is_cpp() ? "this" : "self").EndFunction();
     }
     else
     {
         auto is_bitmaps_list = BitmapList(code, prop_bitmap);
-        code.AddAuto().Str(prop_var_name).CreateClass().Str(code.is_cpp() ? "this" : "self");
+        code.AddAuto().as_string(prop_var_name).CreateClass().Str(code.is_cpp() ? "this" : "self");
         if (code.is_cpp())
         {
             code.Comma().Str("nullptr, nullptr").Comma();

--- a/src/generate/gen_wrap_sizer.cpp
+++ b/src/generate/gen_wrap_sizer.cpp
@@ -40,7 +40,7 @@ bool WrapSizerGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().as_string(prop_orientation).Comma();
     if (code.hasValue(prop_wrap_flags))
-        code.Str(prop_wrap_flags);
+        code.as_string(prop_wrap_flags);
     else
         code += "0";
     code.EndFunction();

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -245,7 +245,7 @@ bool MenuBarFormGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.Str((prop_class_name)).Str("::").Str(prop_class_name);
+        code.as_string(prop_class_name).Str("::").as_string(prop_class_name);
         code.Str("(long style) : wxMenuBar(style)\n{");
     }
     else
@@ -272,7 +272,7 @@ bool MenuBarFormGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {
@@ -321,7 +321,7 @@ bool PopupMenuGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.Str((prop_class_name)).Str("::").Str(prop_class_name);
+        code.as_string(prop_class_name).Str("::").as_string(prop_class_name);
         code.Str("() : wxMenu()\n{");
     }
     else
@@ -348,7 +348,7 @@ bool PopupMenuGenerator::BaseClassNameCode(Code& code)
 {
     if (code.hasValue(prop_derived_class))
     {
-        code.Str((prop_derived_class));
+        code.as_string(prop_derived_class);
     }
     else
     {

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -499,7 +499,7 @@ bool StyledTextGenerator::SettingsCode(Code& code)
 
     if (code.hasValue(prop_stc_lexer) && !code.isPropValue(prop_stc_lexer, "NULL"))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetLexer(").Add("wxSTC_LEX_").Str(prop_stc_lexer).EndFunction();
+        code.Eol(eol_if_needed).NodeName().Function("SetLexer(").Add("wxSTC_LEX_").as_string(prop_stc_lexer).EndFunction();
     }
 
     // Default is false, so only set if true
@@ -566,7 +566,11 @@ bool StyledTextGenerator::SettingsCode(Code& code)
 
     if (code.hasValue(prop_stc_wrap_start_indent))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetWrapStartIndent(").Str(prop_stc_wrap_start_indent).EndFunction();
+        code.Eol(eol_if_needed)
+            .NodeName()
+            .Function("SetWrapStartIndent(")
+            .as_string(prop_stc_wrap_start_indent)
+            .EndFunction();
     }
 
     //////////// Selection category settings ////////////
@@ -608,7 +612,11 @@ bool StyledTextGenerator::SettingsCode(Code& code)
         }
         else
         {
-            code.Eol(eol_if_needed).NodeName().Function("SetMarginLeft(").Str(prop_stc_left_margin_width).EndFunction();
+            code.Eol(eol_if_needed)
+                .NodeName()
+                .Function("SetMarginLeft(")
+                .as_string(prop_stc_left_margin_width)
+                .EndFunction();
         }
     }
 
@@ -627,7 +635,7 @@ bool StyledTextGenerator::SettingsCode(Code& code)
         }
         else
         {
-            code.Str(prop_stc_right_margin_width).EndFunction();
+            code.as_string(prop_stc_right_margin_width).EndFunction();
         }
     }
 
@@ -838,7 +846,7 @@ bool StyledTextGenerator::SettingsCode(Code& code)
             margin = "0";
 
         code.Eol().NodeName().Function("SetMarginWidth(").Add(margin);
-        code.Comma().Str(prop_separator_width).EndFunction();
+        code.Comma().as_string(prop_separator_width).EndFunction();
         code.Eol().NodeName().Function("SetMarginType(").Str(margin).Comma().Add("wxSTC_MARGIN_FORE").EndFunction();
     }
 
@@ -848,7 +856,7 @@ bool StyledTextGenerator::SettingsCode(Code& code)
         if (margin.is_sameas("none"))
             margin = "0";
 
-        code.Eol().NodeName().Function("SetMarginWidth(").Str(margin).Comma().Str(prop_custom_width).EndFunction();
+        code.Eol().NodeName().Function("SetMarginWidth(").Str(margin).Comma().as_string(prop_custom_width).EndFunction();
         code.Eol().NodeName().Function("SetMarginType(").Str(margin);
         code.Comma().AddConstant(prop_custom_type, "stc_").EndFunction();
 
@@ -895,7 +903,7 @@ bool StyledTextGenerator::SettingsCode(Code& code)
 
         if (code.IntValue(prop_tab_width) != 8)
         {
-            code.Eol().NodeName().Function("SetTabWidth(").Str(prop_tab_width).EndFunction();
+            code.Eol().NodeName().Function("SetTabWidth(").as_string(prop_tab_width).EndFunction();
         }
     }
 

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -49,7 +49,7 @@ bool ScrolledCanvasGenerator::SettingsCode(Code& code)
     if (code.hasValue(prop_scroll_rate_x) || code.hasValue(prop_scroll_rate_y))
     {
         code.Eol(eol_if_needed).NodeName().Function("SetScrollRate(");
-        code.Str(prop_scroll_rate_x).Comma().Str(prop_scroll_rate_y).EndFunction();
+        code.as_string(prop_scroll_rate_x).Comma().as_string(prop_scroll_rate_y).EndFunction();
     }
 
     return true;
@@ -98,7 +98,7 @@ bool ScrolledWindowGenerator::SettingsCode(Code& code)
     if (code.hasValue(prop_scroll_rate_x) || code.hasValue(prop_scroll_rate_y))
     {
         code.Eol(eol_if_needed).NodeName().Function("SetScrollRate(");
-        code.Str(prop_scroll_rate_x).Comma().Str(prop_scroll_rate_y).EndFunction();
+        code.as_string(prop_scroll_rate_x).Comma().as_string(prop_scroll_rate_y).EndFunction();
     }
 
     return true;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors the Code class to provide better handling of multiple languages. Most of this revolves around using a single `GetLanguagePrefix()` function for converting all wx prefixes into the prefix required for the language.

`Str(GenEnum::PropName prop_name)` was removed -- it gave the impression that it worked the same as `Str(std::string_view str)` which only does a line length check before writing the string. In fact, `Str(GenEnum::PropName prop_name)` called `as_string()` and that _can_ modify the string based on the current language since it will special-case prop_id, and otherwise calls Add().
