### PR TITLE
Update support for generating image lists for wxPython and wxRuby

### DIFF
--- a/src/generate/gen_book_utils.cpp
+++ b/src/generate/gen_book_utils.cpp
@@ -149,31 +149,32 @@ void BookCtorAddImagelist(Code& code)
                 }
             }
         }
-        else  // wxPython code
+        else if (code.is_python())
         {
-            int bitmap_index = 0;
+            code.Eol().Str("bundle_list = [");
+            code.Indent();
             for (const auto& child_node: code.node()->getChildNodePtrs())
             {
                 if (child_node->hasValue(prop_bitmap))
                 {
                     Code bundle_code(child_node.get(), GEN_LANG_PYTHON);
                     bundle_code.Bundle(prop_bitmap);
-                    code.Eol().Str("bundle_").itoa(++bitmap_index).Str(" = ") << bundle_code;
-                }
-            }
-            code.Eol().Str("bundle_list = [");
-            code.Indent();
-            for (int index = 1; index <= bitmap_index; ++index)
-            {
-                if (index > 1)
-                {
+                    code.Eol() << bundle_code;
                     code.Str(",");
                 }
-                code.Eol();
-                code.Str("bundle_").itoa(index);
+            }
+
+            if (code.back() == ',')
+            {
+                // There may have been a line break, so remove that too
+                code.pop_back();
+                while (code.back() == '\t')
+                    code.pop_back();
+                if (code.back() == '\n')
+                    code.pop_back();
             }
             code.Unindent();
-            code.Eol().Str("]");
+            code.Eol(eol_if_needed).Str("]");
         }
 
         code.Eol().NodeName().Function("SetImages(bundle_list").EndFunction();

--- a/src/generate/gen_book_utils.cpp
+++ b/src/generate/gen_book_utils.cpp
@@ -128,7 +128,7 @@ void BookCtorAddImagelist(Code& code)
         code.Eol(eol_if_needed);
         if (code.is_cpp())
         {
-            code.Eol(eol_if_needed) << "wxBookCtrlBase::Images bundle_list;";
+            code.Eol(eol_if_needed) << "wxWithImages::Images bundle_list;";
             for (const auto& child_node: code.node()->getChildNodePtrs())
             {
                 if (child_node->hasValue(prop_bitmap))

--- a/src/generate/gen_book_utils.cpp
+++ b/src/generate/gen_book_utils.cpp
@@ -137,7 +137,7 @@ void BookCtorAddImagelist(Code& code)
                     if (GenerateBundleCode(child_node->as_string(prop_bitmap), bundle_code))
                     {
                         code.Eol() << bundle_code;
-                        code.Eol() << "bundle_list.push_back(wxBitmapBundle::FromBitmaps(bitmaps));";
+                        code.Eol() << "\tbundle_list.push_back(wxBitmapBundle::FromBitmaps(bitmaps));";
                         // Close the brace that was opened by GenerateBundleCode()
                         code.Eol() << "}";
                     }

--- a/src/generate/gen_book_utils.cpp
+++ b/src/generate/gen_book_utils.cpp
@@ -181,7 +181,6 @@ void BookCtorAddImagelist(Code& code)
             FAIL_MSG("Unknown language");
         }
 
-
         code.Eol().NodeName().Function("SetImages(bundle_list").EndFunction();
 
         if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")

--- a/src/generate/gen_book_utils.cpp
+++ b/src/generate/gen_book_utils.cpp
@@ -149,7 +149,7 @@ void BookCtorAddImagelist(Code& code)
                 }
             }
         }
-        else if (code.is_python())
+        else if (code.is_python() || code.is_ruby())
         {
             code.Eol().Str("bundle_list = [");
             code.Indent();
@@ -157,7 +157,7 @@ void BookCtorAddImagelist(Code& code)
             {
                 if (child_node->hasValue(prop_bitmap))
                 {
-                    Code bundle_code(child_node.get(), GEN_LANG_PYTHON);
+                    Code bundle_code(child_node.get(), code.get_language());
                     bundle_code.Bundle(prop_bitmap);
                     code.Eol() << bundle_code;
                     code.Str(",");
@@ -176,6 +176,11 @@ void BookCtorAddImagelist(Code& code)
             code.Unindent();
             code.Eol(eol_if_needed).Str("]");
         }
+        else
+        {
+            FAIL_MSG("Unknown language");
+        }
+
 
         code.Eol().NodeName().Function("SetImages(bundle_list").EndFunction();
 

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -658,7 +658,7 @@ bool GenerateBundleCode(const tt_string& description, tt_string& code)
             }
             else if (bundle->lst_filenames.size() > 2)
             {
-                code << "{\n\t\t\twxVector<wxBitmap> bitmaps;\n";
+                code << "{\n\t\twxVector<wxBitmap> bitmaps;\n";
                 for (auto& iter: bundle->lst_filenames)
                 {
                     tt_string name(iter.filename());
@@ -672,7 +672,7 @@ bool GenerateBundleCode(const tt_string& description, tt_string& code)
                             name = "wxue_img::" + embed->array_name;
                         }
                     }
-                    code << "\t\t\tbitmaps.push_back(wxueImage(" << name << ", sizeof(" << name << ")));\n";
+                    code << "\t\tbitmaps.push_back(wxueImage(" << name << ", sizeof(" << name << ")));\n";
                 }
 
                 // Return true to indicate a code block was generated

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -731,9 +731,25 @@ bool PythonBundleCode(Code& code, GenEnum::PropName prop)
         }
         else
         {
-            FAIL_MSG("Unexpected number of images in bundle -- should be <= 2");
-            code.Add("wxNullBitmap");
-            return false;
+            code += "wx.BitmapBundle.FromBitmaps([";
+            for (size_t idx = 0; idx < bundle->lst_filenames.size(); ++idx)
+            {
+                if (parts[IndexType].starts_with("Embed"))
+                {
+                    if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[idx]); embed)
+                    {
+                        code.CheckLineLength(embed->array_name.size() + sizeof(".Bitmap"));
+                        AddPythonImageName(code, embed);
+
+                        code += ".Bitmap";
+                        if (idx < bundle->lst_filenames.size() - 1)
+                        {
+                            code.Comma();
+                        }
+                    }
+                }
+            }
+            code += "])";
         }
     }
     else

--- a/tests/SUPPORTED.md
+++ b/tests/SUPPORTED.md
@@ -14,8 +14,8 @@ This does _not_ mean that the class is fully supported in every language -- this
 | wxChoicebook | yes | yes | yes | --- | ../src/generate/gen_choicebook.cpp |
 | wxListbook | yes | yes | yes | --- | ../src/generate/gen_listbook.cpp |
 | wxNotebook | yes | yes | yes | --- | ../src/generate/gen_notebook.cpp |
-| wxSimplebook | yes | ??? | yes | --- | ../src/generate/gen_simplebook.cpp |
-| wxToolbook | yes | yes | --- | --- | ../src/generate/gen_toolbook.cpp |
+| wxSimplebook | yes | yes | yes | --- | ../src/generate/gen_simplebook.cpp |
+| wxToolbook | yes | yes | yes | --- | ../src/generate/gen_toolbook.cpp |
 | wxTreebook | yes | yes | yes | yes | ../src/generate/gen_treebook.cpp |
 
 ### Forms


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates generation of an image list and hooks it into the BookCtorAddImagelist() function. This now works correctly for wxPython and wxRuby.

Note that previously, wxPython only allows a maximum of two images for a bundle -- it now supports any number of images. wxRuby is still limited to a maximum of three images.