### PR TITLE
Add a preference to display fullpath project file

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -942,7 +942,11 @@ void MainFrame::UpdateLayoutTools()
 
 void MainFrame::UpdateFrame()
 {
-    tt_string filename = Project.getProjectFile().filename();
+    tt_string filename;
+    if (UserPrefs.is_FullPathTitle())
+        filename = Project.getProjectFile();
+    else
+        filename = Project.getProjectFile().filename();
 
     if (filename.empty())
     {

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -23,6 +23,7 @@ void Prefs::ReadConfig()
     m_sizers_all_borders = config->ReadBool("all_borders", true);
     m_sizers_always_expand = config->ReadBool("always_expand", true);
     m_var_prefix = config->ReadBool("var_prefix", true);
+    m_fullpath_title = config->ReadBool("fullpath_title", false);
 
     m_enable_wakatime = config->ReadBool("enable_wakatime", true);
     m_dark_mode = config->ReadBool("dark_mode", false);
@@ -52,6 +53,7 @@ void Prefs::WriteConfig()
     config->Write("all_borders", m_sizers_all_borders);
     config->Write("always_expand", m_sizers_always_expand);
     config->Write("var_prefix", m_var_prefix);
+    config->Write("fullpath_title", m_fullpath_title);
 
     config->Write("enable_wakatime", m_enable_wakatime);
     config->Write("dark_mode", m_dark_mode);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -47,6 +47,9 @@ public:
     bool is_HighContrast() const { return m_high_constrast; }
     void set_HighContrast(bool value) { m_high_constrast = value; }
 
+    bool is_FullPathTitle() const { return m_fullpath_title; }
+    void set_FullPathTitle(bool value) { m_fullpath_title = value; }
+
     bool is_LoadLastProject() const { return m_is_load_last_project; }
     void set_LoadLastProject(bool value) { m_is_load_last_project = value; }
 
@@ -151,6 +154,8 @@ private:
 
     bool m_dark_mode { false };
     bool m_high_constrast { false };
+
+    bool m_fullpath_title { false };  // If true, the full path to the project is displayed in the title bar
 
     bool m_enable_wakatime { true };
     bool m_is_load_last_project { false };

--- a/src/ui/preferences_dlg.h
+++ b/src/ui/preferences_dlg.h
@@ -54,6 +54,7 @@ protected:
     wxBoxSizer* m_box_dark_settings;
     wxCheckBox* m_check_cpp_snake_case;
     wxCheckBox* m_check_dark_mode;
+    wxCheckBox* m_check_fullpath;
     wxCheckBox* m_check_high_contrast;
     wxCheckBox* m_check_load_last;
     wxCheckBox* m_check_right_propgrid;

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -6351,11 +6351,18 @@
                 class="wxCheckBox"
                 label="Property Panel on Right"
                 var_name="m_check_right_propgrid"
-                tooltip="If checked, the Property panel will be moved to the right side" />
+                tooltip="If checked, the Property panel will be moved to the right side"
+                proportion="1" />
               <node
                 class="wxCheckBox"
                 label="Always load last project"
-                var_name="m_check_load_last" />
+                var_name="m_check_load_last"
+                proportion="1" />
+              <node
+                class="wxCheckBox"
+                label="Full project path in title bar"
+                var_name="m_check_fullpath"
+                proportion="1" />
               <node
                 class="wxCheckBox"
                 checked="1"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a "Full project path in title bar" to the Preferences dialog. The default is unchecked, displaying just the filename.

I also changed the Preferences dialog so that the message about having to restart is only displayed for a subset of the options rather than all of the options.