### PR TITLE
Dark mode support

### DIFF
--- a/src/dark_settings.cpp
+++ b/src/dark_settings.cpp
@@ -1,0 +1,182 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Dark Settings class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#if !wxCHECK_VERSION(3, 3, 0)
+    #error "You must have wxWidgets 3.3.0 or later to include dark_settings.h"
+#endif
+
+#include <algorithm>
+
+#include "dark_settings.h"
+#include "preferences.h"  // Set/Get wxUiEditor preferences
+
+wxColour DarkSettings::GetColour(wxSystemColour index)
+{
+    switch (index)
+    {
+        case wxSYS_COLOUR_WINDOW:
+        case wxSYS_COLOUR_LISTBOX:
+        case wxSYS_COLOUR_BTNFACE:
+            if (UserPrefs.is_HighContrast())
+                return wxColour(0, 0, 0);
+            else
+                return wxColour(0x202020);
+
+#if 0
+            case wxSYS_COLOUR_ACTIVECAPTION:
+            case wxSYS_COLOUR_APPWORKSPACE:
+            case wxSYS_COLOUR_INFOBK:
+                // Default colour used here is 0x202020.
+                return wxColour(0x202020);
+#endif
+
+        default:
+            return wxDarkModeSettings::GetColour(index);
+    }
+}
+
+void wxColourToHSL(const wxColour& colour, double& hue, double& saturation, double& luminance)
+{
+    double r = colour.Red() / 255.0;
+    double g = colour.Green() / 255.0;
+    double b = colour.Blue() / 255.0;
+    double cmax = std::max({ r, g, b });
+    double cmin = std::min({ r, g, b });
+    double delta = cmax - cmin;
+
+    // Calculate hue
+    if (delta == 0)
+    {
+        hue = 0;
+    }
+    else if (cmax == r)
+    {
+        hue = fmod((g - b) / delta, 6);
+    }
+    else if (cmax == g)
+    {
+        hue = (b - r) / delta + 2;
+    }
+    else
+    {
+        hue = (r - g) / delta + 4;
+    }
+    hue *= 60;
+    if (hue < 0)
+    {
+        hue += 360;
+    }
+
+    // Calculate luminance
+    luminance = (cmax + cmin) / 2;
+
+    // Calculate saturation
+    if (delta == 0)
+    {
+        saturation = 0;
+    }
+    else
+    {
+        saturation = delta / (1 - fabs(2 * luminance - 1));
+    }
+}
+
+wxColour HSLToWxColour(double hue, double saturation, double luminance)
+{
+    double c = (1 - fabs(2 * luminance - 1)) * saturation;
+    double x = c * (1 - fabs(fmod(hue / 60, 2) - 1));
+    double m = luminance - c / 2;
+    double r, g, b;
+
+    if (hue < 60)
+    {
+        r = c;
+        g = x;
+        b = 0;
+    }
+    else if (hue < 120)
+    {
+        r = x;
+        g = c;
+        b = 0;
+    }
+    else if (hue < 180)
+    {
+        r = 0;
+        g = c;
+        b = x;
+    }
+    else if (hue < 240)
+    {
+        r = 0;
+        g = x;
+        b = c;
+    }
+    else if (hue < 300)
+    {
+        r = x;
+        g = 0;
+        b = c;
+    }
+    else
+    {
+        r = c;
+        g = 0;
+        b = x;
+    }
+
+    r += m;
+    g += m;
+    b += m;
+
+    r = std::clamp(r, 0.0, 1.0);
+    g = std::clamp(g, 0.0, 1.0);
+    b = std::clamp(b, 0.0, 1.0);
+
+    return wxColour(static_cast<unsigned char>(r * 255), static_cast<unsigned char>(g * 255),
+                    static_cast<unsigned char>(b * 255));
+}
+
+wxColour wxColourToDarkForeground(const wxColour& colour)
+{
+    double hue, saturation, luminance;
+    wxColourToHSL(colour, hue, saturation, luminance);
+
+    if (UserPrefs.is_HighContrast())
+    {
+        if (luminance < 0.85)
+        {
+            luminance = 0.85;
+        }
+    }
+    else
+    {
+        luminance = 0.75;
+    }
+
+    return HSLToWxColour(hue, saturation, luminance);
+}
+
+wxColour wxColourToDarkBackground(const wxColour& colour)
+{
+    double hue, saturation, luminance;
+    wxColourToHSL(colour, hue, saturation, luminance);
+
+    if (UserPrefs.is_HighContrast())
+    {
+        if (luminance > 0.05)
+        {
+            luminance = 0.05;
+        }
+    }
+    else
+    {
+        luminance = 0.20;
+    }
+
+    return HSLToWxColour(hue, saturation, luminance);
+}

