### PR TITLE
Fix wxPython/wxRuby code generation of fonts and fontinfo

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -663,6 +663,21 @@ Code& Code::ClassMethod(tt_string_view function_name)
     return *this;
 }
 
+Code& Code::VariableMethod(tt_string_view function_name)
+{
+    *this += '.';
+    if (is_ruby())
+    {
+        *this += ConvertToSnakeCase(function_name);
+    }
+    else
+    {
+        *this += function_name;
+    }
+
+    return *this;
+}
+
 Code& Code::FormFunction(tt_string_view text)
 {
     if (is_python())

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1879,11 +1879,19 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
         EndFunction();
 
         if (fontprop.GetSymbolSize() != wxFONTSIZE_MEDIUM)
-            Eol().Str("font").VariableMethod("SetSymbolicSize(").Add(font_symbol_pairs.GetValue(fontprop.GetSymbolSize())).EndFunction();
+            Eol()
+                .Str("font")
+                .VariableMethod("SetSymbolicSize(")
+                .Add(font_symbol_pairs.GetValue(fontprop.GetSymbolSize()))
+                .EndFunction();
         if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)
             Eol().Str("font").VariableMethod("SetStyle(").Add(font_style_pairs.GetValue(fontprop.GetStyle())).EndFunction();
         if (fontprop.GetWeight() != wxFONTWEIGHT_NORMAL)
-            Eol().Str("font").VariableMethod("SetWeight(").Add(font_weight_pairs.GetValue(fontprop.GetWeight())).EndFunction();
+            Eol()
+                .Str("font")
+                .VariableMethod("SetWeight(")
+                .Add(font_weight_pairs.GetValue(fontprop.GetWeight()))
+                .EndFunction();
         if (fontprop.IsUnderlined())
             Eol().Str("font").VariableMethod("SetUnderlined(").True().EndFunction();
         if (fontprop.IsStrikethrough())

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1867,19 +1867,27 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
     if (fontprop.isDefGuiFont())
     {
         OpenBrace();
-        Add("wxFont font(").Add("wxSystemSettings").ClassMethod("GetFont(").Add("wxSYS_DEFAULT_GUI_FONT").Str(")");
+        if (is_cpp())
+        {
+            Add("wxFont font(");
+        }
+        else
+        {
+            Add("font").CreateClass(false, "wxFont");
+        }
+        Add("wxSystemSettings").ClassMethod("GetFont(").Add("wxSYS_DEFAULT_GUI_FONT").Str(")");
         EndFunction();
 
         if (fontprop.GetSymbolSize() != wxFONTSIZE_MEDIUM)
-            Eol().Str("font.SetSymbolicSize(").Add(font_symbol_pairs.GetValue(fontprop.GetSymbolSize())).EndFunction();
+            Eol().Str("font").VariableMethod("SetSymbolicSize(").Add(font_symbol_pairs.GetValue(fontprop.GetSymbolSize())).EndFunction();
         if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)
-            Eol().Str("font.SetStyle(").Add(font_style_pairs.GetValue(fontprop.GetStyle())).EndFunction();
+            Eol().Str("font").VariableMethod("SetStyle(").Add(font_style_pairs.GetValue(fontprop.GetStyle())).EndFunction();
         if (fontprop.GetWeight() != wxFONTWEIGHT_NORMAL)
-            Eol().Str("font.SetWeight(").Str(font_weight_pairs.GetValue(fontprop.GetWeight())).EndFunction();
+            Eol().Str("font").VariableMethod("SetWeight(").Add(font_weight_pairs.GetValue(fontprop.GetWeight())).EndFunction();
         if (fontprop.IsUnderlined())
-            Eol().Str("font.SetUnderlined(").True().EndFunction();
+            Eol().Str("font").VariableMethod("SetUnderlined(").True().EndFunction();
         if (fontprop.IsStrikethrough())
-            Eol().Str("font.SetStrikethrough(").True().EndFunction();
+            Eol().Str("font").VariableMethod("SetStrikethrough(").True().EndFunction();
         Eol();
 
         if (m_node->isForm())
