### PR TITLE
Support wxAuiToolbar tool that has class access

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -74,6 +74,11 @@ void BaseCodeGenerator::CollectMemberVariables(Node* node, Permission perm, std:
                 (perm == Permission::Protected && prop->as_string() == "protected:"))
             {
                 auto code = GetDeclaration(node);
+                if (code.empty() && node->isGen(gen_auitool))
+                {
+                    code += "wxAuiToolBarItem* " + node->as_string(prop_var_name) + ';';
+                }
+
                 if (code.size())
                 {
                     if (node->hasProp(prop_platforms) && node->as_string(prop_platforms) != "Windows|Unix|Mac")

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1191,7 +1191,7 @@ void GenToolCode(Code& code)
     }
     bool need_variable_result =
         (node->hasValue(prop_var_name) &&
-         (node->isGen(gen_tool_dropdown) ||
+         ((node->as_string(prop_class_access) != "none") || node->isGen(gen_tool_dropdown) ||
           (node->isGen(gen_auitool) && node->as_string(prop_initial_state) != "wxAUI_BUTTON_STATE_NORMAL")));
 
     if (need_variable_result)

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -456,6 +456,7 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
                 continue;
             widget_keywords << ' ' << iter->declName();
         }
+        widget_keywords << " wxAuiToolBarItem wxToolBarToolBase";
 
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) widget_keywords.c_str());

--- a/tests/sdi/cpp/tools_dlg.cpp
+++ b/tests/sdi/cpp/tools_dlg.cpp
@@ -64,7 +64,7 @@ bool ToolBarsDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     auto* box_sizer = new wxBoxSizer(wxVERTICAL);
 
     m_tool_bar = new wxToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTB_HORIZONTAL);
-    auto* tool_svg = m_tool_bar->AddTool(wxID_ANY, wxEmptyString,
+    m_tool_svg = m_tool_svg = m_tool_bar->AddTool(wxID_ANY, wxEmptyString,
         wxueBundleSVG(wxue_img::left_svg, 585, 1857, FromDIP(wxSize(24, 24))));
 
     m_tool_bar->AddTool(wxID_ANY, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_CUT, wxART_TOOLBAR));
@@ -83,7 +83,7 @@ bool ToolBarsDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     m_aui_tool_bar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
         wxAUI_TB_PLAIN_BACKGROUND);
-    m_aui_tool_bar->AddTool(wxID_ANY, wxEmptyString,
+    m_aui_tool_svg = m_aui_tool_bar->AddTool(wxID_ANY, wxEmptyString,
         wxueBundleSVG(wxue_img::left_svg, 585, 1857, FromDIP(wxSize(24, 24))));
     m_aui_tool_bar->AddTool(wxID_ANY, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_CUT, wxART_TOOLBAR));
     m_aui_tool_bar->AddTool(wxID_ANY, wxEmptyString, wxBitmapBundle::FromBitmaps(wxueImage(wxue_img::redo_png, sizeof(wxue_img::redo_png)), wxueImage(wxue_img::redo_2x_png, sizeof(wxue_img::redo_2x_png))));
@@ -128,7 +128,7 @@ bool ToolBarsDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     // Event handlers
     Bind(wxEVT_INIT_DIALOG, &ToolBarsDialog::OnInit, this);
-    Bind(wxEVT_TOOL, &ToolBarsDialog::OnTool, this, tool_svg->GetId());
+    Bind(wxEVT_TOOL, &ToolBarsDialog::OnTool, this, m_tool_svg->GetId());
 
     return true;
 }

--- a/tests/sdi/cpp/tools_dlg.h
+++ b/tests/sdi/cpp/tools_dlg.h
@@ -68,8 +68,10 @@ protected:
     // Class member variables
 
     wxAuiToolBar* m_aui_tool_bar;
+    wxAuiToolBarItem* m_aui_tool_svg;
     wxRibbonBar* m_rbnBar;
     wxToolBar* m_tool_bar;
+    wxToolBarToolBase* m_tool_svg;
 };
 
 // ************* End of generated code ***********

--- a/tests/sdi/python/tools_dlg.py
+++ b/tests/sdi/python/tools_dlg.py
@@ -110,7 +110,7 @@ class ToolBarsDialog(wx.Dialog):
         self.tool_bar = wx.ToolBar(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize,
             wx.TB_HORIZONTAL)
         _svg_string_ = zlib.decompress(base64.b64decode(left_svg))
