### PR TITLE
Generate SetFocus after other controls created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Color properties dialog now supports _all_ CSS color names
 - Generated code for colors now uses a CSS HTML String (#RRGGBB) instead of numerical values for red, green and blue.
 - Generated code for wxRibbonToolBar images are now scaled on high DPI displays
+- A control within a wxDialog or wxFrame with the focus property set will now call SetFocus() after all other controls have been created.
 
 ### Fixed
 

--- a/src/customprops/include_files_dlg.cpp
+++ b/src/customprops/include_files_dlg.cpp
@@ -35,7 +35,6 @@ bool IncludeFilesDialog::Create(wxWindow* parent, wxWindowID id, const wxString&
     auto* box_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     m_listbox = new wxListBox(this, wxID_ANY);
-    m_listbox->SetFocus();
     m_listbox->SetMinSize(ConvertDialogToPixels(wxSize(100, 80)));
     box_sizer->Add(m_listbox, wxSizerFlags().Border(wxALL));
 
@@ -69,6 +68,8 @@ bool IncludeFilesDialog::Create(wxWindow* parent, wxWindowID id, const wxString&
     dlg_sizer->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));
 
     SetSizerAndFit(dlg_sizer);
+    m_listbox->SetFocus();
+
     Centre(wxBOTH);
 
     // Event handlers

--- a/src/generate/gen_bitmap_combo.cpp
+++ b/src/generate/gen_bitmap_combo.cpp
@@ -111,8 +111,13 @@ bool BitmapComboBoxGenerator::SettingsCode(Code& code)
 
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty);
-        code.NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty);
+            code.NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     if (code.hasValue(prop_contents))

--- a/src/generate/gen_calendar_ctrl.cpp
+++ b/src/generate/gen_calendar_ctrl.cpp
@@ -50,7 +50,12 @@ bool CalendarCtrlGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
     return true;
 }

--- a/src/generate/gen_check_listbox.cpp
+++ b/src/generate/gen_check_listbox.cpp
@@ -80,7 +80,12 @@ bool CheckListBoxGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
     if (code.hasValue(prop_contents))
     {

--- a/src/generate/gen_choice.cpp
+++ b/src/generate/gen_choice.cpp
@@ -93,8 +93,13 @@ bool ChoiceGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty);
-        code.NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty);
+            code.NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     if (code.hasValue(prop_contents))

--- a/src/generate/gen_combobox.cpp
+++ b/src/generate/gen_combobox.cpp
@@ -96,8 +96,13 @@ bool ComboBoxGenerator::SettingsCode(Code& code)
 
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty);
-        code.NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty);
+            code.NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     if (code.hasValue(prop_contents))

--- a/src/generate/gen_dir_ctrl.cpp
+++ b/src/generate/gen_dir_ctrl.cpp
@@ -65,7 +65,12 @@ bool GenericDirCtrlGenerator::SettingsCode(Code& code)
 
     if (code.IsTrue(prop_focus))
     {
-        code.NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     return true;

--- a/src/generate/gen_dir_picker.cpp
+++ b/src/generate/gen_dir_picker.cpp
@@ -71,7 +71,12 @@ bool DirPickerGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     return true;

--- a/src/generate/gen_file_ctrl.cpp
+++ b/src/generate/gen_file_ctrl.cpp
@@ -74,7 +74,12 @@ bool FileCtrlGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     if (code.IntValue(prop_filter_index) > 0)

--- a/src/generate/gen_file_picker.cpp
+++ b/src/generate/gen_file_picker.cpp
@@ -88,7 +88,12 @@ bool FilePickerGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     return true;

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -164,6 +164,43 @@ bool FrameFormGenerator::SettingsCode(Code& code)
 
 bool FrameFormGenerator::AfterChildrenCode(Code& code)
 {
+    Node* form = code.node();
+    if (form->getChildCount())
+    {
+        bool is_focus_set = false;
+        auto SetChildFocus = [&](Node* child, auto&& SetChildFocus) -> void
+        {
+            if (child->hasProp(prop_focus))
+            {
+                if (child->as_bool(prop_focus))
+                {
+                    code.NodeName(child).Function("SetFocus(").EndFunction();
+                    is_focus_set = true;
+                    return;
+                }
+            }
+            else if (child->getChildCount())
+            {
+                for (auto& iter: child->getChildNodePtrs())
+                {
+                    SetChildFocus(iter.get(), SetChildFocus);
+                    if (is_focus_set)
+                        return;
+                }
+            }
+        };
+
+        for (auto& iter: form->getChildNodePtrs())
+        {
+            SetChildFocus(iter.get(), SetChildFocus);
+            if (is_focus_set)
+            {
+                code.Eol();
+                break;
+            }
+        }
+    }
+
     auto& center = code.node()->as_string(prop_center);
     if (center.size() && !center.is_sameas("no"))
     {

--- a/src/generate/gen_html_listbox.cpp
+++ b/src/generate/gen_html_listbox.cpp
@@ -76,8 +76,13 @@ bool HtmlListBoxGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty);
-        code.NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty);
+            code.NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     if (code.hasValue(prop_contents))

--- a/src/generate/gen_listbox.cpp
+++ b/src/generate/gen_listbox.cpp
@@ -72,7 +72,12 @@ bool ListBoxGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     if (code.hasValue(prop_contents))

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -104,7 +104,12 @@ bool RearrangeCtrlGenerator::SettingsCode(Code& code)
 {
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
     if (code.hasValue(prop_contents))
     {

--- a/src/generate/gen_rich_text.cpp
+++ b/src/generate/gen_rich_text.cpp
@@ -47,7 +47,12 @@ bool RichTextCtrlGenerator::SettingsCode(Code& code)
 
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_needed).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     return true;

--- a/src/generate/gen_search_ctrl.cpp
+++ b/src/generate/gen_search_ctrl.cpp
@@ -56,7 +56,12 @@ bool SearchCtrlGenerator::SettingsCode(Code& code)
 
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_empty).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     if (code.IsTrue(prop_search_button))

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -118,7 +118,12 @@ bool TextCtrlGenerator::SettingsCode(Code& code)
 
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_needed).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     if (code.IsTrue(prop_maxlength))

