### PR TITLE
Remove/conditionalize obsolete tt_string methods

### DIFF
--- a/src/customprops/art_prop_dlg.cpp
+++ b/src/customprops/art_prop_dlg.cpp
@@ -195,7 +195,7 @@ void ArtBrowserDialog::OnSelectItem(wxListEvent& event)
     {
         m_canvas->SetSize(bmp.GetWidth(), bmp.GetHeight());
         m_canvas->SetBitmap(bmp);
-        m_text->SetLabel(tt_string().Format("Size: %d x %d", bmp.GetWidth(), bmp.GetHeight()));
+        m_text->SetLabel(wxString().Format("Size: %d x %d", bmp.GetWidth(), bmp.GetHeight()));
         Layout();
     }
     Refresh();

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -503,7 +503,7 @@ NodeSharedPtr NodeCreator::createNodeFromXml(pugi::xml_node& xml_obj, Node* pare
 
                     tt_string prop_name = iter.name();
                     tt_string prop_value = iter.value();
-                    wxMessageBox(tt_string().Format(
+                    wxMessageBox(wxString().Format(
                         "The property named \"%s\" of class \"%s\" is not supported by this version of wxUiEditor.\n\n"
                         "If your project file was just converted from an older version, then the conversion was not "
                         "complete. Otherwise, this project is from a newer version of wxUiEditor.\n\n"

--- a/src/tt/tt_string.cpp
+++ b/src/tt/tt_string.cpp
@@ -945,11 +945,14 @@ tt_string& tt_string::Format(std::string_view format, ...)
                     buffer << va_arg(args, char);
                 else
                 {
+                    FAIL_MSG("%lc should not be used, since it only works on Windows");
+#if defined(_WIN32)
                     std::wstring str16;
                     str16 += va_arg(args, wchar_t);
                     std::string str8;
                     tt::utf16to8(str16, str8);
                     buffer << str8;
+#endif
                 }
             }
             else if (format.at(pos) == 's')
@@ -963,6 +966,8 @@ tt_string& tt_string::Format(std::string_view format, ...)
                 }
                 else
                 {
+                    FAIL_MSG("%ls should not be used, since it only works on Windows");
+#if defined(_WIN32)
                     std::wstring str16;
                     str16 += va_arg(args, const wchar_t*);
                     std::string str8;
@@ -971,6 +976,7 @@ tt_string& tt_string::Format(std::string_view format, ...)
                         buffer << std::quoted(str8);
                     else
                         buffer << str8;
+#endif
                 }
             }
             else if (format.at(pos) == 'd' || format.at(pos) == 'i')

--- a/src/tt/tt_string.cpp
+++ b/src/tt/tt_string.cpp
@@ -768,12 +768,14 @@ size_t tt_string::stepover(size_t start) const
     return pos;
 }
 
+#if defined(_WIN32)
 std::wstring tt_string::to_utf16() const
 {
     std::wstring str16;
     tt::utf8to16(*this, str16);
     return str16;
 }
+#endif
 
 tt_string_view tt_string::subview(size_t start, size_t len) const
 {

--- a/src/tt/tt_string.h
+++ b/src/tt/tt_string.h
@@ -72,6 +72,14 @@ public:
     // Caution: std::string_view will be invalid if tt_string is modified or destroyed.
     tt_string_view subview(size_t start = 0) const;
 
+    // Used when caller refuses to accept tt_string as a std::string (e.g., std::format()).
+    // Name is identical to wxString::ToStdString()
+    const std::string& ToStdString() const { return *this; }
+
+    // Used when caller refuses to accept tt_string_view via subview as a std::string_view
+    // (e.g. std::format())
+    const std::string_view ToStdView(size_t start = 0) const { return subview(start); }
+
     // Case-insensitive comparison.
     int comparei(std::string_view str) const;
 

--- a/src/tt/tt_string.h
+++ b/src/tt/tt_string.h
@@ -34,40 +34,26 @@ public:
 
     tt_string(const std::filesystem::directory_entry& dir) : std_base(dir.path().string(), dir.path().string().size()) {}
 
+#if wxUSE_UNICODE_UTF8
+    tt_string(const wxString& str) { *this = str.ToStdString(); }
+#else
     tt_string(const wxString& str) { *this = str.utf8_string(); }
+#endif
 
+#if defined(_WIN32)
     tt_string& from_utf16(std::wstring_view str)
     {
         clear();
         tt::utf16to8(str, *this);
         return *this;
     }
+
     std::wstring to_utf16() const;
-    std::wstring as_utf16() const { return to_utf16(); };
-
-    tt_string& utf(std::wstring_view str)
-    {
-        clear();
-        tt::utf16to8(str, *this);
-        return *this;
-    }
-
-    tt_string& utf(std::string_view str)
-    {
-        *this = str;
-        return *this;
-    }
+#endif
 
     // FromUTF8() is very efficient if wxUSE_UNICODE_UTF8 is defined as no UTF conversion is
     // done.
     wxString make_wxString() const { return wxString::FromUTF8(data(), size()); }
-
-// If on Windows, and not a wxUSE_UNICODE_UTF8 build, return value converts to UTF16
-#if defined(_WIN32) && !(wxUSE_UNICODE_UTF8)
-    std::wstring wx_str() const { return to_utf16(); };
-#else
-    std::string wx_str() const { return substr(); }
-#endif  // _WIN32
 
     // Caution: std::string_view will be invalid if tt_string is modified or destroyed.
     tt_string_view subview(size_t start = 0) const;
@@ -307,7 +293,6 @@ public:
 
     // Replaces the filename portion of the string. Returns a view to the entire string.
     tt_string& replace_filename(std::string_view newFilename);
-    tt_string& replace_filename(std::wstring_view newFilename) { return replace_filename(tt::utf16to8(newFilename)); }
 
     // Removes the filename portion of the string. Returns a view to the entire string.
     tt_string& remove_filename() { return replace_filename(""); }
@@ -315,7 +300,6 @@ public:
     // Appends the filename -- assumes current string is a path. This will add a trailing
     // slash (if needed) before adding the filename.
     tt_string& append_filename(std::string_view filename);
-    tt_string& append_filename(std::wstring_view filename) { return append_filename(tt::utf16to8(filename)); }
 
     // Makes the current path relative to the supplied path. Use an empty string to be
     // relative to the current directory. Supplied path should not contain a filename.
@@ -345,12 +329,6 @@ public:
         return *this;
     }
 
-    tt_string& operator<<(std::wstring_view str)
-    {
-        tt::utf16to8(str, *this);
-        return *this;
-    }
-
     tt_string& operator<<(char ch)
     {
         *this += ch;
@@ -371,7 +349,11 @@ public:
 
     tt_string& assign_wx(const wxString& str)
     {
+#if wxUSE_UNICODE_UTF8
+        *this = str.ToStdString();
+#else
         *this = str.utf8_string();
+#endif
         return *this;
     }
 

--- a/src/tt/tt_string_view.h
+++ b/src/tt/tt_string_view.h
@@ -37,6 +37,13 @@ public:
     std::string wx_str() const { return std::string(*this); }
 #endif  // _WIN32
 
+    // Used when caller refuses to accept tt_string_view as a std::string_view (e.g.
+    // std::format())
+    const std::string_view& ToStdView() const { return *this; }
+
+    // Same result as wxString::ToStdString()
+    const std::string ToStdString() const { return std::string(*this); }
+
     std::string as_str() const { return std::string(*this); }
     std::wstring as_utf16() const { return to_utf16(); };
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes or conditionalizes methods in tt_string that either shouldn't be used at all or should only be used under Windows. The main problem was that converting to/from UTF16 assumed that wchar_t was 16 bits -- and that is not the case on some POSIX systems.