--- a/src/dark_settings.h
+++ b/src/dark_settings.h
@@ -1,0 +1,27 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Dark Settings class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#if !wxCHECK_VERSION(3, 3, 0)
+    #error "You must have wxWidgets 3.3.0 or later to include dark_settings.h"
+#endif
+
+#include <wx/msw/darkmode.h>
+
+class DarkSettings : public wxDarkModeSettings
+{
+public:
+    wxColour GetColour(wxSystemColour index);
+};
+
+extern DarkSettings* DarkModeSettings;
+
+void wxColourToHSL(const wxColour& colour, double& hue, double& saturation, double& luminance);
+wxColour HSLToWxColour(double hue, double saturation, double luminance);
+wxColour wxColourToDarkForeground(const wxColour& colour);
+wxColour wxColourToDarkBackground(const wxColour& colour);

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -11,6 +11,7 @@ set (file_list
     bitmaps.cpp           # Map of bitmaps accessed by name
     clipboard.cpp         # Handles reading and writing OS clipboard data
     cstm_event.cpp        # Custom Event handling
+    dark_settings.cpp     # Dark Settings class
     frame_status_bar.cpp  # MainFrame status bar functions
     gen_enums.cpp         # Enumerations for generators
     paths.cpp             # Handles *_directory properties

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -17,14 +17,7 @@
 #include <wx/utils.h>    // Miscellaneous utilities
 
 #if wxCHECK_VERSION(3, 3, 0) && defined(_WIN32)
-
-    #include <wx/msw/darkmode.h>
-class DarkSettings : public wxDarkModeSettings
-{
-public:
-    wxColour GetColour(wxSystemColour index);
-};
-
+    #include "dark_settings.h"
 #endif
 
 #include "mainapp.h"
@@ -86,35 +79,7 @@ wxIMPLEMENT_APP(App);
 #endif  // _WIN32 && defined(_DEBUG)
 
 tt_string tt_empty_cstr;
-
-#if wxCHECK_VERSION(3, 3, 0) && defined(_WIN32)
-
-wxColour DarkSettings::GetColour(wxSystemColour index)
-{
-    switch (index)
-    {
-        case wxSYS_COLOUR_WINDOW:
-        case wxSYS_COLOUR_LISTBOX:
-        case wxSYS_COLOUR_BTNFACE:
-            if (UserPrefs.is_HighContrast())
-                return wxColour(0, 0, 0);
-            else
-                return wxColour(0x202020);
-
-    #if 0
-            case wxSYS_COLOUR_ACTIVECAPTION:
-            case wxSYS_COLOUR_APPWORKSPACE:
-            case wxSYS_COLOUR_INFOBK:
-                // Default colour used here is 0x202020.
-                return wxColour(0x202020);
-    #endif
-
-        default:
-            return wxDarkModeSettings::GetColour(index);
-    }
-}
-
-#endif  // wxCHECK_VERSION(3, 3, 0) && defined(_WIN32)
+DarkSettings* DarkModeSettings;
 
 App::App() {}
 
@@ -167,8 +132,8 @@ bool App::OnInit()
     // colors in our property sheet and scintilla code displays.
     if (UserPrefs.is_DarkMode())
     {
-        auto* darkSettings = new DarkSettings;
-        MSWEnableDarkMode(0, darkSettings);
+        DarkModeSettings = new DarkSettings;
+        MSWEnableDarkMode(0, DarkModeSettings);
     }
 #endif
 

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -9,6 +9,10 @@
 #include <wx/fdrepdlg.h>     // wxFindReplaceDialog class
 #include <wx/msgdlg.h>       // common header and base class for wxMessageDialog
 
+#if wxCHECK_VERSION(3, 3, 0) && defined(_WIN32)
+    #include "dark_settings.h"
+#endif
+
 #include "code_display.h"  // auto-generated: wxui/codedisplay_base.h and wxui/codedisplay_base.cpp
 
 #include "base_panel.h"      // BasePanel -- Code generation panel
@@ -51,13 +55,34 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_xrc_keywords);
 
         m_scintilla->StyleSetBold(wxSTC_H_TAG, true);
