### PR TITLE
Fix problems with generation of Images list header file in a form

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -268,11 +268,15 @@ void BaseCodeGenerator::GatherGeneratorIncludes(Node* node, std::set<std::string
                         {
                             if (form->isGen(gen_Images))
                             {
-                                tt_string image_file = Project.getProjectPath();
-                                image_file.append_filename(form->as_string(prop_base_file));
-                                image_file.replace_extension(m_header_ext);
-                                image_file.make_relative(m_baseFullPath);
-                                set_src.insert(tt_string() << "#include \"" << image_file << '\"');
+                                if (form->hasValue(prop_base_file))
+                                {
+                                    tt_string image_file = Project.getBaseDirectory(form);
+                                    image_file.append_filename(form->as_string(prop_base_file));
+                                    image_file.replace_extension(m_header_ext);
+                                    image_file.make_relative(Project.getBaseDirectory(node->getForm()).make_absolute());
+                                    image_file.backslashestoforward();
+                                    set_src.insert(tt_string() << "#include \"" << image_file << '\"');
+                                }
                                 break;
                             }
                         }

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -194,6 +194,13 @@ tt_string ProjectHandler::getBaseDirectory(Node* node, int language) const
     if (result.empty())
         result = m_projectPath;
 
+    tt_string base_file = node->as_string(prop_base_file);
+    base_file.remove_filename();
+    if (base_file.size())
+    {
+        result.append_filename(base_file);
+    }
+
     result.make_absolute();
 
     return result;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes problems with locating the Images list header file. It can now handle the Images file being in a different directory then the form's output directory, include both sibling and parent directories. It also correctly converts back slashes to forward slashes so that the generated file can be compiled on both Windows and Unix ( closes #1274 ).