### PR TITLE
Support embedded bitmaps in RUby

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1992,6 +1992,10 @@ Code& Code::Bundle(GenEnum::PropName prop_name)
         case GEN_LANG_PYTHON:
             PythonBundleCode(*this, prop_name);
             break;
+
+        case GEN_LANG_RUBY:
+            RubyBundleCode(*this, prop_name);
+            break;
     }
 
     return *this;

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -280,9 +280,15 @@ public:
     // This will call CheckLineLength(str.size()) first.
     Code& Str(std::string_view str)
     {
-        if (!is_ruby() || (str.size() && str[0] != '('))
+        if (is_ruby() && size() && (back() == '$' || back() == '('))
+        {
+            *this += str;
+        }
+        else
+        {
             CheckLineLength(str.size());
-        *this += str;
+            *this += str;
+        }
         return *this;
     }
 

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -105,7 +105,7 @@ bool AnimationGenerator::ConstructionCode(Code& code)
         {
             code << GenerateBitmapCode(code.node()->as_string(prop_inactive_bitmap));
         }
-        else
+        else if (code.is_python())
         {
             bool is_list_created = PythonBitmapList(code, prop_inactive_bitmap);
             if (is_list_created)
@@ -116,6 +116,10 @@ bool AnimationGenerator::ConstructionCode(Code& code)
             {
                 code.Bundle(prop_inactive_bitmap);
             }
+        }
+        else if (code.is_ruby())
+        {
+            code.Bundle(prop_inactive_bitmap);
         }
         code.EndFunction();
     }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1242,7 +1242,7 @@ void GenToolCode(Code& code, const bool is_bitmaps_list)
                 code.CheckLineLength();
             }
         }
-        else if (code.is_python())
+        else if (code.is_python() || code.is_ruby())
         {
             code.Bundle(prop_bitmap);
         }
@@ -1294,7 +1294,8 @@ void GenToolCode(Code& code, const bool is_bitmaps_list)
 
 bool BitmapList(Code& code, const GenEnum::PropName prop)
 {
-    if (!code.node()->hasValue(prop))
+    // Note that Ruby always uses a function, and therefore has no need for a list
+    if (!code.node()->hasValue(prop) || code.is_ruby())
     {
         return false;
     }

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -106,6 +106,10 @@ tt_string GenerateIconCode(const tt_string& description);
 // wxSize will be converted to dialog units if the size contains a 'd' character.
 tt_string GenerateWxSize(Node* node, PropName prop);
 
+// Creates a string using either wxSystemSettings::GetColour(name) or wxColour(r, g, b).
+// Generates wxNullColour if the property is empty.
+void ColourCode(Code& code, GenEnum::PropName prop_name);
+
 /////////////////////////////////////// Code-enabled Functions ///////////////////////////////////////
 
 // Generate settings common to all forms
@@ -132,13 +136,14 @@ bool PythonBundleCode(Code& code, GenEnum::PropName prop);
 // location which can be used as the parameter for make_relative().
 tt_string MakePythonPath(Node* node);
 
+// Python version of GenBtnBimapCode()
+void PythonBtnBimapCode(Code& code, bool is_single = false);
+
+/////////////////////////////////////// wxRuby Functions ///////////////////////////////////////
+
 // Deterimes where the ruby code will be written to, and returns an absolute path to that
 // location which can be used as the parameter for make_relative().
 tt_string MakeRubyPath(Node* node);
 
-// Creates a string using either wxSystemSettings::GetColour(name) or wxColour(r, g, b).
-// Generates wxNullColour if the property is empty.
-void ColourCode(Code& code, GenEnum::PropName prop_name);
-
-// Python version of GenBtnBimapCode()
-void PythonBtnBimapCode(Code& code, bool is_single = false);
+// Generates code to load a bitmap from Art, SVG, or up to three bitmap files.
+bool RubyBundleCode(Code& code, GenEnum::PropName prop);

--- a/src/generate/gen_menuitem.cpp
+++ b/src/generate/gen_menuitem.cpp
@@ -220,7 +220,7 @@ bool MenuItemGenerator::SettingsCode(Code& code)
         }
         else if (code.is_ruby())
         {
-            // TODO: [Randalphwa - 08-02-2023] Fill in once we have figured out how to handle bitmaps in Ruby
+            code.Bundle(prop_bitmap).EndFunction();
         }
         else
         {
@@ -281,8 +281,7 @@ bool MenuItemGenerator::SettingsCode(Code& code)
             }
         }
 
