### PR TITLE
Output file

### DIFF
--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -546,6 +546,15 @@ namespace GenEnum
             return prop_unknown;
     }
 
+    // Given a prop_ name, this will return the actual string used in the XRC file.
+    inline std::optional<tt_string_view> GetPropStringName(PropName prop_name)
+    {
+        if (auto result = map_PropNames.find(prop_name); result != map_PropNames.end())
+            return result->second;
+        else
+            return {};
+    }
+
     enum GenType : size_t
     {
 

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -525,6 +525,21 @@ bool BaseGenerator::VerifyProperty(NodeProperty* prop)
     return result;
 }
 
+static const std::set<GenEnum::PropName> set_output_files = {
+    prop_base_file,
+    prop_python_file,
+    prop_ruby_file,
+    prop_xrc_file,
+
+    // experimental
+
+    prop_golang_file,
+    prop_lua_file,
+    prop_perl_file,
+    prop_rust_file,
+
+};
+
 std::optional<tt_string> BaseGenerator::GetHint(NodeProperty* prop)
 {
     if (prop->isProp(prop_derived_class_name) && !prop->hasValue())
@@ -540,7 +555,7 @@ std::optional<tt_string> BaseGenerator::GetHint(NodeProperty* prop)
     {
         return tt_string(!prop->getNode()->as_bool(prop_use_derived_class) ? "requires python_use_xrc" : "");
     }
-    else if (prop->isProp(prop_base_file) && !prop->hasValue())
+    else if (set_output_files.contains(prop->getPropDeclaration()->get_name()) && !prop->hasValue())
     {
         return tt_string("change class_name to auto-fill");
     }

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -67,8 +67,11 @@ protected:
                        bool is_child_cat = false);
 
     void ReplaceDerivedName(const tt_string& formName, NodeProperty* propType);
-    void ReplaceBaseFile(const tt_string& formName, NodeProperty* propType);
     void ReplaceDerivedFile(const tt_string& formName, NodeProperty* propType);
+
+    // Called when the class_name for a form changes. If the preferred code language output
+    // file is empty, then create a suggested file name based on the class name.
+    void CheckOutputFile(const tt_string& formName, Node* node);
 
     wxPGProperty* CreatePGProperty(NodeProperty* prop);
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -56,6 +56,10 @@ bool isConvertibleMime(const tt_string& suffix);
 // Checks whether a string is a valid C++ variable name.
 bool isValidVarName(const std::string& str);
 
+// This takes the class_name of the form, converts it to lowercase, and if the class name
+// ends with Base, the a "_base" suffix is added.
+//
+// This does *not* check to see if the file already exists.
 tt_string CreateBaseFilename(Node* form_node, const tt_string& class_name);
 
 tt_string CreateDerivedFilename(Node* form_node, const tt_string& class_name);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the way empty output filenames are modified when the class name is changed. Instead of only changing the C++ prop_base_file, this changes the output file for whatever the preferred code language is. It also sets the "change class_name to auto-fill" hint for all language output files.

One of the reasons for this change is because the Event handler dialog box uses output filenames to determine which event tabs to display. If the C++ prop_base_file is set even if Python or Ruby are the preferred code languages, then you still see the C++ event tab.
