### PR TITLE
Change default build to use wxSnapshot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,24 @@ option(BUILD_FORK "Builds wxWidgets using wxWidgets/wx_3_3")
 # to verify the wxUSE_UNICODE_UTF8 build option for MSW.
 
 option(BUILD_CUSTOM "Builds with custom version of wxWidgets")
+option(BUILD_WIDGETS_3_2 "Builds with wxWidgets 3.2")
 
-if (BUILD_CUSTOM AND BUILD_FORK)
-    message(FATAL_ERROR "BUILD_FORK and BUILD_CUSTOM cannot be combined")
+if (BUILD_WIDGETS_3_2)
+    if (BUILD_CUSTOM OR BUILD_FORK)
+        message(FATAL_ERROR "BUILD_WIDGETS_3_2 cannot be combined with BUILD_FORK or BUILD_CUSTOM")
+    endif()
+endif()
+
+if (BUILD_FORK)
+    if (BUILD_CUSTOM OR BUILD_WIDGETS_3_2)
+        message(FATAL_ERROR "BUILD_FORK cannot be combined with BUILD_WIDGETS_3_2 or BUILD_CUSTOM")
+    endif()
+endif()
+
+if (BUILD_CUSTOM)
+    if (BUILD_FORK OR BUILD_WIDGETS_3_2)
+        message(FATAL_ERROR "BUILD_CUSTOM cannot be combined with BUILD_WIDGETS_3_2 or BUILD_FORK")
+    endif()
 endif()
 
 if (BUILD_FORK)
@@ -60,10 +75,14 @@ if (BUILD_FORK)
 elseif (BUILD_CUSTOM)
     set(BUILD_ROOT ${BUILD_CUSTOM_DIR} CACHE PATH "${CMAKE_CURRENT_LIST_DIR}/../" FORCE)
     message(NOTICE "Building with custom build of wxWidgets")
-else()
+elseif (BUILD_WIDGETS_3_2)
     set(BUILD_ROOT wxWidgets CACHE PATH "wxWidgets" FORCE)
+    message(NOTICE "Building with wxWidgets 3.2")
+else()
+    set(BUILD_ROOT wxSnapshot CACHE PATH "wxSnapshot" FORCE)
 endif()
 
+#  These settings will force dark mode on unless user preferences has shut it off. Shouldn't really be needed anymore.
 option(INTERNAL_DARK_MODE "Enable dark mode (used with wxWidgets 3.3 in _WIN32 builds)" OFF)
 option(INTERNAL_DARK_HIGH_CONTRAST "Enable dark mode high contrast (used with wxWidgets 3.3 in _WIN32 builds)" OFF)
 
@@ -167,9 +186,12 @@ if (BUILD_FORK)
 elseif(BUILD_CUSTOM)
     set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/wxWidgets/wx_custom)
     add_subdirectory(${widget_dir})
-else()
+elseif(BUILD_WXWIN_3_2)
     set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/wxWidgets)
     add_subdirectory(${widget_dir}/wx_3_2)
+else()
+    set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot)
+    add_subdirectory(${widget_dir})
 endif()
 
 message(STATUS "widget_dir: ${widget_dir}")
@@ -179,13 +201,14 @@ if (WIN32)
         set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/wxWidgets/wx_3_3/setup/win)
     elseif(BUILD_CUSTOM)
         set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/wxWidgets/wx_custom/setup/win)
-    else()
+    elseif(BUILD_WIDGETS_3_2)
         set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/wxWidgets/wx_3_2/setup/win)
+    else()
+        set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot/win)
     endif()
-else()
-    if (NOT BUILD_FORK)
-        set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/wxWidgets/wx_3_3/setup/unix)
-    endif()
+elseif (UNIX)
+    # Currently, this is the only build location supported for a UNIX build
+    set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot/unix)
 endif()
 
 ####################### Libraries and Executables #######################
