### PR TITLE
Support order-dependent header files

### DIFF
--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -225,6 +225,33 @@ void BaseCodeGenerator::GenerateCppClass(Node* form_node, PANEL_PAGE panel_type)
             }
         }
 
+        std::vector<std::string> ordered_includes;
+        if (auto pos = hdr_includes.find("#include <wx/generic/stattextg.h>"); pos != hdr_includes.end())
+        {
+            hdr_includes.erase(pos);
+            if (pos = hdr_includes.find("#include <wx/stattext.h>"); pos != hdr_includes.end())
+            {
+                hdr_includes.erase(pos);
+            }
+
+            if (ordered_includes.empty())
+            {
+                ordered_includes.emplace_back("// Order dependent includes");
+            }
+
+            ordered_includes.emplace_back("#include <wx/stattext.h>");
+            ordered_includes.emplace_back("#include <wx/generic/stattextg.h>");
+        }
+
+        if (ordered_includes.size())
+        {
+            for (auto& iter: ordered_includes)
+            {
+                m_header->writeLine(iter);
+            }
+            m_header->writeLine();
+        }
+
         // First output all the wxWidget header files
         for (auto& iter: hdr_includes)
         {
@@ -332,7 +359,33 @@ void BaseCodeGenerator::GenerateCppClass(Node* form_node, PANEL_PAGE panel_type)
 
     if (m_TranslationUnit)
     {
-        // First output all the wxWidget header files
+        std::vector<std::string> ordered_includes;
+        if (auto pos = src_includes.find("#include <wx/generic/stattextg.h>"); pos != src_includes.end())
+        {
+            src_includes.erase(pos);
+            if (pos = src_includes.find("#include <wx/stattext.h>"); pos != src_includes.end())
+            {
+                src_includes.erase(pos);
+            }
+
+            if (ordered_includes.empty())
+            {
+                ordered_includes.emplace_back("// Order dependent includes");
+            }
+
+            ordered_includes.emplace_back("#include <wx/stattext.h>");
+            ordered_includes.emplace_back("#include <wx/generic/stattextg.h>");
+        }
+
+        if (ordered_includes.size())
+        {
+            for (auto& iter: ordered_includes)
+            {
+                m_source->writeLine(iter);
+            }
+            m_source->writeLine();
+        }
+
         for (auto& iter: src_includes)
         {
             if (tt::contains(iter, "<wx"))


### PR DESCRIPTION
Currently, this is just including stattext.h before generic/stattextg.h. Others can be added as needed.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR provides the ability to output some header files that need to be in a specific order. Currently, this is just including `wx/stattext.h` before `generic/stattextg.h`, though it would be easy to add others should the need arise.

Closes #1172