### PR TITLE
Improve wxGlade importing

### DIFF
--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -529,6 +529,23 @@ bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
             node->set_value(prop_source_preamble, xml_obj.text().as_string());
         return true;
     }
+    else if (node_name == "stockitem" && node->isGen(gen_wxButton))
+    {
+        if (node->as_string(prop_id).empty() || node->as_string(prop_id) == "wxID_ANY")
+        {
+            tt_string id("wxID_");
+            id << xml_obj.text().as_string();
+            node->set_value(prop_id, id);
+
+            if (node->as_string(prop_label).empty() || node->as_string(prop_label) == "MyButton")
+            {
+                // This is a stock button, so let wxWidgets set the label
+                node->set_value(prop_label, "");
+            }
+
+            return true;
+        }
+    }
     else if (node_name == "scrollable")
     {
         // [Randalphwa - 10-11-2023]

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -488,6 +488,27 @@ bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
     {
         // wxGlade adds these even when the exact same buttons
     }
+    else if (node_name == "option" && node->isGen(gen_sizeritem))
+    {
+        node->set_value(prop_proportion, xml_obj.text().as_string());
+        return true;
+    }
+    else if (node_name == "scroll_rate")
+    {
+        tt_string param = xml_obj.text().as_string();
+        tt_view_vector params(param, ',');
+        node->set_value(prop_scroll_rate_x, params[0]);
+        node->set_value(prop_scroll_rate_y, params[1]);
+        return true;
+    }
+    else if (node_name == "extracode_post")
+    {
+        if (m_language == GEN_LANG_PYTHON)
+            node->set_value(prop_python_insert, xml_obj.text().as_string());
+        else if (m_language == GEN_LANG_CPLUSPLUS)
+            node->set_value(prop_source_preamble, xml_obj.text().as_string());
+        return true;
+    }
     else if (node_name == "scrollable")
     {
         // [Randalphwa - 10-11-2023]

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -173,8 +173,10 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
 
     bool isBitmapButton = (object_name == "wxBitmapButton");
     auto getGenName = ConvertToGenName(object_name, parent);
+    bool object_not_generator = false;
     if (getGenName == gen_unknown)
     {
+        object_not_generator = true;
         // If we don't recognize the class, then try the base= attribute
         auto base = xml_obj.attribute("base").as_string();
         if (base == "EditFrame")
@@ -217,6 +219,11 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
     }
 
     auto new_node = NodeCreation.createNode(getGenName, parent);
+    if (new_node && object_not_generator)
+    {
+        new_node->set_value(prop_class_name, object_name);
+    }
+
     if (getGenName == gen_BookPage && new_node)
     {
         if (!xml_obj.attribute("name").empty())

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -224,12 +224,8 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
         new_node->set_value(prop_class_name, object_name);
     }
 
-    if (getGenName == gen_wxMenuBar && new_node)
+    if (new_node)
     {
-        parent->adoptChild(new_node);
-        CreateMenus(xml_obj, new_node.get());
-        return new_node;
-    }
         if (getGenName == gen_wxMenuBar)
         {
             parent->adoptChild(new_node);
@@ -243,13 +239,14 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
             return new_node;
         }
 
-    if (getGenName == gen_BookPage && new_node)
-    {
-        if (!xml_obj.attribute("name").empty())
+        else if (getGenName == gen_BookPage)
         {
-            if (auto tab = m_notebook_tabs.find(xml_obj.attribute("name").as_string()); tab != m_notebook_tabs.end())
+            if (!xml_obj.attribute("name").empty())
             {
-                new_node->set_value(prop_label, tab->second);
+                if (auto tab = m_notebook_tabs.find(xml_obj.attribute("name").as_string()); tab != m_notebook_tabs.end())
+                {
+                    new_node->set_value(prop_label, tab->second);
+                }
             }
         }
     }
@@ -560,6 +557,11 @@ bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
         // This gets set to 1 if the form has a menubar. We don't need to do anything with it.
         return true;
     }
+    else if (node_name == "focused" && node->isForm())
+    {
+        // This is an option for dialogs -- no idea what it is supposed to do...
+        return true;
+    }
     return false;
 }
 
