### PR TITLE
Fix regression in C++ code generation for check and radio static box.

### DIFF
--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -125,6 +125,8 @@ bool StaticCheckboxBoxSizerGenerator::ConstructionCode(Code& code)
             else if (parent->isGen(gen_wxStaticBoxSizer) || parent->isGen(gen_StaticCheckboxBoxSizer) ||
                      parent->isGen(gen_StaticRadioBtnBoxSizer))
             {
+                // The () isn't added because Python and Ruby don't use it. C++ adds it in its
+                // own section below.
                 parent_name.NodeName(parent).Function("GetStaticBox");
                 break;
             }
@@ -138,6 +140,8 @@ bool StaticCheckboxBoxSizerGenerator::ConstructionCode(Code& code)
 
     if (code.is_cpp())
     {
+        if (parent_name.ends_with("GetStaticBox"))
+            parent_name += "()";
         code.NodeName() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY";
         code.Comma();
         if (Project.as_string(prop_wxWidgets_version) == "3.1")

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -117,6 +117,8 @@ bool StaticRadioBtnBoxSizerGenerator::ConstructionCode(Code& code)
             else if (parent->isGen(gen_wxStaticBoxSizer) || parent->isGen(gen_StaticCheckboxBoxSizer) ||
                      parent->isGen(gen_StaticRadioBtnBoxSizer))
             {
+                // The () isn't added because Python and Ruby don't use it. C++ adds it in its
+                // own section below.
                 parent_name.NodeName(parent).Function("GetStaticBox");
                 break;
             }
@@ -130,6 +132,8 @@ bool StaticRadioBtnBoxSizerGenerator::ConstructionCode(Code& code)
 
     if (code.is_cpp())
     {
+        if (parent_name.ends_with("GetStaticBox"))
+            parent_name += "()";
         code.AddAuto().NodeName() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY";
         code.Comma();
         if (Project.as_string(prop_wxWidgets_version) == "3.1")

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -64,7 +64,7 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     m_notebook = new wxNotebook(this, wxID_ANY);
     {
-        wxBookCtrlBase::Images bundle_list;
+        wxWithImages::Images bundle_list;
         bundle_list.push_back(wxue_img::bundle_cpp_logo_svg(16, 16));
         bundle_list.push_back(wxue_img::bundle_wxPython_png());
         bundle_list.push_back(wxueBundleSVG(wxue_img::ruby_logo_svg, 1853, 10034, wxSize(16, 16)));


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a regression in C++ code generation for check and radio static boxes. In order to get this to work correctly in Ruby (and someday in Python if it ever gets supported there), the initial function is generated as "GetStaticBox" instead of the ""GetStaticBox()" that is required for C++. This PR adds the "()" to the C++ code generation.

I also regenerated the the wxUiEditor code, but still commenting out the code in mainframe_base.cpp that breaks Unix compilation.