### PR TITLE
Final ruby code gen fixes for wxRuby3 0.9.1

### DIFF
--- a/src/generate/gen_file_ctrl.cpp
+++ b/src/generate/gen_file_ctrl.cpp
@@ -43,11 +43,6 @@ wxObject* FileCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool FileCtrlGenerator::ConstructionCode(Code& code)
 {
-    if (code.is_ruby() && Project.getProjectNode()->as_string(prop_wxRuby_version) == "0.9.0")
-    {
-        code << "# wxRuby 0.9.0 does not support wxFileCtrl";
-        return true;
-    }
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
     code.Comma().QuotedString(prop_initial_folder).Comma().QuotedString(prop_initial_filename);

--- a/src/generate/gen_file_picker.cpp
+++ b/src/generate/gen_file_picker.cpp
@@ -67,10 +67,7 @@ bool FilePickerGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        if (code.is_ruby() && Project.getProjectNode()->as_string(prop_wxRuby_version) == "0.9.0")
-            code << "'" << wxFileSelectorPromptStr << "'";
-        else
-            code.AddType("wxFileSelectorPromptStr");
+        code.AddType("wxFileSelectorPromptStr");
     }
 
     code.Comma();

--- a/src/xml/project_interfaces_xml.xml
+++ b/src/xml/project_interfaces_xml.xml
@@ -72,9 +72,9 @@ inline const char* project_interfaces_xml = R"===(<?xml version="1.0"?>
 	<gen class="wxRuby" type="interface">
 		<property name="wxRuby_version" type="option"
 			help="Specifies the minimum version of wxRuby needed to run the generated code.">
-			<option name="0.9.0" />
+			<option name="0.9.1" />
 			<option name="1.0.0" />
-			0.9.0
+			0.9.1
 		</property>
 		<property name="ruby_output_folder" type="path"
 			help="If a folder name is specified, it will be used for all ruby code." />

--- a/tests/sdi/ruby/booktest_dlg.rb
+++ b/tests/sdi/ruby/booktest_dlg.rb
@@ -39,17 +39,13 @@ class BookTestDlg < Wx::Dialog
     @choicebook.set_min_size(Wx::Size.new(400, 400))
     page_sizer_1.add(@choicebook, Wx::SizerFlags.new.border(Wx::ALL))
 
-    if Wx::PLATFORM == 'WXUNIX' || Wx::PLATFORM == 'WXOSX'
-      btn = Wx::Button.new(@choicebook, Wx::ID_ANY, 'First')
-      @choicebook.get_control_sizer.add(btn,
-        Wx::SizerFlags.new.expand.border(Wx::ALL))
-    end
+    btn = Wx::Button.new(@choicebook, Wx::ID_ANY, 'First')
+    @choicebook.get_control_sizer.add(btn,
+      Wx::SizerFlags.new.expand.border(Wx::ALL))
 
-    if Wx::PLATFORM == 'WXUNIX' || Wx::PLATFORM == 'WXOSX'
-      btn_2 = Wx::Button.new(@choicebook, Wx::ID_ANY, 'Last')
-      @choicebook.get_control_sizer.add(btn_2,
-        Wx::SizerFlags.new.expand.border(Wx::ALL))
-    end
+    btn_2 = Wx::Button.new(@choicebook, Wx::ID_ANY, 'Last')
+    @choicebook.get_control_sizer.add(btn_2,
+      Wx::SizerFlags.new.expand.border(Wx::ALL))
 
     page_20 = Wx::Panel.new(@choicebook, Wx::ID_ANY, Wx::DEFAULT_POSITION,
       Wx::DEFAULT_SIZE, Wx::TAB_TRAVERSAL)
@@ -390,6 +386,10 @@ class BookTestDlg < Wx::Dialog
 
     set_sizer_and_fit(dlg_sizer)
     centre(Wx::BOTH)
+
+    # Event handlers
+    evt_button(btn.get_id, :OnEvent)
+    evt_button(btn_2.get_id, :OnEvent)
   end
 end
 # ************* End of generated code ***********

--- a/tests/sdi/ruby/main_test_dlg.rb
+++ b/tests/sdi/ruby/main_test_dlg.rb
@@ -503,9 +503,9 @@ class MainTestDialog < Wx::Dialog
       'File:')
     box_sizer.add(staticText__2, Wx::SizerFlags.new.center.border(Wx::ALL))
 
-    @filePicker = Wx::FilePickerCtrl.new(static_box_2.get_static_box, Wx::ID_ANY, (''), 'Select a file',
-      'BMP files|*.bmp', Wx::DEFAULT_POSITION, Wx::DEFAULT_SIZE,
-      Wx::FLP_USE_TEXTCTRL|Wx::FLP_OPEN|Wx::FLP_FILE_MUST_EXIST)
+    @filePicker = Wx::FilePickerCtrl.new(static_box_2.get_static_box, Wx::ID_ANY, (''),
+      Wx::FILE_SELECTOR_PROMPT_STR, 'BMP files|*.bmp', Wx::DEFAULT_POSITION,
+      Wx::DEFAULT_SIZE, Wx::FLP_USE_TEXTCTRL|Wx::FLP_OPEN|Wx::FLP_FILE_MUST_EXIST)
     box_sizer.add(@filePicker, Wx::SizerFlags.new.border(Wx::ALL))
 
     grid_sizer.add(box_sizer, Wx::SizerFlags.new.border(Wx::ALL))
@@ -578,7 +578,10 @@ class MainTestDialog < Wx::Dialog
 
     parent_sizer2.add(static_box_2, Wx::SizerFlags.new.expand.border(Wx::ALL))
 
-    # wxRuby 0.9.0 does not support wxFileCtrl
+    @fileCtrl = Wx::FileCtrl.new(page_6, Wx::ID_ANY, '', '',
+      Wx::FILE_SELECTOR_DEFAULT_WILDCARD_STR, Wx::FC_OPEN,
+      Wx::DEFAULT_POSITION, Wx::DEFAULT_SIZE)
+    parent_sizer2.add(@fileCtrl, Wx::SizerFlags.new.border(Wx::ALL))
     page_6.set_sizer_and_fit(parent_sizer2)
 
     page = Wx::Panel.new(@notebook, Wx::ID_ANY, Wx::DEFAULT_POSITION,

--- a/tests/sdi/sdi_test.wxui
+++ b/tests/sdi/sdi_test.wxui
@@ -1206,14 +1206,12 @@
                   class_access="none"
                   label="First"
                   var_name="btn"
-                  platforms="Unix|Mac"
                   wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@m_choicebook->SetSelection(0);@@}[python:lambda]self.m_choicebook.SetSelection(0)" />
                 <node
                   class="wxButton"
                   class_access="none"
                   label="Last"
                   var_name="btn_2"
-                  platforms="Unix|Mac"
                   wxEVT_BUTTON="[this](wxCommandEvent&amp;)@@{@@m_choicebook->SetSelection(2);@@}[python:lambda]self.m_choicebook.SetSelection(2)" />
                 <node
                   class="BookPage"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates the wxRuby3 code generation to sync with wxRuby3 version 0.9.1 (now a required minimum), incorporating the three reported issues in the 0.9.0 release. With this PR, all wxRuby3 code generation is complete and ready for the wxUiEditor 1.2 release.