@@ -656,8 +658,8 @@ void WxGlade::CreateMenus(pugi::xml_node& xml_obj, Node* parent)
         {
             auto id = item.child("id");
 
-            auto new_item = NodeCreation.createNode(id.text().as_string() == "---" ? gen_separator :
-                gen_wxMenuItem, menu_node.get());
+            auto new_item =
+                NodeCreation.createNode(id.text().as_string() == "---" ? gen_separator : gen_wxMenuItem, menu_node.get());
             menu_node->adoptChild(new_item);
 
             for (auto& iter: item.children())

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -512,6 +512,40 @@ bool WxGlade::HandleNormalProperty(const pugi::xml_node& xml_obj, Node* node, No
         node->set_value(prop_id, id);
         return true;
     }
+    else if (wxue_prop == prop_font)
+    {
+        FontProperty font_info;
+        if (auto size_child = xml_obj.child("size"); size_child)
+        {
+            font_info.PointSize(size_child.text().as_double());
+        }
+        if (auto family_child = xml_obj.child("family"); family_child && family_child.text().as_string() != "default")
+        {
+            FontFamilyPairs family_pair;
+            font_info.Family(family_pair.GetValue(family_child.text().as_string()));
+        }
+        if (auto style_child = xml_obj.child("style"); style_child && style_child.text().as_string() != "normal")
+        {
+            FontStylePairs style_pair;
+            font_info.Style(style_pair.GetValue(style_child.text().as_string()));
+        }
+        if (auto weight_child = xml_obj.child("weight"); weight_child && weight_child.text().as_string() != "normal")
+        {
+            FontWeightPairs weight_pair;
+            font_info.Weight(weight_pair.GetValue(weight_child.text().as_string()));
+        }
+        if (auto underline_child = xml_obj.child("underline"); underline_child)
+        {
+            font_info.Underlined(underline_child.text().as_bool());
+        }
+        if (auto face_child = xml_obj.child("face"); face_child)
+        {
+            font_info.FaceName(face_child.text().as_cstr().make_wxString());
+        }
+
+        node->set_value(prop_font, font_info.as_string());
+        return true;
+    }
 
     return false;
 }

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -224,6 +224,13 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
         new_node->set_value(prop_class_name, object_name);
     }
 
+    if (getGenName == gen_wxMenuBar && new_node)
+    {
+        parent->adoptChild(new_node);
+        CreateMenus(xml_obj, new_node.get());
+        return new_node;
+    }
+
     if (getGenName == gen_BookPage && new_node)
     {
         if (!xml_obj.attribute("name").empty())
@@ -387,6 +394,8 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
     }
 
     auto child = xml_obj.child("object");
+    if (!child && new_node->isGen(gen_wxMenuBar))
+        child = xml_obj.child("menus");
     if (NodeCreation.isOldHostType(new_node->declName()))
     {
         ProcessAttributes(xml_obj, new_node.get());
@@ -413,7 +422,6 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
     else if (parent)
     {
         parent->adoptChild(new_node);
-
         ProcessAttributes(xml_obj, new_node.get());
         ProcessProperties(xml_obj, new_node.get());
     }
@@ -527,7 +535,7 @@ bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
 }
 
 // Called by ImportXML -- return true if the property is processed. Use this when the property conversion
-// is incorrect for the type of note being processed.
+// is different in wxGlade then for other XML projects for the type of node being processed.
 bool WxGlade::HandleNormalProperty(const pugi::xml_node& xml_obj, Node* node, Node* parent, GenEnum::PropName wxue_prop)
 {
     if (node->isGen(gen_sizeritem))

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -481,6 +481,20 @@ bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
     {
         // wxGlade adds these even when the exact same buttons
     }
+    else if (node_name == "scrollable")
+    {
+        // [Randalphwa - 10-11-2023]
+        // wxGlade will set this to 1 for wxScrolledWindow. In the wxGlade interface (1.1.0) if
+        // you uncheck this it will generate an Error in wxGlade, but will generate code and
+        // XML file using wxPanel without this property. Unless it's used for something besides
+        // wxScrolledWindow, I think we can just ignore it.
+        return true;
+    }
+    else if (node_name == "menubar")
+    {
+        // This gets set to 1 if the form has a menubar. We don't need to do anything with it.
+        return true;
+    }
     return false;
 }
 

--- a/src/import/import_wxglade.h
+++ b/src/import/import_wxglade.h
@@ -25,6 +25,7 @@ public:
 
 protected:
     NodeSharedPtr CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, Node* sizeritem = nullptr);
+    void CreateMenus(pugi::xml_node& xml_obj, Node* parent);
 
 private:
 };

--- a/src/import/import_wxglade.h
+++ b/src/import/import_wxglade.h
@@ -25,7 +25,12 @@ public:
 
 protected:
     NodeSharedPtr CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, Node* sizeritem = nullptr);
+
+    // parent should be a wxMenuBar
     void CreateMenus(pugi::xml_node& xml_obj, Node* parent);
