### PR TITLE
Languages

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -426,6 +426,14 @@ Code& Code::AddAuto()
     {
         *this += "auto* ";
     }
+    else if (is_perl())
+    {
+        *this += "my ";
+    }
+    else if (is_rust())
+    {
+        *this += "let ";
+    }
     return *this;
 }
 
@@ -561,11 +569,11 @@ Code& Code::AddConstant(GenEnum::PropName prop_name, tt_string_view short_name)
 
 Code& Code::Function(tt_string_view text)
 {
-    if (is_cpp())
+    if (is_cpp() || is_perl())
     {
         *this << "->" << text;
     }
-    else if (is_python() || is_ruby() || is_rust())
+    else if (is_golang() || is_lua() || is_python() || is_ruby() || is_rust())
     {
         *this << '.';
         if (text.is_sameprefix("wx"))
@@ -619,6 +627,10 @@ Code& Code::FormFunction(tt_string_view text)
     {
         *this += "self.";
     }
+    else if (is_golang())
+    {
+        *this += "f.";
+    }
     else if (is_ruby())
     {
         *this += ConvertToSnakeCase(text);
@@ -662,7 +674,10 @@ Code& Code::Class(tt_string_view text)
 
 Code& Code::CreateClass(bool use_generic, tt_string_view override_name)
 {
-    *this += " = ";
+    if (is_golang())
+        *this += " := ";
+    else
+        *this += " = ";
     if (is_cpp())
     {
         *this += "new ";
@@ -781,6 +796,10 @@ Code& Code::NodeName(Node* node)
     if (is_python() && !node->isForm() && !node->isLocal())
     {
         *this += "self.";
+    }
+    else if (is_perl())
+    {
+        *this += "$";
     }
     else if (is_ruby())
     {

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -172,7 +172,9 @@ public:
 
     Code& CloseBrace();
 
-    // If C++ and node is a local variable, will add "auto* " -- otherwise, it does nothing.
+    // If C++ and node is a local variable, will add "auto* "
+    // If Perl, it will add "my "
+    // If Rust, it will add "let "
     Code& AddAuto();
 
     void EnableAutoLineBreak(bool auto_break = true) { m_auto_break = auto_break; }

--- a/src/generate/gen_activity.cpp
+++ b/src/generate/gen_activity.cpp
@@ -32,9 +32,7 @@ wxObject* ActivityIndicatorGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool ActivityIndicatorGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -59,9 +59,7 @@ wxObject* AnimationGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool AnimationGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().CheckLineLength();
     // TODO: [Randalphwa - 12-08-2022] Enable Python support once image handling is worked out
     if (code.hasValue(prop_animation))

--- a/src/generate/gen_aui_notebook.cpp
+++ b/src/generate/gen_aui_notebook.cpp
@@ -48,9 +48,7 @@ void AuiNotebookGenerator::OnPageChanged(wxNotebookEvent& event)
 
 bool AuiNotebookGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
     BookCtorAddImagelist(code);
 

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -396,9 +396,7 @@ void AuiToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent
 
 bool AuiToolBarGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(false, "wxAUI_TB_DEFAULT_STYLE");
 

--- a/src/generate/gen_bitmap_combo.cpp
+++ b/src/generate/gen_bitmap_combo.cpp
@@ -67,8 +67,6 @@ bool BitmapComboBoxGenerator::OnPropertyChange(wxObject* widget, Node* node, Nod
 
 bool BitmapComboBoxGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     if (code.hasValue(prop_style))

--- a/src/generate/gen_book_page.cpp
+++ b/src/generate/gen_book_page.cpp
@@ -194,9 +194,7 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool BookPageGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
 
     Node* node = code.node();
     if (node->getParent()->isGen(gen_BookPage))

--- a/src/generate/gen_button.cpp
+++ b/src/generate/gen_button.cpp
@@ -144,9 +144,7 @@ bool ButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePropert
 
 bool ButtonGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma();
 
     // If prop_markup is set, then the label will be set in SettingsCode()

--- a/src/generate/gen_calendar_ctrl.cpp
+++ b/src/generate/gen_calendar_ctrl.cpp
@@ -31,9 +31,7 @@ wxObject* CalendarCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool CalendarCtrlGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma();
     if (code.is_ruby())
     {

--- a/src/generate/gen_check_listbox.cpp
+++ b/src/generate/gen_check_listbox.cpp
@@ -53,9 +53,7 @@ wxObject* CheckListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool CheckListBoxGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     auto params_needed = code.WhatParamsNeeded();
     if (params_needed != nothing_needed || !code.IsEqualTo(prop_type, "wxLB_SINGLE"))

--- a/src/generate/gen_checkbox.cpp
+++ b/src/generate/gen_checkbox.cpp
@@ -50,9 +50,7 @@ bool CheckBoxGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePrope
 
 bool CheckBoxGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true);
 
@@ -148,9 +146,7 @@ bool Check3StateGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePr
 
 bool Check3StateGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass(false, "wxCheckBox");
+    code.AddAuto().NodeName().CreateClass(false, "wxCheckBox");
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeForceStyle("wxCHK_3STATE");
 

--- a/src/generate/gen_choice.cpp
+++ b/src/generate/gen_choice.cpp
@@ -64,9 +64,7 @@ bool ChoiceGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePropert
 
 bool ChoiceGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     if (code.hasValue(prop_style))
     {

--- a/src/generate/gen_choicebook.cpp
+++ b/src/generate/gen_choicebook.cpp
@@ -35,9 +35,7 @@ void ChoicebookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 
 bool ChoicebookGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false, "wxCHB_DEFAULT");
 
     return true;

--- a/src/generate/gen_close_btn.cpp
+++ b/src/generate/gen_close_btn.cpp
@@ -28,9 +28,7 @@ wxObject* CloseButtonGenerator::CreateMockup(Node* /* node */, wxObject* parent)
 
 bool CloseButtonGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().Add(" = ").Add("wxBitmapButton") << (code.is_cpp() ? "::" : ".");
+    code.AddAuto().NodeName().Add(" = ").Add("wxBitmapButton") << (code.is_cpp() ? "::" : ".");
     code.Add("NewCloseButton(").ValidParentName().Comma().as_string(prop_id);
     if (code.hasValue(prop_window_name))
         code.Comma().QuotedString(prop_window_name);

--- a/src/generate/gen_clr_picker.cpp
+++ b/src/generate/gen_clr_picker.cpp
@@ -28,9 +28,7 @@ wxObject* ColourPickerGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool ColourPickerGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma();
     if (code.node()->as_string(prop_colour).size())
         ColourCode(code, prop_colour);

--- a/src/generate/gen_cmd_link_btn.cpp
+++ b/src/generate/gen_cmd_link_btn.cpp
@@ -62,9 +62,7 @@ wxObject* CommandLinkBtnGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool CommandLinkBtnGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_main_label);
     code.Comma().QuotedString(prop_note).PosSizeFlags(true);
 

--- a/src/generate/gen_collapsible.cpp
+++ b/src/generate/gen_collapsible.cpp
@@ -56,9 +56,7 @@ void CollapsiblePaneGenerator::OnCollapse(wxCollapsiblePaneEvent& event)
 
 bool CollapsiblePaneGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true, "wxCP_DEFAULT_STYLE");
 

--- a/src/generate/gen_combobox.cpp
+++ b/src/generate/gen_combobox.cpp
@@ -52,9 +52,7 @@ wxObject* ComboBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool ComboBoxGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     if (code.hasValue(prop_style))
     {

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1160,9 +1160,11 @@ void GenToolCode(Code& code, const bool is_bitmaps_list)
     code.Eol(eol_if_needed);
     if (node->as_bool(prop_disabled) || (node->as_string(prop_id) == "wxID_ANY" && node->getInUseEventCount()))
     {
-        if (node->isLocal() && code.is_cpp())
-            code << "auto* ";
-        code.NodeName() << " = ";
+        code.AddAuto().NodeName();
+        if (code.is_golang())
+            code += " := ";
+        else
+            code += " = ";
     }
 
     if ((node->isLocal() && node->isGen(gen_tool_dropdown)) ||

--- a/src/generate/gen_dir_picker.cpp
+++ b/src/generate/gen_dir_picker.cpp
@@ -37,9 +37,7 @@ wxObject* DirPickerGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool DirPickerGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma();
 
     if (auto& path = code.node()->as_string(prop_initial_path); path.size())

--- a/src/generate/gen_edit_listbox.cpp
+++ b/src/generate/gen_edit_listbox.cpp
@@ -34,9 +34,7 @@ wxObject* EditListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool EditListBoxGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_file_ctrl.cpp
+++ b/src/generate/gen_file_ctrl.cpp
@@ -42,9 +42,7 @@ wxObject* FileCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool FileCtrlGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     code.Comma().QuotedString(prop_initial_folder).Comma().QuotedString(prop_initial_filename);
     code.Comma();

--- a/src/generate/gen_file_picker.cpp
+++ b/src/generate/gen_file_picker.cpp
@@ -47,9 +47,7 @@ wxObject* FilePickerGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool FilePickerGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma();
 
     if (auto& path = code.node()->as_string(prop_initial_path); path.size())

--- a/src/generate/gen_flexgrid_sizer.cpp
+++ b/src/generate/gen_flexgrid_sizer.cpp
@@ -62,9 +62,7 @@ wxObject* FlexGridSizerGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool FlexGridSizerGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
 
     Node* node = code.node();
 

--- a/src/generate/gen_gauge.cpp
+++ b/src/generate/gen_gauge.cpp
@@ -40,9 +40,7 @@ bool GaugeGenerator::OnPropertyChange(wxObject* widget, Node* /* node */, NodePr
 
 bool GaugeGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().as_string(prop_range);
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_html_window.cpp
+++ b/src/generate/gen_html_window.cpp
@@ -57,9 +57,7 @@ wxObject* HtmlWindowGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool HtmlWindowGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true, "wxHW_SCROLLBAR_AUTO");
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/generate/gen_hyperlink.cpp
+++ b/src/generate/gen_hyperlink.cpp
@@ -61,9 +61,7 @@ wxObject* HyperlinkGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool HyperlinkGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     if (code.is_cpp() && !code.IsTrue(prop_underlined))
         code.Replace("wxHyperlinkCtrl", "wxGenericHyperlinkCtrl");
 

--- a/src/generate/gen_infobar.cpp
+++ b/src/generate/gen_infobar.cpp
@@ -38,9 +38,7 @@ wxObject* InfoBarGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool InfoBarGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName();
     if (code.node()->as_string(prop_id) != "wxID_ANY")
         code.Comma().as_string(prop_id);

--- a/src/generate/gen_listbook.cpp
+++ b/src/generate/gen_listbook.cpp
@@ -41,9 +41,7 @@ void ListbookGenerator::OnPageChanged(wxListbookEvent& event)
 
 bool ListbookGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false, "wxBK_DEFAULT");
     BookCtorAddImagelist(code);
 

--- a/src/generate/gen_listbox.cpp
+++ b/src/generate/gen_listbox.cpp
@@ -45,9 +45,7 @@ wxObject* ListBoxGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool ListBoxGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     auto params_needed = code.WhatParamsNeeded();
     if (params_needed != nothing_needed || !code.IsEqualTo(prop_type, "wxLB_SINGLE"))

--- a/src/generate/gen_notebook.cpp
+++ b/src/generate/gen_notebook.cpp
@@ -40,9 +40,7 @@ void NotebookGenerator::OnPageChanged(wxNotebookEvent& event)
 
 bool NotebookGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
     BookCtorAddImagelist(code);
 

--- a/src/generate/gen_radio_box.cpp
+++ b/src/generate/gen_radio_box.cpp
@@ -80,9 +80,7 @@ bool RadioBoxGenerator::ConstructionCode(Code& code)
     }
 
     code.Str((code.is_cpp() ? "// " : "# ")).Str("Trailing spaces added to avoid clipping").Eol();
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.Comma().Pos().Comma().WxSize().Comma();
     if (code.is_cpp())

--- a/src/generate/gen_radio_btn.cpp
+++ b/src/generate/gen_radio_btn.cpp
@@ -48,9 +48,7 @@ bool RadioButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePr
 
 bool RadioButtonGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -51,9 +51,7 @@ wxObject* RearrangeCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool RearrangeCtrlGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     code.Comma().Pos().Comma().WxSize();
     code.Comma();

--- a/src/generate/gen_rich_text.cpp
+++ b/src/generate/gen_rich_text.cpp
@@ -31,9 +31,7 @@ wxObject* RichTextCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool RichTextCtrlGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_value);
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_search_ctrl.cpp
+++ b/src/generate/gen_search_ctrl.cpp
@@ -40,9 +40,7 @@ wxObject* SearchCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool SearchCtrlGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_value);
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_simplebook.cpp
+++ b/src/generate/gen_simplebook.cpp
@@ -44,9 +44,7 @@ void SimplebookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 
 bool SimplebookGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
 
     return true;

--- a/src/generate/gen_slider.cpp
+++ b/src/generate/gen_slider.cpp
@@ -57,9 +57,7 @@ bool SliderGenerator::OnPropertyChange(wxObject* widget, Node* /* node */, NodeP
 
 bool SliderGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma();
     code.as_string(prop_position).Comma().as_string(prop_minValue).Comma().as_string(prop_maxValue);
     code.PosSizeFlags(true);

--- a/src/generate/gen_spin_btn.cpp
+++ b/src/generate/gen_spin_btn.cpp
@@ -35,9 +35,7 @@ wxObject* SpinButtonGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool SpinButtonGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
+    code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(false, "wxSP_VERTICAL");
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's

--- a/src/generate/gen_split_win.cpp
+++ b/src/generate/gen_split_win.cpp
@@ -162,9 +162,7 @@ void SplitterWindowGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpa
 
 bool SplitterWindowGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 

--- a/src/generate/gen_static_line.cpp
+++ b/src/generate/gen_static_line.cpp
@@ -28,9 +28,7 @@ wxObject* StaticLineGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool StaticLineGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName();
     if (!code.IsEqualTo(prop_id, "wxID_ANY") || code.hasValue(prop_pos) || code.hasValue(prop_size) ||
         code.hasValue(prop_window_name) || code.PropContains(prop_style, "wxLI_VERTICAL"))

--- a/src/generate/gen_status_bar.cpp
+++ b/src/generate/gen_status_bar.cpp
@@ -86,10 +86,7 @@ bool StatusBarGenerator::ConstructionCode(Code& code)
     else
         num_fields = node->as_int(prop_fields);
 
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-
-    code.NodeName().Str(" = ").FormFunction("CreateStatusBar(");
+    code.AddAuto().NodeName().Str(" = ").FormFunction("CreateStatusBar(");
     if (node->hasValue(prop_window_name))
     {
         code.itoa(num_fields).Comma().as_string(prop_id).Comma().Style();

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -101,9 +101,7 @@ bool TextCtrlGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePrope
 
 bool TextCtrlGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().CheckLineLength();
     code.QuotedString(prop_value);
     code.PosSizeFlags(true);

--- a/src/generate/gen_time_picker.cpp
+++ b/src/generate/gen_time_picker.cpp
@@ -28,9 +28,7 @@ wxObject* TimePickerCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool TimePickerCtrlGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().Add("wxDefaultDateTime");
     code.PosSizeFlags(true, "wxTP_DEFAULT");
 

--- a/src/generate/gen_toggle_btn.cpp
+++ b/src/generate/gen_toggle_btn.cpp
@@ -92,9 +92,7 @@ bool ToggleButtonGenerator::OnPropertyChange(wxObject* widget, Node* node, NodeP
 
 bool ToggleButtonGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma();
 
     // If prop_markup is set, then the label will be set in SettingsCode()

--- a/src/generate/gen_toolbook.cpp
+++ b/src/generate/gen_toolbook.cpp
@@ -48,9 +48,7 @@ void ToolbookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 
 bool ToolbookGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
 
     BookCtorAddImagelist(code);

--- a/src/generate/gen_treebook.cpp
+++ b/src/generate/gen_treebook.cpp
@@ -39,9 +39,7 @@ void TreebookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 
 bool TreebookGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
     BookCtorAddImagelist(code);
 

--- a/src/generate/gen_web_view.cpp
+++ b/src/generate/gen_web_view.cpp
@@ -32,9 +32,7 @@ wxObject* WebViewGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool WebViewGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().Str(" = ").Add("wxWebView").ClassMethod("New(");
+    code.AddAuto().NodeName().Str(" = ").Add("wxWebView").ClassMethod("New(");
     code.ValidParentName().Comma().Add(prop_id).Comma().QuotedString(prop_url);
 
     auto params_needed = code.WhatParamsNeeded();

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -188,9 +188,7 @@ wxMenu* MenuBarBase::MakeSubMenu(Node* menu_node)
 
 bool MenuBarGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     if (code.hasValue(prop_style))
     {
         code.Add(code.node()->as_string(prop_style));

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -476,9 +476,7 @@ wxObject* StyledTextGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool StyledTextGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_cpp() && code.is_local_var())
-        code << "auto* ";
-    code.NodeName().CreateClass();
+    code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(true);
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
C++ isn't the only language that needs to insert code before a variable assignment ("auto* " in the case of C++. This PR changes the generators to call Code::AddAuto() instead of hard-coding the C++ code. This ensures the generators work with all languages at least as far as variable assignments are concerned.