-        m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#FF00FF"));
-        m_scintilla->StyleSetForeground(wxSTC_H_TAG, *wxBLUE);
-        m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, *wxRED);
-        m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, *wxRED);
-        m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+
+            m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#FF00FF"));
+            m_scintilla->StyleSetForeground(wxSTC_H_TAG, wxColour("#80ccff"));
+            m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, wxColour("#ff6666"));
+            m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, wxColour("#ff6666"));
+            m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour("#85e085"));
+        }
+        else
+        {
+            m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#FF00FF"));
+            m_scintilla->StyleSetForeground(wxSTC_H_TAG, *wxBLUE);
+            m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, *wxRED);
+            m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, *wxRED);
+            m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
+        }
     }
     else if (panel_type == GEN_LANG_PYTHON)
     {
@@ -83,13 +108,38 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
 
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) wxPython_keywords.c_str());
-
-        m_scintilla->StyleSetForeground(wxSTC_P_WORD, *wxBLUE);
         m_scintilla->StyleSetForeground(wxSTC_P_WORD2, UserPrefs.get_PythonColour());
-        m_scintilla->StyleSetForeground(wxSTC_P_STRING, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_P_STRINGEOL, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_P_COMMENTLINE, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_P_NUMBER, *wxRED);
+
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+
+            double hue, saturation, luminance;
+            wxColourToHSL(wxColour(0, 128, 0), hue, saturation, luminance);
+            luminance = .80;
+            auto light_green = HSLToWxColour(hue, saturation, luminance);
+
+            m_scintilla->StyleSetForeground(wxSTC_P_WORD, wxColour("#80ccff"));
+            // m_scintilla->StyleSetForeground(wxSTC_P_STRING, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_P_STRING, light_green);
+            m_scintilla->StyleSetForeground(wxSTC_P_STRINGEOL, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_P_COMMENTLINE, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_P_NUMBER, wxColour("#ff6666"));
+        }
+        else
+        {
+            m_scintilla->StyleSetForeground(wxSTC_P_WORD, *wxBLUE);
+            m_scintilla->StyleSetForeground(wxSTC_P_STRING, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_P_STRINGEOL, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_P_COMMENTLINE, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_P_NUMBER, *wxRED);
+        }
     }
     else if (panel_type == GEN_LANG_RUBY)
     {
@@ -122,11 +172,28 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // the wxWidgets keywords.
 
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) wxRuby_keywords.c_str());
-
         m_scintilla->StyleSetForeground(wxSTC_RB_WORD, UserPrefs.get_RubyColour());
-        m_scintilla->StyleSetForeground(wxSTC_RB_STRING, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_RB_COMMENTLINE, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_RB_NUMBER, *wxRED);
+
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+
+            m_scintilla->StyleSetForeground(wxSTC_RB_STRING, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_RB_COMMENTLINE, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_RB_NUMBER, wxColour("#ff6666"));
+        }
+        else
+        {
+            m_scintilla->StyleSetForeground(wxSTC_RB_STRING, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_RB_COMMENTLINE, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_RB_NUMBER, *wxRED);
+        }
     }
 #if defined(_DEBUG)
     // The following language panels are experimental and only appear in a Debug build
@@ -161,16 +228,41 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) widget_keywords.c_str());
         m_scintilla->StyleSetBold(wxSTC_C_WORD, true);
-        m_scintilla->StyleSetForeground(wxSTC_C_WORD, *wxBLUE);
         m_scintilla->StyleSetForeground(wxSTC_C_WORD2, UserPrefs.get_CppColour());
