### PR TITLE
Switch to building wxWidgets32.* and wxWidgets33.*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,7 @@ endif()
 
 if (NOT BUILD_FORK AND NOT BUILD_CUSTOM)
     if (WIN32)
-        target_link_libraries(wxUiEditor PRIVATE wxWidgets ${CLib} comctl32 Imm32 Shlwapi Version UxTheme)
+        target_link_libraries(wxUiEditor PRIVATE wxWidgets33 ${CLib} comctl32 Imm32 Shlwapi Version UxTheme)
     elseif (UNIX)
         target_link_libraries(wxUiEditor PRIVATE libwxWidgets ${CLib})
     endif()

--- a/tests/sdi/CMakeLists.txt
+++ b/tests/sdi/CMakeLists.txt
@@ -137,9 +137,9 @@ else()
 endif()
 
 if (WIN32)
-    target_link_libraries(sdi_test PRIVATE wxWidgets ${CLib} comctl32 Imm32 Shlwapi Version UxTheme)
+    target_link_libraries(sdi_test PRIVATE wxWidgets32 ${CLib} comctl32 Imm32 Shlwapi Version UxTheme)
 else()
-    target_link_libraries(sdi_test PRIVATE wxWidgets ${CLib})
+    target_link_libraries(sdi_test PRIVATE wxWidgets32 ${CLib})
 endif()
 
 if (MSVC)