-        // wxPython version
-        else
+        else if (code.is_python())
         {
             code.Eol(eol_if_needed);
             bool is_list_created = PythonBitmapList(code, prop_unchecked_bitmap);
@@ -295,8 +294,12 @@ bool MenuItemGenerator::SettingsCode(Code& code)
             {
                 code.Bundle(prop_bitmap);
             }
-            code.Comma() += "False";
-            code.EndFunction();
+            code.Comma().False().EndFunction();
+        }
+        else if (code.is_ruby())
+        {
+            code.Eol(eol_if_needed).NodeName().Function("SetBitmap(");
+            code.Bundle(prop_bitmap).Comma().False().EndFunction();
         }
     }
 

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -52,10 +52,11 @@ def get_bundle(image_name1, image_name2 = nil, image_name3 = nil)
     if (image_name3)
       image3 = Wx::Image.new
       image3.load_stream(StringIO.new(image_name3))
-      bundle = Wx::BitmapBundle.new(image1, image2, image3)
+      bitmaps = [image1, image2, image3]
+      bundle = Wx::BitmapBundle.new.from_bitmaps(bitmaps)
       return bundle
     else
-      bundle = Wx::BitmapBundle.new(image1, image2)
+      bundle = Wx::BitmapBundle.new.from_bitmaps(image1, image2)
       return bundle
     end
   end

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -572,6 +572,7 @@ void BaseCodeGenerator::GenerateRubyClass(Node* form_node, PANEL_PAGE panel_type
         {
             WriteImageConstruction(code);
             m_source->doWrite("\n");  // force an extra line break
+            m_source->SetLastLineBlank();
             break;
         }
     }
