### PR TITLE
Color properties overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - controls that have one or more default window styles set (e.g., wxPanel has wxTAB_TRAVERSAL set) can now have that style unchecked and that state will be stored with the project file.
+- Color properties dialog now supports _all_ CSS color names
+- Generated code for colors now uses a CSS HTML String (#RRGGBB) instead of numerical values for red, green and blue.
 
 ### Fixed
 
 - You can now change the Window styles in a wxRichTextCtrl without generating an invalid constructor.
+- Color properties are correctly saved in a project
 
 ## [Released (1.1.2)]
 

--- a/src/custom_ctrls/kw_color_picker.cpp
+++ b/src/custom_ctrls/kw_color_picker.cpp
@@ -1,0 +1,328 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Modified version of wxColourPickerCtrl
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "kw_color_picker.h"
+
+// Contains all the colors from https://www.w3.org/TR/css-color-3/
+
+const std::map<std::string, std::string, std::less<>> kw_css_colors = {
+
+    { "aliceblue", "#F0F8FF" },
+    { "antiquewhite", "#FAEBD7" },
+    { "aqua", "#00FFFF" },
+    { "aquamarine", "#7FFFD4" },
+    { "azure", "#F0FFFF" },
+    { "beige", "#F5F5DC" },
+    { "bisque", "#FFE4C4" },
+    { "black", "#000000" },
+    { "blanchedalmond", "#FFEBCD" },
+    { "blue", "#0000FF" },
+    { "blueviolet", "#8A2BE2" },
+    { "brown", "#A52A2A" },
+    { "burlywood", "#DEB887" },
+    { "cadetblue", "#5F9EA0" },
+    { "chartreuse", "#7FFF00" },
+    { "chocolate", "#D2691E" },
+    { "coral", "#FF7F50" },
+    { "cornflowerblue", "#6495ED" },
+    { "cornsilk", "#FFF8DC" },
+    { "crimson", "#DC143C" },
+    { "cyan", "#00FFFF" },
+    { "darkblue", "#00008B" },
+    { "darkcyan", "#008B8B" },
+    { "darkgoldenrod", "#B8860B" },
+    { "darkgray", "#A9A9A9" },
+    { "darkgreen", "#006400" },
+    { "darkgrey", "#A9A9A9" },
+    { "darkkhaki", "#BDB76B" },
+    { "darkmagenta", "#8B008B" },
+    { "darkolivegreen", "#556B2F" },
+    { "darkorange", "#FF8C00" },
+    { "darkorchid", "#9932CC" },
+    { "darkred", "#8B0000" },
+    { "darksalmon", "#E9967A" },
+    { "darkseagreen", "#8FBC8F" },
+    { "darkslateblue", "#483D8B" },
+    { "darkslategray", "#2F4F4F" },
+    { "darkslategrey", "#2F4F4F" },
+    { "darkturquoise", "#00CED1" },
+    { "darkviolet", "#9400D3" },
+    { "deeppink", "#FF1493" },
+    { "deepskyblue", "#00BFFF" },
+    { "dimgray", "#696969" },
+    { "dimgrey", "#696969" },
+    { "dodgerblue", "#1E90FF" },
+    { "firebrick", "#B22222" },
+    { "floralwhite", "#FFFAF0" },
+    { "forestgreen", "#228B22" },
+    { "fuchsia", "#FF00FF" },
+    { "gainsboro", "#DCDCDC" },
+    { "ghostwhite", "#F8F8FF" },
+    { "gold", "#FFD700" },
+    { "goldenrod", "#DAA520" },
+    { "gray", "#808080" },
+    { "green", "#008000" },
+    { "greenyellow", "#ADFF2F" },
+    { "grey", "#808080" },
+    { "honeydew", "#F0FFF0" },
+    { "hotpink", "#FF69B4" },
+    { "indianred", "#CD5C5C" },
+    { "indigo", "#4B0082" },
+    { "ivory", "#FFFFF0" },
+    { "khaki", "#F0E68C" },
+    { "lavender", "#E6E6FA" },
+    { "lavenderblush", "#FFF0F5" },
+    { "lawngreen", "#7CFC00" },
+    { "lemonchiffon", "#FFFACD" },
+    { "lightblue", "#ADD8E6" },
+    { "lightcoral", "#F08080" },
+    { "lightcyan", "#E0FFFF" },
+    { "lightgoldenrodyellow", "#FAFAD2" },
+    { "lightgray", "#D3D3D3" },
+    { "lightgreen", "#90EE90" },
+    { "lightgrey", "#D3D3D3" },
+    { "lightpink", "#FFB6C1" },
+    { "lightsalmon", "#FFA07A" },
+    { "lightseagreen", "#20B2AA" },
+    { "lightskyblue", "#87CEFA" },
+    { "lightslategray", "#778899" },
+    { "lightslategrey", "#778899" },
+    { "lightsteelblue", "#B0C4DE" },
+    { "lightyellow", "#FFFFE0" },
+    { "lime", "#00FF00" },
+    { "limegreen", "#32CD32" },
+    { "linen", "#FAF0E6" },
+    { "magenta", "#FF00FF" },
+    { "maroon", "#800000" },
+    { "mediumaquamarine", "#66CDAA" },
+    { "mediumblue", "#0000CD" },
+    { "mediumorchid", "#BA55D3" },
+    { "mediumpurple", "#9370DB" },
+    { "mediumseagreen", "#3CB371" },
+    { "mediumslateblue", "#7B68EE" },
+    { "mediumspringgreen", "#00FA9A" },
+    { "mediumturquoise", "#48D1CC" },
+    { "mediumvioletred", "#C71585" },
+    { "midnightblue", "#191970" },
+    { "mintcream", "#F5FFFA" },
+    { "mistyrose", "#FFE4E1" },
+    { "moccasin", "#FFE4B5" },
+    { "navajowhite", "#FFDEAD" },
+    { "navy", "#000080" },
+    { "oldlace", "#FDF5E6" },
+    { "olive", "#808000" },
+    { "olivedrab", "#6B8E23" },
+    { "orange", "#FFA500" },
+    { "orangered", "#FF4500" },
+    { "orchid", "#DA70D6" },
+    { "palegoldenrod", "#EEE8AA" },
+    { "palegreen", "#98FB98" },
+    { "paleturquoise", "#AFEEEE" },
+    { "palevioletred", "#DB7093" },
+    { "papayawhip", "#FFEFD5" },
+    { "peachpuff", "#FFDAB9" },
+    { "peru", "#CD853F" },
+    { "pink", "#FFC0CB" },
+    { "plum", "#DDA0DD" },
+    { "powderblue", "#B0E0E6" },
+    { "purple", "#800080" },
+    { "red", "#FF0000" },
+    { "rosybrown", "#BC8F8F" },
+    { "royalblue", "#4169E1" },
+    { "saddlebrown", "#8B4513" },
+    { "salmon", "#FA8072" },
+    { "sandybrown", "#F4A460" },
+    { "seagreen", "#2E8B57" },
+    { "seashell", "#FFF5EE" },
+    { "sienna", "#A0522D" },
+    { "silver", "#C0C0C0" },
+    { "skyblue", "#87CEEB" },
+    { "slateblue", "#6A5ACD" },
+    { "slategray", "#708090" },
+    { "slategrey", "#708090" },
+    { "snow", "#FFFAFA" },
+    { "springgreen", "#00FF7F" },
+    { "steelblue", "#4682B4" },
+    { "tan", "#D2B48C" },
+    { "teal", "#008080" },
+    { "thistle", "#D8BFD8" },
+    { "tomato", "#FF6347" },
+    { "turquoise", "#40E0D0" },
+    { "violet", "#EE82EE" },
+    { "wheat", "#F5DEB3" },
+    { "white", "#FFFFFF" },
+    { "whitesmoke", "#F5F5F5" },
+    { "yellow", "#FFFF00" },
+    { "yellowgreen", "#9ACD32" },
+
+};
+
+// For convenience, provide a macro to cast m_picker to wxColourPickerWidget*
+#define clr_picker static_cast<wxColourPickerWidget*>(m_picker)
+
+// Provide our own Create() so as to default to the HTML colour syntax (#rrggbb) and to
+// bind to our own event handler that works with all CSS color names.
+bool kwColourPickerCtrl::Create(wxWindow* parent, wxWindowID id, const wxColour& color, const wxPoint& pos,
+                                const wxSize& size, long style, const wxValidator& validator, const wxString& name)
+{
+    if (!wxPickerBase::CreateBase(parent, id, color.GetAsString(wxC2S_HTML_SYNTAX), pos, size, style, validator, name))
+        return false;
+
+    m_picker = new wxColourPickerWidget(this, wxID_ANY, color, wxDefaultPosition, wxDefaultSize, GetPickerStyle(style));
+
+    wxPickerBase::PostCreation();
+
+    if (m_text)
+    {
+        // This will add all of the CSS color names to the auto-complete list
+        wxArrayString tmp_array;
+        for (auto& iter: kw_css_colors)
+        {
+            tmp_array.Add(iter.first);
+        }
+        m_text->AutoComplete(tmp_array);
+    }
+
+    m_picker->Bind(wxEVT_COLOURPICKER_CHANGED, &kwColourPickerCtrl::OnColorChange, this);
+
+    return true;
+}
+
+// This is a static function, so it cannot access any class data
+wxColour kwColourPickerCtrl::GetColorFromString(const wxString& color_string)
+{
+    wxColour color;
+    if (color_string.empty())
+        return color;
+
+    if (color_string.starts_with("wx"))
+    {
+#define IS_SYSCOLOUR(name)     \
+    if (color_string == #name) \
+        color = name;
+#define ELSE_IS_SYSCOLOUR(name) else if (color_string == #name) color = name;
+
+        IS_SYSCOLOUR(wxSYS_COLOUR_SCROLLBAR)
+
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_BACKGROUND)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_ACTIVECAPTION)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_INACTIVECAPTION)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_MENU)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_WINDOW)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_WINDOWFRAME)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_MENUTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_WINDOWTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_CAPTIONTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_ACTIVEBORDER)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_INACTIVEBORDER)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_APPWORKSPACE)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_HIGHLIGHT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_HIGHLIGHTTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_BTNFACE)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_BTNSHADOW)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_GRAYTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_BTNTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_INACTIVECAPTIONTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_BTNHIGHLIGHT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_3DDKSHADOW)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_3DLIGHT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_INFOTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_INFOBK)
+
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_LISTBOX)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_HOTLIGHT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_GRADIENTACTIVECAPTION)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_GRADIENTINACTIVECAPTION)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_MENUHILIGHT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_MENUBAR)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_LISTBOXTEXT)
+        ELSE_IS_SYSCOLOUR(wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT)
+
+        else color = wxSYS_COLOUR_BTNFACE;
+    }
+    else if (color_string.starts_with('#') || color_string.starts_with("RGB") || color_string.starts_with("rgb"))
+    {
+        color.Set(color_string);
+    }
+    else if (auto result = kw_css_colors.find(color_string); result != kw_css_colors.end())
+    {
+        color.Set(result->second);
+    }
+    else
+    {
+        color.Set(color_string);
+    }
+    return color;
+}
+
+// This is a static function, so it cannot access any class data
+std::string kwColourPickerCtrl::GetHexColorFromString(const wxString& color_string)
+{
+    if (auto result = kw_css_colors.find(color_string); result != kw_css_colors.end())
+    {
+        return result->second;
+    }
+    return {};
+}
+
+void kwColourPickerCtrl::SetColour(const wxString& color_string)
+{
+    if (auto color = GetColorFromString(color_string); color.IsOk())
+    {
+        clr_picker->SetColour(color);
+        UpdateTextCtrlFromPicker();
+    }
+}
+
+void kwColourPickerCtrl::SetColour(const wxColour& color)
+{
+    clr_picker->SetColour(color);
+    UpdateTextCtrlFromPicker();
+}
+
+// This function is required when deriving from wxPickerBase
+void kwColourPickerCtrl::UpdatePickerFromTextCtrl()
+{
+    if (m_text)
+    {
+        wxColour new_color = GetColorFromString(m_text->GetValue());
+        if (new_color.IsOk() && new_color != clr_picker->GetColour())
+        {
+            clr_picker->SetColour(new_color);
+        }
+    }
+}
+
+// This function is required when deriving from wxPickerBase
+void kwColourPickerCtrl::UpdateTextCtrlFromPicker()
+{
+    if (m_text)
+    {
+        auto hex_string = clr_picker->GetColour().GetAsString(wxC2S_HTML_SYNTAX);
+
+        // find the value hex_string in the map
+        if (auto result = std::find_if(kw_css_colors.begin(), kw_css_colors.end(),
+                                       [&hex_string](const auto& pair)
+                                       {
+                                           return pair.second == hex_string;
+                                       });
+            result != kw_css_colors.end())
+        {
+            m_text->ChangeValue(result->first);
+        }
+        else
+        {
+            m_text->ChangeValue(hex_string);
+        }
+    }
+}
+
+void kwColourPickerCtrl::OnColorChange(wxColourPickerEvent& event)
+{
+    UpdateTextCtrlFromPicker();
+    event.Skip();
+}