-        m_scintilla->StyleSetForeground(wxSTC_C_STRING, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, *wxRED);
+
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+
+            m_scintilla->StyleSetForeground(wxSTC_C_WORD, wxColour("#80ccff"));
+            m_scintilla->StyleSetForeground(wxSTC_C_STRING, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, wxColour("#ff6666"));
+            m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, wxColour("#ff6666"));
+        }
+        else
+        {
+            m_scintilla->StyleSetForeground(wxSTC_C_WORD, *wxBLUE);
+            m_scintilla->StyleSetForeground(wxSTC_C_STRING, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, *wxRED);
+        }
     }
 
     else if (panel_type == GEN_LANG_LUA)
@@ -200,16 +292,39 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) widget_keywords.c_str());
         m_scintilla->StyleSetBold(wxSTC_LUA_WORD, true);
-        m_scintilla->StyleSetForeground(wxSTC_LUA_WORD, *wxBLUE);
         m_scintilla->StyleSetForeground(wxSTC_LUA_WORD2, UserPrefs.get_CppColour());
-        m_scintilla->StyleSetForeground(wxSTC_LUA_STRING, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_LUA_STRINGEOL, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_LUA_PREPROCESSOR, wxColour(49, 106, 197));
-        m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENT, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENTLINE, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENTDOC, wxColour(0, 128, 0));
-        // Currently, wxSTC_LUA_COMMENTLINEDOC doesn't exist
-        // m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENTLINEDOC, wxColour(0, 128, 0));
+
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+
+            m_scintilla->StyleSetForeground(wxSTC_C_WORD, wxColour("#80ccff"));
+            m_scintilla->StyleSetForeground(wxSTC_C_STRING, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, wxColour("#ff6666"));
+            m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, wxColour("#ff6666"));
+        }
+        else
+        {
+            m_scintilla->StyleSetForeground(wxSTC_LUA_WORD, *wxBLUE);
+            m_scintilla->StyleSetForeground(wxSTC_LUA_STRING, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_LUA_STRINGEOL, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_LUA_PREPROCESSOR, wxColour(49, 106, 197));
+            m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENT, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENTLINE, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENTDOC, wxColour(0, 128, 0));
+        }
         m_scintilla->StyleSetForeground(wxSTC_LUA_NUMBER, *wxRED);
     }
 
@@ -239,18 +354,32 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
 
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) widget_keywords.c_str());
-
         m_scintilla->StyleSetBold(wxSTC_PL_WORD, true);
-        m_scintilla->StyleSetForeground(wxSTC_PL_WORD, *wxBLUE);
-        // m_scintilla->StyleSetForeground(wxSTC_PL_WORD2, UserPrefs.get_CppColour());
-        m_scintilla->StyleSetForeground(wxSTC_PL_STRING, wxColour(0, 128, 0));
-        // m_scintilla->StyleSetForeground(wxSTC_PL_STRINGEOL, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_PL_PREPROCESSOR, wxColour(49, 106, 197));
-        // m_scintilla->StyleSetForeground(wxSTC_PL_COMMENT, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_PL_COMMENTLINE, wxColour(0, 128, 0));
-        // m_scintilla->StyleSetForeground(wxSTC_PL_COMMENTDOC, wxColour(0, 128, 0));
-        // m_scintilla->StyleSetForeground(wxSTC_PL_COMMENTLINEDOC, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_PL_NUMBER, *wxRED);
+
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+
+            m_scintilla->StyleSetForeground(wxSTC_PL_WORD, wxColour("#80ccff"));
+            m_scintilla->StyleSetForeground(wxSTC_PL_STRING, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_PL_PREPROCESSOR, wxColour(49, 106, 197));
+            m_scintilla->StyleSetForeground(wxSTC_PL_COMMENTLINE, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_PL_NUMBER, wxColour("#ff6666"));
+        }
+        else
+        {
+            m_scintilla->StyleSetForeground(wxSTC_PL_WORD, *wxBLUE);
+            m_scintilla->StyleSetForeground(wxSTC_PL_STRING, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_PL_PREPROCESSOR, wxColour(49, 106, 197));
+            m_scintilla->StyleSetForeground(wxSTC_PL_COMMENTLINE, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_PL_NUMBER, *wxRED);
+        }
     }
 
     else if (panel_type == GEN_LANG_RUST)
