### PR TITLE
Additional and improved Property change validation

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -127,9 +127,9 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
         if (newValue.empty())
             return true;
 
-        if (!isValidVarName(newValue))
+        if (!isValidVarName(newValue, Project.getCodePreference()))
         {
-            event->SetValidationFailureMessage("The name you have specified is not a valid C++ variable name.");
+            event->SetValidationFailureMessage("The name you have specified is not a valid variable name.");
             event->Veto();
             return false;
         }

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -134,7 +134,9 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
             return false;
         }
         auto unique_name = node->getUniqueName(newValue);
-        // getUniqueName() won't check the current node so if the name is unique, we still need to check within the same node
+
+        // The above call to getUniqueName() won't check the current node so if the name is
+        // unique, we still need to check within the same node
         bool is_duplicate = !newValue.is_sameas(unique_name);
         if (!is_duplicate)
         {
@@ -188,7 +190,6 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
         {
             event->SetValidationFailureMessage("The name you have chosen is already in use by another variable.");
             event->Veto();
-            wxGetFrame().setStatusField("Either change the name, or press ESC to restore the original value.");
             return false;
         }
 

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Base widget generator class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -219,7 +219,6 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
             {
                 event->SetValidationFailureMessage("The name you have chosen is already in use by another class.");
                 event->Veto();
-                wxGetFrame().setStatusField("Either change the name, or press ESC to restore the original value.");
                 return false;
             }
         }
@@ -236,8 +235,45 @@ bool BaseGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeProperty
         {
             event->SetValidationFailureMessage("This label is already in use by another PropertyGrid item.");
             event->Veto();
-            wxGetFrame().setStatusField("Either change the name, or press ESC to restore the original value.");
             return false;
+        }
+    }
+    else if (prop->isProp(prop_get_function) || prop->isProp(prop_set_function))
+    {
+        auto property = wxStaticCast(event->GetProperty(), wxStringProperty);
+        auto variant = event->GetPropertyValue();
+        tt_string newValue = property->ValueToString(variant).utf8_string();
+
+        auto rlambda = [&](Node* check_node, auto&& rlambda) -> bool
+        {
+            if (check_node != node)
+            {
+                if (check_node->hasValue(prop_get_function) && check_node->as_string(prop_get_function) == newValue)
+                {
+                    event->SetValidationFailureMessage("This function name is already in use.");
+                    event->Veto();
+                    return false;
+                }
+                else if (check_node->hasValue(prop_set_function) && check_node->as_string(prop_set_function) == newValue)
+                {
+                    event->SetValidationFailureMessage("This function name is already in use.");
+                    event->Veto();
+                    return false;
+                }
+            }
+
+            for (auto& iter: check_node->getChildNodePtrs())
+            {
+                if (!rlambda(iter.get(), rlambda))
+                    return false;
+            }
+            return true;
+        };
+
+        if (auto form = node->getForm(); form)
+        {
+            if (!rlambda(form, rlambda))
+                return false;
         }
     }
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -336,9 +336,22 @@ bool isConvertibleMime(const tt_string& suffix)
 }
 
 extern const char* g_u8_cpp_keywords;  // defined in ../panels/base_panel.cpp
-std::set<std::string> g_set_cpp_keywords;
+extern const char* g_python_keywords;
+extern const char* g_ruby_keywords;
+extern const char* g_golang_keywords;
+extern const char* g_lua_keywords;
+extern const char* g_perl_keywords;
+extern const char* g_rust_keywords;
 
-bool isValidVarName(const std::string& str)
+std::set<std::string> g_set_cpp_keywords;
+std::set<std::string> g_set_python_keywords;
+std::set<std::string> g_set_ruby_keywords;
+std::set<std::string> g_set_golang_keywords;
+std::set<std::string> g_set_lua_keywords;
+std::set<std::string> g_set_perl_keywords;
+std::set<std::string> g_set_rust_keywords;
+
+bool isValidVarName(const std::string& str, int language)
 {
     // variable names must start with an alphabetic character or underscore character
     if (!((str[0] >= 'a' && str[0] <= 'z') || (str[0] >= 'A' && str[0] <= 'Z') || str[0] == '_'))
@@ -350,20 +363,54 @@ bool isValidVarName(const std::string& str)
             return false;
     }
 
-    // Ensure that the variable name is not a C++ keyword
+    // Ensure that the variable name is not a keyword in the specified language
+
+    auto lambda = [&](std::set<std::string>& set_keywords, const char* language_keywords) -> bool
+    {
+        if (set_keywords.empty())
+        {
+            tt_string_vector keywords(language_keywords, ' ');
+            for (auto& iter: keywords)
+            {
+                set_keywords.emplace(iter);
+            }
+        }
+
+        if (set_keywords.contains(str))
+            return false;
+
+        return true;
+    };
 
     // The set is only initialized the first time this function is called.
-    if (g_set_cpp_keywords.empty())
+    if (language == GEN_LANG_CPLUSPLUS)
     {
-        tt_string_vector keywords(g_u8_cpp_keywords, ' ');
-        for (auto& iter: keywords)
-        {
-            g_set_cpp_keywords.emplace(iter);
-        }
+        return lambda(g_set_cpp_keywords, g_u8_cpp_keywords);
     }
-
-    if (g_set_cpp_keywords.contains(str))
-        return false;
+    else if (language == GEN_LANG_PYTHON)
+    {
+        return lambda(g_set_python_keywords, g_python_keywords);
+    }
+    else if (language == GEN_LANG_RUBY)
+    {
+        return lambda(g_set_ruby_keywords, g_ruby_keywords);
+    }
+    else if (language == GEN_LANG_GOLANG)
+    {
+        return lambda(g_set_golang_keywords, g_golang_keywords);
+    }
+    else if (language == GEN_LANG_LUA)
+    {
+        return lambda(g_set_lua_keywords, g_lua_keywords);
+    }
+    else if (language == GEN_LANG_PERL)
+    {
+        return lambda(g_set_perl_keywords, g_perl_keywords);
+    }
+    else if (language == GEN_LANG_RUST)
+    {
+        return lambda(g_set_rust_keywords, g_rust_keywords);
+    }
 
     return true;
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -51,7 +51,7 @@ extern std::map<std::string, const char*> g_stc_wrap_mode;
 bool isConvertibleMime(const tt_string& suffix);
 
 // Checks whether a string is a valid C++ variable name.
-bool isValidVarName(const std::string& str);
+bool isValidVarName(const std::string& str, int language = GEN_LANG_CPLUSPLUS);
 
 // This takes the class_name of the form, converts it to lowercase, and if the class name
 // ends with Base, the a "_base" suffix is added.


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR prevents duplicate validator functions within a form. The variable name check uses the keywords of the preferred language to prevent the user from using a variable name that is a keyword in that language.

I also removed all changes to the status bar if a property change was invalid. That status bar is a long ways away from where the user is focusing -- I doubt they will ever see it.