### PR TITLE
Support scalable border size

### DIFF
--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -355,6 +355,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_sashpos, "sashpos" },
     { prop_sashsize, "sashsize" },
     { prop_scale_mode, "scale_mode" },
+    { prop_scale_border_size, "scale_border_size" },
     { prop_scroll_rate_x, "scroll_rate_x" },
     { prop_scroll_rate_y, "scroll_rate_y" },
     { prop_search_button, "search_button" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -371,6 +371,7 @@ namespace GenEnum
         prop_sashgravity,
         prop_sashpos,
         prop_sashsize,
+        prop_scale_border_size,
         prop_scale_mode,
         prop_scroll_rate_x,
         prop_scroll_rate_y,

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1618,18 +1618,19 @@ Code& Code::GenSizerFlags()
 
     if (auto& prop = m_node->as_string(prop_borders); prop.size())
     {
-        auto border_size = m_node->as_string(prop_border_size);
+        auto border_size = m_node->as_int(prop_border_size);
         if (prop.contains("wxALL"))
         {
-            if (border_size == "5")
+            if (border_size == 5)
                 SizerFlagsFunction("Border").Add("wxALL)");
-            else if (border_size == "10")
+            else if (border_size == 10)
                 SizerFlagsFunction("DoubleBorder").Add("wxALL)");
-            else if (border_size == "15")
+            else if (border_size == 15)
                 SizerFlagsFunction("TripleBorder").Add("wxALL)");
             else
             {
-                SizerFlagsFunction("Border").Add("wxALL, ") << border_size << ')';
+                SizerFlagsFunction("Border").Add("wxALL, ");
+                BorderSize() += ')';
             }
         }
         else
@@ -1665,7 +1666,7 @@ Code& Code::GenSizerFlags()
                 border_flags = "0";
 
             *this << border_flags << ", ";
-            if (border_size == "5")
+            if (border_size == 5)
             {
                 if (is_cpp())
                     *this += "wxSizerFlags::GetDefaultBorder())";
@@ -1676,7 +1677,7 @@ Code& Code::GenSizerFlags()
             }
             else
             {
-                *this << border_size << ')';
+                BorderSize() += ')';
             }
         }
     }
@@ -1688,6 +1689,29 @@ Code& Code::GenSizerFlags()
         InsertLineBreak(cur_pos);
     }
 
+    return *this;
+}
+
+Code& Code::BorderSize(GenEnum::PropName prop_name)
+{
+    int border_size = m_node->as_int(prop_name);
+    bool is_scalable_border = (border_size > 0 && border_size != 5 && border_size != 10 && border_size != 15);
+    if ((prop_name == prop_border_size && m_node->as_bool(prop_scale_border_size)) && is_scalable_border)
+    {
+        if (is_ruby())
+        {
+            Str("from_dip(").Add("wxSize.new");
+        }
+        else
+        {
+            FormFunction("FromDIP(").Add("wxSize");
+        }
+        Str("(").itoa(border_size).Comma().Str("-1)).x");
+    }
+    else
+    {
+        *this += std::to_string(border_size);
+    }
     return *this;
 }
 

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -395,6 +395,11 @@ public:
     // Will either generate wxSize(...) or ConvertDialogToPixels(wxSize(...))
     Code& WxSize(GenEnum::PropName prop_name = GenEnum::PropName::prop_size, bool enable_dlg_units = allow_dlg_units);
 
+    // If scale_border_size is true, will add the language-specific code for
+    // "FromDIP(wxSize(prop_border_size,-1)).x". Otherwise, it will just add
+    // prop_border_size
+    Code& BorderSize(GenEnum::PropName prop_name = prop_border_size);
+
     Code& EmptyString()
     {
         *this += is_cpp() ? "wxEmptyString" : "\"\"";

--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -415,7 +415,7 @@ bool BaseCodeGenerator::GenAfterChildren(Node* node, bool need_closing_brace)
                 if (!node->hasValue(prop_borders) && !node->hasValue(prop_flags))
                     gen_code.GetCode() += '0';
 
-                gen_code.Comma().as_string(prop_border_size).EndFunction();
+                gen_code.Comma().BorderSize().EndFunction();
                 gen_code.GetCode().Replace(", 0, 0)", ")");
             }
             else
