### PR TITLE
Add prop_project_src_includes to Project

### DIFF
--- a/src/customprops/include_files_dlg.cpp
+++ b/src/customprops/include_files_dlg.cpp
@@ -160,7 +160,8 @@ void IncludeFilesDialog::OnAdd(wxCommandEvent& WXUNUSED(event))
     tt_string path;
     tt_string cur_file;
     if (m_prop->isProp(prop_local_hdr_includes) || m_prop->isProp(prop_local_src_includes) ||
-        m_prop->isProp(prop_relative_require_list) || m_prop->isProp(prop_python_import_list))
+        m_prop->isProp(prop_project_src_includes) || m_prop->isProp(prop_relative_require_list) ||
+        m_prop->isProp(prop_python_import_list))
     {
         auto* form = m_prop->getNode();
         GenEnum::PropName file_prop;

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -336,6 +336,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_pressed, "pressed" },
     { prop_pressed_bmp, "pressed_bmp" },
     { prop_private_members, "private_members" },
+    { prop_project_src_includes, "project_src_includes" },
     { prop_proportion, "proportion" },
     { prop_python_import_list, "python_import_list" },
     { prop_radiobtn_var_name, "radiobtn_var_name" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -354,6 +354,7 @@ namespace GenEnum
         prop_pressed,
         prop_pressed_bmp,
         prop_private_members,
+        prop_project_src_includes,
         prop_proportion,
         prop_python_import_list,
         prop_radiobtn_var_name,

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -398,6 +398,23 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
 
         m_source->writeLine();
 
+        if (Project.getProjectNode()->hasValue(prop_project_src_includes))
+        {
+            m_source->writeLine();
+            tt_view_vector list;
+            list.SetString(Project.getProjectNode()->as_string(prop_project_src_includes));
+            for (auto& iter: list)
+            {
+                tt_string include = iter;
+                include.make_absolute();
+                include.make_relative(Project.getBaseDirectory(m_form_node));
+                include.backslashestoforward();
+                m_source->writeLine(tt_string("#include \"") << include << '"');
+            }
+
+            m_source->writeLine();
+        }
+
         // Now output all the other header files (this will include derived_class header files)
         for (auto& iter: src_includes)
         {

--- a/src/xml/project_interfaces_xml.xml
+++ b/src/xml/project_interfaces_xml.xml
@@ -30,7 +30,9 @@ inline const char* project_interfaces_xml = R"===(<?xml version="1.0"?>
 		<property name="local_pch_file" type="file"
 			help="The filename of a local precompiled header file. The file will be included in quotes." />
 		<property name="src_preamble" type="code_edit"
-			help="Code to generate at the top of the source file after the inclusion of any local precompiled header file. This can include header files, comments, macros, etc." />
+			help="Code to generate at the top of all source files after the inclusion of any local precompiled header file. This can include header files, comments, macros, etc." />
+		<property name="project_src_includes" type="include_files"
+			help="Lists one or more local header files to include in all generated source files." />
 		<property name="name_space" type="string"
 			help="Namespace to enclose class declarations in. Separate nested namespaces with a double colon (e.g. company::app::subname)" />
 		<property name="generate_cmake" type="bool"


### PR DESCRIPTION
Like local_src_includes for individual forms, this property adds local header files to every source file in the project.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new property to the C++ Settings section of the project file called `project_src_includes`. The reason for adding this is because when code generation for src_preamble was moved to the top of the source file, it broke projects that were using it to include local header files after the wxWidgets header files were included.