### PR TITLE
Importer refactoring, initial work on 

### DIFF
--- a/src/generate/gen_flexgrid_sizer.cpp
+++ b/src/generate/gen_flexgrid_sizer.cpp
@@ -43,9 +43,9 @@ wxObject* FlexGridSizerGenerator::CreateMockup(Node* node, wxObject* parent)
                         proportion = tt::atoi(tt::find_nonspace(iter.data() + pos + 1));
                     }
                     if (prop_name == prop_growablerows)
-                        sizer->AddGrowableCol(value, proportion);
-                    else
                         sizer->AddGrowableRow(value, proportion);
+                    else
+                        sizer->AddGrowableCol(value, proportion);
                 }
             }
         }

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -795,6 +795,22 @@ constexpr auto set_borders_flags = frozen::make_set<std::string_view>({
     "wxTOP",
 });
 
+constexpr auto set_modes = frozen::make_set<std::string_view>({
+    "wxLC_ICON",
+    "wxLC_SMALL_ICON",
+    "wxLC_LIST",
+    "wxLC_REPORT",
+    "wxDATAVIEW_CELL_INERT",
+    "wxDATAVIEW_CELL_ACTIVATABLE",
+    "wxDATAVIEW_CELL_EDITABLE",
+});
+
+constexpr auto set_listbox_types = frozen::make_set<std::string_view>({
+    "wxLB_SINGLE",
+    "wxLB_MULTIPLE",
+    "wxLB_EXTENDED_LIST",
+});
+
 // These are used to set prop_style
 constexpr auto set_styles = frozen::make_set<std::string_view>({
     "wxLI_HORIZONTAL",
@@ -869,9 +885,6 @@ constexpr auto set_styles = frozen::make_set<std::string_view>({
     "wxCB_READONLY",
     "wxCB_SORT",
 
-    "wxLB_SINGLE",
-    "wxLB_MULTIPLE",
-    "wxLB_EXTENDED",
     "wxLB_HSCROLL",
     "wxLB_ALWAYS_SB",
     "wxLB_NEEDED_SB",
@@ -963,10 +976,6 @@ constexpr auto set_styles = frozen::make_set<std::string_view>({
     "wxLC_SORT_DESCENDING",
     "wxLC_HRULES",
     "wxLC_VRULES",
-    "wxLC_ICON",
-    "wxLC_SMALL_ICON",
-    "wxLC_LIST",
-    "wxLC_REPORT",
     "wxLC_ALIGN_MASK",
     "wxLC_MASK_TYPE",
     "wxLC_MASK_ALIGN",
@@ -1190,6 +1199,18 @@ void DialogBlocks::ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& 
             if (border_flags.size())
                 border_flags << '|';
             border_flags << name;
+        }
+        else if (set_modes.contains(name))
+        {
+            // Only one mode can be set
+            new_node->set_value(prop_mode, name);
+            continue;
+        }
+        else if (set_listbox_types.contains(name))
+        {
+            // A wxListBox can only have one type set.
+            new_node->set_value(prop_type, name);
+            continue;
         }
     }
 
@@ -1448,6 +1469,8 @@ void DialogBlocks::ProcessMisc(pugi::xml_node& node_xml, const NodeSharedPtr& no
                             node->set_value(prop_selection_mode, "wxITEM_CHECK");
                         else if (str == "Radio")
                             node->set_value(prop_selection_mode, "wxITEM_RADIO");
+                        else if (str == "Dropdown")
+                            node->set_value(prop_selection_mode, "wxITEM_DROPDOWN");
                         break;
 
                     case prop_background_colour:

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -18,117 +18,108 @@
 
 using namespace GenEnum;
 
-// clang-format off
-
-// See g_xrc_keywords in generate/gen_xrc_utils.cpp for a list of XRC keywords
-
 namespace xrc_import
 {
+    constexpr auto map_import_prop_names = frozen::make_map<std::string_view, GenEnum::PropName>({
+        { "accel", prop_shortcut },
+        { "art-provider", prop_art_provider },
+        { "bg", prop_background_colour },
+        { "bitmap-bg", prop_bmp_background_colour },
+        { "bitmap-minwidth", prop_bmp_min_width },
+        { "bitmap-placement", prop_bmp_placement },
+        { "bitmapposition", prop_position },
+        { "bitmapsize", prop_image_size },  // BUGBUG: [Randalphwa - 06-17-2022] should this be prop_bitmapsize?
+        { "choices", prop_contents },
+        { "class", prop_class_name },
+        { "content", prop_contents },
+        { "defaultdirectory", prop_initial_folder },
+        { "defaultfilename", prop_initial_filename },
+        { "dimension", prop_majorDimension },
+        { "effectduration", prop_duration },
+        { "empty_cellsize", prop_empty_cell_size },
+        { "extra-accels", prop_extra_accels },
+        { "fg", prop_foreground_colour },
+        { "flexibledirection", prop_flexible_direction },
+        { "gradient-end", prop_end_colour },
+        { "gradient-start", prop_start_colour },
+        { "gravity", prop_sashgravity },
+        { "hideeffect", prop_hide_effect },
+        { "hover", prop_current },
+        { "htmlcode", prop_html_content },
+        { "inactive-bitmap", prop_inactive_bitmap },
+        { "include_file", prop_derived_header },
+        { "linesize", prop_line_size },
+        { "longhelp", prop_statusbar },  // Used by toolbar tools
+        { "minsize", prop_min_size },
+        { "nonflexiblegrowmode", prop_non_flexible_grow_mode },
+        { "pagesize", prop_page_size },
+        { "running", prop_auto_start },
+        { "selmax", prop_sel_end },
+        { "selmin", prop_sel_start },
+        { "settings", prop_settings_code },
+        { "showeffect", prop_show_effect },
+        { "tab_ctrl_height", prop_tab_height },
+        { "thumb", prop_thumb_length },
+        { "tickfreq", prop_tick_frequency },
+        { "windowlabel", prop_tab_height },
+        { "wrapmode", prop_stc_wrap_mode },
+    });
 
-constexpr auto map_import_prop_names = frozen::make_map<std::string_view, GenEnum::PropName>({
-    { "accel", prop_shortcut },
-    { "art-provider", prop_art_provider },
-    { "bg", prop_background_colour },
-    { "bitmap-bg", prop_bmp_background_colour },
-    { "bitmap-minwidth", prop_bmp_min_width },
-    { "bitmap-placement", prop_bmp_placement },
-    { "bitmapposition", prop_position },
-    { "bitmapsize", prop_image_size },  // BUGBUG: [Randalphwa - 06-17-2022] should this be prop_bitmapsize?
-    { "choices", prop_contents },
-    { "class", prop_class_name },
-    { "content", prop_contents },
-    { "defaultdirectory", prop_initial_folder },
-    { "defaultfilename", prop_initial_filename },
-    { "dimension", prop_majorDimension },
-    { "effectduration", prop_duration },
-    { "empty_cellsize", prop_empty_cell_size },
-    { "extra-accels", prop_extra_accels },
-    { "fg", prop_foreground_colour },
-    { "flexibledirection", prop_flexible_direction },
-    { "gradient-end", prop_end_colour },
-    { "gradient-start", prop_start_colour },
-    { "gravity", prop_sashgravity },
-    { "hideeffect", prop_hide_effect },
-    { "hover", prop_current },
-    { "htmlcode", prop_html_content },
-    { "inactive-bitmap", prop_inactive_bitmap },
-    { "include_file", prop_derived_header },
-    { "linesize", prop_line_size },
-    { "longhelp", prop_statusbar },  // Used by toolbar tools
-    { "minsize", prop_min_size },
-    { "nonflexiblegrowmode", prop_non_flexible_grow_mode },
-    { "pagesize", prop_page_size },
-    { "running", prop_auto_start },
-    { "selmax", prop_sel_end },
-    { "selmin", prop_sel_start },
-    { "settings", prop_settings_code },
-    { "showeffect", prop_show_effect },
-    { "tab_ctrl_height", prop_tab_height },
-    { "thumb", prop_thumb_length },
-    { "tickfreq", prop_tick_frequency },
-    { "windowlabel", prop_tab_height },
-    { "wrapmode", prop_stc_wrap_mode },
-});
+    constexpr auto import_GenNames = frozen::make_map<std::string_view, GenEnum::GenName>({
+        { "Custom", gen_CustomControl },
+        { "CustomWidget", gen_CustomControl },
+        { "Dialog", gen_wxDialog },
+        { "Frame", gen_wxFrame },
+        { "Panel", gen_PanelForm },
+        { "Wizard", gen_wxWizard },
+        { "WizardPageSimple", gen_wxWizardPageSimple },
+        { "bookpage", gen_oldbookpage },
+        { "panewindow", gen_VerticalBoxSizer },
+        { "unknown", gen_CustomControl },
+        { "wxBitmapButton", gen_wxButton },
+        { "wxListCtrl", gen_wxListView },
+        { "wxScintilla", gen_wxStyledTextCtrl },
 
-constexpr auto import_GenNames = frozen::make_map<std::string_view, GenEnum::GenName>({
-    { "Custom", gen_CustomControl },
-    { "CustomWidget", gen_CustomControl },
-    { "Dialog", gen_wxDialog },
-    { "Frame", gen_wxFrame },
-    { "Panel", gen_PanelForm },
-    { "Wizard", gen_wxWizard },
-    { "WizardPageSimple", gen_wxWizardPageSimple },
-    { "bookpage", gen_oldbookpage },
-    { "panewindow", gen_VerticalBoxSizer },
-    { "unknown", gen_CustomControl },
-    { "wxBitmapButton", gen_wxButton },
-    { "wxListCtrl", gen_wxListView },
-    { "wxScintilla", gen_wxStyledTextCtrl },
+        // DialogBlocks proxy conversion
+        { "wxSpacer", gen_spacer },
+        { "wxMenuSeparator", gen_separator },
+        { "wxSubmenu", gen_submenu },
+        { "wxToolBarSeparator", gen_toolSeparator },
+        { "wxToolBarButton", gen_tool },
+    });
 
-    // DialogBlocks proxy conversion
-    { "wxSpacer", gen_spacer },
-    { "wxMenuSeparator", gen_separator },
-    { "wxSubmenu", gen_submenu },
-    { "wxToolBarSeparator", gen_toolSeparator },
-    { "wxToolBarButton", gen_tool },
-});
-
-static const view_map s_map_old_events = {
-
-
-    { "wxEVT_COMMAND_BUTTON_CLICKED",          "wxEVT_BUTTON" },
-    { "wxEVT_COMMAND_CHECKBOX_CLICKED",        "wxEVT_CHECKBOX" },
-    { "wxEVT_COMMAND_CHECKLISTBOX_TOGGLED",    "wxEVT_CHECKLISTBOX" },
-    { "wxEVT_COMMAND_CHOICE_SELECTED",         "wxEVT_CHOICE" },
-    { "wxEVT_COMMAND_COMBOBOX_CLOSEUP",        "wxEVT_COMBOBOX_CLOSEUP" },
-    { "wxEVT_COMMAND_COMBOBOX_DROPDOWN",       "wxEVT_COMBOBOX_DROPDOWN" },
-    { "wxEVT_COMMAND_COMBOBOX_SELECTED",       "wxEVT_COMBOBOX" },
-    { "wxEVT_COMMAND_LISTBOX_DOUBLECLICKED",   "wxEVT_LISTBOX_DCLICK" },
-    { "wxEVT_COMMAND_LISTBOX_SELECTED",        "wxEVT_LISTBOX" },
-    { "wxEVT_COMMAND_MENU_SELECTED",           "wxEVT_MENU" },
-    { "wxEVT_COMMAND_RADIOBOX_SELECTED",       "wxEVT_RADIOBOX" },
-    { "wxEVT_COMMAND_RADIOBUTTON_SELECTED",    "wxEVT_RADIOBUTTON" },
-    { "wxEVT_COMMAND_SCROLLBAR_UPDATED",       "wxEVT_SCROLLBAR" },
-    { "wxEVT_COMMAND_SLIDER_UPDATED",          "wxEVT_SLIDER" },
-    { "wxEVT_COMMAND_TEXT_COPY",               "wxEVT_TEXT_COPY" },
-    { "wxEVT_COMMAND_TEXT_CUT",                "wxEVT_TEXT_CUT" },
-    { "wxEVT_COMMAND_TEXT_ENTER",              "wxEVT_TEXT_ENTER" },
-    { "wxEVT_COMMAND_TEXT_MAXLEN",             "wxEVT_TEXT_MAXLEN" },
-    { "wxEVT_COMMAND_TEXT_PASTE",              "wxEVT_TEXT_PASTE" },
-    { "wxEVT_COMMAND_TEXT_UPDATED",            "wxEVT_TEXT" },
-    { "wxEVT_COMMAND_TEXT_URL",                "wxEVT_TEXT_URL" },
-    { "wxEVT_COMMAND_THREAD",                  "wxEVT_THREAD" },
-    { "wxEVT_COMMAND_TOOL_CLICKED",            "wxEVT_TOOL" },
-    { "wxEVT_COMMAND_TOOL_DROPDOWN_CLICKED",   "wxEVT_TOOL_DROPDOWN" },
-    { "wxEVT_COMMAND_TOOL_ENTER",              "wxEVT_TOOL_ENTER" },
-    { "wxEVT_COMMAND_TOOL_RCLICKED",           "wxEVT_TOOL_RCLICKED" },
-    { "wxEVT_COMMAND_VLBOX_SELECTED",          "wxEVT_VLBOX" },
-
-};
+    constexpr auto map_old_events = frozen::make_map<std::string_view, std::string_view>({
+        { "wxEVT_COMMAND_BUTTON_CLICKED", "wxEVT_BUTTON" },
+        { "wxEVT_COMMAND_CHECKBOX_CLICKED", "wxEVT_CHECKBOX" },
+        { "wxEVT_COMMAND_CHECKLISTBOX_TOGGLED", "wxEVT_CHECKLISTBOX" },
+        { "wxEVT_COMMAND_CHOICE_SELECTED", "wxEVT_CHOICE" },
+        { "wxEVT_COMMAND_COMBOBOX_CLOSEUP", "wxEVT_COMBOBOX_CLOSEUP" },
+        { "wxEVT_COMMAND_COMBOBOX_DROPDOWN", "wxEVT_COMBOBOX_DROPDOWN" },
+        { "wxEVT_COMMAND_COMBOBOX_SELECTED", "wxEVT_COMBOBOX" },
+        { "wxEVT_COMMAND_LISTBOX_DOUBLECLICKED", "wxEVT_LISTBOX_DCLICK" },
+        { "wxEVT_COMMAND_LISTBOX_SELECTED", "wxEVT_LISTBOX" },
+        { "wxEVT_COMMAND_MENU_SELECTED", "wxEVT_MENU" },
+        { "wxEVT_COMMAND_RADIOBOX_SELECTED", "wxEVT_RADIOBOX" },
+        { "wxEVT_COMMAND_RADIOBUTTON_SELECTED", "wxEVT_RADIOBUTTON" },
+        { "wxEVT_COMMAND_SCROLLBAR_UPDATED", "wxEVT_SCROLLBAR" },
+        { "wxEVT_COMMAND_SLIDER_UPDATED", "wxEVT_SLIDER" },
+        { "wxEVT_COMMAND_TEXT_COPY", "wxEVT_TEXT_COPY" },
+        { "wxEVT_COMMAND_TEXT_CUT", "wxEVT_TEXT_CUT" },
+        { "wxEVT_COMMAND_TEXT_ENTER", "wxEVT_TEXT_ENTER" },
+        { "wxEVT_COMMAND_TEXT_MAXLEN", "wxEVT_TEXT_MAXLEN" },
+        { "wxEVT_COMMAND_TEXT_PASTE", "wxEVT_TEXT_PASTE" },
+        { "wxEVT_COMMAND_TEXT_UPDATED", "wxEVT_TEXT" },
+        { "wxEVT_COMMAND_TEXT_URL", "wxEVT_TEXT_URL" },
+        { "wxEVT_COMMAND_THREAD", "wxEVT_THREAD" },
+        { "wxEVT_COMMAND_TOOL_CLICKED", "wxEVT_TOOL" },
+        { "wxEVT_COMMAND_TOOL_DROPDOWN_CLICKED", "wxEVT_TOOL_DROPDOWN" },
+        { "wxEVT_COMMAND_TOOL_ENTER", "wxEVT_TOOL_ENTER" },
+        { "wxEVT_COMMAND_TOOL_RCLICKED", "wxEVT_TOOL_RCLICKED" },
+        { "wxEVT_COMMAND_VLBOX_SELECTED", "wxEVT_VLBOX" },
+    });
 
 };  // namespace xrc_import
 
-// clang-format on
 using namespace xrc_import;
 
 std::optional<pugi::xml_document> ImportXML::LoadDocFile(const tt_string& file)
@@ -1416,7 +1407,7 @@ GenEnum::GenName ImportXML::MapClassName(std::string_view name) const
 
 tt_string_view ImportXML::GetCorrectEventName(tt_string_view name)
 {
-    if (auto result = s_map_old_events.find(name); result != s_map_old_events.end())
+    if (auto result = map_old_events.find(name); result != map_old_events.end())
     {
         return result->second;
     }

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -834,6 +834,7 @@ bool ProjectHandler::Import(ImportXML& import, tt_string& file, bool append, boo
         FinalImportCheck(project_node.get());
         // Calling this will also initialize the ProjectImage class
         Project.Initialize(project_node, allow_ui);
+        file.replace_extension(".wxui");
         Project.setProjectFile(file);
         ProjectImages.CollectBundles();
 
@@ -841,7 +842,6 @@ bool ProjectHandler::Import(ImportXML& import, tt_string& file, bool append, boo
         // If the file has been created once before, then for the first form, copy the old classname and base filename to
         // the re-converted first form.
 
-        file.replace_extension(".wxui");
         if (m_project_node->getChildCount() && file.file_exists())
         {
             doc.reset();
@@ -919,6 +919,7 @@ bool ProjectHandler::NewProject(bool create_empty, bool allow_ui)
         FinalImportCheck(project.get());
         // Calling this will also initialize the ProjectImage class
         Project.Initialize(project);
+        file.replace_extension(".wxui");
         Project.setProjectFile(file);
 
         if (allow_ui)
@@ -945,6 +946,7 @@ bool ProjectHandler::NewProject(bool create_empty, bool allow_ui)
     FinalImportCheck(project.get());
     // Calling this will also initialize the ProjectImage class
     Project.Initialize(project);
+    file.replace_extension(".wxui");
     Project.setProjectFile(file);
 
     tt_string imported_from;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR has two parts. The first refactors that maps and arrays used in the project importers to utilize the `frozen` library to convert these into compile-time maps instead of runtime maps. The second part adds a function that is run on all imported files after their initial conversion to fix any problems the main importers didn't catch. This now fixes invalid alignment flags that generate an assertion in Debug builds of wxWidgets. It also removes the hard-coded row value in a `wxGridSizer` or `wxFlexGridSizer` if the column value has been set.