### PR TITLE
Generate C++ lambda if needed

### DIFF
--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -499,19 +499,21 @@ bool AuiToolGenerator::ConstructionCode(Code& code)
     if (code.hasValue(prop_bitmap))
     {
         auto is_bitmaps_list = BitmapList(code, prop_bitmap);
+        bool uses_lambda = (code.is_cpp() && code.GetCode().ends_with("};\n"));
         GenToolCode(code, is_bitmaps_list);
         if (is_bitmaps_list && code.is_cpp())
         {
-            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (!uses_lambda)
             {
                 code.CloseBrace();
+            }
+            code.Eol();
+
+            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            {
                 code.Add("#else").Eol();
                 GenToolCode(code, false);
                 code.Eol().Add("#endif").Eol();
-            }
-            else
-            {
-                code.Eol() += "}\n";
             }
         }
     }

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -510,14 +510,14 @@ bool ToolGenerator::ConstructionCode(Code& code)
     {
         if (Project.as_string(prop_wxWidgets_version) == "3.1")
         {
-            code.CloseBrace();
+            code.CloseBrace().Eol();
             code.Add("#else").Eol();
             GenToolCode(code, false);
             code.Eol().Add("#endif").Eol();
         }
         else
         {
-            code.Eol() += "}\n";
+            code.CloseBrace().Eol();
         }
     }
 
@@ -555,19 +555,21 @@ bool ToolDropDownGenerator::ConstructionCode(Code& code)
     if (code.hasValue(prop_bitmap))
     {
         auto is_bitmaps_list = BitmapList(code, prop_bitmap);
+        bool uses_lambda = (code.is_cpp() && code.GetCode().ends_with("};\n"));
         GenToolCode(code, is_bitmaps_list);
         if (is_bitmaps_list && code.is_cpp())
         {
-            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (!uses_lambda)
             {
                 code.CloseBrace();
+            }
+            code.Eol();
+
+            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            {
                 code.Add("#else").Eol();
                 GenToolCode(code, false);
                 code.Eol().Add("#endif").Eol();
-            }
-            else
-            {
-                code.Eol() += "}\n";
             }
         }
     }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR special-case adding a dropdown tool or an aui tool that doesn't use a normal button state, and there are three or more bitmaps for the tool. In this case the return value from adding the tool is required. For C++, the bitmaps are added via a lambda so that the tool can be added outside of the bracketed section that would normally be created.

Closes #1211