### PR TITLE
Refactor NodeDeclaration/PropDeclaration

### DIFF
--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -187,3 +187,13 @@ public:
 
     virtual void AddPropsAndEvents(NodeDeclaration*) {}
 };
+
+PropDeclaration* DeclAddProp(NodeDeclaration* declaration, PropName prop_name, PropType type, std::string_view help = {},
+                             std::string_view def_value = {});
+void DeclAddOption(PropDeclaration* prop_info, std::string_view name, std::string_view help = {});
+
+// This will add prop_var_name, prop_var_comment and prop_class_access
+void DeclAddVarNameProps(NodeDeclaration* declaration, std::string_view def_value);
+
+void DeclAddEvent(NodeDeclaration* declaration, const std::string& evt_name, std::string_view event_class,
+                  std::string_view help);

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -184,4 +184,6 @@ public:
     //
     // You will need to Bind to any commands you add.
     virtual bool PopupMenuAddCommands(NavPopupMenu*, Node*) { return false; }
+
+    virtual void AddPropsAndEvents(NodeDeclaration*) {}
 };

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -297,3 +297,99 @@ void TextCtrlGenerator::RequiredHandlers(Node* /* node */, std::set<std::string>
 {
     handlers.emplace("wxActivityIndicatorXmlHandler");
 }
+
+void TextCtrlGenerator::AddPropsAndEvents(NodeDeclaration* declaration)
+{
+    DeclAddVarNameProps(declaration, "m_textCtrl");
+    // DeclAddProp(declaration, prop_var_name, type_string, "", "m_textCtrl");
+    DeclAddProp(declaration, prop_value, type_string_escapes, "Specifies the initial value of the text control.");
+    DeclAddProp(declaration, prop_hint, type_string_escapes,
+                "The maximum length of user-entered text. 0 means no limit. Note that in wxGTK "
+                "this function may only be used with single line text controls.");
+    DeclAddProp(declaration, prop_maxlength, type_string,
+                "The maximum length of user-entered text. 0 means no limit. Note that in wxGTK this function may only be "
+                "used with single line text controls.");
+    DeclAddProp(declaration, prop_auto_complete, type_stringlist_semi,
+                "If one or more strings are entered, they will be used to initialize autocomplete.");
+
+    auto* prop_info = DeclAddProp(declaration, prop_spellcheck, type_bitlist);
+    {
+        DeclAddOption(
+            prop_info, "enabled",
+            "Currently this is supported in wxMSW (when running under Windows 8 or later), wxGTK when using GTK 3 and "
+            "wxOSX. In addition, wxMSW requires that the text control has the wxTE_RICH2 style set, while wxOSX "
+            "requires that the control has the wxTE_MULTILINE style.\n\nAvailable since 3.1.6");
+        DeclAddOption(
+            prop_info, "grammar",
+            "Enables grammar checking in addition to spell checking. Currently this is supported in wxMSW (when "
+            "running under Windows 8 or later), wxGTK when using GTK 3 and wxOSX. In addition, wxMSW requires that "
+            "the text control has the wxTE_RICH2 style set, while wxOSX requires that the control has the "
+            "wxTE_MULTILINE style.\n\nAvailable since 3.1.6");
+    }
+
+    prop_info = DeclAddProp(declaration, prop_style, type_bitlist);
+    {
+        DeclAddOption(
+            prop_info, "wxTE_PROCESS_ENTER",
+            "The control will generate the event wxEVT_TEXT_ENTER (otherwise pressing Enter key is either processed "
+            "internally by the control or used for navigation between dialog controls).");
+        DeclAddOption(
+            prop_info, "wxTE_PROCESS_TAB",
+            "The control will receive wxEVT_CHAR events for TAB pressed - normally, TAB is used for passing to the "
+            "next control in a dialog instead. For the control created with this style, you can still use Ctrl-Enter "
+            "to pass to the next control from the keyboard.");
+        DeclAddOption(prop_info, "wxTE_MULTILINE", "The text control allows multiple lines.");
+        DeclAddOption(prop_info, "wxTE_PASSWORD", "The text will be echoed as asterisks.");
+        DeclAddOption(prop_info, "wxTE_READONLY", "The text will not be user-editable.");
+        DeclAddOption(prop_info, "wxTE_RICH",
+                      "Use rich text control under Windows. This allows having more than 64KB of text in the control. This "
+                      "style is ignored under other platforms.");
+        DeclAddOption(
+            prop_info, "wxTE_RICH2",
+            "Use rich text control version 2.0 or 3.0 under Windows. This style is ignored under other platforms.");
+        DeclAddOption(prop_info, "wxTE_AUTO_URL",
+                      "Highlight the URLs and generate the wxTextUrlEvents when mouse events occur over them. This style is "
+                      "only supported for wxTE_RICH Win32 and multi-line wxGTK2 text controls.");
+        DeclAddOption(
+            prop_info, "wxTE_NOHIDESEL",
+            "By default, the Windows text control doesn't show the selection when it doesn't have focus - use this "
+            "style to force it to always show it. This style is ignored under other platforms.");
+        DeclAddOption(
+            prop_info, "wxTE_NO_VSCROLL",
+            "For multiline controls only: a vertical scrollbar will never be created. This limits the amount of text "
+            "which can be entered into the control to what can be displayed in it under MSW but not under GTK2. "
+            "Currently not implemented for the other platforms.");
+        DeclAddOption(prop_info, "wxTE_LEFT", "The text in the control will be left-justified (default).");
+        DeclAddOption(prop_info, "wxTE_CENTER",
+                      "The text in the control will be centered (currently Windows and wxGTK2 only).");
+        DeclAddOption(prop_info, "wxTE_RIGHT",
+                      "The text in the control will be right-justified (currently Windows and wxGTK2 only).");
+        DeclAddOption(prop_info, "wxTE_DONTWRAP",
+                      "Same as wxHSCROLL style: don't wrap at all, show horizontal scrollbar instead.");
+        DeclAddOption(prop_info, "wxTE_CHARWRAP",
+                      "Wrap the lines too long to be shown entirely at any position (wxUniv and wxGTK2 only).");
+        DeclAddOption(prop_info, "wxTE_WORDWRAP",
+                      "Wrap the lines too long to be shown entirely at word boundaries (wxUniv and wxGTK2 only).");
+        DeclAddOption(
+            prop_info, "wxTE_BESTWRAP",
+            "Wrap the lines at word boundaries or at any other character if there are words longer than the window "
+            "width (this is the default).");
+    }
+
+    DeclAddProp(declaration, prop_focus, type_bool,
+                "When checked, this control will be set to receive keyboard input when the parent form is first created.",
+                "0");
+
+    // Add events
+    DeclAddEvent(declaration, "wxEVT_TEXT", "wxCommandEvent",
+                 "Generated when the text changes. Notice that this event will always be generated when the text controls "
+                 "contents changes - whether this is due to user input or comes from the program itself (for example, if "
+                 "SetValue() is called.)");
+    DeclAddEvent(declaration, "wxEVT_TEXT_ENTER", "wxCommandEvent",
+                 "Generated when enter is pressed in a text control (which must have wxTE_PROCESS_ENTER style for this "
+                 "event to be generated).");
+    DeclAddEvent(declaration, "wxEVT_TEXT_URL", "wxTextUrlEvent",
+                 "Generated when the a mouse event occurred over an URL in the text control (Windows and wxGTK2 only)");
+    DeclAddEvent(declaration, "wxEVT_TEXT_MAXLEN", "wxCommandEvent",
+                 "Generated when the user tries to enter more text into the control than the limit set by SetMaxLength.");
+}

--- a/src/generate/gen_text_ctrl.h
+++ b/src/generate/gen_text_ctrl.h
@@ -25,4 +25,6 @@ public:
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
+
+    void AddPropsAndEvents(NodeDeclaration* declaration) override;
 };