@@ -580,6 +581,7 @@ void BaseCodeGenerator::GenerateRubyClass(Node* form_node, PANEL_PAGE panel_type
     {
         if (Project.as_bool(prop_disable_rubo_cop))
         {
+            m_source->writeLine();
 #if defined(_DEBUG)
             for (auto& iter: disable_list)
             {

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -662,7 +662,7 @@ bool RubyBundleCode(Code& code, GenEnum::PropName prop)
     {
         if (description.starts_with("SVG"))
         {
-            // TODO: [Randalphwa - 08-17-2023]
+            // TODO: [Randalphwa - 08-17-2023] This is waiting for wxRuby3 to implement the .from_...() methods
 #if 0
             auto embed = ProjectImages.GetEmbeddedImage(parts[IndexImage]);
             ASSERT(embed);
@@ -699,7 +699,7 @@ bool RubyBundleCode(Code& code, GenEnum::PropName prop)
             }
             if (const EmbeddedImage* embed1 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed1)
             {
-                code.Str("get_bundle($").Str(embed1->array_name);
+                code.Str("get_bundle(").Str("$").Str(embed1->array_name);
                 if (bundle->lst_filenames.size() > 1)
                 {
                     if (EmbeddedImage* embed2 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[1]); embed2)

--- a/src/generate/gen_static_bmp.cpp
+++ b/src/generate/gen_static_bmp.cpp
@@ -52,15 +52,23 @@ bool StaticBitmapGenerator::ConstructionCode(Code& code)
     {
         if (code.hasValue(prop_bitmap))
         {
-            bool is_list_created = PythonBitmapList(code, prop_bitmap);
-            code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
+            if (code.is_python())
+            {
+                bool is_list_created = PythonBitmapList(code, prop_bitmap);
+                code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
 
-            if (is_list_created)
-            {
-                code += "wx.BitmapBundle.FromBitmaps(bitmaps)";
+                if (is_list_created)
+                {
+                    code += "wx.BitmapBundle.FromBitmaps(bitmaps)";
+                }
+                else
+                {
+                    code.Bundle(prop_bitmap);
+                }
             }
-            else
+            else if (code.is_ruby())
             {
+                code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
                 code.Bundle(prop_bitmap);
             }
             code.PosSizeFlags();

--- a/src/generate/gen_submenu.cpp
+++ b/src/generate/gen_submenu.cpp
@@ -94,8 +94,7 @@ bool SubMenuGenerator::AfterChildrenCode(Code& code)
             }
         }
 
-        // wxPython version
-        else
+        else if (code.is_python())
         {
             bool is_list_created = PythonBitmapList(code, prop_bitmap);
             code.Str(submenu_item_name).Function("SetBitmap(");
@@ -108,6 +107,10 @@ bool SubMenuGenerator::AfterChildrenCode(Code& code)
                 code.Bundle(prop_bitmap);
             }
             code.EndFunction();
+        }
+        else if (code.is_ruby())
+        {
+            code.Str(submenu_item_name).Function("SetBitmap(").Bundle(prop_bitmap).EndFunction();
         }
     }
 

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -108,7 +108,7 @@ bool WizardFormGenerator::SettingsCode(Code& code)
         {
             if (code.is_cpp())
                 code += "wxBitmapBundle::FromBitmaps(bitmaps)";
-            else
+            else if (code.is_python())
                 code += "wx.BitmapBundle.FromBitmaps(bitmaps)";
         }
         else
@@ -435,7 +435,7 @@ bool WizardPageGenerator::ConstructionCode(Code& code)
                     code.Eol() += "#endif";
                 }
             }
-            else
+            else if (code.is_python())
                 code += "wx.BitmapBundle.FromBitmaps(bitmaps)";
         }
         else

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -464,11 +464,16 @@ std::vector<std::string> base64_encode(unsigned char const* data, size_t data_si
         char_array_4[3] = char_array_3[2] & 0x3f;
     };
 
-    std::string line_end = "\"";
     std::string line_begin = "\tb\"";
-    if (language == GEN_LANG_RUBY)
+    std::string line_end = "\"";
+    if (language == GEN_LANG_PYTHON)
     {
-        line_begin = "  `";
+        line_begin = "\tb\"";
+        line_end = "\"";
+    }
+    else if (language == GEN_LANG_RUBY)
+    {
+        line_begin = "  '";
         line_end = "' +";
     }
 

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -13,6 +13,7 @@
 #include "code.h"             // Code -- Helper class for generating code
 #include "gen_base.h"         // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "gen_common.h"       // Common component functions
+#include "gen_enums.h"        // Enumerations for generators
 #include "image_handler.h"    // ImageHandler class
 #include "project_handler.h"  // ProjectHandler class
 #include "utils.h"            // Utility functions that work with properties
@@ -136,7 +137,7 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             }
             code += "};\n";
         }
-        else
+        else if (code.is_python())
         {
             if (iter_array->form->isGen(gen_Images))
             {
@@ -157,9 +158,41 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             }
             m_source->writeLine(code);
             code.clear();
-            auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF);
+            auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF, GEN_LANG_PYTHON);
             if (encoded.size())
             {
+                encoded.back() += ")";
+                m_source->writeLine(encoded);
+            }
+        }
+        else if (code.is_ruby())
+        {
+            if (iter_array->form->isGen(gen_Images))
+            {
+                continue;
+            }
+            if (iter_array->filename.size())
+            {
+                code.Eol().Str("# ").Str(iter_array->filename);
+            }
+            code.Eol().Str("$").Str(iter_array->array_name);
+            if (iter_array->type == wxBITMAP_TYPE_INVALID)
+            {
+                code.Str(" = (");
+            }
+            else
+            {
+                code.Str(" = Base64.decode64(");
+            }
+            m_source->writeLine(code);
+            code.clear();
+            auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF, GEN_LANG_RUBY);
+            if (encoded.size())
+            {
+                // Remove the trailing '+' character
+                encoded.back().pop_back();
+                // and the now trailing space
+                encoded.back().pop_back();
                 encoded.back() += ")";
                 m_source->writeLine(encoded);
             }
@@ -383,10 +416,32 @@ void BaseCodeGenerator::WriteImagePostHeader()
     }
 }
 
