### PR TITLE
Scale SVG images added to a toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - controls that have one or more default window styles set (e.g., wxPanel has wxTAB_TRAVERSAL set) can now have that style unchecked and that state will be stored with the project file.
 - Color properties dialog now supports _all_ CSS color names
 - Generated code for colors now uses a CSS HTML String (#RRGGBB) instead of numerical values for red, green and blue.
+- Generated code for wxRibbonToolBar images are now scaled on high DPI displays
 
 ### Fixed
 

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -482,7 +482,10 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
     {
         if (auto function_name = ProjectImages.GetBundleFuncName(parts); function_name.size())
         {
-            code.Eol().Str(function_name).Comma().Str("FromDIP(wxSize(").itoa(svg_size.x).Comma().itoa(svg_size.y) += ")))";
+            // The function name includes the size, but we need to replace the size with a DIP version.
+            function_name.erase_from("(");
+            code.Eol().Tab().Str(function_name).Str("(FromDIP(").itoa(svg_size.x).Str("), FromDIP(").itoa(svg_size.y);
+            code += "))";
             if (get_bitmap)
             {
                 code.Str(".").Add("GetBitmap(").Add("wxDefaultSize)");
@@ -511,7 +514,7 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
         }
         else
         {
-            code.Add("wxSize(").itoa(svg_size.x).Comma().itoa(svg_size.y) += "))";
+            code.Add("FromDIP(wxSize(").itoa(svg_size.x).Comma().itoa(svg_size.y) += ")))";
         }
         return;
     }

--- a/src/panels/doc_view.cpp
+++ b/src/panels/doc_view.cpp
@@ -57,12 +57,14 @@ bool DocViewPanel::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos, c
     m_toolBar->AddTool(wxID_FORWARD, "Forward", wxArtProvider::GetBitmapBundle(wxART_GO_FORWARD, wxART_TOOLBAR));
 
     m_toolBar->AddSeparator();
-    m_toolBar->AddTool(ID_CPLUS, "C++", wxue_img::bundle_cpp_logo_svg(16, 16), wxEmptyString, wxITEM_RADIO);
+    m_toolBar->AddTool(ID_CPLUS, "C++",
+        wxue_img::bundle_cpp_logo_svg(FromDIP(16), FromDIP(16)), wxEmptyString, wxITEM_RADIO);
 
-    m_toolBar->AddTool(ID_PYTHON, "Python", wxue_img::bundle_python_logo_only_svg(16, 16), wxEmptyString, wxITEM_RADIO);
+    m_toolBar->AddTool(ID_PYTHON, "Python",
+        wxue_img::bundle_python_logo_only_svg(FromDIP(16), FromDIP(16)), wxEmptyString, wxITEM_RADIO);
 
-    m_toolBar->AddTool(ID_RUBY, "Ruby", wxueBundleSVG(wxue_img::ruby_logo_svg, 1853, 10034, wxSize(16, 16)), wxEmptyString,
-        wxITEM_RADIO);
+    m_toolBar->AddTool(ID_RUBY, "Ruby",
+        wxueBundleSVG(wxue_img::ruby_logo_svg, 1853, 10034, FromDIP(wxSize(16, 16))), wxEmptyString, wxITEM_RADIO);
 
     m_toolBar->Realize();
     m_parent_sizer->Add(m_toolBar, wxSizerFlags().Expand().Border(wxALL));

--- a/src/panels/nav_toolbar.cpp
+++ b/src/panels/nav_toolbar.cpp
@@ -39,15 +39,17 @@ NavToolbar::NavToolbar(wxWindow* parent, wxWindowID id, const wxPoint& pos, cons
 
     AddStretchableSpace();
 
-    AddTool(id_NavCollExpand, wxEmptyString, wxueBundleSVG(wxue_img::nav_coll_expand_svg, 249, 482, wxSize(16, 16)),
-        wxNullBitmap, wxITEM_NORMAL, "Collapse siblings, expand children",
-        "Expand selected item, collapse all other items at the same level");
+    AddTool(id_NavCollExpand, wxEmptyString,
+        wxueBundleSVG(wxue_img::nav_coll_expand_svg, 249, 482, FromDIP(wxSize(16, 16))), wxNullBitmap, wxITEM_NORMAL,
+        "Collapse siblings, expand children", "Expand selected item, collapse all other items at the same level");
 
-    AddTool(id_NavExpand, wxEmptyString, wxueBundleSVG(wxue_img::nav_expand_svg, 248, 410, wxSize(16, 16)), wxNullBitmap,
-        wxITEM_NORMAL, "Expand all children", "Expand selected item and all of it\'s sub-items");
+    AddTool(id_NavExpand, wxEmptyString,
+        wxueBundleSVG(wxue_img::nav_expand_svg, 248, 410, FromDIP(wxSize(16, 16))), wxNullBitmap, wxITEM_NORMAL,
+        "Expand all children", "Expand selected item and all of it\'s sub-items");
 
-    AddTool(id_NavCollapse, wxEmptyString, wxueBundleSVG(wxue_img::nav_collapse_svg, 244, 432, wxSize(16, 16)), wxNullBitmap,
-        wxITEM_NORMAL, "Collapse all siblings", "Collapse selected item and all items at the same level");
+    AddTool(id_NavCollapse, wxEmptyString,
+        wxueBundleSVG(wxue_img::nav_collapse_svg, 244, 432, FromDIP(wxSize(16, 16))), wxNullBitmap, wxITEM_NORMAL,
+        "Collapse all siblings", "Collapse selected item and all items at the same level");
 
     AddSeparator();
     AddTool(id_NavMoveLeft, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_GO_BACK, wxART_MENU), wxNullBitmap,

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -60,22 +60,24 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     m_toolbar = new wxToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTB_FLAT|wxTB_HORIZONTAL|wxTB_NODIVIDER);
 
     m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_NewProject, "New", wxueBundleSVG(wxue_img::new_project_svg, 921, 2208, wxSize(24, 24)),
-        "New Project (Ctrl+N)");
+    m_toolbar->AddTool(id_NewProject, "New",
+        wxueBundleSVG(wxue_img::new_project_svg, 921, 2208, FromDIP(wxSize(24, 24))), "New Project (Ctrl+N)");
 
     m_toolbar->AddTool(id_OpenProject, "Open", wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN, wxART_TOOLBAR),
         "Open Project (Ctrl+O)");
 