--- a/src/generate/styled_text.cpp
+++ b/src/generate/styled_text.cpp
@@ -928,7 +928,12 @@ bool StyledTextGenerator::SettingsCode(Code& code)
 
     if (code.IsTrue(prop_focus))
     {
-        code.Eol(eol_if_needed).NodeName().Function("SetFocus(").EndFunction();
+        auto form = code.node()->getForm();
+        // wxDialog and wxFrame will set the focus to this control after all controls are created.
+        if (!form->isGen(gen_wxDialog) && !form->isGen(gen_wxFrame))
+        {
+            code.Eol(eol_if_needed).NodeName().Function("SetFocus(").EndFunction();
+        }
     }
 
     // REVIEW: [Randalphwa - 12-28-2022] The caller closes the brace -- but it makes more sense

--- a/src/internal/node_search_dlg.cpp
+++ b/src/internal/node_search_dlg.cpp
@@ -60,7 +60,6 @@ bool NodeSearchDlg::Create(wxWindow* parent, wxWindowID id, const wxString& titl
 
     m_text_search = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
     m_text_search->SetHint("Enter item to search for");
-    m_text_search->SetFocus();
     box_sizer->Add(m_text_search, wxSizerFlags().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
 
     dlg_sizer->Add(box_sizer, wxSizerFlags().Border(wxALL));
@@ -96,6 +95,8 @@ bool NodeSearchDlg::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     dlg_sizer->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));
 
     SetSizerAndFit(dlg_sizer);
+    m_text_search->SetFocus();
+
     Centre(wxBOTH);
 
     wxPersistentRegisterAndRestore(this, "NodeSearchDlg");

--- a/src/newdialogs/new_mdi.cpp
+++ b/src/newdialogs/new_mdi.cpp
@@ -48,7 +48,6 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     box_sizer_8->Add(staticText_6, wxSizerFlags().Center().Border(wxALL));
 
     auto* folder_name = new wxTextCtrl(this, wxID_ANY, "Mdi Application");
-    folder_name->SetFocus();
     folder_name->SetValidator(wxTextValidator(wxFILTER_NONE, &m_folder_name));
     folder_name->SetToolTip("Change this to something unique to your project.");
     box_sizer_8->Add(folder_name, wxSizerFlags(1).Border(wxALL));
@@ -158,6 +157,8 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     box_sizer->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));
 
     SetSizerAndFit(box_sizer);
+    folder_name->SetFocus();
+
     Centre(wxBOTH);
 
     // Event handlers

--- a/src/tools/global_ids_dlg.cpp
+++ b/src/tools/global_ids_dlg.cpp
@@ -29,7 +29,6 @@ bool GlobalCustomIDS::Create(wxWindow* parent, wxWindowID id, const wxString& ti
     box_sizer_13->Add(staticText, wxSizerFlags().Border(wxALL));
 
     m_lb_folders = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_MULTIPLE);
-    m_lb_folders->SetFocus();
     m_lb_folders->SetMinSize(ConvertDialogToPixels(wxSize(-1, 80)));
     box_sizer_13->Add(m_lb_folders, wxSizerFlags().Expand().Border(wxALL));
 
@@ -165,6 +164,8 @@ bool GlobalCustomIDS::Create(wxWindow* parent, wxWindowID id, const wxString& ti
     dlg_sizer->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));
 
     SetSizerAndFit(dlg_sizer);
+    m_lb_folders->SetFocus();
+
     Centre(wxBOTH);
 
     // Event handlers

--- a/src/wxui/editstringdialog_base.cpp
+++ b/src/wxui/editstringdialog_base.cpp
@@ -26,7 +26,6 @@ bool EditStringDialogBase::Create(wxWindow* parent, wxWindowID id, const wxStrin
     parent_sizer->Add(m_static_hdr_text, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT|wxTOP, 15));
 
     m_textCtrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
-    m_textCtrl->SetFocus();
     m_textCtrl->SetValidator(wxTextValidator(wxFILTER_NONE, &m_value));
     m_textCtrl->SetMinSize(wxSize(500, -1));
     parent_sizer->Add(m_textCtrl, wxSizerFlags().Expand().TripleBorder(wxALL));
@@ -35,6 +34,8 @@ bool EditStringDialogBase::Create(wxWindow* parent, wxWindowID id, const wxStrin
     parent_sizer->Add(CreateSeparatedSizer(stdBtn_2), wxSizerFlags().Expand().Border(wxALL));
 
     SetSizerAndFit(parent_sizer);
+    m_textCtrl->SetFocus();
+
     Centre(wxBOTH);
 
     return true;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes when a control calls SetFocus(). If the control is within a wxDialog or wxFrame, then SetFocus() is called after all other controls in the form have been created.

Closes #1202