-std::vector<std::string> base64_encode(unsigned char const* data, size_t data_size)
+// clang-format off
+
+std::map<int, GenEnum::PropName> map_lang_to_prop = {
+
+    { GEN_LANG_CPLUSPLUS, prop_cpp_line_length },
+    { GEN_LANG_GOLANG, prop_golang_line_length },
+    { GEN_LANG_LUA, prop_lua_line_length },
+    { GEN_LANG_PERL, prop_perl_line_length },
+    { GEN_LANG_PYTHON, prop_python_line_length },
+    { GEN_LANG_RUBY, prop_ruby_line_length  },
+    { GEN_LANG_RUST, prop_rust_line_length },
+
+};
+
+// clang-format on
+
+std::vector<std::string> base64_encode(unsigned char const* data, size_t data_size, int language)
 {
-    const size_t tab_quote_prefix = 7;  // 4 for tab, 2 for quotes, 1 for 'b' prefix
-    size_t line_length = Project.as_size_t(prop_python_line_length) - tab_quote_prefix;
+    size_t tab_quote_prefix = 7;  // 4 for tab, 2 for quotes, 1 for 'b' prefix
+    if (language == GEN_LANG_RUBY)
+        tab_quote_prefix = 6;  // 2 for tab, 2 for quotes, 2 for " +" suffix
+    GenEnum::PropName prop = prop_python_line_length;
+    if (auto result = map_lang_to_prop.find(language); result != map_lang_to_prop.end())
+        prop = result->second;
+
+    size_t line_length = Project.as_size_t(prop) - tab_quote_prefix;
 
     const std::array<char, 64> base64_chars = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
                                                 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
@@ -409,8 +464,16 @@ std::vector<std::string> base64_encode(unsigned char const* data, size_t data_si
         char_array_4[3] = char_array_3[2] & 0x3f;
     };
 
-    line = "\tb\"";
-    size_t line_pos = 3;
+    std::string line_end = "\"";
+    std::string line_begin = "\tb\"";
+    if (language == GEN_LANG_RUBY)
+    {
+        line_begin = "  `";
+        line_end = "' +";
+    }
+
+    line = line_begin;
+    size_t line_pos = line_begin.size();
     size_t a3_pos = 0;
     for (size_t idx = 0; idx < data_size; ++idx)
     {
@@ -428,9 +491,9 @@ std::vector<std::string> base64_encode(unsigned char const* data, size_t data_si
             line_pos += 4;
             if (line_pos >= line_length)
             {
-                line += "\"";
+                line += line_end;
                 result.emplace_back(line);
-                line_pos = 3;
+                line_pos = line_begin.size();
                 line.resize(line_pos);
             }
         }
@@ -454,7 +517,7 @@ std::vector<std::string> base64_encode(unsigned char const* data, size_t data_si
             line += '=';
         }
     }
-    line += "\"";
+    line += line_end;
     result.emplace_back(line);
 
     return result;
@@ -493,7 +556,7 @@ void BaseCodeGenerator::GeneratePythonImagesForm()
 
         m_source->writeLine(code);
         code.clear();
-        auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF);
+        auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF, GEN_LANG_PYTHON);
         if (encoded.size())
         {
             encoded.back() += ")";

--- a/src/generate/image_gen.h
+++ b/src/generate/image_gen.h
@@ -10,7 +10,7 @@
 class Code;
 struct EmbeddedImage;
 
-std::vector<std::string> base64_encode(unsigned char const* data, size_t data_size);
+std::vector<std::string> base64_encode(unsigned char const* data, size_t data_size, int language = GEN_LANG_PYTHON);
 void AddPythonImageName(Code& code, const EmbeddedImage* embed);
 
 // Primarily designed for wxRibbon which doesn't support wxBitmapBundle.


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR enables generating Ruby code for Embed and Art for bitmap properties. Bitmaps are embedded in the form using base64 and a class method which can extract them.

Note that while the function for getting the embedded bitmap is setup for up to three bitmaps, it will fail if you specify more then one bitmap due to wxRuby3 not having implementation for the necessary .from_...() function. See #1176