### PR TITLE
Fix codegen for when const_values property is set

### DIFF
--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -797,7 +797,7 @@ void BaseCodeGenerator::GenerateCppClassHeader()
         code.clear();
         if (m_form_node->hasProp(prop_id))
         {
-            code.Eol(eol_if_needed).Str("const int form_id = ");
+            code.Eol(eol_if_needed).Str("static const int form_id = ");
             if (m_form_node->as_string(prop_id).size())
                 code.as_string(prop_id) += ";";
             else
@@ -805,7 +805,7 @@ void BaseCodeGenerator::GenerateCppClassHeader()
         }
         if (m_form_node->hasProp(prop_style))
         {
-            code.Eol(eol_if_needed).Str("const int form_style = ");
+            code.Eol(eol_if_needed).Str("static const int form_style = ");
             if (m_form_node->as_string(prop_style).size())
                 code.as_string(prop_style) += ";";
             else
@@ -813,16 +813,21 @@ void BaseCodeGenerator::GenerateCppClassHeader()
         }
         else if (m_form_node->hasProp(prop_window_style))
         {
-            code.Eol(eol_if_needed).Str("const int form_style = ");
+            code.Eol(eol_if_needed).Str("static const int form_style = ");
             if (m_form_node->as_string(prop_window_style).size())
                 code.as_string(prop_window_style) += ";";
             else
                 code.Str("0;");
         }
         if (m_form_node->hasProp(prop_pos))
-            code.Eol(eol_if_needed).Str("const wxPoint form_pos = ").Pos(prop_pos, no_dlg_units) += ";";
+        {
+            code.Eol(eol_if_needed).Str("static const wxPoint form_pos() { return ").Pos(prop_pos, no_dlg_units) += "; }";
+        }
         if (m_form_node->hasProp(prop_size))
-            code.Eol(eol_if_needed).Str("const wxSize form_size = ").WxSize(prop_size, no_dlg_units) += ";";
+        {
+            code.Eol(eol_if_needed).Str("static const wxSize form_size() { return  ").WxSize(prop_size, no_dlg_units) +=
+                "; }";
+        }
         if (m_form_node->hasProp(prop_title))
         {
             code.Eol(eol_if_needed).Str("static const wxString form_title() { return ");

--- a/tests/sdi/cpp/dlgissue_960.h
+++ b/tests/sdi/cpp/dlgissue_960.h
@@ -16,10 +16,10 @@
 class DlgIssue_960 : public wxDialog
 {
 public:
-    const int form_id = wxID_ANY;
-    const int form_style = wxDEFAULT_DIALOG_STYLE;
-    const wxPoint form_pos = wxDefaultPosition;
-    const wxSize form_size = wxDefaultSize;
+    static const int form_id = wxID_ANY;
+    static const int form_style = wxDEFAULT_DIALOG_STYLE;
+    static const wxPoint form_pos() { return wxDefaultPosition; }
+    static const wxSize form_size() { return  wxDefaultSize; }
     static const wxString form_title() { return wxEmptyString; }
 
     DlgIssue_960() {}

--- a/tests/sdi/cpp/maintestdialog.cpp
+++ b/tests/sdi/cpp/maintestdialog.cpp
@@ -1037,6 +1037,6 @@ void MainFrame::OnDlgIssue_956(wxCommandEvent& WXUNUSED(event))
 
 void MainFrame::OnDlgIssue_960(wxCommandEvent& WXUNUSED(event))
 {
-    DlgIssue_960 dlg(this);
+    DlgIssue_960 dlg(this, DlgIssue_960::form_id, DlgIssue_960::form_title(), DlgIssue_960::form_pos());
     dlg.ShowModal();
 }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the way const values are generated when the const_values property is checked. The int values are now generated as `static const int` and form_pos and form_size have been changed to `static const form_pos()` and `static const form_size()` respectively.

I also added a test case to sdi_test to verify that both int and function can be used outside of the class provided the class header file is \#included.

Closes #1271 