### PR TITLE
Change Mockup for unsupported language controls

### DIFF
--- a/src/generate/gen_banner_window.cpp
+++ b/src/generate/gen_banner_window.cpp
@@ -1,24 +1,33 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   wxBannerWindow generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
 #include <wx/bannerwindow.h>  // wxBannerWindow class declaration
+#include <wx/stattext.h>      // wxStaticText base header
 
-#include "code.h"           // Code -- Helper class for generating code
-#include "gen_common.h"     // GeneratorLibrary -- Generator classes
-#include "gen_xrc_utils.h"  // Common XRC generating functions
-#include "node.h"           // Node class
-#include "pugixml.hpp"      // xml read/write/create/process
-#include "utils.h"          // Utility functions that work with properties
-#include "write_code.h"     // WriteCode -- Write code to Scintilla or file
+#include "code.h"             // Code -- Helper class for generating code
+#include "gen_common.h"       // GeneratorLibrary -- Generator classes
+#include "gen_xrc_utils.h"    // Common XRC generating functions
+#include "node.h"             // Node class
+#include "project_handler.h"  // ProjectHandler class
+#include "pugixml.hpp"        // xml read/write/create/process
+#include "utils.h"            // Utility functions that work with properties
+#include "write_code.h"       // WriteCode -- Write code to Scintilla or file
 
 #include "gen_banner_window.h"
 
 wxObject* BannerWindowGenerator::CreateMockup(Node* node, wxObject* parent)
 {
+    if (Project.getCodePreference() == GEN_LANG_RUBY)
+    {
+        auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, "wxBannerWindow not available in wxRuby3",
+                                        wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
+        widget->Wrap(DlgPoint(parent, 150));
+        return widget;
+    }
     auto widget = new wxBannerWindow(wxStaticCast(parent, wxWindow),
                                      (wxDirection) NodeCreation.getConstantAsInt(node->as_string(prop_direction)));
 

--- a/src/generate/gen_infobar.cpp
+++ b/src/generate/gen_infobar.cpp
@@ -1,23 +1,32 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   wxInfoBar generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include <wx/infobar.h>  // declaration of wxInfoBarBase defining common API of wxInfoBar
-#include <wx/timer.h>    // wxTimer, wxStopWatch and global time-related functions
+#include <wx/infobar.h>   // declaration of wxInfoBarBase defining common API of wxInfoBar
+#include <wx/stattext.h>  // wxStaticText base header
+#include <wx/timer.h>     // wxTimer, wxStopWatch and global time-related functions
 
-#include "gen_common.h"     // GeneratorLibrary -- Generator classes
-#include "gen_xrc_utils.h"  // Common XRC generating functions
-#include "node.h"           // Node class
-#include "pugixml.hpp"      // xml read/write/create/process
-#include "utils.h"          // Utility functions that work with properties
+#include "gen_common.h"       // GeneratorLibrary -- Generator classes
+#include "gen_xrc_utils.h"    // Common XRC generating functions
+#include "node.h"             // Node class
+#include "project_handler.h"  // ProjectHandler class
+#include "pugixml.hpp"        // xml read/write/create/process
+#include "utils.h"            // Utility functions that work with properties
 
 #include "gen_infobar.h"
 
 wxObject* InfoBarGenerator::CreateMockup(Node* node, wxObject* parent)
 {
+    if (Project.getCodePreference() == GEN_LANG_RUBY)
+    {
+        auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, "wxInfoBar not available in wxRuby3",
+                                        wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
+        widget->Wrap(DlgPoint(parent, 150));
+        return widget;
+    }
     m_infobar = new wxInfoBar(wxStaticCast(parent, wxWindow));
 
     // Show the message before effects are added in case the show_effect has a delay (which would delay the display of

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -20,10 +20,15 @@
 
 wxObject* RearrangeCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    if (Project.getCodePreference() == GEN_LANG_RUBY)
+    if (Project.getCodePreference() == GEN_LANG_RUBY || Project.getCodePreference() == GEN_LANG_XRC)
     {
-        auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, "wxRearrangeCtrl not available in wxRuby3",
-                                        wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
+        tt_string msg = "wxRearrangeCtrl not available in ";
+        if (Project.getCodePreference() == GEN_LANG_RUBY)
+            msg += "wxRuby3";
+        else
+            msg += "XRC";
+        auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, msg.make_wxString(), wxDefaultPosition,
+                                        wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
         widget->Wrap(DlgPoint(parent, 150));
         return widget;
     }

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -6,18 +6,27 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include <wx/rearrangectrl.h>  // various controls for rearranging the items interactively
+#include <wx/stattext.h>       // wxStaticText base header
 
-#include "gen_common.h"     // GeneratorLibrary -- Generator classes
-#include "gen_xrc_utils.h"  // Common XRC generating functions
-#include "node.h"           // Node class
-#include "pugixml.hpp"      // xml read/write/create/process
-#include "utils.h"          // Utility functions that work with properties
-#include "write_code.h"     // WriteCode -- Write code to Scintilla or file
+#include "gen_common.h"       // GeneratorLibrary -- Generator classes
+#include "gen_xrc_utils.h"    // Common XRC generating functions
+#include "node.h"             // Node class
+#include "project_handler.h"  // ProjectHandler class
+#include "pugixml.hpp"        // xml read/write/create/process
+#include "utils.h"            // Utility functions that work with properties
+#include "write_code.h"       // WriteCode -- Write code to Scintilla or file
 
 #include "gen_rearrange.h"
 
 wxObject* RearrangeCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 {
+    if (Project.getCodePreference() == GEN_LANG_RUBY)
+    {
+        auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, "wxRearrangeCtrl not available in wxRuby3",
+                                        wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
+        widget->Wrap(DlgPoint(parent, 150));
+        return widget;
+    }
     auto widget = new wxRearrangeCtrl(wxStaticCast(parent, wxWindow), wxID_ANY, DlgPoint(parent, node, prop_pos),
                                       DlgSize(parent, node, prop_size), wxArrayInt(), wxArrayString(),
                                       node->as_int(prop_type) | GetStyleInt(node));

--- a/src/generate/gen_spin_ctrl.cpp
+++ b/src/generate/gen_spin_ctrl.cpp
@@ -7,10 +7,12 @@
 
 #include <wx/propgrid/propgrid.h>  // wxPropertyGrid
 #include <wx/spinctrl.h>           // wxSpinCtrlBase class
+#include <wx/stattext.h>           // wxStaticText base header
 
-#include "gen_common.h"  // GeneratorLibrary -- Generator classes
-#include "node.h"        // Node class
-#include "utils.h"       // Utility functions that work with properties
+#include "gen_common.h"       // GeneratorLibrary -- Generator classes
+#include "node.h"             // Node class
+#include "project_handler.h"  // ProjectHandler class
+#include "utils.h"            // Utility functions that work with properties
 
 #include "gen_spin_ctrl.h"
 
@@ -143,6 +145,14 @@ bool SpinCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
 
 wxObject* SpinCtrlDoubleGenerator::CreateMockup(Node* node, wxObject* parent)
 {
+    if (Project.getCodePreference() == GEN_LANG_RUBY)
+    {
+        auto* widget =
+            new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, "wxSpinCtrlDouble not available in wxRuby3",
+                             wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
+        widget->Wrap(DlgPoint(parent, 150));
+        return widget;
+    }
     auto widget = new wxSpinCtrlDouble(wxStaticCast(parent, wxWindow), wxID_ANY, node->as_wxString(prop_value),
                                        DlgPoint(parent, node, prop_pos), DlgSize(parent, node, prop_size), GetStyleInt(node),
                                        node->as_double(prop_min), node->as_double(prop_max), node->as_double(prop_initial),

--- a/src/generate/gen_web_view.cpp
+++ b/src/generate/gen_web_view.cpp
@@ -5,7 +5,8 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include <wx/webview.h>  // Common interface and events for web view component
+#include <wx/stattext.h>  // wxStaticText base header
+#include <wx/webview.h>   // Common interface and events for web view component
 
 #include "code.h"             // Code -- Helper class for generating code
 #include "gen_common.h"       // GeneratorLibrary -- Generator classes
@@ -23,6 +24,13 @@
 
 wxObject* WebViewGenerator::CreateMockup(Node* node, wxObject* parent)
 {
+    if (Project.getCodePreference() == GEN_LANG_RUBY)
+    {
+        auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, "wxWebView not available in wxRuby3",
+                                        wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
+        widget->Wrap(DlgPoint(parent, 150));
+        return widget;
+    }
     auto widget = wxWebView::New(wxStaticCast(parent, wxWindow), wxID_ANY, node->as_wxString(prop_url),
                                  DlgPoint(parent, node, prop_pos), DlgSize(parent, node, prop_size), wxWebViewBackendDefault,
                                  GetStyleInt(node));

--- a/src/generate/gen_web_view.cpp
+++ b/src/generate/gen_web_view.cpp
@@ -24,10 +24,15 @@
 
 wxObject* WebViewGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    if (Project.getCodePreference() == GEN_LANG_RUBY)
+    if (Project.getCodePreference() == GEN_LANG_RUBY || Project.getCodePreference() == GEN_LANG_XRC)
     {
-        auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, "wxWebView not available in wxRuby3",
-                                        wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
+        tt_string msg = "wxWebView not available in ";
+        if (Project.getCodePreference() == GEN_LANG_RUBY)
+            msg += "wxRuby3";
+        else
+            msg += "XRC";
+        auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY, msg.make_wxString(), wxDefaultPosition,
+                                        wxDefaultSize, wxALIGN_CENTER_HORIZONTAL | wxBORDER_RAISED);
         widget->Wrap(DlgPoint(parent, 150));
         return widget;
     }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR modifies the generators that we know don't currently work in wxRuby3 (e.g., wxRearrangeCtrl). Instead of displaying the control, a static text box with a raised border is created, wrapped to 150 in dialog units, and displaying:

```
    wxRearrangeCtrl not available in wxRuby3"
```

with "wxRearrangeCtrl" replaced with the actual wxWidget class name in each case. Note that this will almost certainly mess up the appearance of the form, but it does make it very clear that the control is unavailable.

This replacement of the widget _only_ occurs if the preferred code language doesn't support it. That means that it is ultimately available for all code preferred languages.

I have _not_ tested this with controls that are likely to have children, such as wxPropertyGrid which is not supported in XRC.

Related to #1163