@@ -279,16 +408,32 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) widget_keywords.c_str());
         m_scintilla->StyleSetBold(wxSTC_RUST_WORD, true);
-        m_scintilla->StyleSetForeground(wxSTC_RUST_WORD, *wxBLUE);
         m_scintilla->StyleSetForeground(wxSTC_RUST_WORD2, UserPrefs.get_CppColour());
-        m_scintilla->StyleSetForeground(wxSTC_RUST_STRING, wxColour(0, 128, 0));
-        // m_scintilla->StyleSetForeground(wxSTC_RUST_STRINGEOL, wxColour(0, 128, 0));
-        // m_scintilla->StyleSetForeground(wxSTC_RUST_PREPROCESSOR, wxColour(49, 106, 197));
-        // m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENT, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENTLINE, wxColour(0, 128, 0));
-        // m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENTDOC, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENTLINEDOC, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_RUST_NUMBER, *wxRED);
+
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+
+            m_scintilla->StyleSetForeground(wxSTC_RUST_WORD, wxColour("#80ccff"));
+            m_scintilla->StyleSetForeground(wxSTC_RUST_STRING, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENTLINE, wxColour("#85e085"));
+            m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENTLINEDOC, wxColour("#ff6666"));
+            m_scintilla->StyleSetForeground(wxSTC_RUST_NUMBER, wxColour("#ff6666"));
+        }
+        else
+        {
+            m_scintilla->StyleSetForeground(wxSTC_RUST_WORD, *wxBLUE);
+            m_scintilla->StyleSetForeground(wxSTC_RUST_STRING, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENTLINE, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENTLINEDOC, wxColour(0, 128, 0));
+            m_scintilla->StyleSetForeground(wxSTC_RUST_NUMBER, *wxRED);
+        }
     }
 #endif  // _DEBUG
 
@@ -319,16 +464,59 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) widget_keywords.c_str());
         m_scintilla->StyleSetBold(wxSTC_C_WORD, true);