--- a/src/custom_ctrls/kw_color_picker.h
+++ b/src/custom_ctrls/kw_color_picker.h
@@ -1,0 +1,80 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Modified version of wxColourPickerCtrl
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+/*
+
+    Currently (08-12-2023) wxColourPickerCtrl only supports about half
+    of the W3C CSS colors (see https://www.w3.org/TR/css-color-3/ ).
+    This class has a map of all the CSS colors which are mapped to a
+    CSS Hex string. This allows the user to specify any of the CSS colors,
+    and convert that to a hex (#RRGGBB) string that wxColour will accept.
+
+    Note that the text control has auto-complete enabled with all the CSS
+    color names.
+
+*/
+
+#pragma once
+
+#include <map>
+
+#include <wx/clrpicker.h>   // wxColourBase definition
+#include <wx/colour.h>      // wxColourBase definition
+#include <wx/pickerbase.h>  // wxPickerBase class
+
+#if !defined(wxCLRP_SHOW_LABEL)
+    #define wxCLRP_SHOW_LABEL 0x0008
+    #define wxCLRP_SHOW_ALPHA 0x0010
+#endif
+
+class kwColourPickerCtrl : public wxPickerBase
+{
+public:
+    // This can convert any CSS color name, #rrggbb, rgb(r,g,b), or a wxSYS_COLOUR_* to a
+    // wxColour.
+    static wxColour GetColorFromString(const wxString& color_string);
+
+    // Given a named CSS color, return the hex string (#RRGGBB).
+    static std::string GetHexColorFromString(const wxString& color_string);
+
+public:
+    kwColourPickerCtrl() {}
+    kwColourPickerCtrl(wxWindow* parent, wxWindowID id, const wxColour& col = *wxBLACK,
+                       const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+                       long style = wxCLRP_DEFAULT_STYLE, const wxValidator& validator = wxDefaultValidator,
+                       const wxString& name = wxASCII_STR(wxColourPickerCtrlNameStr))
+    {
+        Create(parent, id, col, pos, size, style, validator, name);
+    }
+
+    bool Create(wxWindow* parent, wxWindowID id, const wxColour& col = *wxBLACK, const wxPoint& pos = wxDefaultPosition,
+                const wxSize& size = wxDefaultSize, long style = wxCLRP_DEFAULT_STYLE,
+                const wxValidator& validator = wxDefaultValidator,
+                const wxString& name = wxASCII_STR(wxColourPickerCtrlNameStr));
+
+    // This can be a named CSS color, hex string, RGB string, or system
+    // color (such as wxSYS_COLOUR_BTNTEXT).
+    void SetColour(const wxString& color_string);
+
+    void SetColour(const wxColour& color);
+
+    wxColour GetColour() const { return static_cast<wxColourPickerWidget*>(m_picker)->GetColour(); }
+
+protected:
+    // Event handlers
+    void OnColorChange(wxColourPickerEvent& event);
+
+    // The following two overrides are required when deriving from wxPickerBase
+
+    void UpdatePickerFromTextCtrl() override;
+    void UpdateTextCtrlFromPicker() override;
+
+    long GetPickerStyle(long style) const override { return (style & (wxCLRP_SHOW_LABEL | wxCLRP_SHOW_ALPHA)); }
+};
+
+// This is a CSS_name/hex_string map of all the CSS colors.
+extern const std::map<std::string, std::string, std::less<>> kw_css_colors;