@@ -1903,7 +1911,16 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
     {
         const auto point_size = fontprop.GetFractionalPointSize();
         OpenBrace();
-        Add("wxFontInfo font_info(");
+
+        if (is_cpp())
+        {
+            Add("wxFontInfo font_info(");
+        }
+        else
+        {
+            Add("font_info").CreateClass(false, "wxFontInfo");
+        }
+
         if (point_size != static_cast<int>(point_size))  // is there a fractional value?
         {
             if (is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
@@ -1955,19 +1972,19 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
             }
         }
 
-        Eol(eol_if_needed).Str("font_info.");
+        Eol(eol_if_needed).Str("font_info");
         if (fontprop.GetFaceName().size() && fontprop.GetFaceName() != "default")
-            Str("FaceName(").QuotedString(tt_string() << fontprop.GetFaceName().utf8_string()) += ").";
+            VariableMethod("FaceName(").QuotedString(tt_string() << fontprop.GetFaceName().utf8_string()) += ")";
         if (fontprop.GetFamily() != wxFONTFAMILY_DEFAULT)
-            Str("Family(").Str(font_family_pairs.GetValue(fontprop.GetFamily())) += ").";
+            VariableMethod("Family(").Add(font_family_pairs.GetValue(fontprop.GetFamily())) += ")";
         if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)
-            Str("Style(").Str(font_style_pairs.GetValue(fontprop.GetStyle())) += ").";
+            VariableMethod("Style(").Add(font_style_pairs.GetValue(fontprop.GetStyle())) += ")";
         if (fontprop.GetWeight() != wxFONTWEIGHT_NORMAL)
-            Str("Weight(").Str(font_weight_pairs.GetValue(fontprop.GetWeight())) += ").";
+            VariableMethod("Weight(").Add(font_weight_pairs.GetValue(fontprop.GetWeight())) += ")";
         if (fontprop.IsUnderlined())
-            Str("Underlined().");
+            VariableMethod("Underlined()");
         if (fontprop.IsStrikethrough())
-            Str("Strikethrough()");
+            VariableMethod("Strikethrough()");
 
         if (back() == '.')
         {
@@ -1979,11 +1996,11 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
 
         if (m_node->isForm())
         {
-            FormFunction(font_function).Add("wxFont(font_info)").EndFunction();
+            FormFunction(font_function).Object("wxFont").Str("font_info").Str(")").EndFunction();
         }
         else
         {
-            NodeName().Function(font_function).Add("wxFont(font_info)").EndFunction();
+            NodeName().Function(font_function).Object("wxFont").Str("font_info").Str(")").EndFunction();
         }
         CloseBrace();
     }

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -300,6 +300,12 @@ public:
     // Ruby changes the function to snake_case.
     Code& ClassMethod(tt_string_view function_name);
 
+    // Like ClassMethod(), but assumes a variable not a class. C++ and Python add "." and the
+    // name.
+    //
+    // Ruby adds "." and changes the function to snake_case.
+    Code& VariableMethod(tt_string_view function_name);
+
     // For C++, this simply calls the function. For Python it prefixes "self." to the
     // function name. Ruby changes the function to snake_case.
     Code& FormFunction(tt_string_view text);

--- a/tests/sdi/cpp/maintestdialog.cpp
+++ b/tests/sdi/cpp/maintestdialog.cpp
@@ -75,6 +75,42 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     m_text_ctrl->SetHint("wxTextCtrl");
     page_sizer_1->Add(m_text_ctrl, wxSizerFlags().Expand().Border(wxALL));
 