--- a/src/nodes/node_decl.cpp
+++ b/src/nodes/node_decl.cpp
@@ -36,15 +36,15 @@ PropDeclaration* NodeDeclaration::getPropDeclaration(size_t idx) const
     }
 
     if (it != m_properties.end())
-        return it->second.get();
+        return it->second;
 
     return nullptr;
 }
 
-NodeEventInfo* NodeDeclaration::getEventInfo(tt_string_view name)
+const NodeEventInfo* NodeDeclaration::getEventInfo(tt_string_view name) const
 {
     if (auto it = m_events.find(name); it != m_events.end())
-        return it->second.get();
+        return it->second;
 
     return nullptr;
 }
@@ -62,7 +62,7 @@ const NodeEventInfo* NodeDeclaration::getEventInfo(size_t idx) const
     }
 
     if (it != m_events.end())
-        return it->second.get();
+        return it->second;
 
     return nullptr;
 }

--- a/src/nodes/node_decl.h
+++ b/src/nodes/node_decl.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   NodeDeclaration class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -21,9 +21,8 @@
 
 using namespace GenEnum;
 
-using DblStrMap = std::map<std::string, std::string, std::less<>>;
-using PropDeclarationPtr = std::shared_ptr<PropDeclaration>;
-using PropDeclarationMap = std::map<std::string, PropDeclarationPtr>;
+using DeclPropMap = std::map<std::string, PropDeclaration*>;
+using DeclEventMap = std::map<std::string, NodeEventInfo*, std::less<>>;
 
 namespace pugi
 {
@@ -45,10 +44,11 @@ public:
 
     PropDeclaration* getPropDeclaration(size_t idx) const;
 
-    NodeEventInfo* getEventInfo(tt_string_view name);
+    const NodeEventInfo* getEventInfo(tt_string_view name) const;
     const NodeEventInfo* getEventInfo(size_t idx) const;
 
-    PropDeclarationMap& GetPropInfoMap() { return m_properties; }
+    auto& GetPropInfoMap() { return m_properties; }
+    auto& GetEventInfoMap() { return m_events; }
 
     NodeType* getNodeType() const { return m_type; }
 
@@ -106,8 +106,8 @@ private:
 
     NodeCategory m_category;
 
-    PropDeclarationMap m_properties;  // std::map<std::string, PropDeclarationPtr>
-    std::map<std::string, std::unique_ptr<NodeEventInfo>, std::less<>> m_events;
+    std::map<std::string, PropDeclaration*> m_properties;
+    std::map<std::string, NodeEventInfo*, std::less<>> m_events;
 
     std::map<GenEnum::PropName, std::string> m_override_def_values;
     std::set<GenEnum::PropName> m_hide_properties;

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -5,6 +5,8 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
+#include <frozen/set.h>
+
 #include "node_creator.h"
 
 #include "base_generator.h"  // BaseGenerator -- Base widget generator class
@@ -98,7 +100,8 @@ inline const char* lst_xml_generators[] = {
 };
 
 // var_names for these generators will default to "none" for class access
-inline const GenName lst_no_class_access[] = {
+// inline const GenName set_no_class_access[] = {
+constexpr auto set_no_class_access = frozen::make_set<GenName>({
 
     gen_BookPage,
     gen_CloseButton,
@@ -130,7 +133,7 @@ inline const GenName lst_no_class_access[] = {
     gen_wxWizardPageSimple,
     gen_wxWrapSizer,
 
-};
+});
 
 // clang-format on
 
@@ -469,7 +472,7 @@ void NodeCreator::Initialize()
             continue;
         if (auto gen = declaration->getGenerator(); gen)
         {
-            gen->AddPropsAndEvents(declaration->GetPropInfoMap(), declaration->GetEventInfoMap());
+            gen->AddPropsAndEvents(declaration);
         }
     }
 
@@ -795,16 +798,12 @@ void NodeCreator::parseProperties(pugi::xml_node& elem_obj, NodeDeclaration* nod
             category.addProperty(prop_class_access);
             tt_string access("protected:");
 
-            // Most widgets will default to protected: as their class access. Those in the lst_no_class_access array should
-            // have "none" as the default class access.
+            // Most widgets will default to protected: as their class access. Those in the
+            // set_no_class_access array should have "none" as the default class access.
 
-            for (auto generator: lst_no_class_access)
+            if (set_no_class_access.contains(node_declaration->getGenName()))
             {
-                if (node_declaration->isGen(generator))
-                {
-                    access = "none";
-                    break;
-                }
+                access = "none";
             }
 
             prop_info = new PropDeclaration(prop_class_access, type_option, access,

--- a/src/nodes/node_init.cpp
+++ b/src/nodes/node_init.cpp
@@ -7,11 +7,12 @@
 
 #include "node_creator.h"
 
-#include "bitmaps.h"     // Contains various images handling functions
-#include "gen_enums.h"   // Enumerations for generators
-#include "node.h"        // Node class
-#include "node_types.h"  // NodeType -- Class for storing node types and allowable child count
-#include "prop_decl.h"   // PropChildDeclaration and PropDeclaration classes
+#include "base_generator.h"  // BaseGenerator -- Base widget generator class
+#include "bitmaps.h"         // Contains various images handling functions
+#include "gen_enums.h"       // Enumerations for generators
+#include "node.h"            // Node class
+#include "node_types.h"      // NodeType -- Class for storing node types and allowable child count
+#include "prop_decl.h"       // PropChildDeclaration and PropDeclaration classes
 
 #include "pugixml.hpp"
 
@@ -462,6 +463,16 @@ void NodeCreator::Initialize()
 
     initGenerators();
 
+    for (auto* declaration: m_a_declarations)
+    {
+        if (!declaration)
+            continue;
+        if (auto gen = declaration->getGenerator(); gen)
+        {
+            gen->AddPropsAndEvents(declaration->GetPropInfoMap(), declaration->GetEventInfoMap());
+        }
+    }
+
     for (auto& iter: fb_ImportTypes)
     {
         m_setOldHostTypes.emplace(iter);
@@ -686,7 +697,7 @@ void NodeCreator::parseGeneratorFile(const char* xml_data)
     }
 }
 
-void NodeCreator::parseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj_info, NodeCategory& category)
+void NodeCreator::parseProperties(pugi::xml_node& elem_obj, NodeDeclaration* node_declaration, NodeCategory& category)
 {
     auto elem_category = elem_obj.child("category");
     while (elem_category)
@@ -698,12 +709,12 @@ void NodeCreator::parseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
         {
             if (auto node = m_interfaces.find(base_name); node != m_interfaces.end())
             {
-                parseProperties(node->second, obj_info, new_cat);
+                parseProperties(node->second, node_declaration, new_cat);
             }
         }
         else
         {
-            parseProperties(elem_category, obj_info, new_cat);
+            parseProperties(elem_category, node_declaration, new_cat);
         }
 
         elem_category = elem_category.next_sibling("category");
@@ -726,7 +737,6 @@ void NodeCreator::parseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
         category.addProperty(prop_name);
 
         auto description = elem_prop.attribute("help").as_string();
-        auto customEditor = elem_prop.attribute("editor").as_string();
 
         auto prop_type = elem_prop.attribute("type").as_sview();
 
@@ -754,8 +764,8 @@ void NodeCreator::parseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
             }
         }
 