@@ -216,7 +239,11 @@ if (BUILD_SHARED_LIBS)
     target_compile_definitions(check_build PRIVATE WXUSINGDLL)
 else()
     # This is built into wxWidgets if a shared library is created
-    set(CLib wxCLib)
+    if (WIN32)
+        set(CLib wxCLib)
+    elseif(UNIX)
+        set(CLib libwxCLib)
+    endif()
 endif()
 
 if (NOT BUILD_FORK)
@@ -246,19 +273,29 @@ endif()
 if (NOT BUILD_FORK AND NOT BUILD_CUSTOM)
     if (WIN32)
         target_link_libraries(wxUiEditor PRIVATE wxWidgets ${CLib} comctl32 Imm32 Shlwapi Version UxTheme)
+    elseif (UNIX)
+        target_link_libraries(wxUiEditor PRIVATE libwxWidgets ${CLib})
     endif()
-else()
+elseif(BUILD_FORK)
     if (WIN32)
         target_link_directories(wxUiEditor PRIVATE
             $<$<CONFIG:Debug>:${widget_dir}/bld/build/Debug>
             $<$<CONFIG:Release>:${widget_dir}/bld/build/Release>
         )
         target_link_libraries(wxUiEditor PRIVATE wxWidgets ${CLib})
-    else()
-        target_link_libraries(wxUiEditor PRIVATE wxWidgets ${CLib})
+    endif()
+elseif(BUILD_CUSTOM)
+    if (WIN32)
         target_link_directories(wxUiEditor PRIVATE
-            $<$<CONFIG:Debug>:${widget_lib_dir}>
-            $<$<CONFIG:Release>:${widget_lib_dir}>
+            $<$<CONFIG:Debug>:${widget_dir}/build/Debug>
+            $<$<CONFIG:Release>:${widget_dir}/build/Release>
+        )
+        target_link_libraries(wxUiEditor PRIVATE wxWidgets ${CLib} comctl32 Imm32 Shlwapi Version UxTheme)
+    elseif(UNIX)
+        target_link_libraries(wxUiEditor PRIVATE libwxWidgets ${CLib})
+        target_link_directories(wxTest PRIVATE
+            $<$<CONFIG:Debug>:${widget_dir}/build/Debug>
+            $<$<CONFIG:Release>:${widget_dir}/build/Release>
         )
     endif()
 endif()

--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -4,6 +4,12 @@ If you are planning on contributing code, the following sections contain informa
 
 Note that the code requires a C++20 compliant compiler -- which means you should be using C++20 coding conventions. That includes using `std::string_view` (or `tt_stringview`) for strings when practical. See the **Strings** section below for information about working with `wxString`.
 
+## wxWidgets libraries
+
+Abbreviated versions of wxWidgets 3.2 and 3.3 are part of the repository. These versions generally only contain source and header files, and they are built with a custom CMakeLists.txt file. The default is to build with `wxSnapshot/` which is a subtree of `https://github.com/KeyWorksRW/wxSnapshot.git` which contains a development version of wxWidgets 3.3. This is _not_ necessarily a release version of wxWidgets -- it's being used to get Dark mode and UTF8 when building on Windows.
+
+The `wxWidgets/` directory contains a snapshot of wxWidgets 3.2. At some point, it may not be possible to build wxUiEditor with this library, but it will still be available for building the projects in the `tests/` directory.
+
 ## Debug builds
 
 When you create a Debug build, there will be an additional `Testing` and `Internal` menu to the right of the **Help** menu that will give you access to additional functionality for easier debugging. You can also get these menus in a Release build if you set INTERNAL_BLD_TESTING to true in your CMake configuration.


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR switches the build from wxWidgets to wxSnapshot -- which means it is now being built on wxWidgets 3.3. Note that wxWidgets 3.3 is _not_ a release build. However, it allows us to build wxString with UTF8 on Windows, and it allows the user to set Dark mode on Windows. The wxSnapshot library also builds on UNIX, so using that will allow us to start making the necessary fixes to get a UNIX build working.