+    auto* grid_sizer2 = new wxGridSizer(2, 0, 0);
+
+    static_text = new wxStaticText(page_2, wxID_ANY, "12-pt default font");
+    {
+        wxFontInfo font_info(11.5);
+        font_info.FaceName("Segoe UI");
+        static_text->SetFont(wxFont(font_info));
+    }
+    grid_sizer2->Add(static_text, wxSizerFlags().Border(wxALL));
+
+    m_static_text = new wxStaticText(page_2, wxID_ANY, "Comic Sans MS");
+    {
+        wxFontInfo font_info(10.5);
+        font_info.FaceName("Comic Sans MS");
+        m_static_text->SetFont(wxFont(font_info));
+    }
+    grid_sizer2->Add(m_static_text, wxSizerFlags().Border(wxALL));
+
+    static_text2 = new wxStaticText(page_2, wxID_ANY, "italic");
+    {
+        wxFont font(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
+        font.SetStyle(wxFONTSTYLE_ITALIC);
+        static_text2->SetFont(font);
+    }
+    grid_sizer2->Add(static_text2, wxSizerFlags().Border(wxALL));
+
+    static_text3 = new wxStaticText(page_2, wxID_ANY, "bold, underlined Times New Roman, 12.5");
+    {
+        wxFontInfo font_info(12.5);
+        font_info.FaceName("Times New Roman").Weight(wxFONTWEIGHT_BOLD).Underlined();
+        static_text3->SetFont(wxFont(font_info));
+    }
+    grid_sizer2->Add(static_text3, wxSizerFlags().Border(wxALL));
+
+    page_sizer_1->Add(grid_sizer2, wxSizerFlags().Border(wxALL));
+
     m_richText = new wxRichTextCtrl(page_2, ID_RICHTEXT, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxRE_MULTILINE|
         wxVSCROLL | wxHSCROLL | wxNO_BORDER | wxWANTS_CHARS);
     m_richText->SetHint("wxRichTextCtrl");

--- a/tests/sdi/cpp/maintestdialog.h
+++ b/tests/sdi/cpp/maintestdialog.h
@@ -174,7 +174,11 @@ protected:
     wxStaticText* m_staticText_2;
     wxStaticText* m_staticText_3;
     wxStaticText* m_staticText_4;
+    wxStaticText* m_static_text;
     wxStaticText* staticText_5;
+    wxStaticText* static_text2;
+    wxStaticText* static_text3;
+    wxStaticText* static_text;
     wxStyledTextCtrl* m_scintilla;
     wxTextCtrl* m_text_ctrl;
     wxTimePickerCtrl* m_timePicker;

--- a/tests/sdi/python/mainframe.py
+++ b/tests/sdi/python/mainframe.py
@@ -310,6 +310,9 @@ class MainFrame(wx.Frame):
         dlg.ShowModal()
         dlg.Destroy()
 
+    def on_tools_dlg(self, event):
+        event.Skip()
+
 class MyApp(wx.App):
     def OnInit(self):
         frame = MainFrame(None)

--- a/tests/sdi/sdi_test.wxui
+++ b/tests/sdi/sdi_test.wxui
@@ -339,7 +339,8 @@
               class="wxBoxSizer"
               orientation="wxVERTICAL"
               var_name="page_sizer_1"
-              minimum_size="-1,-1d">
+              minimum_size="-1,-1d"
+              flags="wxEXPAND">
               <node
                 class="wxTextCtrl"
                 hint="wxTextCtrl"
@@ -348,6 +349,30 @@
                 id="TXT_CTRL"
                 flags="wxEXPAND"
                 wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{@@OnEventName(&quot;wxTextCtrl: wxEVT_TEXT&quot;);@@}[python:lambda]self.OnEventName(&quot;wx.TextCtrl: wx.EVT_TEXT&quot;)" />
+              <node
+                class="wxGridSizer"
+                var_name="grid_sizer2">
+                <node
+                  class="wxStaticText"
+                  label="12-pt default font"
+                  var_name="static_text"
+                  font="Segoe UI,11.5" />
+                <node
+                  class="wxStaticText"
+                  label="Comic Sans MS"
+                  var_name="m_static_text"
+                  font="Comic Sans MS,10.5" />
+                <node
+                  class="wxStaticText"
+                  label="italic"
+                  var_name="static_text2"
+                  font="normal size,italic" />
+                <node
+                  class="wxStaticText"
+                  label="bold, underlined Times New Roman, 12.5"
+                  var_name="static_text3"
+                  font="Times New Roman,12.5,,bold,,underlined" />
+              </node>
               <node
                 class="wxRichTextCtrl"
                 hint="wxRichTextCtrl"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes problems generating font code for wxPython and wxRuby. I also added several static text controls with different type of fonts to the main test code to hopefully catch bugs like this in the future.
