### PR TITLE
Import DialogBlocks custom controls

### DIFF
--- a/src/import/import_dialogblocks.h
+++ b/src/import/import_dialogblocks.h
@@ -41,6 +41,7 @@ protected:
     bool CreateFormNode(pugi::xml_node& form_xml, const NodeSharedPtr& parent);
     bool CreateFolderNode(pugi::xml_node& form_xml, const NodeSharedPtr& parent);
     void createChildNode(pugi::xml_node& child_node, Node* parent);
+    void CreateCustomNode(pugi::xml_node& child_node, Node* parent);
 
     // Process all the style-like attributes for the current node
     void ProcessStyles(pugi::xml_node& node_xml, const NodeSharedPtr& new_node);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability to import Custom Controls from DialogBlocks (see #1232). Code generation for CustomControls that use macros has been changed for ${pos} and ${size} generating wxPoint or wxSize respectively. The default constant is used if both values are -1. Code generation now works correctly in wxPython and wxRuby as well.