--- a/src/customprops/custom_colour_prop.cpp
+++ b/src/customprops/custom_colour_prop.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Property editor for colour
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -16,6 +16,7 @@
 #include "utils.h"      // Utility functions that work with properties
 
 #include "../custom_ctrls/colour_rect_ctrl.h"  // ColourRectCtrl -- Control that displays a solid color
+#include "../custom_ctrls/kw_color_picker.h"   // Modified version of wxColourPickerCtrl
 
 #include "wxui/colourprop_base.h"  // auto-generated: wxui/colourprop_base.h wxui/colourprop_base.cpp
 
@@ -49,9 +50,7 @@ public:
 protected:
     void OnColourChanged(wxColourPickerEvent&) override;
     void OnSetDefault(wxCommandEvent&) override;
-    void OnSystemColourChange(wxCommandEvent&) override;
     void OnRadioCustomColour(wxCommandEvent& event) override;
-    void OnRadioSystemColour(wxCommandEvent& event) override;
 
     void SetSampleColour(wxColor clr);
 
@@ -75,37 +74,6 @@ bool EditColourDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGPropert
     return false;
 }
 
-// clang-format off
-std::map<std::string, const char*> g_sys_colour_pair = {
-
-    { "App Workspace", "wxSYS_COLOUR_APPWORKSPACE" },
-    { "Active Border", "wxSYS_COLOUR_ACTIVEBORDER" },
-    { "Active Caption", "wxSYS_COLOUR_ACTIVECAPTION" },
-    { "Button Face", "wxSYS_COLOUR_BTNFACE" },
-    { "Button Highlight", "wxSYS_COLOUR_BTNHIGHLIGHT" },
-    { "Button Shadow", "wxSYS_COLOUR_BTNSHADOW" },
-    { "Button Text", "wxSYS_COLOUR_BTNTEXT" },
-    { "Caption Text", "wxSYS_COLOUR_CAPTIONTEXT" },
-    { "Control Dark", "wxSYS_COLOUR_3DDKSHADOW" },
-    { "Control Light", "wxSYS_COLOUR_3DLIGHT" },
-    { "Desktop", "wxSYS_COLOUR_BACKGROUND" },
-    { "Gray Text", "wxSYS_COLOUR_GRAYTEXT" },
-    { "Highlight", "wxSYS_COLOUR_HIGHLIGHT" },
-    { "Highlight Text", "wxSYS_COLOUR_HIGHLIGHTTEXT" },
-    { "Inactive Border", "wxSYS_COLOUR_INACTIVEBORDER" },
-    { "Inactive Caption", "wxSYS_COLOUR_INACTIVECAPTION" },
-    { "Inactive Caption Text", "wxSYS_COLOUR_INACTIVECAPTIONTEXT" },
-    { "Menu", "wxSYS_COLOUR_MENU" },
-    { "Scrollbar", "wxSYS_COLOUR_SCROLLBAR" },
-    { "Tooltip", "wxSYS_COLOUR_INFOBK" },
-    { "Tooltip Text", "wxSYS_COLOUR_INFOTEXT" },
-    { "Window", "wxSYS_COLOUR_WINDOW" },
-    { "Window Frame", "wxSYS_COLOUR_WINDOWFRAME" },
-    { "Window Text", "wxSYS_COLOUR_WINDOWTEXT" },
-
-};
-// clang-format on
-
 EditColourDialog::EditColourDialog(wxWindow* parent, NodeProperty* prop) : ColourPropBase(parent)
 {
     SetTitle(tt_string() << prop->declName() << " property editor");
@@ -118,86 +86,6 @@ EditColourDialog::EditColourDialog(wxWindow* parent, NodeProperty* prop) : Colou
     if (m_node->hasValue(prop_background_colour))
         m_background = m_node->as_wxColour(prop_background_colour);
 
-    wxArrayString tmp_array;
-
-    tmp_array.Add("aquamarine");
-    tmp_array.Add("black");
-    tmp_array.Add("blue");
-    tmp_array.Add("blue violet");
-    tmp_array.Add("brown");
-    tmp_array.Add("cadet blue");
-    tmp_array.Add("coral");
-    tmp_array.Add("cornflower blue");
-    tmp_array.Add("cyan");
-    tmp_array.Add("dark grey");
-    tmp_array.Add("dark green");
-    tmp_array.Add("dark olive green");
-    tmp_array.Add("dark orchid");
-    tmp_array.Add("dark slate blue");
-    tmp_array.Add("dark slate grey");
-    tmp_array.Add("dark turquoise");
-    tmp_array.Add("dim grey");
-    tmp_array.Add("firebrick");
-    tmp_array.Add("forest green");
-    tmp_array.Add("gold");
-    tmp_array.Add("goldenrod");
-    tmp_array.Add("grey");
-    tmp_array.Add("green");
-    tmp_array.Add("green yellow");
-    tmp_array.Add("indian red");
-    tmp_array.Add("khaki");
-    tmp_array.Add("light blue");
-    tmp_array.Add("light grey");
-    tmp_array.Add("light steel blue");
-    tmp_array.Add("lime green");
-    tmp_array.Add("light magenta");
-    tmp_array.Add("magenta");
-    tmp_array.Add("maroon");
-    tmp_array.Add("medium aquamarine");
-    tmp_array.Add("medium grey");
-    tmp_array.Add("medium blue");
-    tmp_array.Add("medium forest green");
-    tmp_array.Add("medium goldenrod");
-    tmp_array.Add("medium orchid");
-    tmp_array.Add("medium sea green");
-    tmp_array.Add("medium slate blue");
-    tmp_array.Add("medium spring green");
-    tmp_array.Add("medium turquoise");
-    tmp_array.Add("medium violet red");
-    tmp_array.Add("midnight blue");
-    tmp_array.Add("navy");
-    tmp_array.Add("orange");
-    tmp_array.Add("orange red");
-    tmp_array.Add("orchid");
-    tmp_array.Add("pale green");
-    tmp_array.Add("pink");
-    tmp_array.Add("plum");
-    tmp_array.Add("purple");
-    tmp_array.Add("red");
-    tmp_array.Add("salmon");
-    tmp_array.Add("sea green");
-    tmp_array.Add("sienna");
-    tmp_array.Add("sky blue");
-    tmp_array.Add("slate blue");
-    tmp_array.Add("spring green");
-    tmp_array.Add("steel blue");
-    tmp_array.Add("tan");
-    tmp_array.Add("thistle");
-    tmp_array.Add("turquoise");
-    tmp_array.Add("violet");
-    tmp_array.Add("violet red");
-    tmp_array.Add("wheat");
-    tmp_array.Add("white");
-    tmp_array.Add("yellow");
-    tmp_array.Add("yellow green");
-
-    m_colourPicker->GetTextCtrl()->AutoComplete(tmp_array);
-
-    for (auto& iter: g_sys_colour_pair)
-    {
-        m_combo_system->AppendString(wxString(iter.first));
-    }
-
     if (m_foreground.IsOk())
         m_static_sample_text->SetForegroundColour(m_foreground);
     if (m_background.IsOk())
@@ -206,36 +94,12 @@ EditColourDialog::EditColourDialog(wxWindow* parent, NodeProperty* prop) : Colou
     if (!prop->hasValue())
     {
         m_colour_rect->SetColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
-        m_combo_system->Select(m_combo_system->FindString("WindowText", true));
-    }
-    else if (prop->as_string().starts_with("wx"))
-    {
-        m_radio_default->SetValue(false);
-        m_radio_custom->SetValue(false);
-        m_radio_system->SetValue(true);
-        m_colourPicker->Enable(false);
-        m_combo_system->Enable(true);
-
-        for (auto& iter: g_sys_colour_pair)
-        {
-            if (prop->as_string() == iter.second)
-            {
-                wxColour clr = wxSystemSettings::GetColour(ConvertToSystemColour(iter.second));
-                m_colour_rect->SetColour(clr);
-                m_colourPicker->SetColour(prop->as_color());
-                m_combo_system->Select(m_combo_system->FindString(iter.first, true));
-                break;
-            }
-        }
     }
     else
     {
         m_radio_default->SetValue(false);
         m_radio_custom->SetValue(true);
-        m_radio_system->SetValue(false);
         m_colourPicker->Enable(true);
-        m_combo_system->Enable(false);
-        m_combo_system->Select(m_combo_system->FindString("WindowText", true));
 
         auto clr = prop->as_color();
         m_colour_rect->SetColour(prop->as_color());
@@ -250,43 +114,12 @@ wxString EditColourDialog::GetResults()
     // The property string needs to be empty for the default value, 3 comma-separated numbers if it's a custom colour, and a
     // wxSYS_COLOUR_... string if it's a system colour.
 
-    if (m_radio_default->GetValue())
-        return result;
-    else if (m_radio_custom->GetValue())
+    if (!m_radio_default->GetValue())
     {
-        m_value = m_colourPicker->GetColour();
-        result << m_value.Red() << ',' << m_value.Green() << ',' << m_value.Blue();
-    }
-    else
-    {
-        auto str = m_combo_system->GetStringSelection().utf8_string();
-        for (auto& iter: g_sys_colour_pair)
-        {
-            if (str == iter.first)
-            {
-                result = iter.second;
-                break;
-            }
-        }
+        result = m_colourPicker->GetColour().GetAsString(wxC2S_HTML_SYNTAX);
     }
 
     return result;
-}
-
-void EditColourDialog::OnSystemColourChange(wxCommandEvent& /* event */)
-{
-    auto str = m_combo_system->GetStringSelection().utf8_string();
-    for (auto& iter: g_sys_colour_pair)
-    {
-        if (str == iter.first)
-        {
-            wxColour clr = wxSystemSettings::GetColour(ConvertToSystemColour(iter.second));
-            m_colour_rect->SetColour(clr);
-            SetSampleColour(clr);
-            Refresh();
-            break;
-        }
-    }
 }
 
 void EditColourDialog::OnColourChanged(wxColourPickerEvent&)
@@ -302,11 +135,8 @@ void EditColourDialog::OnSetDefault(wxCommandEvent&)
     m_colour_rect->SetColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
     m_static_sample_text->SetForegroundColour(*wxBLACK);
 
-    m_radio_system->SetValue(false);
     m_colourPicker->Enable(false);
-
     m_radio_custom->SetValue(false);
-    m_combo_system->Enable(false);
     Refresh();
 }
 