-    m_toolbar->AddTool(wxID_SAVE, "Save", wxueBundleSVG(wxue_img::save_svg, 717, 2603, wxSize(24, 24)),
-        "Save current project");
+    m_toolbar->AddTool(wxID_SAVE, "Save",
+        wxueBundleSVG(wxue_img::save_svg, 717, 2603, FromDIP(wxSize(24, 24))), "Save current project");
 
-    m_toolbar->AddTool(id_GenerateCode, wxEmptyString, wxueBundleSVG(wxue_img::generate_svg, 780, 2716, wxSize(24, 24)),
-        "Generate code");
+    m_toolbar->AddTool(id_GenerateCode, wxEmptyString,
+        wxueBundleSVG(wxue_img::generate_svg, 780, 2716, FromDIP(wxSize(24, 24))), "Generate code");
 
     m_toolbar->AddSeparator();
-    m_toolbar->AddTool(wxID_UNDO, wxEmptyString, wxue_img::bundle_undo_svg(16, 16), "Undo");
+    m_toolbar->AddTool(wxID_UNDO, wxEmptyString,
+        wxue_img::bundle_undo_svg(FromDIP(16), FromDIP(16)), "Undo");
 
-    m_toolbar->AddTool(wxID_REDO, wxEmptyString, wxue_img::bundle_redo_svg(16, 16), "Redo");
+    m_toolbar->AddTool(wxID_REDO, wxEmptyString,
+        wxue_img::bundle_redo_svg(FromDIP(16), FromDIP(16)), "Redo");
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(wxID_CUT, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_CUT, wxART_TOOLBAR), "Cut");
@@ -88,51 +90,54 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
         "Delete selected object without using clipboard.");
 
     m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_AlignLeft, wxEmptyString, wxueBundleSVG(wxue_img::alignleft_svg, 688, 1442, wxSize(24, 24)),
