### PR TITLE
Generate warnings for unsupporte controls in current language

### DIFF
--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -186,6 +186,9 @@ public:
     virtual bool PopupMenuAddCommands(NavPopupMenu*, Node*) { return false; }
 
     virtual void AddPropsAndEvents(NodeDeclaration*) {}
+
+    // Call this to retrieve any warning text when generating code for the specific language.
+    virtual std::optional<tt_string> GetWarning(Node*, int /* language */) { return {}; }
 };
 
 PropDeclaration* DeclAddProp(NodeDeclaration* declaration, PropName prop_name, PropType type, std::string_view help = {},

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -163,6 +163,25 @@ void DataViewCtrl::RequiredHandlers(Node* /* node */, std::set<std::string>& han
     handlers.emplace("wxDataViewXmlHandler");
 }
 
+std::optional<tt_string> DataViewCtrl::GetWarning(Node* node, int language)
+{
+    switch (language)
+    {
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support Wx::DataViewCtrl";
+                return msg;
+            }
+        default:
+            return {};
+    }
+}
+
 //////////////////////////////////////////  DataViewListCtrl  //////////////////////////////////////////
 
 wxObject* DataViewListCtrl::CreateMockup(Node* node, wxObject* parent)
@@ -274,6 +293,25 @@ void DataViewListCtrl::RequiredHandlers(Node* /* node */, std::set<std::string>&
     handlers.emplace("wxDataViewXmlHandler");
 }
 
+std::optional<tt_string> DataViewListCtrl::GetWarning(Node* node, int language)
+{
+    switch (language)
+    {
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support Wx::DataViewListCtrl";
+                return msg;
+            }
+        default:
+            return {};
+    }
+}
+
 //////////////////////////////////////////  DataViewTreeCtrl  //////////////////////////////////////////
 
 wxObject* DataViewTreeCtrl::CreateMockup(Node* node, wxObject* parent)
@@ -298,6 +336,25 @@ bool DataViewTreeCtrl::GetIncludes(Node* node, std::set<std::string>& set_src, s
 {
     InsertGeneratorInclude(node, "#include <wx/dataview.h>", set_src, set_hdr);
     return true;
+}
+
+std::optional<tt_string> DataViewTreeCtrl::GetWarning(Node* node, int language)
+{
+    switch (language)
+    {
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support Wx::DataViewTreeCtrl";
+                return msg;
+            }
+        default:
+            return {};
+    }
 }
 
 // ../../wxSnapShot/src/xrc/xh_dataview.cpp

--- a/src/generate/dataview_widgets.h
+++ b/src/generate/dataview_widgets.h
@@ -21,6 +21,8 @@ public:
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
+
+    std::optional<tt_string> GetWarning(Node* node, int language) override;
 };
 
 class DataViewListCtrl : public BaseGenerator
@@ -35,6 +37,8 @@ public:
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
+
+    std::optional<tt_string> GetWarning(Node* node, int language) override;
 };
 
 class DataViewTreeCtrl : public BaseGenerator
@@ -48,6 +52,8 @@ public:
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
+
+    std::optional<tt_string> GetWarning(Node* node, int language) override;
 };
 
 class DataViewColumn : public BaseGenerator

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -85,6 +85,9 @@ public:
 
     static void CollectIDs(Node* node, std::set<std::string>& set_enum_ids, std::set<std::string>& set_const_ids);
 
+    // Retrieve a list of any warnings the generators have created
+    auto getWarnings() { return m_warnings; }
+
 protected:
     // Generate extern references to images used in the current form that are defined in the
     // gen_Images node.
@@ -192,6 +195,9 @@ private:
     std::set<wxBitmapType> m_type_generated;
     std::set<std::string> m_set_enum_ids;
     std::set<std::string> m_set_const_ids;
+
+    // Warnings to be displayed to the user when generating code to a file
+    std::set<tt_string> m_warnings;
 
     Node* m_form_node { nullptr };
     Node* m_ImagesForm { nullptr };

--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -37,6 +37,11 @@ void BaseCodeGenerator::GenConstruction(Node* node)
     if (!generator)
         return;
 
+    if (auto warning_msg = generator->GetWarning(node, m_language); warning_msg)
+    {
+        m_warnings.emplace(warning_msg.value());
+    }
+
     if (node->hasValue(prop_platforms) && node->as_string(prop_platforms) != "Windows|Unix|Mac")
     {
         BeginPlatformCode(node);

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -153,6 +153,14 @@ bool GeneratePythonFiles(GenResults& results, std::vector<tt_string>* pClassList
                 flags |= flag_test_only;
             auto retval = cpp_cw->WriteFile(GEN_LANG_PYTHON, flags);
 
+            if (auto warning_msgs = codegen.getWarnings(); warning_msgs.size())
+            {
+                for (auto& iter: warning_msgs)
+                {
+                    results.msgs.emplace_back() << iter << '\n';
+                }
+            }
+
             if (retval > 0)
             {
                 if (!pClassList)
@@ -186,6 +194,11 @@ bool GeneratePythonFiles(GenResults& results, std::vector<tt_string>* pClassList
                          "Code generation");
             continue;
         }
+    }
+
+    if (results.msgs.size())
+    {
+        results.msgs.emplace_back() << '\n';
     }
 
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -163,6 +163,14 @@ bool GenerateRubyFiles(GenResults& results, std::vector<tt_string>* pClassList)
                 flags |= flag_test_only;
             auto retval = cpp_cw->WriteFile(GEN_LANG_RUBY, flags);
 
+            if (auto warning_msgs = codegen.getWarnings(); warning_msgs.size())
+            {
+                for (auto& iter: warning_msgs)
+                {
+                    results.msgs.emplace_back() << iter << '\n';
+                }
+            }
+
             if (retval > 0)
             {
                 if (!pClassList)
@@ -196,6 +204,11 @@ bool GenerateRubyFiles(GenResults& results, std::vector<tt_string>* pClassList)
                          "Code generation");
             continue;
         }