@@ -315,27 +145,10 @@ void EditColourDialog::OnRadioCustomColour(wxCommandEvent& event)
     if (event.IsChecked())
     {
         m_radio_default->SetValue(false);
-        m_radio_system->SetValue(false);
         m_colourPicker->Enable(true);
-        m_combo_system->Enable(false);
 
         wxColourPickerEvent dummy;
         OnColourChanged(dummy);
-    }
-    event.Skip();
-}
-
-void EditColourDialog::OnRadioSystemColour(wxCommandEvent& event)
-{
-    if (event.IsChecked())
-    {
-        m_radio_default->SetValue(false);
-        m_radio_custom->SetValue(false);
-        m_colourPicker->Enable(false);
-        m_combo_system->Enable(true);
-
-        wxCommandEvent dummy;
-        OnSystemColourChange(dummy);
     }
     event.Skip();
 }

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -54,6 +54,7 @@ set (file_list
     # (generated) customprops/id_editor_dlg.cpp
 
     custom_ctrls/colour_rect_ctrl.cpp   # Control that displays a solid color
+    custom_ctrls/kw_color_picker.cpp    # Modified version of wxColourPickerCtrl
 
     # Code generation modules
 

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -966,7 +966,6 @@ Code& Code::QuotedString(tt_string_view text)
 
     if (Project.as_bool(prop_internationalize))
     {
-        *this += is_cpp() ? "_(" : "wx.GetTranslation(";
         if (is_cpp())
         {
             *this += "_(";
@@ -1901,8 +1900,16 @@ void Code::GenFontColourSettings()
         }
         else
         {
-            const auto colour = m_node->as_wxColour(prop_foreground_colour);
-            Add(tt_string().Format("wxColour(%i, %i, %i)", colour.Red(), colour.Green(), colour.Blue()));
+            if (fg_clr.starts_with('#'))
+            {
+                Add("wxColour(").QuotedString(fg_clr) += ')';
+            }
+            else
+            {
+                // This handles older project versions, and hand-edited project files
+                const auto colour = m_node->as_wxColour(prop_foreground_colour);
+                Add("wxColour(").QuotedString(colour.GetAsString(wxC2S_HTML_SYNTAX).ToStdString()) += ')';
+            }
         }
         EndFunction();
     }
@@ -1924,8 +1931,16 @@ void Code::GenFontColourSettings()
         }
         else
         {
-            const auto colour = m_node->as_wxColour(prop_background_colour);
-            Add(tt_string().Format("wxColour(%i, %i, %i)", colour.Red(), colour.Green(), colour.Blue()));
+            if (bg_clr.starts_with('#'))
+            {
+                Add("wxColour(").QuotedString(bg_clr) += ')';
+            }
+            else
+            {
+                // This handles older project versions, and hand-edited project files
+                const auto colour = m_node->as_wxColour(prop_background_colour);
+                Add("wxColour(").QuotedString(colour.GetAsString(wxC2S_HTML_SYNTAX).ToStdString()) += ')';
+            }
         }
         EndFunction();
     }