-        "Align left", wxITEM_CHECK);
+    m_toolbar->AddTool(id_AlignLeft, wxEmptyString,
+        wxueBundleSVG(wxue_img::alignleft_svg, 688, 1442, FromDIP(wxSize(24, 24))), "Align left", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_AlignCenterHorizontal, wxEmptyString,
-        wxueBundleSVG(wxue_img::aligncenter_svg, 898, 1976, wxSize(24, 24)), "Center horizontally", wxITEM_CHECK);
+        wxueBundleSVG(wxue_img::aligncenter_svg, 898, 1976, FromDIP(wxSize(24, 24))), "Center horizontally", wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_AlignRight, wxEmptyString, wxueBundleSVG(wxue_img::alignright_svg, 690, 1441, wxSize(24, 24)),
-        "Align right", wxITEM_CHECK);
+    m_toolbar->AddTool(id_AlignRight, wxEmptyString,
+        wxueBundleSVG(wxue_img::alignright_svg, 690, 1441, FromDIP(wxSize(24, 24))), "Align right", wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_AlignTop, wxEmptyString, wxueBundleSVG(wxue_img::aligntop_svg, 688, 1440, wxSize(24, 24)),
-        "Align top", wxITEM_CHECK);
+    m_toolbar->AddTool(id_AlignTop, wxEmptyString,
+        wxueBundleSVG(wxue_img::aligntop_svg, 688, 1440, FromDIP(wxSize(24, 24))), "Align top", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_AlignCenterVertical, wxEmptyString,
-        wxueBundleSVG(wxue_img::alignvertcenter_svg, 911, 2016, wxSize(24, 24)), "Center vertically", wxITEM_CHECK);
+        wxueBundleSVG(wxue_img::alignvertcenter_svg, 911, 2016, FromDIP(wxSize(24, 24))), "Center vertically", wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_AlignBottom, wxEmptyString, wxueBundleSVG(wxue_img::alignbottom_svg, 658, 1392, wxSize(24, 24)),
-        "Align bottom", wxITEM_CHECK);
+    m_toolbar->AddTool(id_AlignBottom, wxEmptyString,
+        wxueBundleSVG(wxue_img::alignbottom_svg, 658, 1392, FromDIP(wxSize(24, 24))), "Align bottom", wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_BorderLeft, wxEmptyString, wxueBundleSVG(wxue_img::left_svg, 585, 1857, wxSize(24, 24)),
-        "Left border", wxITEM_CHECK);
+    m_toolbar->AddTool(id_BorderLeft, wxEmptyString,
+        wxueBundleSVG(wxue_img::left_svg, 585, 1857, FromDIP(wxSize(24, 24))), "Left border", wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_BorderRight, wxEmptyString, wxueBundleSVG(wxue_img::right_svg, 599, 1878, wxSize(24, 24)),
-        "Right border", wxITEM_CHECK);
+    m_toolbar->AddTool(id_BorderRight, wxEmptyString,
+        wxueBundleSVG(wxue_img::right_svg, 599, 1878, FromDIP(wxSize(24, 24))), "Right border", wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_BorderTop, wxEmptyString, wxueBundleSVG(wxue_img::top_svg, 586, 1859, wxSize(24, 24)), "Top border",
+    m_toolbar->AddTool(id_BorderTop, wxEmptyString,
+        wxueBundleSVG(wxue_img::top_svg, 586, 1859, FromDIP(wxSize(24, 24))), "Top border", wxITEM_CHECK);
+
+    m_toolbar->AddTool(id_BorderBottom, wxEmptyString,
+        wxueBundleSVG(wxue_img::bottom_svg, 585, 1859, FromDIP(wxSize(24, 24))), "Bottom border", wxITEM_CHECK);
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(id_Expand, wxEmptyString,
+        wxueBundleSVG(wxue_img::expand_svg, 819, 1685, FromDIP(wxSize(24, 24))), "Expand to fill the space", wxITEM_CHECK);
+
+    m_toolbar->AddSeparator();
+    m_toolbar->AddTool(id_ShowHidden, wxEmptyString,
+        wxueBundleSVG(wxue_img::hidden_svg, 2111, 5129, FromDIP(wxSize(24, 24))), "Show hidden controls in Mockup panel",
         wxITEM_CHECK);
 
-    m_toolbar->AddTool(id_BorderBottom, wxEmptyString, wxueBundleSVG(wxue_img::bottom_svg, 585, 1859, wxSize(24, 24)),
-        "Bottom border", wxITEM_CHECK);
+    m_toolbar->AddTool(id_Magnify, wxEmptyString,
+        wxueBundleSVG(wxue_img::magnify_svg, 3953, 8849, FromDIP(wxSize(24, 24))), "Magnify the size of the Mockup window",
+        wxITEM_CHECK);
 
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_Expand, wxEmptyString, wxueBundleSVG(wxue_img::expand_svg, 819, 1685, wxSize(24, 24)),
-        "Expand to fill the space", wxITEM_CHECK);
-
-    m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_ShowHidden, wxEmptyString, wxueBundleSVG(wxue_img::hidden_svg, 2111, 5129, wxSize(24, 24)),
-        "Show hidden controls in Mockup panel", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_Magnify, wxEmptyString, wxueBundleSVG(wxue_img::magnify_svg, 3953, 8849, wxSize(24, 24)),
-        "Magnify the size of the Mockup window", wxITEM_CHECK);
-
-    m_toolbar->AddTool(id_PreviewForm, "Preview Form...", wxueBundleSVG(wxue_img::xrc_preview_svg, 469, 1326, wxSize(24, 24)),
-        "Preview form using XRC and/or C++", wxITEM_CHECK);
+    m_toolbar->AddTool(id_PreviewForm, "Preview Form...",
+        wxueBundleSVG(wxue_img::xrc_preview_svg, 469, 1326, FromDIP(wxSize(24, 24))), "Preview form using XRC and/or C++",
+        wxITEM_CHECK);
 
     m_toolbar->Realize();
     m_mainframe_sizer->Add(m_toolbar, wxSizerFlags().Expand());