-        tool_svg = self.tool_bar.AddTool(wx.ID_ANY, "",
+        self.tool_svg = self.tool_svg = self.tool_bar.AddTool(wx.ID_ANY, "",
             wx.BitmapBundle.FromSVG(_svg_string_, wx.Size(24, 24)))
 
         self.tool_bar.AddTool(wx.ID_ANY, "", wx.ArtProvider.GetBitmapBundle(wx.ART_CUT,
@@ -137,7 +137,7 @@ class ToolBarsDialog(wx.Dialog):
         self.aui_tool_bar = wx.aui.AuiToolBar(self, wx.ID_ANY, wx.DefaultPosition,
             wx.DefaultSize, wx.aui.AUI_TB_PLAIN_BACKGROUND|wx.aui.AUI_TB_DEFAULT_STYLE)
         _svg_string_ = zlib.decompress(base64.b64decode(left_svg))
-        self.aui_tool_bar.AddTool(wx.ID_ANY, "",
+        self.aui_tool_svg = self.aui_tool_bar.AddTool(wx.ID_ANY, "",
             wx.BitmapBundle.FromSVG(_svg_string_, wx.Size(24, 24)))
         self.aui_tool_bar.AddTool(wx.ID_ANY, "", wx.ArtProvider.GetBitmapBundle(wx.ART_CUT,
             wx.ART_TOOLBAR))
@@ -197,7 +197,7 @@ class ToolBarsDialog(wx.Dialog):
 
         # Bind Event handlers
         self.Bind(wx.EVT_INIT_DIALOG, self.on_init)
-        self.Bind(wx.EVT_TOOL, self.OnTool, id=tool_svg.GetId())
+        self.Bind(wx.EVT_TOOL, self.OnTool, id=self.tool_svg.GetId())
 
     # Unimplemented Event handler functions
     # Copy any listed and paste them below the comment block, or to your inherited class.

--- a/tests/sdi/ruby/tools_dlg.rb
+++ b/tests/sdi/ruby/tools_dlg.rb
@@ -35,7 +35,7 @@ class ToolBarsDialog < Wx::Dialog
     @tool_bar = Wx::ToolBar.new(self, Wx::ID_ANY, Wx::DEFAULT_POSITION,
       Wx::DEFAULT_SIZE, Wx::TB_HORIZONTAL)
     _svg_string_ = Zlib::Inflate.inflate(Base64.decode64($left_svg))
-    tool_svg = @tool_bar.add_tool(Wx::ID_ANY, '', Wx::BitmapBundle.from_svg(_svg_string_,
+    @tool_svg = @tool_svg = @tool_bar.add_tool(Wx::ID_ANY, '', Wx::BitmapBundle.from_svg(_svg_string_,
       Wx::Size.new(24, 24)))
 
     @tool_bar.add_tool(Wx::ID_ANY, '', Wx::ArtProvider.get_bitmap_bundle(
@@ -58,7 +58,7 @@ class ToolBarsDialog < Wx::Dialog
       Wx::DEFAULT_POSITION, Wx::DEFAULT_SIZE, Wx::AUI::AUI_TB_PLAIN_BACKGROUND|
       Wx::AUI::AUI_TB_DEFAULT_STYLE)
     _svg_string_ = Zlib::Inflate.inflate(Base64.decode64($left_svg))
-    @aui_tool_bar.add_tool(Wx::ID_ANY, '', Wx::BitmapBundle.from_svg(_svg_string_,
+    @aui_tool_svg = @aui_tool_bar.add_tool(Wx::ID_ANY, '', Wx::BitmapBundle.from_svg(_svg_string_,
       Wx::Size.new(24, 24)))
     @aui_tool_bar.add_tool(Wx::ID_ANY, '', Wx::ArtProvider.get_bitmap_bundle(
       Wx::ART_CUT, Wx::ART_TOOLBAR))
@@ -110,7 +110,7 @@ class ToolBarsDialog < Wx::Dialog
 
     # Event handlers
     evt_init_dialog(:on_init)
-    evt_tool(tool_svg.get_id, :OnTool)
+    evt_tool(@tool_svg.get_id, :OnTool)
   end
 end
 

--- a/tests/sdi/sdi_test.wxui
+++ b/tests/sdi/sdi_test.wxui
@@ -1849,8 +1849,9 @@
           <node
             class="tool"
             bitmap="SVG;left.svg;[24,24]"
+            class_access="protected:"
             label=""
-            var_name="tool_svg"
+            var_name="m_tool_svg"
             wxEVT_TOOL="OnTool" />
           <node
             class="tool"
@@ -1885,8 +1886,9 @@
           <node
             class="auitool"
             bitmap="SVG;left.svg;[24,24]"
+            class_access="protected:"
             label=""
-            var_name="aui_tool_svg" />
+            var_name="m_aui_tool_svg" />
           <node
             class="auitool"
             bitmap="Art;wxART_CUT|wxART_TOOLBAR"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR will always generate an assignment to a variable if a wxAuiToolbar tool is set to have class access. Previously, the assignment was only created if the tool had an event, and it was never declared in the header file.

Closes #1260