@@ -1962,15 +1977,8 @@ Code& Code::ColourCode(GenEnum::PropName prop_name)
     }
     else
     {
-        if (PropContains(prop_name, "wx"))
-        {
-            Add("wxSystemSettings").ClassMethod("GetColour(").Add(prop_name).Str(")");
-        }
-        else
-        {
-            auto colour = m_node->as_wxColour(prop_name);
-            Add(tt_string().Format("wxColour(%i, %i, %i)", colour.Red(), colour.Green(), colour.Blue()));
-        }
+        auto colour = m_node->as_wxColour(prop_name);
+        Add("wxColour(").QuotedString(colour) += ')';
     }
 
     return *this;

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -365,6 +365,14 @@ public:
     // Empty strings generate wxEmptyString for C++, '' for Ruby and "" for other languages.
     Code& QuotedString(GenEnum::PropName prop_name);
 
+    // Calls color.GetAsString(wxC2S_HTML_SYNTAX).ToStdString() and places the result in
+    // quotes.
+    Code& QuotedString(wxColour clr)
+    {
+        QuotedString(clr.GetAsString(wxC2S_HTML_SYNTAX).ToStdString());
+        return *this;
+    }
+
     // Places string in quotes (single for Ruby, double for other languages). If
     // prop_internationalize is set, quoted string is placed in function call to
     // wxGetTranslation().