--- a/src/wxui/ribbonpanel_base.cpp
+++ b/src/wxui/ribbonpanel_base.cpp
@@ -106,12 +106,10 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         forms_bar_bars->AddTool(gen_ToolBar,
             wxueImage(wxue_img::wxToolBar_png, sizeof(wxue_img::wxToolBar_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxToolBar", wxRIBBON_BUTTON_NORMAL);
-        forms_bar_bars->AddTool(gen_AuiToolBar,
-            wxueImage(wxue_img::auitoolbar_png, sizeof(wxue_img::auitoolbar_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxAuiToolBar", wxRIBBON_BUTTON_NORMAL);
-        forms_bar_bars->AddTool(CreateNewFormRibbon,
-            wxueImage(wxue_img::ribbon_bar_png, sizeof(wxue_img::ribbon_bar_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxRibbonBar", wxRIBBON_BUTTON_NORMAL);
+        forms_bar_bars->AddTool(gen_AuiToolBar, wxue_img::bundle_auitoolbar_png().GetBitmap(wxDefaultSize), "wxAuiToolBar",
+            wxRIBBON_BUTTON_NORMAL);
+        forms_bar_bars->AddTool(CreateNewFormRibbon, wxue_img::bundle_ribbon_bar_png().GetBitmap(wxDefaultSize), "wxRibbonBar",
+            wxRIBBON_BUTTON_NORMAL);
     }
     forms_bar_bars->Realize();
 
@@ -141,10 +139,8 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         forms_bar_images->AddTool(gen_embedded_image,
             wxueImage(wxue_img::static_bitmap_png, sizeof(wxue_img::static_bitmap_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Add an embedded image to an Images file", wxRIBBON_BUTTON_NORMAL);
-        forms_bar_images->AddTool(gen_folder,
-            wxueImage(wxue_img::folder_png, sizeof(wxue_img::folder_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Create a folder that can be used to organize forms.",
-            wxRIBBON_BUTTON_NORMAL);
+        forms_bar_images->AddTool(gen_folder, wxue_img::bundle_folder_png().GetBitmap(wxDefaultSize),
+            "Create a folder that can be used to organize forms.", wxRIBBON_BUTTON_NORMAL);
     }
     forms_bar_images->Realize();
 
@@ -160,9 +156,8 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         sizer_bar_basic->AddTool(gen_VerticalBoxSizer,
             wxueImage(wxue_img::sizer_png, sizeof(wxue_img::sizer_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Vertical wxBoxSizer", wxRIBBON_BUTTON_NORMAL);
-        sizer_bar_basic->AddTool(NewStaticSizer,
-            wxueImage(wxue_img::wxStaticBoxSizer_png, sizeof(wxue_img::wxStaticBoxSizer_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxStaticBoxSizer", wxRIBBON_BUTTON_DROPDOWN);
+        sizer_bar_basic->AddTool(NewStaticSizer, wxue_img::bundle_wxStaticBoxSizer_png().GetBitmap(wxDefaultSize),
+            "wxStaticBoxSizer", wxRIBBON_BUTTON_DROPDOWN);
         sizer_bar_basic->AddTool(gen_wxWrapSizer,
             wxueImage(wxue_img::wrap_sizer_png, sizeof(wxue_img::wrap_sizer_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxWrapSizer", wxRIBBON_BUTTON_NORMAL);
@@ -189,9 +184,8 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
 
     auto* sizer_bar_other = new wxRibbonToolBar(sizer_panel_other, wxID_ANY);
     {
-        sizer_bar_other->AddTool(gen_wxStdDialogButtonSizer,
-            wxueImage(wxue_img::stddialogbuttonsizer_png, sizeof(wxue_img::stddialogbuttonsizer_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxStdDialogButtonSizer", wxRIBBON_BUTTON_NORMAL);
+        sizer_bar_other->AddTool(gen_wxStdDialogButtonSizer, wxue_img::bundle_stddialogbuttonsizer_png().GetBitmap(wxDefaultSize),
+            "wxStdDialogButtonSizer", wxRIBBON_BUTTON_NORMAL);
         sizer_bar_other->AddTool(gen_TextSizer,
             wxueImage(wxue_img::text_sizer_png, sizeof(wxue_img::text_sizer_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxTextSizerWrapper", wxRIBBON_BUTTON_NORMAL);
@@ -207,9 +201,8 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
 
     auto* common_bar_controls = new wxRibbonToolBar(panel_common_controls, wxID_ANY);
     {
-        common_bar_controls->AddTool(gen_wxStaticText,
-            wxueImage(wxue_img::wxStaticText_png, sizeof(wxue_img::wxStaticText_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxStaticText", wxRIBBON_BUTTON_NORMAL);
+        common_bar_controls->AddTool(gen_wxStaticText, wxue_img::bundle_wxStaticText_png().GetBitmap(wxDefaultSize),
+            "wxStaticText", wxRIBBON_BUTTON_NORMAL);
         common_bar_controls->AddTool(gen_wxTextCtrl,
             wxueImage(wxue_img::wxtextCtrl_png, sizeof(wxue_img::wxtextCtrl_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxTextCtrl", wxRIBBON_BUTTON_NORMAL);
@@ -219,12 +212,10 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         common_bar_controls->AddTool(gen_wxRadioButton,
             wxueImage(wxue_img::wxradioButton_png, sizeof(wxue_img::wxradioButton_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxRadioButton", wxRIBBON_BUTTON_NORMAL);
-        common_bar_controls->AddTool(NewButton,
-            wxueImage(wxue_img::wxButton_png, sizeof(wxue_img::wxButton_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Buttons", wxRIBBON_BUTTON_DROPDOWN);
-        common_bar_controls->AddTool(NewSpin,
-            wxueImage(wxue_img::spin_ctrl_png, sizeof(wxue_img::spin_ctrl_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Spin controls", wxRIBBON_BUTTON_DROPDOWN);
+        common_bar_controls->AddTool(NewButton, wxue_img::bundle_wxButton_png().GetBitmap(wxDefaultSize), "Buttons",
+            wxRIBBON_BUTTON_DROPDOWN);
+        common_bar_controls->AddTool(NewSpin, wxue_img::bundle_spin_ctrl_png().GetBitmap(wxDefaultSize), "Spin controls",
+            wxRIBBON_BUTTON_DROPDOWN);
     }
     common_bar_controls->Realize();
 
@@ -235,9 +226,8 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         common_bar_choices->AddTool(NewCombobox,
             wxueImage(wxue_img::wxcomboBox_png, sizeof(wxue_img::wxcomboBox_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Combos & Choice", wxRIBBON_BUTTON_DROPDOWN);
-        common_bar_choices->AddTool(NewListbox,
-            wxueImage(wxue_img::wxListBox_png, sizeof(wxue_img::wxListBox_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Lists", wxRIBBON_BUTTON_DROPDOWN);
+        common_bar_choices->AddTool(NewListbox, wxue_img::bundle_wxListBox_png().GetBitmap(wxDefaultSize), "Lists",
+            wxRIBBON_BUTTON_DROPDOWN);
         common_bar_choices->AddTool(gen_wxRadioBox,
             wxueImage(wxue_img::radio_box_png, sizeof(wxue_img::radio_box_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxRadioBox", wxRIBBON_BUTTON_NORMAL);
@@ -279,9 +269,8 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         common_bar_other->AddTool(gen_wxStaticLine,
             wxueImage(wxue_img::static_line_png, sizeof(wxue_img::static_line_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxStaticLine", wxRIBBON_BUTTON_NORMAL);
-        common_bar_other->AddTool(gen_wxSlider,
-            wxueImage(wxue_img::slider_png, sizeof(wxue_img::slider_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxSlider", wxRIBBON_BUTTON_NORMAL);
+        common_bar_other->AddTool(gen_wxSlider, wxue_img::bundle_slider_png().GetBitmap(wxDefaultSize), "wxSlider",
+            wxRIBBON_BUTTON_NORMAL);
         common_bar_other->AddTool(gen_wxGauge,
             wxueImage(wxue_img::gauge_png, sizeof(wxue_img::gauge_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxGauge", wxRIBBON_BUTTON_NORMAL);
@@ -405,9 +394,8 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
 
     auto* data_bar_dataview = new wxRibbonToolBar(panel_trees, wxID_ANY);
     {
-        data_bar_dataview->AddTool(NewDataCtrl,
-            wxueImage(wxue_img::dataview_ctrl_png, sizeof(wxue_img::dataview_ctrl_png)).Rescale(
-            FromDIP(21), FromDIP(21), wxIMAGE_QUALITY_BILINEAR), "Data Control", wxRIBBON_BUTTON_DROPDOWN);
+        data_bar_dataview->AddTool(NewDataCtrl, wxue_img::bundle_dataview_ctrl_png().GetBitmap(wxDefaultSize), "Data Control",
+            wxRIBBON_BUTTON_DROPDOWN);
         data_bar_dataview->AddTool(gen_dataViewColumn,
             wxueImage(wxue_img::dataviewlist_column_png, sizeof(wxue_img::dataviewlist_column_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "DataView Column", wxRIBBON_BUTTON_NORMAL);
@@ -448,16 +436,13 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         bars_bar_tool->AddTool(gen_wxToolBar,
             wxueImage(wxue_img::wxtoolBar_png, sizeof(wxue_img::wxtoolBar_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxToolBar", wxRIBBON_BUTTON_NORMAL);
-        bars_bar_tool->AddTool(BarTools,
-            wxueImage(wxue_img::tool_png, sizeof(wxue_img::tool_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), wxEmptyString, wxRIBBON_BUTTON_DROPDOWN);
+        bars_bar_tool->AddTool(BarTools, wxue_img::bundle_tool_png().GetBitmap(wxDefaultSize), wxEmptyString,
+            wxRIBBON_BUTTON_DROPDOWN);
         bars_bar_tool->AddSeparator();
-        bars_bar_tool->AddTool(gen_wxAuiToolBar,
-            wxueImage(wxue_img::auitoolbar_png, sizeof(wxue_img::auitoolbar_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxAuiToolBar", wxRIBBON_BUTTON_NORMAL);
-        bars_bar_tool->AddTool(AuiBarTools,
-            wxueImage(wxue_img::tool_png, sizeof(wxue_img::tool_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), wxEmptyString, wxRIBBON_BUTTON_DROPDOWN);
+        bars_bar_tool->AddTool(gen_wxAuiToolBar, wxue_img::bundle_auitoolbar_png().GetBitmap(wxDefaultSize), "wxAuiToolBar",
+            wxRIBBON_BUTTON_NORMAL);
+        bars_bar_tool->AddTool(AuiBarTools, wxue_img::bundle_tool_png().GetBitmap(wxDefaultSize), wxEmptyString,
+            wxRIBBON_BUTTON_DROPDOWN);
     }
     bars_bar_tool->Realize();
 
@@ -465,24 +450,21 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
 
     auto* bars_bar_ribbon = new wxRibbonToolBar(panel_bars_ribbon, wxID_ANY);
     {
-        bars_bar_ribbon->AddTool(CreateNewRibbon,
-            wxueImage(wxue_img::ribbon_bar_png, sizeof(wxue_img::ribbon_bar_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxRibbonBar", wxRIBBON_BUTTON_NORMAL);
+        bars_bar_ribbon->AddTool(CreateNewRibbon, wxue_img::bundle_ribbon_bar_png().GetBitmap(wxDefaultSize), "wxRibbonBar",
+            wxRIBBON_BUTTON_NORMAL);
         bars_bar_ribbon->AddTool(gen_wxRibbonPage,
             wxueImage(wxue_img::ribbon_page_png, sizeof(wxue_img::ribbon_page_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxRibbonPage", wxRIBBON_BUTTON_NORMAL);
         bars_bar_ribbon->AddTool(gen_wxRibbonPanel,
             wxueImage(wxue_img::ribbon_panel_png, sizeof(wxue_img::ribbon_panel_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxRibbonPanel", wxRIBBON_BUTTON_NORMAL);
-        bars_bar_ribbon->AddTool(NewRibbonType,
-            wxueImage(wxue_img::ribbon_buttonbar_png, sizeof(wxue_img::ribbon_buttonbar_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Ribbon Bar Type", wxRIBBON_BUTTON_DROPDOWN);
+        bars_bar_ribbon->AddTool(NewRibbonType, wxue_img::bundle_ribbon_buttonbar_png().GetBitmap(wxDefaultSize),
+            "Ribbon Bar Type", wxRIBBON_BUTTON_DROPDOWN);
         bars_bar_ribbon->AddTool(gen_ribbonButton,
             wxueImage(wxue_img::ribbon_button_png, sizeof(wxue_img::ribbon_button_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Ribbon Button", wxRIBBON_BUTTON_NORMAL);
-        bars_bar_ribbon->AddTool(gen_ribbonSeparator,
-            wxueImage(wxue_img::toolspacer_png, sizeof(wxue_img::toolspacer_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Tool Separator", wxRIBBON_BUTTON_NORMAL);
+        bars_bar_ribbon->AddTool(gen_ribbonSeparator, wxue_img::bundle_toolspacer_png().GetBitmap(wxDefaultSize),
+            "Tool Separator", wxRIBBON_BUTTON_NORMAL);
         bars_bar_ribbon->AddTool(gen_ribbonGalleryItem,
             wxueImage(wxue_img::ribbon_gallery_item_png, sizeof(wxue_img::ribbon_gallery_item_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "Ribbon Gallery Item", wxRIBBON_BUTTON_NORMAL);
@@ -536,9 +518,8 @@ bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         other_bar_ctrls->AddTool(gen_wxGenericDirCtrl,
             wxueImage(wxue_img::genericdir_ctrl_png, sizeof(wxue_img::genericdir_ctrl_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxGenericDirCtrl", wxRIBBON_BUTTON_NORMAL);
-        other_bar_ctrls->AddTool(gen_wxScrollBar,
-            wxueImage(wxue_img::scrollbar_png, sizeof(wxue_img::scrollbar_png)).Rescale(
-            FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxScrollBar", wxRIBBON_BUTTON_NORMAL);
+        other_bar_ctrls->AddTool(gen_wxScrollBar, wxue_img::bundle_scrollbar_png().GetBitmap(wxDefaultSize), "wxScrollBar",
+            wxRIBBON_BUTTON_NORMAL);
         other_bar_ctrls->AddTool(gen_wxActivityIndicator,
             wxueImage(wxue_img::wxactivityIndicator_png, sizeof(wxue_img::wxactivityIndicator_png)).Rescale(
             FromDIP(22), FromDIP(22), wxIMAGE_QUALITY_BILINEAR), "wxActivityIndicator", wxRIBBON_BUTTON_NORMAL);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes code generation to use `FromDIP()` to set the size of a SVG image added to a toolbar. While this fixes the display for wxUiEditor, I think that ultimately the toolbar itself is going to need an option to scale. Otherwise, mixing art, SVG and bitmaps are going to result in different sizes.