### PR TITLE
Don't pre or post process initial_path

### DIFF
--- a/src/customprops/directory_prop.cpp
+++ b/src/customprops/directory_prop.cpp
@@ -35,19 +35,32 @@ bool DirectoryDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGProperty
     }
 
     tt_string path = Project.getProjectPath();
-    path.append_filename(m_prop->as_string());
-    path.make_absolute();
+    auto node = m_prop->getNode();
+    if (node->isGen(gen_wxFilePickerCtrl))
+    {
+        path = m_prop->as_string().size() ? m_prop->as_string() : Project.getProjectPath();
+    }
+    else
+    {
+        path.append_filename(m_prop->as_string());
+        path.make_absolute();
+    }
 
     // If the directory doesn't exist, then we need to reset it. Otherwise on Windows, the
     // dialog will be for the computer, requiring the user to drill down to where the project
     // file is.
-    if (!path.dir_exists())
+    if (!node->isGen(gen_wxFilePickerCtrl) && !path.dir_exists())
     {
         path = Project.getProjectPath();
     }
 
-    wxDirDialog dlg(propGrid, "Choose a directory:", path.make_wxString(),
-                    wxDD_DEFAULT_STYLE | wxDD_CHANGE_DIR | wxDD_DIR_MUST_EXIST, dlg_pos, dlg_sz);
+    auto style = wxDD_DEFAULT_STYLE | wxDD_CHANGE_DIR;
+    if (!node->isGen(gen_wxFilePickerCtrl))
+    {
+        style |= wxDD_DIR_MUST_EXIST;
+    }
+
+    wxDirDialog dlg(propGrid, wxDirSelectorPromptStr, path.make_wxString(), style, dlg_pos, dlg_sz);
     if (dlg.ShowModal() == wxID_OK)
     {
         SetValue(dlg.GetPath());

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1035,7 +1035,10 @@ void PropGridPanel::OnPropertyGridChanging(wxPropertyGridEvent& event)
             break;
 
         case type_path:
-            AllowDirectoryChange(event, prop, node);
+            if (!node->isGen(gen_wxFilePickerCtrl))
+            {
+                AllowDirectoryChange(event, prop, node);
+            }
             break;
 
         case type_id:

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -172,16 +172,18 @@ void AllowFileChange(wxPropertyGridEvent& event, NodeProperty* prop, Node* node)
     }
 }
 
-void OnPathChanged(wxPropertyGridEvent& event, NodeProperty* prop, Node* /* node */)
+void OnPathChanged(wxPropertyGridEvent& event, NodeProperty* prop, Node* node)
 {
     // If the user clicked the path button, the current directory may have changed.
     Project.ChangeDir();
 
     tt_string newValue = event.GetPropertyValue().GetString().utf8_string();
-    newValue.make_absolute();
-    newValue.make_relative(Project.getProjectPath());
-    newValue.backslashestoforward();
-
+    if (!node->isGen(gen_wxFilePickerCtrl))
+    {
+        newValue.make_absolute();
+        newValue.make_relative(Project.getProjectPath());
+        newValue.backslashestoforward();
+    }
     // Note that on Windows, even though we changed the property to a forward slash, it will still be displayed
     // with a backslash. However, modifyProperty() will save our forward slash version, so even thought the
     // display isn't correct, it will be stored in the project file correctly.


### PR DESCRIPTION
Special-case type_path whenever the node is for wxFilePickerCtrl.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR prevents pre and post changing of a folder name specified for the `initial_path` property of wxFilePickerCtrl.

Note that on Windows, it doesn't matter if you don't specify wxDD_DIR_MUST_EXIST, it still has to exist. I turned off the style because it might allow Unix or Mac to not require that the folder exists.

Closes #1199
