### PR TITLE
Fix code generation problems with wxWizard

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -591,52 +591,69 @@ Code& Code::AddConstant(GenEnum::PropName prop_name, tt_string_view short_name)
     return Add(m_node->as_constant(prop_name, short_name));
 }
 
-Code& Code::Function(tt_string_view text)
+Code& Code::Function(tt_string_view text, bool add_operator)
 {
-    if (is_cpp() || is_perl())
+    if (!add_operator)
     {
-        *this << "->" << text;
-    }
-    else if (is_ruby())
-    {
-        // Check for a preceeding empty "()" and remove it if found
-        if (ends_with("())"))
-        {
-            resize(size() - 2);
-        }
-
-        *this << '.';
-        if (text.is_sameprefix("wx"))
-        {
-            *this << m_language_wxPrefix << text.substr(sizeof("wx") - 1);
-        }
-        else
-        {
-            *this += ConvertToSnakeCase(text);
-        }
-    }
-    else if (is_golang() || is_lua() || is_python() || is_ruby() || is_rust())
-    {
-        *this << '.';
-        if (text.is_sameprefix("wx"))
-        {
-            *this << m_language_wxPrefix << text.substr(sizeof("wx") - 1);
-        }
-        else
+        if (text.is_sameprefix("wx") && (is_golang() || is_lua() || is_python() || is_ruby() || is_rust()))
         {
             if (is_ruby())
-            {
-                *this += ConvertToSnakeCase(text);
-            }
+                *this << m_language_wxPrefix << ConvertToSnakeCase(text.substr(sizeof("wx") - 1));
             else
-            {
-                *this += text;
-            }
+                *this << m_language_wxPrefix << text.substr(sizeof("wx") - 1);
+        }
+        else
+        {
+            *this += text;
         }
     }
     else
     {
-        *this << "->" << text;
+        if (is_cpp() || is_perl())
+        {
+            *this << "->" << text;
+        }
+        else if (is_ruby())
+        {
+            // Check for a preceeding empty "()" and remove it if found
+            if (ends_with("())"))
+            {
+                resize(size() - 2);
+            }
+
+            *this << '.';
+            if (text.is_sameprefix("wx"))
+            {
+                *this << m_language_wxPrefix << text.substr(sizeof("wx") - 1);
+            }
+            else
+            {
+                *this += ConvertToSnakeCase(text);
+            }
+        }
+        else if (is_golang() || is_lua() || is_python() || is_ruby() || is_rust())
+        {
+            *this << '.';
+            if (text.is_sameprefix("wx"))
+            {
+                *this << m_language_wxPrefix << text.substr(sizeof("wx") - 1);
+            }
+            else
+            {
+                if (is_ruby())
+                {
+                    *this += ConvertToSnakeCase(text);
+                }
+                else
+                {
+                    *this += text;
+                }
+            }
+        }
+        else
+        {
+            *this << "->" << text;
+        }
     }
     return *this;
 }

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -293,8 +293,11 @@ public:
         return *this;
     }
 
-    // Adds -> or . to the string, then function (fixing wx prefix if needed)
-    Code& Function(tt_string_view text);
+    // If add_operator is true, adds -> or . to the string, then function (fixing wx prefix
+    // if needed)
+    //
+    // Use add_operator = false to convert a wxFunction to snake_case for Ruby.
+    Code& Function(tt_string_view text, bool add_operator = true);
 
     // C++ will add "::" and the function name. Python will add "." and the function name.
     // Ruby changes the function to snake_case.

--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -132,8 +132,15 @@ void BaseCodeGenerator::GenConstruction(Node* node)
         }
         else
         {
-            gen_code.ParentName().Function("GetControlSizer()").Function("Add(").NodeName();
-            gen_code.CheckLineLength().Comma().Add("wxSizerFlags()").Add(".Expand().Border(").Add("wxALL)").EndFunction();
+            gen_code.ParentName().Function("GetControlSizer").AddIfCpp("()").Function("Add(").NodeName().Comma();
+            gen_code.CheckLineLength(sizeof("wxSizerFlags().Expand().Border(wxALL));")).Add("wxSizerFlags");
+            if (gen_code.is_ruby())
+                gen_code.Str(".new.expand.border(Wx::ALL)");
+            else if (gen_code.is_cpp())
+                gen_code.Str(".Expand().Border(").Add("wxALL)");
+            else
+                FAIL_MSG("Unknown language!");
+            gen_code.EndFunction();
         }
         m_source->writeLine(gen_code);
     }

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -167,7 +167,16 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
                            });
 
             if (event->getNode()->isForm())