--- a/wxSnapshot/CMakeLists.txt
+++ b/wxSnapshot/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(wxWidgets 
+project(wxWidgets33
     LANGUAGES
     CXX C
     VERSION 3.3.0.0
@@ -79,11 +79,11 @@ endif()
 
 
 if (WIN32)
-    add_library(wxWidgets ${common_sources} ${msw_sources} )
+    add_library(wxWidgets33 ${common_sources} ${msw_sources} )
 elseif (APPLE)
-    add_library(wxWidgets ${common_sources} ${osx_sources} )
+    add_library(wxWidgets33 ${common_sources} ${osx_sources} )
 elseif (UNIX)
-    add_library(wxWidgets ${common_sources} ${unix_sources} )
+    add_library(wxWidgets33 ${common_sources} ${unix_sources} )
 endif()
 
 add_library(wxCLib STATIC 
@@ -91,27 +91,27 @@ add_library(wxCLib STATIC
 )
 
 if (BUILD_SHARED_LIBS)
-    target_compile_definitions(wxWidgets PRIVATE WXMAKINGDLL)
+    target_compile_definitions(wxWidgets33 PRIVATE WXMAKINGDLL)
 endif()
 
 if (MSVC)
     # /GL -- combined with the Linker flag /LTCG allows whole program optimization in Release build
-    target_compile_options(wxWidgets PRIVATE "$<$<CONFIG:Release>:/GL>")
+    target_compile_options(wxWidgets33 PRIVATE "$<$<CONFIG:Release>:/GL>")
 endif()
 
 if (WIN32)
-    target_compile_definitions(wxWidgets PRIVATE
+    target_compile_definitions(wxWidgets33 PRIVATE
         __WXMSW__
         WIN32
     )
 elseif (UNIX)
-    target_compile_definitions(wxWidgets PRIVATE
+    target_compile_definitions(wxWidgets33 PRIVATE
         __WXGTK3__
         __UNIX__
     )
 endif()
 
-target_compile_definitions(wxWidgets PRIVATE
+target_compile_definitions(wxWidgets33 PRIVATE
     WXBUILDING
     _CRT_SECURE_NO_DEPRECATE=1
     _CRT_NON_CONFORMING_SWPRINTFS=1
@@ -147,7 +147,7 @@ else()
     )
 endif()
 
-target_precompile_headers(wxWidgets PRIVATE "include/wx/wxprec.h")
+target_precompile_headers(wxWidgets33 PRIVATE "include/wx/wxprec.h")
 
 if (WIN32)
     set(setup_dir win)
@@ -155,7 +155,7 @@ elseif (UNIX)
     set(setup_dir unix)
 endif()
 
-target_include_directories(wxWidgets PRIVATE
+target_include_directories(wxWidgets33 PRIVATE
     include
     ${setup_dir}
     src/tiff/libtiff
@@ -185,6 +185,6 @@ target_include_directories(wxCLib PRIVATE
 
 if (BUILD_SHARED_LIBS)
     if (WIN32)
-        target_link_libraries(wxWidgets PRIVATE wxCLib Winmm Ws2_32 Rpcrt4 Comctl32)
+        target_link_libraries(wxWidgets33 PRIVATE wxCLib Winmm Ws2_32 Rpcrt4 Comctl32)
     endif()
 endif()

--- a/wxWidgets/wx_3_2/CMakeLists.txt
+++ b/wxWidgets/wx_3_2/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(wxWidgets
+project(wxWidgets32
     LANGUAGES
     CXX C
     VERSION 3.2.3.0
@@ -87,32 +87,32 @@ list(TRANSFORM wxCLib_sources PREPEND "${cmn_src_dir}/")
 message(STATUS "common_sources: ${cmn_src_dir}/src")
 
 if (WIN32)
-    add_library(wxWidgets ${override_sources} ${common_sources} ${msw_sources} )
+    add_library(wxWidgets32 ${override_sources} ${common_sources} ${msw_sources} )
 elseif (APPLE)
-    add_library(wxWidgets ${override_sources} ${common_sources} ${osx_sources} )
+    add_library(wxWidgets32 ${override_sources} ${common_sources} ${osx_sources} )
 elseif (UNIX)
-    add_library(wxWidgets ${override_sources} ${common_sources} ${unix_sources} )
+    add_library(wxWidgets32 ${override_sources} ${common_sources} ${unix_sources} )
 endif()
 
 add_library(wxCLib STATIC ${wxCLib_sources} )
 
 if (MSVC)
     # /GL -- combined with the Linker flag /LTCG allows whole program optimization in Release build
-    target_compile_options(wxWidgets PRIVATE "$<$<CONFIG:Release>:/GL>")
+    target_compile_options(wxWidgets32 PRIVATE "$<$<CONFIG:Release>:/GL>")
 endif()
 
 if (WIN32)
-    target_compile_definitions(wxWidgets PRIVATE
+    target_compile_definitions(wxWidgets32 PRIVATE
         __WXMSW__
         WIN32
     )
 endif()
 
 if (BUILD_SHARED_LIBS)
-    target_compile_definitions(wxWidgets PRIVATE WXMAKINGDLL)
+    target_compile_definitions(wxWidgets32 PRIVATE WXMAKINGDLL)
 endif()
 
-target_compile_definitions(wxWidgets PRIVATE
+target_compile_definitions(wxWidgets32 PRIVATE
     WXBUILDING
     _CRT_SECURE_NO_DEPRECATE=1
     _CRT_NON_CONFORMING_SWPRINTFS=1
@@ -149,7 +149,7 @@ if (WIN32)
     )
 endif()
 
-target_precompile_headers(wxWidgets PRIVATE "../include/wx/wxprec.h")
+target_precompile_headers(wxWidgets32 PRIVATE "../include/wx/wxprec.h")
 
 if (WIN32)
     set(setup_dir ${CMAKE_CURRENT_LIST_DIR}/setup/win)
@@ -157,7 +157,7 @@ endif()
 
 message(STATUS "setup_dir: ${setup_dir}")
 
-target_include_directories(wxWidgets PRIVATE
+target_include_directories(wxWidgets32 PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/../include
     ${setup_dir}
     ../src/tiff/libtiff
@@ -186,6 +186,6 @@ target_include_directories(wxCLib PRIVATE
 
 if (BUILD_SHARED_LIBS)
     if (WIN32)
-        target_link_libraries(wxWidgets PRIVATE wxCLib Winmm Ws2_32 Rpcrt4 Comctl32)
+        target_link_libraries(wxWidgets32 PRIVATE wxCLib Winmm Ws2_32 Rpcrt4 Comctl32)
     endif()
 endif()


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR switches wxWidgets builds so that they now have a major version number suffix. wxWidgets\wx_3_2 creates wxWidgets32.* and wxSnapshot creates wxWidgets33.*.