+    }
+
+    if (results.msgs.size())
+    {
+        results.msgs.emplace_back() << '\n';
     }
 
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -267,3 +267,33 @@ void StaticCheckboxBoxSizerGenerator::RequiredHandlers(Node* /* node */, std::se
 {
     handlers.emplace("wxSizerXmlHandler");
 }
+
+std::optional<tt_string> StaticCheckboxBoxSizerGenerator::GetWarning(Node* node, int language)
+{
+    switch (language)
+    {
+        case GEN_LANG_PYTHON:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxPython currently does not support a checkbox as a static box label";
+                return msg;
+            }
+
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support a checkbox as a static box label";
+                return msg;
+            }
+        default:
+            return {};
+    }
+}

--- a/src/generate/gen_statchkbox_sizer.h
+++ b/src/generate/gen_statchkbox_sizer.h
@@ -28,6 +28,8 @@ public:
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
+    std::optional<tt_string> GetWarning(Node* node, int language) override;
+
 private:
     wxCheckBox* m_checkbox;
 };

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -258,3 +258,33 @@ void StaticRadioBtnBoxSizerGenerator::RequiredHandlers(Node* /* node */, std::se
 {
     handlers.emplace("wxSizerXmlHandler");
 }
+
+std::optional<tt_string> StaticRadioBtnBoxSizerGenerator::GetWarning(Node* node, int language)
+{
+    switch (language)
+    {
+        case GEN_LANG_PYTHON:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxPython currently does not support a radio button as a static box label";
+                return msg;
+            }
+
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support a radio button as a static box label";
+                return msg;
+            }
+        default:
+            return {};
+    }
+}

--- a/src/generate/gen_statradiobox_sizer.h
+++ b/src/generate/gen_statradiobox_sizer.h
@@ -28,6 +28,8 @@ public:
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
+    std::optional<tt_string> GetWarning(Node* node, int language) override;
+
 private:
     wxRadioButton* m_radiobtn;
 };

--- a/src/generate/gen_tree_list.cpp
+++ b/src/generate/gen_tree_list.cpp
@@ -48,6 +48,36 @@ bool TreeListCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
     return true;
 }
 
+std::optional<tt_string> TreeListCtrlGenerator::GetWarning(Node* node, int language)
+{
+    switch (language)
+    {
+        case GEN_LANG_PYTHON:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxPython currently does not support wxTreeListCtrl";
+                return msg;
+            }
+
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support wxTreeListCtrl";
+                return msg;
+            }
+        default:
+            return {};
+    }
+}
+
 //////////////////////////////////////////  TreeListCtrlColumnGenerator  //////////////////////////////////////////
 
 bool TreeListCtrlColumnGenerator::ConstructionCode(Code& code)

--- a/src/generate/gen_tree_list.h
+++ b/src/generate/gen_tree_list.h
@@ -18,6 +18,8 @@ public:
     bool ConstructionCode(Code&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
+    std::optional<tt_string> GetWarning(Node* node, int language) override;
 };
 
 class TreeListCtrlColumnGenerator : public BaseGenerator

--- a/src/generate/gen_web_view.cpp
+++ b/src/generate/gen_web_view.cpp
@@ -88,3 +88,22 @@ bool WebViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, s
     InsertGeneratorInclude(node, "#include <wx/webview.h>", set_src, set_hdr);
     return true;
 }
+
+std::optional<tt_string> WebViewGenerator::GetWarning(Node* node, int language)
+{
+    switch (language)
+    {
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support Wx::WebView";
+                return msg;
+            }
+        default:
+            return {};
+    }
+}

--- a/src/generate/gen_web_view.h
+++ b/src/generate/gen_web_view.h
@@ -19,4 +19,6 @@ public:
     void GenEvent(Code&, NodeEvent*, const std::string&) override;
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr) override;
+
+    std::optional<tt_string> GetWarning(Node* node, int language) override;
 };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a virtual `GetWarning()` method to the `BaseGenerator` interface so that generators can output a warning when they don't support generating code in the current output language. The errors are stored in a `std::set` to avoid duplication, and are output after each form is generated.

Warnings are only generated for wxPython and wxRuby. XRC code generation goes through a very different path, so generating warnings for that is much more difficult. Since I don't think wxUE is used to generate XRC files very often, I'm not going to add support to it unless requested.

Closes #1185