### PR TITLE
Refactor using frozen library

### DIFF
--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -238,7 +238,6 @@ set (file_list
 
     # Importers (also see Windows Resource importer below)
 
-    import/import_crafter_maps.cpp  # wxCrafter mappings
     import/import_dialogblocks.cpp  # Import a DialogBlocks project
     import/import_formblder.cpp     # Import a wxFormBuider project
     import/import_wxcrafter.cpp     # Import a wxCrafter project

--- a/src/import/import_arrays.cpp
+++ b/src/import/import_arrays.cpp
@@ -2,17 +2,65 @@
 // Purpose:   Array of formbuilder/wxuieditor event name pairs
 /////////////////////////////////////////////////////////////////////////////
 
-// This file just gets the long array out of the way of the main source code in import_form.cpp
+constexpr auto set_ignore_flags = frozen::make_set<std::string_view>({
+    "xrc_skip_sizer",  // used for XRC code generation which we don't support
 
-struct IMPORT_NAME_PAIR
-{
-    const char* wxfb_name;
-    const char* wxui_name;
-};
+    "event_handler",  // all events are now declared as virtual
+
+    // The following are wxFormBuilder properties for wxAuiToolBar
+
+    "label_visible",
+    "toolbar_label",
+    "use_explicit_ids",
+
+    // The following are AUI properties. Unless AUI frame windows gets implemented, these will all be ignored
+
+    "BottomDockable",
+    "LeftDockable",
+    "RightDockable",
+    "TopDockable",
+    "aui_layer",
+    "aui_managed",
+    "aui_manager_style",
+    "aui_name",
+    "aui_position",
+    "aui_row",
+    "best_size",
+    "caption",
+    "caption_visible",
+    "center_pane",
+    "close_button",
+    "context_menu",
+    "default_pane",
+    "dock",
+    "dock_fixed",
+    "docking",
+    "event_generation",
+    "first_id",
+    "floatable",
+    "gripper",
+    "max_size",
+    "maximize_button",
+    "min_size",
+    "minimize_button",
+    "moveable",
+    "pane_border",
+    "pane_position",
+    "pane_size",
+    "parent",
+    "pin_button",
+    "resize",
+    "show",
+    "toolbar_pane",
+
+    // This are miscellanious properties that we don't support
+
+    "two_step_creation",
+    "use_enum",
+});
 
 // The left name is what wxFormBuilder calls the event, the right name is what wxUiEditor calls the event
-constexpr const IMPORT_NAME_PAIR evt_pair[] = {
-
+constexpr auto evt_pair = frozen::make_map<std::string_view, std::string_view>({
     { "OnActivate", "wxEVT_ACTIVATE" },
 
     { "OnAuiFindManager", "wxEVT_AUI_FIND_MANAGER" },
@@ -353,6 +401,4 @@ constexpr const IMPORT_NAME_PAIR evt_pair[] = {
     { "OnOKButtonClick", "OKButtonClicked" },
     { "OnSaveButtonClick", "SaveButtonClicked" },
     { "OnYesButtonClick", "YesButtonClicked" },
-
-    { nullptr, nullptr },
-};
+});

--- a/src/import/import_crafter_maps.cpp
+++ b/src/import/import_crafter_maps.cpp
@@ -1,16 +1,10 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxCrafter mappings
-// Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2022 KeyWorks Software (Ralph Walden)
-// License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
-
-#include "gen_enums.h"
 
 using namespace GenEnum;
 
-std::map<int, GenEnum::GenName> g_map_id_generator = {
-
+constexpr auto map_id_generator = frozen::make_map<int, GenEnum::GenName>({
     { 4400, gen_wxButton },         // verified
     { 4401, gen_wxBoxSizer },       // verified
     { 4402, gen_wxFrame },          // verified
@@ -138,10 +132,10 @@ std::map<int, GenEnum::GenName> g_map_id_generator = {
     { 4516, gen_unknown /* WXAUITOOLBARITEM_STRETCHSPACE */ },
     { 4517, gen_unknown /* WXTOOLBARITEM_STRETCHSPACE */ },
     { 4518, gen_unknown /* WXAUITOOLBARTOPLEVEL */ },
+});
 
-};
-
-std::map<std::string, GenEnum::PropName> g_map_crafter_props = {
+// std::map<std::string, GenEnum::PropName> g_map_crafter_props = {
+constexpr auto map_crafter_props = frozen::make_map<std::string_view, GenEnum::PropName>({
 
     // strings must be lower case even though they appear mixed case in the .wxcp file -- they are converted to lower-case
     // before pattern matching.
@@ -202,5 +196,32 @@ std::map<std::string, GenEnum::PropName> g_map_crafter_props = {
     { "use native header", prop_native_col_header },
     { "vertical gap", prop_vgap },
     { "visited colour", prop_visited_color },
+});
 
-};
+// wxCrafter doesn't put a space between the words
+constexpr auto map_sys_colour_pair = frozen::make_map<std::string_view, std::string_view>({
+    { "AppWorkspace", "wxSYS_COLOUR_APPWORKSPACE" },
+    { "ActiveBorder", "wxSYS_COLOUR_ACTIVEBORDER" },
+    { "ActiveCaption", "wxSYS_COLOUR_ACTIVECAPTION" },
+    { "ButtonFace", "wxSYS_COLOUR_BTNFACE" },
+    { "ButtonHighlight", "wxSYS_COLOUR_BTNHIGHLIGHT" },
+    { "ButtonShadow", "wxSYS_COLOUR_BTNSHADOW" },
+    { "ButtonText", "wxSYS_COLOUR_BTNTEXT" },
+    { "CaptionText", "wxSYS_COLOUR_CAPTIONTEXT" },
+    { "ControlDark", "wxSYS_COLOUR_3DDKSHADOW" },
+    { "ControlLight", "wxSYS_COLOUR_3DLIGHT" },
+    { "Desktop", "wxSYS_COLOUR_BACKGROUND" },
+    { "GrayText", "wxSYS_COLOUR_GRAYTEXT" },
+    { "Highlight", "wxSYS_COLOUR_HIGHLIGHT" },
+    { "HighlightText", "wxSYS_COLOUR_HIGHLIGHTTEXT" },
+    { "InactiveBorder", "wxSYS_COLOUR_INACTIVEBORDER" },
+    { "InactiveCaption", "wxSYS_COLOUR_INACTIVECAPTION" },
+    { "InactiveCaptionText", "wxSYS_COLOUR_INACTIVECAPTIONTEXT" },
+    { "Menu", "wxSYS_COLOUR_MENU" },
+    { "Scrollbar", "wxSYS_COLOUR_SCROLLBAR" },
+    { "Tooltip", "wxSYS_COLOUR_INFOBK" },
+    { "TooltipText", "wxSYS_COLOUR_INFOTEXT" },
+    { "Window", "wxSYS_COLOUR_WINDOW" },
+    { "WindowFrame", "wxSYS_COLOUR_WINDOWFRAME" },
+    { "WindowText", "wxSYS_COLOUR_WINDOWTEXT" },
+});

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -24,7 +24,7 @@
 #include "node_creator.h"    // NodeCreator class
 #include "utils.h"           // Utility functions that work with properties
 
-#include "import_arrays.cpp"  // Array of formbuilder/wxuieditor event name pairs
+#include "import_frmbldr_maps.cpp"  // set_ignore_flags and map_evt_pair
 
 bool FormBuilder::Import(const tt_string& filename, bool write_doc)
 {
@@ -513,7 +513,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
         if (auto event_name = xml_event.attribute("name").as_string();
             event_name.size() && xml_event.text().as_string().size())
         {
-            if (auto result = evt_pair.find(event_name); result != evt_pair.end())
+            if (auto result = map_evt_pair.find(event_name); result != map_evt_pair.end())
             {
                 event_name = result->second;
                 if (event_name == "wxEVT_MENU" && newobject->isGen(gen_tool))

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -11,7 +11,6 @@
 
 #include <frozen/map.h>
 #include <frozen/set.h>
-#include <frozen/string.h>
 
 #include <wx/mstream.h>  // Memory stream classes
 

--- a/src/import/import_formblder.h
+++ b/src/import/import_formblder.h
@@ -20,7 +20,7 @@ using ImportNameMap = std::unordered_map<std::string, const char*>;
 class FormBuilder : public ImportXML
 {
 public:
-    FormBuilder();
+    FormBuilder() {};
     ~FormBuilder() {};
 
     bool Import(const tt_string& filename, bool write_doc = true) override;
@@ -36,8 +36,6 @@ protected:
     void createProjectNode(pugi::xml_node& xml_obj, Node* new_node);
 
 private:
-    ImportNameMap m_mapEventNames;
-
     tt_string m_embedPath;
     tt_string m_eventGeneration;
     tt_string m_baseFile;

--- a/src/import/import_frmbldr_maps.cpp
+++ b/src/import/import_frmbldr_maps.cpp
@@ -60,7 +60,7 @@ constexpr auto set_ignore_flags = frozen::make_set<std::string_view>({
 });
 
 // The left name is what wxFormBuilder calls the event, the right name is what wxUiEditor calls the event
-constexpr auto evt_pair = frozen::make_map<std::string_view, std::string_view>({
+constexpr auto map_evt_pair = frozen::make_map<std::string_view, std::string_view>({
     { "OnActivate", "wxEVT_ACTIVATE" },
 
     { "OnAuiFindManager", "wxEVT_AUI_FIND_MANAGER" },

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -10,7 +10,6 @@
 #include <set>
 
 #include <frozen/map.h>
-#include <frozen/string.h>
 
 #include <wx/mstream.h>  // Memory stream classes
 

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -5,6 +5,8 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
+#include <frozen/map.h>
+
 #include "import_xml.h"
 
 #include "base_generator.h"  // BaseGenerator -- Base Generator class
@@ -23,8 +25,7 @@ using namespace GenEnum;
 namespace xrc_import
 {
 
-std::map<std::string_view, GenEnum::PropName, std::less<>> import_PropNames = {
-
+constexpr auto map_import_prop_names = frozen::make_map<std::string_view, GenEnum::PropName>({
     { "accel", prop_shortcut },
     { "art-provider", prop_art_provider },
     { "bg", prop_background_colour },
@@ -67,11 +68,9 @@ std::map<std::string_view, GenEnum::PropName, std::less<>> import_PropNames = {
     { "tickfreq", prop_tick_frequency },
     { "windowlabel", prop_tab_height },
     { "wrapmode", prop_stc_wrap_mode },
+});
 
-};
-
- std::map<std::string_view, GenEnum::GenName, std::less<>> import_GenNames = {
-
+constexpr auto import_GenNames = frozen::make_map<std::string_view, GenEnum::GenName>({
     { "Custom", gen_CustomControl },
     { "CustomWidget", gen_CustomControl },
     { "Dialog", gen_wxDialog },
@@ -92,8 +91,7 @@ std::map<std::string_view, GenEnum::PropName, std::less<>> import_PropNames = {
     { "wxSubmenu", gen_submenu },
     { "wxToolBarSeparator", gen_toolSeparator },
     { "wxToolBarButton", gen_tool },
-
-};
+});
 
 static const view_map s_map_old_events = {
 
@@ -1392,7 +1390,7 @@ GenEnum::PropName ImportXML::MapPropName(std::string_view name) const
             return prop;
         }
 
-        if (auto result = import_PropNames.find(name); result != import_PropNames.end())
+        if (auto result = map_import_prop_names.find(name); result != map_import_prop_names.end())
         {
             return result->second;
         }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors that maps and arrays used in the project importers to utilize the `frozen` library to convert these into compile-time maps instead of runtime maps.