--- a/src/generate/gen_banner_window.cpp
+++ b/src/generate/gen_banner_window.cpp
@@ -100,37 +100,14 @@ bool BannerWindowGenerator::SettingsCode(Code& code)
     }
     else if (code.hasValue(prop_start_colour) && code.hasValue(prop_end_colour))
     {
-        auto& start_colour = code.node()->as_string(prop_start_colour);
         code.NodeName().Function("SetGradient(");
-        if (start_colour.contains("wx"))
-        {
-            code.Add("wxSystemSettings").ClassMethod("GetColour(").Add(start_colour) << ")";
-        }
-        else
-        {
-            wxColour colour = ConvertToColour(start_colour);
-            tt_string clr_format;
-            clr_format.Format("wxColour(%i, %i, %i)", colour.Red(), colour.Green(), colour.Blue());
-            code.CheckLineLength(clr_format.size());
-            code.Add(clr_format);
-        }
 
+        auto colour = code.node()->as_wxColour(prop_start_colour);
+        code.Add("wxColour(").QuotedString(colour) += ')';
         code.Comma().CheckLineLength();
+        colour = code.node()->as_wxColour(prop_end_colour);
+        code.Add("wxColour(").QuotedString(colour) += ')';
 
-        auto& end_colour = code.node()->as_string(prop_end_colour);
-        if (end_colour.contains("wx"))
-        {
-            code.CheckLineLength(sizeof("wxSystemSettings::GetColour(") + end_colour.size() + sizeof(")"));
-            code.Add("wxSystemSettings").ClassMethod("GetColour(").Add(end_colour) << ")";
-        }
-        else
-        {
-            wxColour colour = ConvertToColour(end_colour);
-            tt_string clr_format;
-            clr_format.Format("wxColour(%i, %i, %i)", colour.Red(), colour.Green(), colour.Blue());
-            code.CheckLineLength(clr_format.size());
-            code.Add(clr_format);
-        }
         code.EndFunction();
     }
 

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -39,15 +39,8 @@ void ColourCode(Code& code, GenEnum::PropName prop_name)
     }
     else
     {
-        if (code.PropContains(prop_name, "wx"))
-        {
-            code.Add("wxSystemSettings").ClassMethod("GetColour(").as_string(prop_name).Str(")");
-        }
-        else
-        {
-            auto colour = code.node()->as_wxColour(prop_name);
-            code.Add(tt_string().Format("wxColour(%i, %i, %i)", colour.Red(), colour.Green(), colour.Blue()));
-        }
+        auto colour = code.node()->as_wxColour(prop_name);
+        code.Add("wxColour(").QuotedString(colour) += ')';
     }
 }
 

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -1041,6 +1041,12 @@ void DialogBlocks::ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& 
 
 static const std::map<std::string_view, GenEnum::PropName, std::less<>> map_proxy_names = {
 
+    { "Background colour", prop_background_colour },
+    { "Foreground colour", prop_foreground_colour },
+    { "Hover colour", prop_hover_color },
+    { "Normal colour", prop_normal_color },
+    { "Visited colour", prop_visited_color },
+
     { "Column width", prop_default_col_size },
     { "ColumnSpacing", prop_hgap },
     { "Columns", prop_cols },
@@ -1139,6 +1145,15 @@ void DialogBlocks::ProcessMisc(pugi::xml_node& node_xml, const NodeSharedPtr& no
                             node->set_value(prop_selection_mode, "wxITEM_CHECK");
                         else if (str == "Radio")
                             node->set_value(prop_selection_mode, "wxITEM_RADIO");
+                        break;
+
+                    case prop_background_colour:
+                    case prop_foreground_colour:
+                    case prop_hover_color:
+                    case prop_normal_color:
+                    case prop_visited_color:
+                        str.insert(0, "#");
+                        node->set_value(result->second, str);
                         break;
 
                     default:

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -460,6 +460,12 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
                 else if (!xml_prop.text().empty())
                 {
                     prop_ptr->set_value(xml_prop.text().as_string());
+                    if (prop_ptr->getPropDeclaration()->declName().contains("colour") ||
+                        prop_ptr->getPropDeclaration()->declName().contains("color"))
+                    {
+                        // Convert old style into #RRGGBB
+                        prop_ptr->set_value(prop_ptr->as_color().GetAsString(wxC2S_HTML_SYNTAX));
+                    }
                 }
                 continue;
             }

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Import a wxCrafter project
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -1053,6 +1053,8 @@ void WxCrafter::KnownProperty(Node* node, const Value& value, GenEnum::PropName 
         if (auto& colour = FindValue(value, "colour"); colour.IsString())
         {
             node->set_value(prop_name, ConvertColour(colour));
+            // Convert old style into #RRGGBB
+            node->set_value(prop_name, node->as_wxColour(prop_name).GetAsString(wxC2S_HTML_SYNTAX));
         }
     }
     else if (prop_name == prop_id)

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Base class for XML importing
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -707,6 +707,12 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
         if (prop)
         {
             prop->set_value(iter.text().as_string());
+            if (prop->getPropDeclaration()->declName().contains("colour") ||
+                prop->getPropDeclaration()->declName().contains("color"))
+            {
+                // Convert old style into #RRGGBB
+                prop->set_value(prop->as_color().GetAsString(wxC2S_HTML_SYNTAX));
+            }
             continue;
         }
         else if (node->isGen(gen_BookPage) && wxue_prop == prop_style)

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -369,14 +369,14 @@ void MockupContent::SetWindowProperties(Node* node, wxWindow* window, wxWindow* 
         window->SetFont(node->as_wxFont(prop_font));
     }
 
-    if (auto& fg_colour = node->as_string(prop_foreground_colour); fg_colour.size())
+    if (node->hasValue(prop_foreground_colour))
     {
-        window->SetForegroundColour(ConvertToColour(fg_colour));
+        window->SetForegroundColour(node->as_wxColour(prop_foreground_colour));
     }
 
-    if (auto& bg_colour = node->as_string(prop_background_colour); bg_colour.size())
+    if (node->hasValue(prop_background_colour))
     {
-        window->SetBackgroundColour(ConvertToColour(bg_colour));
+        window->SetBackgroundColour(node->as_wxColour(prop_background_colour));
     }
 
     if (auto extra_style = node->as_int(prop_window_extra_style); extra_style > 0)

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -269,6 +269,8 @@ wxSize NodeProperty::as_size() const
 // Defined in ../custom_ctrls/kw_color_picker.cpp
 extern const std::map<std::string, std::string, std::less<>> kw_css_colors;
 
+// Note that this is not only used to handle older wxUiEditor projects, but also some of the
+// imported projects such as wxFormBuilder.
 wxColour NodeProperty::as_color() const
 {
     if (m_value.empty())

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <charconv>
 #include <cstdlib>
+#include <sstream>
 
 #include <wx/animate.h>                // wxAnimation and wxAnimationCtrl
 #include <wx/propgrid/propgriddefs.h>  // wxPropertyGrid miscellaneous definitions
@@ -265,40 +266,49 @@ wxSize NodeProperty::as_size() const
     return result;
 }
 
+// Defined in ../custom_ctrls/kw_color_picker.cpp
+extern const std::map<std::string, std::string, std::less<>> kw_css_colors;
+
 wxColour NodeProperty::as_color() const
 {
+    if (m_value.empty())
+        return wxNullColour;
     // check for system colour
     if (m_value.starts_with("wx"))
     {
         return wxSystemSettings::GetColour(ConvertToSystemColour(m_value));
     }
+    else if (m_value.starts_with('#') || m_value.starts_with("RGB") || m_value.starts_with("rgb"))
+    {
+        return wxColour(m_value);
+    }
+    else if (tt::is_alpha(m_value[0]))
+    {
+        if (auto result = kw_css_colors.find(m_value); result != kw_css_colors.end())
+            return wxColour(result->second);
+        else
+        {
+            FAIL_MSG(tt_string("Unknown CSS color: ") << m_value);
+            return wxNullColour;
+        }
+    }
     else
     {
         tt_view_vector mstr(m_value, ',');
         unsigned long rgb = 0;
-        if (mstr.size() > 2)
+        size_t shift_value = 0;
+        for (auto& color: mstr)
         {
-            auto blue = mstr[2].atoi();
-            if (blue < 0 || blue > 255)
-                blue = 0;
-            rgb |= (blue << 16);
+            auto value = color.atoi();
+            if (value < 0 || value > 255)  // ensure value is in range
+                value = 0;
+            rgb |= (value << shift_value);
+            shift_value += 8;
+            if (shift_value > 24)  // limited to 4 values (RGBA)
+                break;
         }
-        if (mstr.size() > 1)
-        {
-            auto green = mstr[1].atoi();
-            if (green < 0 || green > 255)
-                green = 0;
-            rgb |= (green << 8);
-        }
-        if (mstr.size() > 0)
-        {
-            auto red = mstr[0].atoi();
-            if (red < 0 || red > 255)
-                red = 0;
-            rgb |= red;
-        }
-        wxColour clr(rgb);
-        return clr;
+
+        return wxColour(rgb);
     }
 }
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1454,30 +1454,8 @@ void PropGridPanel::OnNodePropChange(CustomEvent& event)
 
         case type_wxColour:
             {
-                auto value = prop->as_string();
-                if (value.empty())  // Default Colour
-                {
-                    wxColourPropertyValue def;
-                    def.m_type = wxSYS_COLOUR_WINDOW;
-                    def.m_colour = ConvertToSystemColour("wxSYS_COLOUR_WINDOW");
-                    m_prop_grid->SetPropertyValue(grid_property, def);
-                }
-                else
-                {
-                    if (value.find_first_of("wx") == 0)
-                    {
-                        // System Colour
-                        wxColourPropertyValue def;
-                        def.m_type = ConvertToSystemColour(value);
-                        def.m_colour = prop->as_color();
-                        m_prop_grid->SetPropertyValue(grid_property, def);
-                    }
-                    else
-                    {
-                        wxColourPropertyValue def(wxPG_COLOUR_CUSTOM, prop->as_color());
-                        m_prop_grid->SetPropertyValue(grid_property, def);
-                    }
-                }
+                wxColourPropertyValue def(wxPG_COLOUR_CUSTOM, prop->as_color());
+                m_prop_grid->SetPropertyValue(grid_property, def);
             }
             break;
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -171,43 +171,6 @@ wxSystemColour ConvertToSystemColour(tt_string_view value)
     // clang-format on
 }
 