+
+    // parent should be a wxToolBar
+    void CreateToolbar(pugi::xml_node& xml_obj, Node* parent);
 
 private:
 };

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -1007,7 +1007,7 @@ void ImportXML::ProcessContent(const pugi::xml_node& xml_obj, Node* node)
     tt_string choices;
     for (auto& iter: xml_obj.children())
     {
-        if (iter.name() == "item")
+        if (iter.name() == "item" || iter.name() == "choice")
         {
             auto child = iter.child_as_cstr();
             child.Replace("\"", "\\\"", true);

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -24,6 +24,7 @@ namespace xrc_import
         { "accel", prop_shortcut },
         { "art-provider", prop_art_provider },
         { "bg", prop_background_colour },
+        { "background", prop_background_colour },
         { "bitmap-bg", prop_bmp_background_colour },
         { "bitmap-minwidth", prop_bmp_min_width },
         { "bitmap-placement", prop_bmp_placement },
@@ -31,6 +32,7 @@ namespace xrc_import
         { "bitmapsize", prop_image_size },  // BUGBUG: [Randalphwa - 06-17-2022] should this be prop_bitmapsize?
         { "choices", prop_contents },
         { "class", prop_class_name },
+        { "clicked", prop_checked },
         { "content", prop_contents },
         { "defaultdirectory", prop_initial_folder },
         { "defaultfilename", prop_initial_filename },
@@ -39,9 +41,12 @@ namespace xrc_import
         { "empty_cellsize", prop_empty_cell_size },
         { "extra-accels", prop_extra_accels },
         { "fg", prop_foreground_colour },
+        { "foreground", prop_foreground_colour },
         { "flexibledirection", prop_flexible_direction },
         { "gradient-end", prop_end_colour },
         { "gradient-start", prop_start_colour },
+        { "growable_rows", prop_growablerows },
+        { "growable_cols", prop_growablecols },
         { "gravity", prop_sashgravity },
         { "hideeffect", prop_hide_effect },
         { "hover", prop_current },
@@ -52,6 +57,7 @@ namespace xrc_import
         { "longhelp", prop_statusbar },  // Used by toolbar tools
         { "minsize", prop_min_size },
         { "nonflexiblegrowmode", prop_non_flexible_grow_mode },
+        { "orient", prop_orientation },
         { "pagesize", prop_page_size },
         { "running", prop_auto_start },
         { "selmax", prop_sel_end },
@@ -557,7 +563,6 @@ void ImportXML::ProcessAttributes(const pugi::xml_node& xml_obj, Node* new_node)
             {
                 if (auto prop = new_node->getPropPtr(prop_class_name); prop)
                 {
-                    prop->set_value(iter.value());
                     if (prop->as_string().empty())
                     {
                         prop->set_value(iter.value());

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -558,6 +558,10 @@ void ImportXML::ProcessAttributes(const pugi::xml_node& xml_obj, Node* new_node)
                 if (auto prop = new_node->getPropPtr(prop_class_name); prop)
                 {
                     prop->set_value(iter.value());
+                    if (prop->as_string().empty())
+                    {
+                        prop->set_value(iter.value());
+                    }
                 }
             }
             else if (iter.as_string().starts_with("wxID_"))

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -1061,6 +1061,12 @@ void ImportXML::ProcessBitmap(const pugi::xml_node& xml_obj, Node* node, GenEnum
     else
     {
         auto file = xml_obj.child_as_cstr();
+        if (file.starts_with("code:"))
+        {
+            // This is a wxGlade bitmap
+            // TODO: [Randalphwa - 10-12-2023] wxGlade bitmaps are not yet supported
+        }
+
         if (file.contains(".xpm", tt::CASE::either))
         {
             tt_string bitmap("XPM; ");

--- a/src/utils/font_prop.h
+++ b/src/utils/font_prop.h
@@ -68,6 +68,7 @@ public:
     FontProperty& PointSize(double point_size)
     {
         m_pointSize = point_size;
+        m_isDefGuiFont = false;
         return *this;
     }
 
@@ -83,11 +84,15 @@ public:
     FontProperty& Family(wxFontFamily family)
     {
         m_family = family;
+        if (m_family != wxFONTFAMILY_DEFAULT)
+            m_isDefGuiFont = false;
         return *this;
     }
     FontProperty& FaceName(const wxString& faceName)
     {
         m_faceName = faceName;
+        if (m_faceName.size())
+            m_isDefGuiFont = false;
         return *this;
     }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes several problem with importing wxGlade projects:

- A form's class name is now correctly set
- wxMenuBars are now correctly imported
- wxToolBars are imported, though bitmaps don't work yet
- colors and fonts are now correctly imported
- a checkbox's checked state is now correctly imported
- wxRadioBox now correctly imports the choices
- wxButton stock items are now correctly imported

Related to #929