-                handler.Str(event_name).Str("(:") << event_code << ')';
+            {
+                if (code.is_ruby() && event->get_name().starts_with("wxEVT_WIZARD"))
+                {
+                    handler.Str(event_name).Str("(get_id, ").Str(":") << event_code << ')';
+                }
+                else
+                {
+                    handler.Str(event_name).Str("(:") << event_code << ')';
+                }
+            }
             else
                 handler.Str(event_name).Str("(").NodeName().Str(".get_id, :") << event_code << ')';
         }

--- a/src/generate/gen_menu.cpp
+++ b/src/generate/gen_menu.cpp
@@ -34,22 +34,8 @@ bool MenuGenerator::AfterChildrenCode(Code& code)
         code.ParentName().Function("Append(").NodeName().Comma();
         if (node->as_string(prop_stock_id) != "none")
         {
-            if (code.is_ruby() && Project.getProjectNode()->as_string(prop_wxRuby_version) == "0.9.0")
-            {
-                if (auto stock_id = NodeCreation.getConstantAsInt(node->as_string(prop_stock_id)); stock_id > 0)
-                {
-                    code << "'" << wxGetStockLabel(stock_id).utf8_string() << "'";
-                }
-                else
-                {
-                    FAIL_MSG(tt_string() << "Invalid stock ID: " << node->as_string(prop_stock_id));
-                    code << "'" << node->as_string(prop_stock_id) << "'";
-                }
-            }
-            else
-            {
-                code.Add("wxGetStockLabel(").Add(prop_stock_id).Str(")");
-            }
+            // Call Function(..., false) so that Ruby will convert the function to snake-case
+            code.Function("wxGetStockLabel(", false).Add(prop_stock_id).Str(")");
         }
         else
         {

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -221,7 +221,11 @@ bool WizardFormGenerator::AfterChildrenCode(Code& code)
             {
                 // In C++, Chain() returns a reference, so "." is used instead of "->"
                 // Python and Ruby both use "."
-                code.Str(".").Add("Chain(").Str(panes[pos + 1]->as_string(prop_var_name)) += ")";
+                if (code.is_cpp())
+                    code.Str(".").Add("Chain(");
+                else
+                    code.Function("Chain(");
+                code.Str(panes[pos + 1]->as_string(prop_var_name)) += ")";
             }
             if (code.is_cpp())
                 code += ";";

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -196,12 +196,12 @@ bool WizardFormGenerator::SettingsCode(Code& code)
     {
         if (code.is_cpp())
         {
-            code.Eol(eol_if_needed).FormFunction("if (!Create(").Str("parent, id, title, pos, style, name))");
+            code.Eol(eol_if_needed).FormFunction("if (!Create(").Str("parent, id, title, wxBitmapBundle(), pos, style))");
             code.Eol().Tab().Str("return;");
         }
         else if (code.is_python())
         {
-            code.Eol(eol_if_needed).Str("if not self.Create(parent, id, title, pos, style, name):");
+            code.Eol(eol_if_needed).Str("if not self.Create(parent, id, title, wx.BitmapBundle(), pos, style):");
             code.Eol().Tab().Str("return");
         }
     }

--- a/tests/quick_test/cpp/file_list.cmake
+++ b/tests/quick_test/cpp/file_list.cmake
@@ -6,4 +6,10 @@ set (file_list
     mainapp.cpp
     main_frame.cpp
     rubytest.cpp
+    wizard.cpp
+)
+
+set (other_files
+    python/py_main.py
+    ruby/rb_main.rb
 )

--- a/tests/quick_test/main_test.wxui
+++ b/tests/quick_test/main_test.wxui
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <wxUiEditorData
-  data_version="15">
+  data_version="16">
   <node
     class="Project"
     art_directory="../art"
@@ -19,8 +19,8 @@
       base_file="main_frame"
       use_derived_class="0"
       python_file="py_main"
-      python_import_list="test_dlg.py"
-      relative_require_list="test_dlg.rb"
+      python_import_list="test_dlg.py;wizard.py"
+      relative_require_list="test_dlg.rb;wizard.rb"
       ruby_file="rb_main"
       xrc_file="xrc_main"
       minimum_size="300,-1d">
@@ -46,9 +46,14 @@
           var_name="menu_dialogs">
           <node
             class="wxMenuItem"
-            label="Test Dialog"
+            label="Test Dialog..."
             var_name="menu_item_test_dlg"
             wxEVT_MENU="OnTestDialog[python:on_test_dlg][ruby:on_test_dlg]" />
+          <node
+            class="wxMenuItem"
+            label="Wizard..."
+            var_name="menu_item_test_wizard"
+            wxEVT_MENU="OnWizard[python:on_wizard][ruby:on_wizard]" />
         </node>
       </node>
       <node

--- a/tests/quick_test/python/py_main.py
+++ b/tests/quick_test/python/py_main.py
@@ -9,6 +9,7 @@
 
 import wx
 import test_dlg
+import wizard
 
 class MainFrame(wx.Frame):
 
@@ -29,8 +30,10 @@ class MainFrame(wx.Frame):
         self.menubar.Append(self.menu_file, "&File")
 
         menu_dialogs = wx.Menu()
-        menu_item_test_dlg = wx.MenuItem(menu_dialogs, wx.ID_ANY, "Test Dialog")
+        menu_item_test_dlg = wx.MenuItem(menu_dialogs, wx.ID_ANY, "Test Dialog...")
         menu_dialogs.Append(menu_item_test_dlg)
+        menu_item_test_wizard = wx.MenuItem(menu_dialogs, wx.ID_ANY, "Wizard...")
+        menu_dialogs.Append(menu_item_test_wizard)
         self.menubar.Append(menu_dialogs, "Tests")
 
         self.SetMenuBar(self.menubar)
@@ -55,6 +58,12 @@ class MainFrame(wx.Frame):
         # Bind Event handlers
         self.Bind(wx.EVT_MENU, self.on_quit, id=wx.ID_EXIT)
         self.Bind(wx.EVT_MENU, self.on_test_dlg, id=menu_item_test_dlg.GetId())
+        self.Bind(wx.EVT_MENU, self.on_wizard, id=menu_item_test_wizard.GetId())
+
+    # Unimplemented Event handler functions
+    # Copy any listed and paste them below the comment block, or to your inherited class.
+    """
+    """
 
 # ************* End of generated code ***********
 # DO NOT EDIT THIS COMMENT BLOCK!
@@ -74,7 +83,9 @@ class MainFrame(wx.Frame):
         dlg.Destroy()
 
     def on_wizard(self, event):
-        event.Skip()
+        my_wizard = wizard.Wizard(self)
+        my_wizard.Run()
+        my_wizard.Destroy()
 
 class App(wx.App):
     """Application class."""

--- a/tests/quick_test/ruby/rb_main.rb
+++ b/tests/quick_test/ruby/rb_main.rb
@@ -5,16 +5,14 @@
 # Any changes before that block will be lost if it is re-generated!
 ###############################################################################
 
-# rubocop:disable Metrics/MethodLength
-# rubocop:disable Metrics/ParameterLists
-# rubocop:disable Style/Documentation
-# rubocop:disable Metrics/AbcSize
+# rubocop:disable all
 
 WX_GLOBAL_CONSTANTS = true unless defined? WX_GLOBAL_CONSTANTS
 
 require 'wx/core'
 
 require_relative 'test_dlg'
+require_relative 'wizard'
 
 class MainFrame < Wx::Frame
   def initialize(parent, id = Wx::ID_ANY, title = 'Tests',
@@ -34,8 +32,11 @@ class MainFrame < Wx::Frame
 
     menu_dialogs = Wx::Menu.new
     menu_item_test_dlg = Wx::MenuItem.new(menu_dialogs, Wx::ID_ANY,
-      'Test Dialog')
+      'Test Dialog...')
     menu_dialogs.append(menu_item_test_dlg)
+    menu_item_test_wizard = Wx::MenuItem.new(menu_dialogs, Wx::ID_ANY,
+      'Wizard...')
+    menu_dialogs.append(menu_item_test_wizard)
     @menubar.append(menu_dialogs, 'Tests')
 
     set_menu_bar(@menubar)
@@ -60,13 +61,28 @@ class MainFrame < Wx::Frame
     # Event handlers
     evt_menu(menu_item.get_id, :on_quit)
     evt_menu(menu_item_test_dlg.get_id, :on_test_dlg)
+    evt_menu(menu_item_test_wizard.get_id, :on_wizard)
   end
+# Unimplemented Event handler functions
+# Copy any listed and paste them below the comment block, or to your inherited class.
+
+=begin
+  def on_quit(event)
+    event.skip
+  end
+
+  def on_test_dlg(event)
+    event.skip
+  end
+
+  def on_wizard(event)
+    event.skip
+  end
+
+=end
 end
 
-# rubocop:enable Metrics/MethodLength
-# rubocop:enable Metrics/ParameterLists
-# rubocop:enable Style/Documentation
-# rubocop:enable Metrics/AbcSize
+# rubocop:enable all
 
 # ************* End of generated code ***********
 # DO NOT EDIT THIS COMMENT BLOCK!
@@ -86,8 +102,9 @@ def on_test_dlg
 end
 
 def on_wizard
-  w = MyWizard.new(self)
-  w.run_wizard(w.get_page_area_sizer.get_item(0).get_window)
+  my_wizard = Wizard.new(self)
+  my_wizard.run_wizard(my_wizard.get_page_area_sizer.get_item(0).get_window)
+  my_wizard.destroy
 end
 
 class App < Wx::App

--- a/tests/sdi/cpp/wizard.cpp
+++ b/tests/sdi/cpp/wizard.cpp
@@ -41,21 +41,21 @@ Wizard::Wizard(wxWindow* parent, wxWindowID id, const wxString& title, const wxP
     box_sizer->Add(m_calendar, wxSizerFlags().Border(wxALL));
     wizPage->SetSizerAndFit(box_sizer);
 
-    auto* m_wizPage2 = new wxWizardPageSimple(this);
+    auto* wizPage2 = new wxWizardPageSimple(this);
 
     auto* box_sizer2 = new wxBoxSizer(wxVERTICAL);
 
-    m_staticText2 = new wxStaticText(m_wizPage2, wxID_ANY, "This is the second Wizard page which is wider.");
+    m_staticText2 = new wxStaticText(wizPage2, wxID_ANY, "This is the second Wizard page which is wider.");
     box_sizer2->Add(m_staticText2, wxSizerFlags().Border(wxALL));
 
     auto* parent_sizer3 = new wxBoxSizer(wxVERTICAL);
 
     auto* box_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
 
-    staticText = new wxStaticText(m_wizPage2, wxID_ANY, "Scrollbar:");
+    staticText = new wxStaticText(wizPage2, wxID_ANY, "Scrollbar:");
     box_sizer_2->Add(staticText, wxSizerFlags().Border(wxALL));
 
-    m_scrollBar = new wxScrollBar(m_wizPage2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSB_HORIZONTAL);
+    m_scrollBar = new wxScrollBar(wizPage2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSB_HORIZONTAL);
     m_scrollBar->SetScrollbar(0, 1, 100, 1);
     box_sizer_2->Add(m_scrollBar, wxSizerFlags(1).Expand().Border(wxALL));
 
@@ -63,11 +63,11 @@ Wizard::Wizard(wxWindow* parent, wxWindowID id, const wxString& title, const wxP
 
     auto* box_sizer_3 = new wxBoxSizer(wxHORIZONTAL);
 
-    staticText_2 = new wxStaticText(m_wizPage2, wxID_ANY, "Normal SpinCtrl");
+    staticText_2 = new wxStaticText(wizPage2, wxID_ANY, "Normal SpinCtrl");
     box_sizer_3->Add(staticText_2, wxSizerFlags().Border(wxALL));
 
-    m_spinCtrl = new wxSpinCtrl(m_wizPage2, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0,
-        100, 4);
+    m_spinCtrl = new wxSpinCtrl(wizPage2, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 100,
+        4);
     m_spinCtrl->SetValidator(wxGenericValidator(&m_spinValidate));
     box_sizer_3->Add(m_spinCtrl, wxSizerFlags().Border(wxALL));
 
@@ -75,50 +75,50 @@ Wizard::Wizard(wxWindow* parent, wxWindowID id, const wxString& title, const wxP
 
     auto* box_sizer_4 = new wxBoxSizer(wxHORIZONTAL);
 
-    staticText_3 = new wxStaticText(m_wizPage2, wxID_ANY, "Double SpinCtrl");
+    staticText_3 = new wxStaticText(wizPage2, wxID_ANY, "Double SpinCtrl");
     box_sizer_4->Add(staticText_3, wxSizerFlags().Border(wxALL));
 
-    m_spinCtrlDouble = new wxSpinCtrlDouble(m_wizPage2);
+    m_spinCtrlDouble = new wxSpinCtrlDouble(wizPage2);
     box_sizer_4->Add(m_spinCtrlDouble, wxSizerFlags().Border(wxALL));
 
     parent_sizer3->Add(box_sizer_4, wxSizerFlags().Border(wxALL));
 
     auto* box_sizer_5 = new wxBoxSizer(wxHORIZONTAL);
 
-    staticText_4 = new wxStaticText(m_wizPage2, wxID_ANY, "Spin Button");
+    staticText_4 = new wxStaticText(wizPage2, wxID_ANY, "Spin Button");
     box_sizer_5->Add(staticText_4, wxSizerFlags().Border(wxALL));
 
-    m_spinBtn = new wxSpinButton(m_wizPage2);
+    m_spinBtn = new wxSpinButton(wizPage2);
     m_spinBtn->SetRange(0, 10);
     box_sizer_5->Add(m_spinBtn, wxSizerFlags().Border(wxALL));
 
     parent_sizer3->Add(box_sizer_5, wxSizerFlags().Border(wxALL));
 
     box_sizer2->Add(parent_sizer3, wxSizerFlags().Border(wxALL));
-    m_wizPage2->SetSizerAndFit(box_sizer2);
+    wizPage2->SetSizerAndFit(box_sizer2);
 
-    auto* m_wizPage3 = new wxWizardPageSimple(this, nullptr, nullptr, wxue_img::bundle_wiztest2_png());
+    auto* wizPage3 = new wxWizardPageSimple(this, nullptr, nullptr, wxue_img::bundle_wiztest2_png());
 
     auto* box_sizer3 = new wxBoxSizer(wxVERTICAL);
 
-    m_staticText3 = new wxStaticText(m_wizPage3, wxID_ANY, "This is the final Wizard page");
+    m_staticText3 = new wxStaticText(wizPage3, wxID_ANY, "This is the final Wizard page");
     box_sizer3->Add(m_staticText3, wxSizerFlags().Border(wxALL));
 
     auto* box_sizer_6 = new wxBoxSizer(wxHORIZONTAL);
 
-    m_hyperlink = new wxHyperlinkCtrl(m_wizPage3, wxID_ANY, "Blank Page", "https://blank.page/");
+    m_hyperlink = new wxHyperlinkCtrl(wizPage3, wxID_ANY, "Blank Page", "https://blank.page/");
     box_sizer_6->Add(m_hyperlink, wxSizerFlags().Center().Border(wxALL));
 
-    m_searchCtrl = new wxSearchCtrl(m_wizPage3, wxID_ANY, wxEmptyString);
+    m_searchCtrl = new wxSearchCtrl(wizPage3, wxID_ANY, wxEmptyString);
     m_searchCtrl->SetHint("Search for something...");
     m_searchCtrl->ShowSearchButton(true);
     m_searchCtrl->ShowCancelButton(true);
     box_sizer_6->Add(m_searchCtrl, wxSizerFlags(1).Border(wxALL));
 
     box_sizer3->Add(box_sizer_6, wxSizerFlags().Expand().Border(wxALL));
-    m_wizPage3->SetSizerAndFit(box_sizer3);
+    wizPage3->SetSizerAndFit(box_sizer3);
 
-    wizPage->Chain(m_wizPage2).Chain(m_wizPage3);
+    wizPage->Chain(wizPage2).Chain(wizPage3);
     GetPageAreaSizer()->Add(wizPage);
     Center(wxBOTH);
 

--- a/tests/sdi/python/wizard.py
+++ b/tests/sdi/python/wizard.py
@@ -37,7 +37,7 @@ class Wizard(wx.adv.Wizard):
         box_sizer.Add(self.calendar, wx.SizerFlags().Border(wx.ALL))
         wizPage.SetSizerAndFit(box_sizer)
 
-        m_wizPage2 = wx.adv.WizardPageSimple(self)
+        wizPage2 = wx.adv.WizardPageSimple(self)
 
         box_sizer2 = wx.BoxSizer(wx.VERTICAL)
 
@@ -94,7 +94,7 @@ class Wizard(wx.adv.Wizard):
         box_sizer2.Add(parent_sizer3, wx.SizerFlags().Border(wx.ALL))
         wizPage2.SetSizerAndFit(box_sizer2)
 
-        m_wizPage3 = wx.adv.WizardPageSimple(self, None, None, wx.BitmapBundle.FromBitmap(
+        wizPage3 = wx.adv.WizardPageSimple(self, None, None, wx.BitmapBundle.FromBitmap(
             images.wiztest2_png.Bitmap))
 
         box_sizer3 = wx.BoxSizer(wx.VERTICAL)
@@ -118,7 +118,7 @@ class Wizard(wx.adv.Wizard):
         box_sizer3.Add(box_sizer_6, wx.SizerFlags().Expand().Border(wx.ALL))
         wizPage3.SetSizerAndFit(box_sizer3)
 
-        wizPage.Chain(m_wizPage2).Chain(m_wizPage3)
+        wizPage.Chain(wizPage2).Chain(wizPage3)
         self.GetPageAreaSizer().Add(wizPage)
         self.Center(wx.BOTH)
 

--- a/tests/sdi/ruby/mainframe.rb
+++ b/tests/sdi/ruby/mainframe.rb
@@ -86,7 +86,7 @@ class MainFrame < Wx::Frame
     menuQuit.set_bitmap(Wx::ArtProvider.get_bitmap_bundle(Wx::ART_QUIT,
       Wx::ART_MENU))
     @menu.append(menuQuit)
-    menubar.append(@menu, '&File')
+    menubar.append(@menu, Wx::get_stock_label(Wx::ID_FILE))
 
     menuDialogs = Wx::Menu.new
     menu_item_3 = Wx::MenuItem.new(menuDialogs, Wx::ID_ANY, 'MainTestDlg')

--- a/tests/sdi/ruby/mainframe.rb
+++ b/tests/sdi/ruby/mainframe.rb
@@ -14,6 +14,7 @@ require 'wx/pg'
 require_relative 'dlgissue_956'
 require_relative 'dlgissue_960'
 require_relative 'booktest_dlg'
+require_relative 'wizard'
 
 require_relative 'images'
 require 'base64'
@@ -188,6 +189,10 @@ class MainFrame < Wx::Frame
     event.skip
   end
 
+  def OnWizard(event)
+    event.skip
+  end
+
 =end
 end
 
@@ -288,11 +293,10 @@ def on_quit(event)
   close(true)
 end
 
-def OnWizard(event)
-  event.skip
-# def OnWizard
-  # wizard = Wizard.new(self)
-  # wizard.run_wizard(wizard.get_first_page)
+def OnWizard
+  my_wizard = Wizard.new(self)
+  my_wizard.run_wizard(my_wizard.get_page_area_sizer.get_item(0).get_window)
+  my_wizard.destroy
 end
 
 def on_tools_dlg(event)

--- a/tests/sdi/ruby/wizard.rb
+++ b/tests/sdi/ruby/wizard.rb
@@ -33,7 +33,7 @@ class Wizard < Wx::Wizard
     box_sizer.add(@calendar, Wx::SizerFlags.new.border(Wx::ALL))
     wizPage.set_sizer_and_fit(box_sizer)
 
-    m_wizPage2 = Wx::WizardPageSimple.new(self)
+    wizPage2 = Wx::WizardPageSimple.new(self)
 
     box_sizer2 = Wx::BoxSizer.new(Wx::VERTICAL)
 
@@ -90,7 +90,7 @@ class Wizard < Wx::Wizard
     box_sizer2.add(parent_sizer3, Wx::SizerFlags.new.border(Wx::ALL))
     wizPage2.set_sizer_and_fit(box_sizer2)
 
-    m_wizPage3 = Wx::WizardPageSimple.new(self, nil, nil, wxue_get_bundle($wiztest2_png))
+    wizPage3 = Wx::WizardPageSimple.new(self, nil, nil, wxue_get_bundle($wiztest2_png))
 
     box_sizer3 = Wx::BoxSizer.new(Wx::VERTICAL)
 
@@ -113,23 +113,19 @@ class Wizard < Wx::Wizard
     box_sizer3.add(box_sizer_6, Wx::SizerFlags.new.expand.border(Wx::ALL))
     wizPage3.set_sizer_and_fit(box_sizer3)
 
-    wizPage.chain(m_wizPage2).Chain(m_wizPage3)
+    wizPage.chain(wizPage2).chain(wizPage3)
     get_page_area_sizer().add(wizPage)
     center(Wx::BOTH)
 
     # Event handlers
     evt_init_dialog(:OnInit)
-    evt_wizard_before_page_changed(:OnBeforeChange)
+    evt_wizard_before_page_changed(:on_before_page_change)
   end
-# Event handler functions
-# Add these below the comment block, or to your inherited class.
+# Unimplemented Event handler functions
+# Copy any listed and paste them below the comment block, or to your inherited class.
 
 =begin
-  def OnBeforeChange(event)
-    event.skip
-  end
-
-  def OnInit(event)
+  def on_before_page_change(event)
     event.skip
   end
 
@@ -141,3 +137,11 @@ end
 # Code below this comment block will be preserved
 # if the code for this class is re-generated.
 # ***********************************************
+
+def on_before_page_change(event)
+  event.skip
+end
+
+def OnInit(event)
+  event.skip
+end

--- a/tests/sdi/ruby/wizard.rb
+++ b/tests/sdi/ruby/wizard.rb
@@ -119,17 +119,8 @@ class Wizard < Wx::Wizard
 
     # Event handlers
     evt_init_dialog(:OnInit)
-    evt_wizard_before_page_changed(:on_before_page_change)
+    evt_wizard_before_page_changed(get_id, :on_before_page_change)
   end
-# Unimplemented Event handler functions
-# Copy any listed and paste them below the comment block, or to your inherited class.
-
-=begin
-  def on_before_page_change(event)
-    event.skip
-  end
-
-=end
 end
 # ************* End of generated code ***********
 # DO NOT EDIT THIS COMMENT BLOCK!

--- a/tests/sdi/sdi_test.wxui
+++ b/tests/sdi/sdi_test.wxui
@@ -102,7 +102,7 @@
       python_file="mainframe"
       python_import_list="main_test_dlg.py;booktest_dlg.py;wizard.py;python_dlg.py;tools_dlg.py;dlgissue_956.py;dlgissue_960.py"
       python_inherit_name="mainframe"
-      relative_require_list="dlgissue_956.rb;dlgissue_960.rb;booktest_dlg.rb"
+      relative_require_list="dlgissue_956.rb;dlgissue_960.rb;booktest_dlg.rb;wizard.rb"
       ruby_file="mainframe"
       xrc_file="mainframe"
       size="500,300"
@@ -1625,7 +1625,7 @@
       ruby_file="wizard"
       xrc_file="wizard"
       wxEVT_INIT_DIALOG="OnInit"
-      wxEVT_WIZARD_BEFORE_PAGE_CHANGED="OnBeforeChange">
+      wxEVT_WIZARD_BEFORE_PAGE_CHANGED="OnBeforeChange[python:OnBeforeChange][ruby:on_before_page_change]">
       <node
         class="wxWizardPageSimple">
         <node
@@ -1640,7 +1640,7 @@
       </node>
       <node
         class="wxWizardPageSimple"
-        var_name="m_wizPage2">
+        var_name="wizPage2">
         <node
           class="wxBoxSizer"
           orientation="wxVERTICAL"
@@ -1703,7 +1703,7 @@
       <node
         class="wxWizardPageSimple"
         bitmap="Embed;wiztest2.png"
-        var_name="m_wizPage3">
+        var_name="wizPage3">
         <node
           class="wxBoxSizer"
           orientation="wxVERTICAL"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes code generation problems with Wizards that don't have a bitmap specified for them. The Wizard in the SDI test now works correctly with wxRuby.