-wxColour ConvertToColour(tt_string_view value)
-{
-    // check for system colour
-    if (value.starts_with("wx"))
-    {
-        return wxSystemSettings::GetColour(ConvertToSystemColour(value));
-    }
-    else
-    {
-        tt_view_vector mstr(value, ',');
-        unsigned long rgb = 0;
-        if (mstr.size() > 2)
-        {
-            auto blue = mstr[2].atoi();
-            if (blue < 0 || blue > 255)
-                blue = 0;
-            rgb |= (blue << 16);
-        }
-        if (mstr.size() > 1)
-        {
-            auto green = mstr[1].atoi();
-            if (green < 0 || green > 255)
-                green = 0;
-            rgb |= (green << 8);
-        }
-        if (mstr.size() > 0)
-        {
-            auto red = mstr[0].atoi();
-            if (red < 0 || red > 255)
-                red = 0;
-            rgb |= red;
-        }
-        wxColour clr(rgb);
-        return clr;
-    }
-}
-
 const char* ConvertFontFamilyToString(wxFontFamily family)
 {
     const char* result;

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -30,9 +30,6 @@ wxSystemColour ConvertToSystemColour(tt_string_view value);
 
 const char* ConvertFontFamilyToString(wxFontFamily family);
 
-// if value begins with 'wx' then it is assumed to be a wxSystemColour
-wxColour ConvertToColour(tt_string_view value);
-
 // Replace escape slashes with the actual character. Affects \\, \\n, \\r, and \\t
 tt_string ConvertEscapeSlashes(tt_string_view str);
 
@@ -47,9 +44,6 @@ wxSize DlgSize(wxObject* parent, Node* node, GenEnum::PropName prop);
 
 // Convert the parts[IndexSize] or equivalent string into wxSize dimensions
 wxSize GetSizeInfo(tt_string_view size_description);
-
-// Friendly name/wxSYS_COLOUR_ pairs (e.g. "tooltip"/wxSYS_COLOUR_INFOBK)
-extern std::map<std::string, const char*> g_sys_colour_pair;
 
 // Friendly name/wxSTC_WRAP_ constant
 extern std::map<std::string, const char*> g_stc_wrap_mode;

--- a/src/wxui/colourprop_base.cpp
+++ b/src/wxui/colourprop_base.cpp
@@ -10,6 +10,7 @@
 #include <wx/button.h>
 
 #include "../custom_ctrls/colour_rect_ctrl.h"
+#include "../custom_ctrls/kw_color_picker.h"
 
 #include "colourprop_base.h"
 
@@ -52,29 +53,14 @@ bool ColourPropBase::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     m_staticbox_custom = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radio_custom), wxVERTICAL);
     m_staticbox_custom->GetStaticBox()->Enable(false);
 
-    m_colourPicker = new wxColourPickerCtrl(m_staticbox_custom->GetStaticBox(), wxID_ANY, *wxBLACK, wxDefaultPosition,
-        wxDefaultSize, wxCLRP_USE_TEXTCTRL);
+    m_colourPicker = new kwColourPickerCtrl(m_staticbox_custom->GetStaticBox(), wxID_ANY, *wxBLACK, wxDefaultPosition,
+        wxDefaultSize, wxCLRP_USE_TEXTCTRL|wxCLRP_SHOW_LABEL|wxWANTS_CHARS);
     m_colourPicker->Enable(false);
     m_staticbox_custom->Add(m_colourPicker, wxSizerFlags().Border(wxALL));
 
     dlg_sizer->Add(m_staticbox_custom, wxSizerFlags().Expand().Border(wxALL));
 
     dlg_sizer->AddSpacer(5 + wxSizerFlags::GetDefaultBorder());