@@ -496,7 +496,7 @@ void BaseCodeGenerator::GenParentSizer(Node* node, bool need_closing_brace)
             if (flags.empty())
                 flags << '0';
 
-            code.Add(flags).Comma().as_string(prop_border_size).EndFunction();
+            code.Add(flags).Comma().BorderSize().EndFunction();
             if (is_cpp())
                 code.Replace(", 0, 0);", ");");
             else

--- a/src/generate/gen_html_window.cpp
+++ b/src/generate/gen_html_window.cpp
@@ -71,9 +71,8 @@ bool HtmlWindowGenerator::SettingsCode(Code& code)
 {
     if (code.IntValue(prop_html_borders) >= 0)
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetBorders(");
-        code += (code.is_cpp() ? "this->FromDIP(, " : "self.FromDIP(, ");
-        code.as_string(prop_html_borders).Str(")").EndFunction();
+        code.Eol(eol_if_needed).NodeName().Function("SetBorders(").BorderSize(prop_html_borders);
+        code.EndFunction();
     }
 
     if (code.hasValue(prop_html_content))

--- a/src/generate/gen_spacer_sizer.cpp
+++ b/src/generate/gen_spacer_sizer.cpp
@@ -26,7 +26,7 @@ bool SpacerGenerator::ConstructionCode(Code& code)
         code.Function("Add(").as_string(prop_width).Comma().as_string(prop_height);
         code.Comma().Object("wxGBPosition").as_string(prop_row).Comma().as_string(prop_column) += ")";
         code.Comma().Object("wxGBSpan").as_string(prop_rowspan).Comma().as_string(prop_colspan) += ")";
-        code.Comma().itoa(flags.GetFlags()).Comma().as_string(prop_border_size);
+        code.Comma().itoa(flags.GetFlags()).Comma().BorderSize();
         if (node->as_bool(prop_add_default_border))
         {
             code.Str(" + ").Add("wxSizerFlags").ClassMethod("GetDefaultBorder()");

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -163,7 +163,7 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
                     ->Add(node->as_int(prop_width), node->as_int(prop_height),
                           wxGBPosition(node->as_int(prop_row), node->as_int(prop_column)),
                           wxGBSpan(node->as_int(prop_rowspan), node->as_int(prop_colspan)), flags.GetFlags(),
-                          node->as_int(prop_border_size));
+                          parent->FromDIP(wxSize(node->as_int(prop_border_size), -1)).x);
             }
             else
             {
@@ -292,6 +292,12 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
         {
             auto child_obj = getNode(created_object);
             auto sizer_flags = child_obj->getSizerFlags();
+            int border_size = child_obj->as_int(prop_border_size);
+            if (child_obj->as_bool(prop_scale_border_size) && border_size != 0 && border_size != 5 && border_size != 10 &&
+                border_size != 15)
+            {
+                border_size = FromDIP(wxSize(border_size, -1)).x;
+            }
             if (obj_parent->isGen(gen_wxGridBagSizer))
             {
                 auto sizer = wxStaticCast(parent_object, wxGridBagSizer);
@@ -301,20 +307,18 @@ void MockupContent::CreateChildren(Node* node, wxWindow* parent, wxObject* paren
                 if (created_window)
                     sizer->Add(created_window, position, span, sizer_flags.GetFlags(), sizer_flags.GetBorderInPixels());
                 else
-                    sizer->Add(created_sizer, position, span, sizer_flags.GetFlags(), sizer_flags.GetBorderInPixels());
+                    sizer->Add(created_sizer, position, span, sizer_flags.GetFlags(), border_size);
             }
             else
             {
                 auto sizer = wxStaticCast(parent_object, wxSizer);
                 if (created_window && !child_obj->isStaticBoxSizer())
                 {
-                    sizer->Add(created_window, sizer_flags.GetProportion(), sizer_flags.GetFlags(),
-                               sizer_flags.GetBorderInPixels());
+                    sizer->Add(created_window, sizer_flags.GetProportion(), sizer_flags.GetFlags(), border_size);
                 }
                 else
                 {
-                    sizer->Add(created_sizer, sizer_flags.GetProportion(), sizer_flags.GetFlags(),
-                               sizer_flags.GetBorderInPixels());
+                    sizer->Add(created_sizer, sizer_flags.GetProportion(), sizer_flags.GetFlags(), border_size);
                 }
             }
         }

--- a/src/mockup/mockup_preview.cpp
+++ b/src/mockup/mockup_preview.cpp
@@ -57,7 +57,7 @@ void CreateMockupChildren(Node* node, wxWindow* parent, wxObject* parent_object,
                     ->Add(node->as_int(prop_width), node->as_int(prop_height),
                           wxGBPosition(node->as_int(prop_row), node->as_int(prop_column)),
                           wxGBSpan(node->as_int(prop_rowspan), node->as_int(prop_colspan)), flags.GetFlags(),
-                          node->as_int(prop_border_size));
+                          parent->FromDIP(wxSize(node->as_int(prop_border_size), -1)).x);
             }
             else
             {

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1992,17 +1992,22 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
 }
 
+// clang-format off
 static constexpr std::initializer_list<PropName> lst_LayoutProps = {
 
-    prop_alignment, prop_borders, prop_border_size, prop_flags
+    prop_alignment,
+    prop_borders,
+    prop_border_size,
+    prop_scale_border_size,
+    prop_flags
 
 };
 
-// clang-format off
 static constexpr std::initializer_list<PropName> lst_GridBagProps = {
 
     prop_borders,
     prop_border_size,
+    prop_scale_border_size,
     prop_flags,
     prop_row,
     prop_column,

--- a/src/xml/sizer_child_xml.xml
+++ b/src/xml/sizer_child_xml.xml
@@ -33,6 +33,8 @@ inline const char* sizer_child_xml = R"===(<?xml version="1.0"?>
 		</property>
 		<property name="border_size" type="uint"
 			help="Sets the border size, if the flag parameter is set to include any border flag. The default value of 5 will be scaled on high DPI displayes.">5</property>
+		<property name="scale_border_size" type="bool"
+			help="If checked, the border size will be scaled on high DPI displays. Always scaled if size is 5, 10 or 15.">1</property>
 		<property name="flags" type="bitlist">
 			<option name="wxEXPAND"
 				help="The item will be expanded to fill the space assigned to the item." />
@@ -91,6 +93,8 @@ inline const char* sizer_child_xml = R"===(<?xml version="1.0"?>
 		</property>
 		<property name="border_size" type="uint"
 			help="Sets the border size, if the flag parameter is set to include any border flag. The default value of 5 will be scaled on high DPI displayes.">5</property>
+		<property name="scale_border_size" type="bool"
+			help="If checked, the border size will be scaled on high DPI displays. Always scaled if size is 5, 10 or 15.">1</property>
 		<property name="flags" type="bitlist">
 			<option name="wxEXPAND"
 				help="The item will be expanded to fill the space assigned to the item." />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `scale_border_size` property to the Layout category. When checked and the border is something other than 0, 5, 10 or 15, then `FromDIP(wxSize(border, -1)).x` is used instead of the direct border value. This causes non-default border sizes to scale just as they would with the default border sizes (5, 10, 15).

Note that because the default for `scale_border_size` is `true` all imported projects will have non-default border sizes scaled. For **DialogBlocks** and **wxCrafter**, that was already being done. **wxFormBuilder** and **wxGlade** don't provide the ability, but the assumption is that the user will _want_ to have their UI spacing look correct on high-resolution displays, so we scale any non-default border sizes from these other projects.

Closes #1181