-        m_scintilla->StyleSetForeground(wxSTC_C_WORD, *wxBLUE);
-        m_scintilla->StyleSetForeground(wxSTC_C_WORD2, UserPrefs.get_CppColour());
-        m_scintilla->StyleSetForeground(wxSTC_C_STRING, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, wxColour(0, 128, 0));
-        m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, *wxRED);
+
+        // First set all possible foreground/background colours
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = DarkModeSettings->GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+        }
+
+        auto clr_green = wxColour(0, 128, 0);
+        if (UserPrefs.is_DarkMode())
+        {
+            if (UserPrefs.is_HighContrast())
+            {
+                clr_green = wxColour("#1cc462");
+            }
+            else
+            {
+                wxColour(0, 192, 0);
+            }
+        }
+        m_scintilla->StyleSetForeground(wxSTC_C_STRING, clr_green);
+        m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, clr_green);
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, clr_green);
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, clr_green);
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, clr_green);
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, clr_green);
+
+        if (UserPrefs.is_DarkMode())
+        {
+            m_scintilla->StyleSetForeground(wxSTC_C_WORD2, wxColourToDarkForeground(UserPrefs.get_CppColour()));
+            m_scintilla->StyleSetForeground(wxSTC_C_WORD, wxColourToDarkForeground(*wxBLUE));
+            if (UserPrefs.is_HighContrast())
+            {
+                m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour("#569CD6"));
+            }
+            else
+            {
+                m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
+            }
+            m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, wxColour("#ff6666"));
+        }
+        else
+        {
+            m_scintilla->StyleSetForeground(wxSTC_C_WORD2, UserPrefs.get_CppColour());
+            m_scintilla->StyleSetForeground(wxSTC_C_WORD, *wxBLUE);
+            m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
+            m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, *wxRED);
+        }
     }
 
     // TODO: [KeyWorks - 01-02-2022] We do this because currently font selection uses a facename which is not cross-platform.

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -756,7 +756,10 @@ void PropGridPanel::AddProperties(tt_string_view name, Node* node, NodeCategory&
                 else if (propType == type_image || propType == type_animation)
                 {
                     m_prop_grid->Expand(pg);
-                    m_prop_grid->SetPropertyBackgroundColour(pg, wxColour("#fff1d2"));
+                    if (UserPrefs.is_DarkMode())
+                        m_prop_grid->SetPropertyBackgroundColour(pg, wxColour("#996900"));
+                    else
+                        m_prop_grid->SetPropertyBackgroundColour(pg, wxColour("#fff1d2"));
 
                     // This causes it to display the bitmap in the image/id property
                     pg->RefreshChildren();
@@ -772,7 +775,12 @@ void PropGridPanel::AddProperties(tt_string_view name, Node* node, NodeCategory&
 
             if (name.is_sameas("wxWindow") || name.is_sameas("wxMdiWindow") ||
                 category.GetName().Contains("Window Settings"))
-                m_prop_grid->SetPropertyBackgroundColour(pg, wxColour("#e7f4e4"));
+            {
+                if (UserPrefs.is_DarkMode())
+                    m_prop_grid->SetPropertyBackgroundColour(pg, wxColour("#386d2c"));
+                else
+                    m_prop_grid->SetPropertyBackgroundColour(pg, wxColour("#e7f4e4"));
+            }
 
             // Automatically collapse properties that are rarely used
             if (prop_name == prop_unchecked_bitmap)
@@ -904,7 +912,12 @@ void PropGridPanel::AddEvents(tt_string_view name, Node* node, NodeCategory& cat
             m_event_grid->SetPropertyHelpString(id, wxGetTranslation(eventInfo->get_help()));
 
             if (name.is_sameas("Window Events") || name.is_sameas("wxTopLevelWindow"))
-                m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#e7f4e4"));
+            {
+                if (UserPrefs.is_DarkMode())
+                    m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#386d2c"));
+                else
+                    m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#e7f4e4"));
+            }
 
             if (auto it = m_expansion_map.find(eventName); it != m_expansion_map.end())
             {
@@ -1895,11 +1908,17 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     else if (name.is_sameas("Bitmaps") || name.is_sameas("Command Bitmaps"))
     {
         m_prop_grid->Collapse(id);
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#dce4ef"));
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#304869"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#dce4ef"));
     }
     else if (name.contains("Validator"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#fff1d2"));
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#996900"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#fff1d2"));
 
         // It's going to be rare to want a validator for these classes, so collapse the validator for them
         if (node->isGen(gen_wxButton) || node->isGen(gen_wxStaticText))
@@ -1907,7 +1926,10 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
     else if (name.contains("C++"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#ccccff"));  // Light blue
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#000099"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#ccccff"));  // Light blue
         if (Project.getCodePreference(node) != GEN_LANG_CPLUSPLUS)
         {
             m_prop_grid->Collapse(id);
@@ -1915,7 +1937,10 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
     else if (name.contains("XRC"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#ffe7b3"));  // Light yellow
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#996900"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#ffe7b3"));  // Light yellow
         if (Project.getCodePreference(node) != GEN_LANG_XRC)
         {
             m_prop_grid->Collapse(id);
@@ -1923,7 +1948,10 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
     else if (name.contains("wxPython"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#ccffcc"));  // Light green
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#009900"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#ccffcc"));  // Light green
         if (Project.getCodePreference(node) != GEN_LANG_PYTHON)
         {
             m_prop_grid->Collapse(id);
@@ -1931,7 +1959,10 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
     else if (name.contains("wxRuby"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#f8a9c7"));  // Ruby
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#8e0b3d"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#f8a9c7"));  // Ruby
         if (Project.getCodePreference(node) != GEN_LANG_RUBY)
         {
             m_prop_grid->Collapse(id);
@@ -1939,7 +1970,10 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
     else if (name.contains("wxGo"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#66e0ff"));  // Light Gopher Blue
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#007a99"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#66e0ff"));  // Light Gopher Blue
         if (Project.getCodePreference(node) != GEN_LANG_GOLANG)
         {
             m_prop_grid->Collapse(id);
@@ -1947,7 +1981,10 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
     else if (name.contains("wxLua"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#bf80ff"));  // light purple
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#4d0099"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#bf80ff"));  // light purple
         if (Project.getCodePreference(node) != GEN_LANG_LUA)
         {
             m_prop_grid->Collapse(id);
@@ -1955,7 +1992,10 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
     else if (name.contains("wxPerl"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#eae0c8"));  // Pearl
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#6f5a2a"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#eae0c8"));  // Pearl
         if (Project.getCodePreference(node) != GEN_LANG_PERL)
         {
             m_prop_grid->Collapse(id);
@@ -1963,7 +2003,10 @@ void PropGridPanel::CreatePropCategory(tt_string_view name, Node* node, NodeDecl
     }
     else if (name.contains("wxRust"))
     {
-        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#f49871"));  // Light Rust
+        if (UserPrefs.is_DarkMode())
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#8e320b"));
+        else
+            m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#f49871"));  // Light Rust
         if (Project.getCodePreference(node) != GEN_LANG_RUST)
         {
             m_prop_grid->Collapse(id);
@@ -2062,7 +2105,10 @@ void PropGridPanel::CreateLayoutCategory(Node* node)
 
     m_prop_grid->Expand(id);
 
-    m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#e1f3f8"));
+    if (UserPrefs.is_DarkMode())
+        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#1d677c"));
+    else
+        m_prop_grid->SetPropertyBackgroundColour(id, wxColour("#e1f3f8"));
 }
 
 void PropGridPanel::CreateEventCategory(tt_string_view name, Node* node, NodeDeclaration* declaration, EventSet& event_set)

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -26,6 +26,7 @@ void Prefs::ReadConfig()
 
     m_enable_wakatime = config->ReadBool("enable_wakatime", true);
     m_dark_mode = config->ReadBool("dark_mode", false);
+    m_high_constrast = config->ReadBool("high_contrast", false);
     m_is_load_last_project = config->ReadBool("load_last_project", false);
     m_is_right_propgrid = config->ReadBool("right_propgrid", false);
     m_is_cpp_snake_case = config->ReadBool("cpp_snake_case", true);
@@ -54,6 +55,7 @@ void Prefs::WriteConfig()
 
     config->Write("enable_wakatime", m_enable_wakatime);
     config->Write("dark_mode", m_dark_mode);
+    config->Write("high_contrast", m_high_constrast);
     config->Write("load_last_project", m_is_load_last_project);
     config->Write("right_propgrid", m_is_right_propgrid);
     config->Write("cpp_snake_case", m_is_cpp_snake_case);

--- a/src/ui/preferences_dlg.cpp
+++ b/src/ui/preferences_dlg.cpp
@@ -43,7 +43,8 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     m_check_high_contrast->SetToolTip("Only used if Dark Mode is selected");
     m_box_dark_settings->Add(m_check_high_contrast, wxSizerFlags().Border(wxALL));
 
-    page_sizer_1->Add(m_box_dark_settings, wxSizerFlags().Expand().Border(wxALL));
+    page_sizer_1->Add(m_box_dark_settings,
+    wxSizerFlags().Expand().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     m_check_right_propgrid = new wxCheckBox(page_general, wxID_ANY, "Property Panel on Right");
     m_check_right_propgrid->SetToolTip("If checked, the Property panel will be moved to the right side");

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -6234,6 +6234,7 @@
                 class="wxBoxSizer"
                 class_access="protected:"
                 var_name="m_box_dark_settings"
+                borders="wxTOP|wxBOTTOM|wxRIGHT"
                 flags="wxEXPAND">
                 <node
                   class="wxCheckBox"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds support for Dark Mode and High Contrast Dark Mode by adjusting the background colors in the PropertyGrid Panel, and the foreground and background colors in the Code display panels.

Note that Windows and wxWidgets 3.3 is required for Dark Mode.