-
-    m_radio_system = new wxRadioButton(this, wxID_ANY, "System Colour");
-    m_staticbox_system = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radio_system), wxVERTICAL);
-    m_staticbox_system->GetStaticBox()->Enable(false);
-
-    m_combo_system = new wxComboBox(m_staticbox_system->GetStaticBox(), wxID_ANY);
-    m_combo_system->Enable(false);
-    m_staticbox_system->Add(m_combo_system, wxSizerFlags().Border(wxALL));
-
-    auto* staticText = new wxStaticText(m_staticbox_system->GetStaticBox(), wxID_ANY,
-        "Caution: On Windows, these are classic colours. They may not be the colours the user has set via a Theme or Dark Mode.");
-    staticText->Wrap(250);
-    m_staticbox_system->Add(staticText, wxSizerFlags().Border(wxALL));
-
-    dlg_sizer->Add(m_staticbox_system, wxSizerFlags().Expand().Border(wxALL));
 
     dlg_sizer->AddSpacer(5 + wxSizerFlags::GetDefaultBorder());
 
@@ -87,11 +73,9 @@ bool ColourPropBase::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     // Event handlers
     Bind(wxEVT_BUTTON, &ColourPropBase::OnOK, this, wxID_OK);
     m_colourPicker->Bind(wxEVT_COLOURPICKER_CHANGED, &ColourPropBase::OnColourChanged, this);
-    m_combo_system->Bind(wxEVT_COMBOBOX, &ColourPropBase::OnSystemColourChange, this);
     Bind(wxEVT_INIT_DIALOG, &ColourPropBase::OnInit, this);
     m_radio_default->Bind(wxEVT_RADIOBUTTON, &ColourPropBase::OnSetDefault, this);
     m_radio_custom->Bind(wxEVT_RADIOBUTTON, &ColourPropBase::OnRadioCustomColour, this);
-    m_radio_system->Bind(wxEVT_RADIOBUTTON, &ColourPropBase::OnRadioSystemColour, this);
 
     return true;
 }

--- a/src/wxui/colourprop_base.h
+++ b/src/wxui/colourprop_base.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include <wx/clrpicker.h>
-#include <wx/combobox.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
@@ -19,6 +18,7 @@
 #include <wx/statbox.h>
 #include <wx/stattext.h>
 
+class kwColourPickerCtrl;
 namespace wxue_ctrl
 {
 class ColourRectCtrl;
@@ -47,19 +47,14 @@ protected:
     virtual void OnInit(wxInitDialogEvent& event) { event.Skip(); }
     virtual void OnOK(wxCommandEvent& event) { event.Skip(); }
     virtual void OnRadioCustomColour(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnRadioSystemColour(wxCommandEvent& event) { event.Skip(); }
     virtual void OnSetDefault(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnSystemColourChange(wxCommandEvent& event) { event.Skip(); }
 
     // Class member variables
 
-    wxColourPickerCtrl* m_colourPicker;
-    wxComboBox* m_combo_system;
+    kwColourPickerCtrl* m_colourPicker;
     wxRadioButton* m_radio_custom;
     wxStaticBoxSizer* m_staticbox_custom;
     wxRadioButton* m_radio_default;
-    wxRadioButton* m_radio_system;
-    wxStaticBoxSizer* m_staticbox_system;
     wxStaticText* m_static_sample_text;
     wxue_ctrl::ColourRectCtrl* m_colour_rect;
 };

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -2347,36 +2347,17 @@
             wxEVT_RADIOBUTTON="OnRadioCustomColour">
             <node
               class="wxColourPickerCtrl"
-              style="wxCLRP_USE_TEXTCTRL"
+              style="wxCLRP_USE_TEXTCTRL|wxCLRP_SHOW_LABEL"
+              derived_class="kwColourPickerCtrl"
+              derived_header="../custom_ctrls/kw_color_picker.h"
               disabled="1"
+              window_style="wxWANTS_CHARS"
               wxEVT_COLOURPICKER_CHANGED="OnColourChanged" />
           </node>
           <node
             class="spacer"
             add_default_border="1"
             height="5" />
-          <node
-            class="StaticRadioBtnBoxSizer"
-            checked="0"
-            class_access="protected:"
-            disabled="1"
-            label="System Colour"
-            radiobtn_var_name="m_radio_system"
-            var_name="m_staticbox_system"
-            flags="wxEXPAND"
-            wxEVT_RADIOBUTTON="OnRadioSystemColour">
-            <node
-              class="wxComboBox"
-              var_name="m_combo_system"
-              disabled="1"
-              wxEVT_COMBOBOX="OnSystemColourChange" />
-            <node
-              class="wxStaticText"
-              class_access="none"
-              label="Caution: On Windows, these are classic colours. They may not be the colours the user has set via a Theme or Dark Mode."
-              var_name="staticText"
-              wrap="250" />
-          </node>
           <node
             class="spacer"
             add_default_border="1"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR does an _extensive_ overhaul of Color handling. It adds a new custom control for picking a color, removes System colors from the custom color property dialog, changes how properties get stored in the project file, changes code generation involving colors, and updates importers to convert their colors to #RRGGBB format.

## kwColourPickerCtrl

This is a drop-in replacement for `wxColourPickerCtrl`. It's derived from `wxPickerBase` but you can add it to a project as if it was `wxColourPickerCtrl`, supplying the class name and header file. This version supports _all_ CSS color names, and has a built-in auto-complete with those names. Within the control, if `wxPickerBase` is used to call the OS version of the color picker, the result will be displayed as a named CSS string if there is a match, or a CSS Hmtl string (#RRGGBB) if there is no match.

## EditColourDialog

The System colors section has been removed. This doesn't give valid results on Windows 10 and up, so using it is _not_ cross-platform.

`EditColourDialog::GetResults()` now returns a hex string (#RRGGBB), which means that is also how the string will be stored in the project file (which will fail to be read on any version prior to 1.1.3).

## Bug fix for 1.2.0

Version 1.2.0 mangled the color property, so the value it saved was unusable. 1.1.3 will convert this to black. It _will_ correctly read the color property from 1.1.0 which used comma-separated numbers.

## Code generation

Code generation now uses the hex string instead of the individual RGB numbers. E.G.:

```C++
Before: SetForegroundColour(wxColour(255, 0, 0));

Now: SetForegroundColour(wxColour("#FF0000"));
```

## Removed ConvertToColour()

node->as_wxColour() can handle both old and new project settings.
