### PR TITLE
More fixes for DialogBlocks imports

### DIFF
--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -1396,6 +1396,7 @@ constexpr auto map_proxy_names = frozen::make_map<std::string_view, GenEnum::Pro
     { "Columns", prop_cols },
     { "Default filter", prop_defaultfilter },
     { "Default folder", prop_defaultfolder },
+    { "Field count", prop_fields },
     { "Filter", prop_filter },
     { "Gravity", prop_sashgravity },
     { "GrowableColumns", prop_growablecols },

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -219,6 +219,17 @@ bool DialogBlocks::CreateFormNode(pugi::xml_node& form_xml, const NodeSharedPtr&
             m_errors.emplace(tt_string("Unrecognized form class: ") << type_name);
             return false;
         }
+        else if (getGenName == gen_wxDialog)
+        {
+            if (auto base_class = form_xml.find_child_by_attribute("string", "name", "proxy-Base class"); base_class)
+            {
+                auto base_name = ExtractQuotedString(base_class);
+                if (base_name == "wxPanel")
+                {
+                    getGenName = gen_PanelForm;
+                }
+            }
+        }
 
         auto form = NodeCreation.createNode(getGenName, parent.get());
         if (!form)

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -1402,6 +1402,9 @@ constexpr auto map_proxy_names = frozen::make_map<std::string_view, GenEnum::Pro
     { "Tooltip text", prop_tooltip },
     { "URL", prop_html_url },
 
+    { "wxRA_SPECIFY_COLS", prop_style },
+    { "wxRA_SPECIFY_ROWS", prop_style },
+
     { "Initial value", prop_value },  // In DialogBlocks used for all sorts of properties
 
 });
@@ -1564,6 +1567,15 @@ void DialogBlocks::ProcessMisc(pugi::xml_node& node_xml, const NodeSharedPtr& no
                             node->set_value(prop_pressed, true);
                     }
                     break;
+
+                case prop_style:
+                    if (node->isGen(gen_wxRadioBox))
+                    {
+                        if (name == "wxRA_SPECIFY_COLS")
+                            node->set_value(prop_style, "columns");
+                        else if (name == "wxRA_SPECIFY_ROWS")
+                            node->set_value(prop_style, "rows");
+                    }
 
                 default:
                     if (auto prop = node->getPropPtr(result->second); prop)

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -1287,7 +1287,7 @@ void DialogBlocks::ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& 
             {
                 if (style_str.size())
                     style_str << '|';
-                style_str << "wxALIGN_CENTER";
+                style_str << "wxALIGN_CENTER_HORIZONTAL";
             }
         }
         if (auto value = node_xml.find_child_by_attribute("string", "name", "proxy-AlignV"); value)
@@ -1307,7 +1307,7 @@ void DialogBlocks::ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& 
                 {
                     if (style_str.size())
                         style_str << '|';
-                    style_str << "wxALIGN_CENTER";
+                    style_str << "wxALIGN_CENTER_VERTICAL";
                 }
             }
         }

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -672,6 +672,18 @@ void DialogBlocks::SetNodeDimensions(pugi::xml_node& node_xml, const NodeSharedP
             prop->get_value() << 'd';
         }
     }
+
+    if (new_node->isGen(gen_spacer))
+    {
+        if (auto value = node_xml.find_child_by_attribute("long", "name", "proxy-Width"); value)
+        {
+            new_node->set_value(prop_width, value.text().as_int());
+        }
+        if (auto value = node_xml.find_child_by_attribute("long", "name", "proxy-Height"); value)
+        {
+            new_node->set_value(prop_height, value.text().as_int());
+        }
+    }
 }
 
 void DialogBlocks::SetNodeValidator(pugi::xml_node& node_xml, const NodeSharedPtr& new_node)

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -1408,6 +1408,7 @@ void ProjectHandler::RecursiveNodeCheck(Node* node)
                 prop_ptr->get_value().Replace("wxALIGN_TOP", "");
                 prop_ptr->get_value().Replace("wxALIGN_BOTTOM", "");
                 prop_ptr->get_value().Replace("wxALIGN_CENTER_VERTICAL", "");
+                prop_ptr->get_value().Replace("wxALIGN_CENTER", "");
             }
 
             if (parent->as_string(prop_orientation).contains("wxHORIZONTAL"))
@@ -1423,6 +1424,7 @@ void ProjectHandler::RecursiveNodeCheck(Node* node)
                 prop_ptr->get_value().Replace("wxALIGN_LEFT", "");
                 prop_ptr->get_value().Replace("wxALIGN_RIGHT", "");
                 prop_ptr->get_value().Replace("wxALIGN_CENTER_HORIZONTAL", "");
+                prop_ptr->get_value().Replace("wxALIGN_CENTER", "");
             }
 #if defined(INTERNAL_TESTING)
             if (old_value != prop_ptr->as_string())


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes various problems when importing DialogBlocks projects:

- width/height in spacers now supported
- columns or rows now set for wxRadioBox
- Form version of wxPanel now supported
- field count for wxStatusbar now supported

This also fixes some additional alignment issues where conflicting alignment flags are set in the project file, and wxUiEditor needs to figure out which ones can be used and which ones will be ignored by wxWidgets (and generate an assertion error if specified).