### PR TITLE
Limit check for duplicate ids in menubars and toolbars

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -49,6 +49,62 @@ bool BaseGenerator::AllowIdPropertyChange(wxPropertyGridEvent* event, NodeProper
         return true;
 
     auto form = node->getForm();
+    if (node->isGen(gen_wxMenuItem))
+    {
+        form = node->getParent();
+        while (form && !form->isGen(gen_wxMenuBar) && !form->isGen(gen_MenuBar))
+        {
+            form = form->getParent();
+        }
+
+        // This shouldn't happen, but return true just in case
+        if (!form)
+        {
+            return true;
+        }
+    }
+    else if (node->isGen(gen_auitool))
+    {
+        form = node->getParent();
+        while (form && !form->isGen(gen_AuiToolBar) && !form->isGen(gen_wxAuiToolBar))
+        {
+            form = form->getParent();
+        }
+
+        // This shouldn't happen, but return true just in case
+        if (!form)
+        {
+            return true;
+        }
+    }
+    else if (node->isGen(gen_tool) || node->isGen(gen_tool_dropdown))
+    {
+        form = node->getParent();
+        while (form && !form->isGen(gen_ToolBar) && !form->isGen(gen_wxToolBar))
+        {
+            form = form->getParent();
+        }
+
+        // This shouldn't happen, but return true just in case
+        if (!form)
+        {
+            return true;
+        }
+    }
+    else if (node->isGen(gen_ribbonTool) || node->isGen(gen_ribbonButton) || node->isGen(gen_ribbonGalleryItem))
+    {
+        form = node->getParent();
+        while (form && !form->isGen(gen_RibbonBar) && !form->isGen(gen_wxRibbonBar))
+        {
+            form = form->getParent();
+        }
+
+        // This shouldn't happen, but return true just in case
+        if (!form)
+        {
+            return true;
+        }
+    }
 
     std::set<tt_string> ids;
 

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -135,6 +135,9 @@ public:
     // Called while processing an wxEVT_PG_CHANGING event.
     virtual bool AllowPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*);
 
+    // Called while processing an wxEVT_PG_CHANGING event.
+    virtual bool AllowIdPropertyChange(wxPropertyGridEvent*, NodeProperty*, Node*);
+
     // Bind wxEVT_LEFT_DOWN to this so that clicking on the widget will select it in the navigation panel
     void OnLeftClick(wxMouseEvent& event);
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR moves the check for a duplicate id into the `BaseGenerator` class, and then special-cases menus and tools. When checking a menu or tool item, only the outer bar is checked for duplicates rather than the entire form. This allows for menu items and tools to share ids.

This change affects wxMenuBar, wxAuiToolBar, wxToolBar and wxRibbonBar.

Closes #1231