### PR TITLE
Fix rare crash in Mockup panel

### DIFF
--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -439,7 +439,7 @@ static const GenEnum::GenName lst_select_nodes[] = {
 
 void MockupContent::OnNodeSelected(Node* node)
 {
-    if (node->isForm())
+    if (!node || node->isForm())
         return;
 
     if (node->isType(type_embed_image))

--- a/src/mockup/mockup_parent.h
+++ b/src/mockup/mockup_parent.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Top-level MockUp Parent window
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -43,6 +43,7 @@ public:
 
 protected:
     void OnNodeSelected(CustomEvent& event);
+    void OnNodeDeleted(CustomEvent& event);
     void OnReCreateContent(CustomEvent&);
     void OnNodePropModified(CustomEvent&);
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR prevents a rare crash caused by Mockup attempting to create the children of a deleted node. There is now a specific event handler for `EVT_NodeDeleted` which only deletes the current content, but does not call `CreateContent()` since there is no longer a valid selected node. Once the navigation panel processes the delete event, it will select a new node and fire a `EVT_NodeSelected` event which will recreate and show the Mockup window again.