-        auto prop_info = std::make_shared<PropDeclaration>(prop_name, property_type, def_value, description, customEditor);
-        obj_info->GetPropInfoMap()[name] = prop_info;
+        auto prop_info = new PropDeclaration(prop_name, property_type, def_value, description);
+        node_declaration->GetPropInfoMap()[name] = prop_info;
 
         if (property_type == type_bitlist || property_type == type_option || property_type == type_editoption)
         {
@@ -777,11 +787,10 @@ void NodeCreator::parseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
         if (tt::is_sameas(name, map_PropNames[prop_var_name]))
         {
             category.addProperty(prop_var_comment);
-            prop_info = std::make_shared<PropDeclaration>(prop_var_comment, type_string_edit_single, tt_empty_cstr,
-                                                          "Comment to add to the variable name in the generated header file "
-                                                          "if the class access is set to protected or public",
-                                                          "");
-            obj_info->GetPropInfoMap()[map_PropNames[prop_var_comment]] = prop_info;
+            prop_info = new PropDeclaration(prop_var_comment, type_string_edit_single, tt_empty_cstr,
+                                            "Comment to add to the variable name in the generated header file "
+                                            "if the class access is set to protected or public");
+            node_declaration->GetPropInfoMap()[map_PropNames[prop_var_comment]] = prop_info;
 
             category.addProperty(prop_class_access);
             tt_string access("protected:");
@@ -791,17 +800,16 @@ void NodeCreator::parseProperties(pugi::xml_node& elem_obj, NodeDeclaration* obj
 
             for (auto generator: lst_no_class_access)
             {
-                if (obj_info->isGen(generator))
+                if (node_declaration->isGen(generator))
                 {
                     access = "none";
                     break;
                 }
             }
 
-            prop_info = std::make_shared<PropDeclaration>(
-                prop_class_access, type_option, access,
-                "Determines the type of access your inherited class has to this item.", "");
-            obj_info->GetPropInfoMap()[map_PropNames[prop_class_access]] = prop_info;
+            prop_info = new PropDeclaration(prop_class_access, type_option, access,
+                                            "Determines the type of access your inherited class has to this item.");
+            node_declaration->GetPropInfoMap()[map_PropNames[prop_class_access]] = prop_info;
 
             auto& opts = prop_info->getOptions();
 
@@ -848,7 +856,7 @@ void NodeDeclaration::ParseEvents(pugi::xml_node& elem_obj, NodeCategory& catego
         auto evt_class = nodeEvent.attribute("class").as_std_str("wxEvent");
         auto description = nodeEvent.attribute("help").as_std_str();
 
-        m_events[evt_name] = std::make_unique<NodeEventInfo>(evt_name, evt_class, description);
+        m_events[evt_name] = new NodeEventInfo(evt_name, evt_class, description);
 
         nodeEvent = nodeEvent.next_sibling("event");
     }

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -165,7 +165,6 @@ public:
     bool isType(PropType type) const noexcept { return m_declaration->isType(type); }
 
     PropType type() const noexcept { return m_declaration->get_type(); }
-    const char* name_str() const noexcept { return m_declaration->name_str(); }
     PropName get_name() const noexcept { return m_declaration->get_name(); }
 
     PropDeclaration* getPropDeclaration() { return m_declaration; }

--- a/src/nodes/prop_decl.h
+++ b/src/nodes/prop_decl.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   PropChildDeclaration and PropDeclaration classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -10,46 +10,30 @@
 #include "gen_enums.h"  // Enumerations for generators
 using namespace GenEnum;
 
-struct PropChildDeclaration
+// class PropDeclaration : public PropChildDeclaration
+class PropDeclaration
 {
-    tt_string m_def_value;
-    tt_string m_help;
+public:
+    PropDeclaration(GenEnum::PropName prop_name, GenEnum::PropType prop_type, std::string_view def_value,
+                    std::string_view help)
+    {
+        m_name_enum = prop_name;
+        m_prop_type = prop_type;
+        m_def_value = def_value;
+        m_help = help;
+    }
 
-    // BUGBUG: [KeyWorks - 04-09-2021] NodeCreator::parseProperties does not initialize the following for parent properties
+    // Returns a char pointer to the name. Use get_name() if you want the enum value.
+    tt_string_view declName() const noexcept { return GenEnum::map_PropNames[m_name_enum]; }
 
-    const char* name_str() const noexcept { return m_name_str; }
+    const tt_string& getDefaultValue() const noexcept { return m_def_value; }
+    const tt_string& getDescription() const noexcept { return m_help; }
+
     PropName get_name() const noexcept { return m_name_enum; }
     PropType get_type() const noexcept { return m_prop_type; }
 
     bool isType(PropType type) const noexcept { return (type == m_prop_type); }
     bool isProp(PropName name) const noexcept { return (name == m_name_enum); }
-
-    GenEnum::PropType m_prop_type;
-    GenEnum::PropName m_name_enum;  // enumeration value for the name
-    const char* m_name_str;         // const char* pointer to the name
-};
-
-class PropDeclaration : public PropChildDeclaration
-{
-public:
-    PropDeclaration(GenEnum::PropName prop_name, GenEnum::PropType prop_type, std::string_view def_value,
-                    std::string_view help, std::string_view customEditor)
-    {
-        m_def_value = def_value;
-        m_help = help;
-        m_customEditor = customEditor;
-
-        m_prop_type = prop_type;
-        m_name_enum = prop_name;
-        m_name_str = GenEnum::map_PropNames[m_name_enum];
-    }
-
-    // Returns a char pointer to the name. Use get_name() if you want the enum value.
-    tt_string_view declName() const noexcept { return m_name_str; }
-
-    const tt_string& getDefaultValue() const noexcept { return m_def_value; }
-    const tt_string& getDescription() const noexcept { return m_help; }
-    const tt_string& getCustomEditor() const noexcept { return m_customEditor; }
 
     // These get used to setup wxPGProperty, so both key and value need to be a wxString
     struct Options
@@ -61,7 +45,11 @@ public:
     std::vector<Options>& getOptions() { return m_options; }
 
 private:
-    tt_string m_customEditor;  // an optional custom editor for the property grid
+    tt_string m_def_value;
+    tt_string m_help;
+
+    GenEnum::PropType m_prop_type;
+    GenEnum::PropName m_name_enum;  // enumeration value for the name
 
     // This gets used to setup wxPGProperty, so both key and value need to be a wxString
     std::vector<Options> m_options;

--- a/src/nodes/prop_decl.h
+++ b/src/nodes/prop_decl.h
@@ -35,9 +35,10 @@ public:
     bool isType(PropType type) const noexcept { return (type == m_prop_type); }
     bool isProp(PropName name) const noexcept { return (name == m_name_enum); }
 
-    // These get used to setup wxPGProperty, so both key and value need to be a wxString
     struct Options
     {
+        // REVIEW: [Randalphwa - 08-27-2023] Once *ALL* properties are created via generators,
+        // these can be changed to std::string_view
         tt_string name;
         tt_string help;
     };
@@ -45,6 +46,8 @@ public:
     std::vector<Options>& getOptions() { return m_options; }
 
 private:
+    // REVIEW: [Randalphwa - 08-27-2023] Once *ALL* properties are created via generators,
+    // these can be changed to std::string_view
     tt_string m_def_value;
     tt_string m_help;
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -733,7 +733,6 @@ void PropGridPanel::AddProperties(tt_string_view name, Node* node, NodeCategory&
             if (!IsPropAllowed(node, prop))
                 continue;
 
-            auto propInfo = prop->getPropDeclaration();
             auto pg = m_prop_grid->Append(CreatePGProperty(prop));
             auto propType = prop->type();
             if (propType != type_option)
@@ -768,16 +767,6 @@ void PropGridPanel::AddProperties(tt_string_view name, Node* node, NodeCategory&
                     {
                         m_prop_grid->SetPropertyAttribute(pg, wxPG_ATTR_AUTOCOMPLETE, m_astr_wx_decorations);
                     }
-                }
-            }
-
-            auto& customEditor = propInfo->getCustomEditor();
-            if (!customEditor.empty())
-            {
-                wxPGEditor* editor = m_prop_grid->GetEditorByName(customEditor);
-                if (editor)
-                {
-                    m_prop_grid->SetPropertyEditor(pg, editor);
                 }
             }
 

--- a/src/xml/textctrls_xml.xml
+++ b/src/xml/textctrls_xml.xml
@@ -35,66 +35,6 @@ inline const char* textctrls_xml = R"===(<?xml version="1.0"?>
 		<inherits class="wxWindow" />
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
-		<property name="var_name" type="string">m_textCtrl</property>
-		<property name="value" type="string_escapes" />
-		<property name="hint" type="string_escapes"
-			help="Sets a hint to be shown when the control is empty and does not have the focus." />
-		<property name="maxlength" type="string"
-			help="The maximum length of user-entered text. 0 means no limit. Note that in wxGTK this function may only be used with single line text controls." />
-		<property name="auto_complete" type="stringlist_semi"
-			help="If one or more strings are entered, they will be used to initialize autocomplete." />
-		<property name="spellcheck" type="bitlist">
-			<option name="enabled"
-				help="Currently this is supported in wxMSW (when running under Windows 8 or later), wxGTK when using GTK 3 and wxOSX. In addition, wxMSW requires that the text control has the wxTE_RICH2 style set, while wxOSX requires that the control has the wxTE_MULTILINE style.\n\nAvailable since 3.1.6" />
-			<option name="grammar"
-				help="Enables grammar checking in addition to spell checking. Currently this is supported in wxMSW (when running under Windows 8 or later), wxGTK when using GTK 3 and wxOSX. In addition, wxMSW requires that the text control has the wxTE_RICH2 style set, while wxOSX requires that the control has the wxTE_MULTILINE style.\n\nAvailable since 3.1.6" />
-		</property>
-		<property name="style" type="bitlist">
-			<option name="wxTE_PROCESS_ENTER"
-				help="The control will generate the event wxEVT_TEXT_ENTER (otherwise pressing Enter key is either processed internally by the control or used for navigation between dialog controls)." />
-			<option name="wxTE_PROCESS_TAB"
-				help="The control will receive wxEVT_CHAR events for TAB pressed - normally, TAB is used for passing to the next control in a dialog instead. For the control created with this style, you can still use Ctrl-Enter to pass to the next control from the keyboard." />
-			<option name="wxTE_MULTILINE"
-				help="The text control allows multiple lines." />
-			<option name="wxTE_PASSWORD"
-				help="The text will be echoed as asterisks." />
-			<option name="wxTE_READONLY"
-				help="The text will not be user-editable." />
-			<option name="wxTE_RICH"
-				help="Use rich text control under Windows. This allows having more than 64KB of text in the control. This style is ignored under other platforms." />
-			<option name="wxTE_RICH2"
-				help="Use rich text control version 2.0 or 3.0 under Windows. This style is ignored under other platforms." />
-			<option name="wxTE_AUTO_URL"
-				help="Highlight the URLs and generate the wxTextUrlEvents when mouse events occur over them. This style is only supported for wxTE_RICH Win32 and multi-line wxGTK2 text controls." />
-			<option name="wxTE_NOHIDESEL"
-				help="By default, the Windows text control doesn't show the selection when it doesn't have focus - use this style to force it to always show it. This style is ignored under other platforms." />
-			<option name="wxTE_NO_VSCROLL"
-				help="For multiline controls only: a vertical scrollbar will never be created. This limits the amount of text which can be entered into the control to what can be displayed in it under MSW but not under GTK2. Currently not implemented for the other platforms." />
-			<option name="wxTE_LEFT"
-				help="The text in the control will be left-justified (default)." />
-			<option name="wxTE_CENTER"
-				help="The text in the control will be centered (currently Windows and wxGTK2 only). " />
-			<option name="wxTE_RIGHT"
-				help="The text in the control will be right-justified (currently Windows and wxGTK2 only)." />
-			<option name="wxTE_DONTWRAP"
-				help="Same as wxHSCROLL style: don't wrap at all, show horizontal scrollbar instead." />
-			<option name="wxTE_CHARWRAP"
-				help="Wrap the lines too long to be shown entirely at any position (wxUniv and wxGTK2 only)." />
-			<option name="wxTE_WORDWRAP"
-				help="Wrap the lines too long to be shown entirely at word boundaries (wxUniv and wxGTK2 only)." />
-			<option name="wxTE_BESTWRAP"
-				help="Wrap the lines at word boundaries or at any other character if there are words longer than the window width (this is the default)." />
-		</property>
-		<property name="focus" type="bool"
-			help="When checked, this control will be set to receive keyboard input when the parent form is first created.">0</property>
-		<event name="wxEVT_TEXT" class="wxCommandEvent"
-			help="Generated when the text changes. Notice that this event will always be generated when the text controls contents changes - whether this is due to user input or comes from the program itself (for example, if SetValue() is called.)" />
-		<event name="wxEVT_TEXT_ENTER" class="wxCommandEvent"
-			help="Generated when enter is pressed in a text control (which must have wxTE_PROCESS_ENTER style for this event to be generated)." />
-		<event name="wxEVT_TEXT_URL" class="wxTextUrlEvent"
-			help="Generated when the a mouse event occurred over an URL in the text control (Windows and wxGTK2 only)" />
-		<event name="wxEVT_TEXT_MAXLEN" class="wxCommandEvent"
-			help="Generated when the user tries to enter more text into the control than the limit set by SetMaxLength." />
 	</gen>
 
 	<gen class="wxRichTextCtrl" image="richtextctrl" type="widget">


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors some of the base classes which are created on startup, and never changed or destroyed for as long as the app is running.

- `NodeDeclaration::m_properties` -- the pointer is now created with `new` instead of `make_shared`.
- `NodeDeclaration::m_events` -- the pointer is now created with `new` instead of `make_unique`.
- Removed `PropChildDeclaration::m_name_str` -- the string name can be retrieved from the rmap
- Removed `PropDeclaration::m_customEditor` -- this was never used

The second part of this PR adds functionality to `BaseGenerator` that allows individual generators to provide the properties and events the generator supports instead of having them set in the XML file. This doesn't eliminate the generator in the XML file, it just eliminates the property and event nodes.

Until all generators and XML files get changed, `NodeCreator::parseGeneratorFile()` will first check the XML file for properties and events, and then later call each generator. That means properties and events can be created either in the XML file or the generator.
