### PR TITLE
Update Font handling (code generationg and font property dialog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - A control within a wxDialog or wxFrame with the focus property set will now call SetFocus() after all other controls have been created.
 - Limiting the platforms for a container (such as a wxPanel) will now also limit the platforms for any child widgets.
 - C++ src_preamble contents is now placed at the top of the file instead of after the includes.
+- Custom font point size can be set to -1 to indicate that a default point size should be used.
 
 ### Fixed
 
@@ -33,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Color properties are correctly saved in a project
 - widgets set to specific platforms will also place events in a conditional block
 - For C++, widgets set to specific platforms will have the header member declarations in a conditional block
+- C++ code generation for fonts with a negative point size fixed
 
 ## [Released (1.1.2)]
 

--- a/src/customprops/font_prop_dlg.cpp
+++ b/src/customprops/font_prop_dlg.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog for editing Font Property
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -169,7 +169,11 @@ void FontPropDlg::OnSymbolSize(wxCommandEvent& WXUNUSED(event))
 
 void FontPropDlg::OnEditPointSize(wxCommandEvent& event)
 {
-    if (auto digit = std::atof(event.GetString().ToStdString().c_str()); digit >= 4.0 && digit <= 72.0)
+    if (event.GetString() == "-" || event.GetString() == "." || event.GetString() == "+")
+    {
+        return;
+    }
+    if (auto digit = std::atof(event.GetString().ToStdString().c_str()); digit >= -1.0 && digit <= 72.0)
     {
         auto control = wxDynamicCast(event.GetEventObject(), wxSpinCtrlDouble);
         control->SetValue(digit);
@@ -191,7 +195,14 @@ void FontPropDlg::UpdateFontInfo()
     else
     {
         m_custom_font.Family(font_family_pairs.GetValue((const char*) m_comboFamily->GetValue().mb_str()));
-        m_custom_font.PointSize(m_spinCustomPointSize->GetValue());
+        if (m_spinCustomPointSize->GetValue() <= 0.0)
+        {
+            m_custom_font.PointSize(wxSystemSettings().GetFont(wxSYS_DEFAULT_GUI_FONT).GetFractionalPointSize());
+        }
+        else
+        {
+            m_custom_font.PointSize(m_spinCustomPointSize->GetValue());
+        }
         m_custom_font.Style(font_style_pairs.GetValue((const char*) m_comboCustomStyles->GetValue().mb_str()));
         m_custom_font.Weight(font_weight_pairs.GetValue((const char*) m_comboCustomWeight->GetStringSelection().mb_str()));
         m_custom_font.Underlined(m_checkCustomUnderlined->GetValue());
@@ -233,7 +244,10 @@ void FontPropDlg::OnOK(wxCommandEvent& event)
     {
         m_custom_font.setDefGuiFont(false);
         m_custom_font.Family(font_family_pairs.GetValue((const char*) m_comboFamily->GetValue().mb_str()));
-        m_custom_font.PointSize(m_spinCustomPointSize->GetValue());
+        if (m_spinCustomPointSize->GetValue() <= 0.0)
+            m_custom_font.PointSize(-1.0);
+        else
+            m_custom_font.PointSize(m_spinCustomPointSize->GetValue());
         m_custom_font.Style(font_style_pairs.GetValue((const char*) m_comboCustomStyles->GetValue().mb_str()));
         m_custom_font.Weight(font_weight_pairs.GetValue((const char*) m_comboCustomWeight->GetStringSelection().mb_str()));
         m_custom_font.Underlined(m_checkCustomUnderlined->GetValue());

--- a/src/wxui/fontpropdlg_base.cpp
+++ b/src/wxui/fontpropdlg_base.cpp
@@ -149,7 +149,7 @@ bool FontPropDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& ti
     box_sizer_6->Add(staticText_4, wxSizerFlags().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
 
     m_spinCustomPointSize = new wxSpinCtrlDouble(m_custom_box->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
-        wxDefaultSize, wxSP_ARROW_KEYS, 4, 72, 9, 0.5);
+        wxDefaultSize, wxSP_ARROW_KEYS, -1, 72, 9, 0.5);
     m_spinCustomPointSize->SetDigits(1);
     box_sizer_6->Add(m_spinCustomPointSize, wxSizerFlags().Border(wxALL));
 
@@ -169,7 +169,7 @@ bool FontPropDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& ti
 
     box_sizer_13->Add(box_sizer_7, wxSizerFlags().Border(wxALL));
 
-    box_sizer_5->Add(box_sizer_13, wxSizerFlags().Border(wxALL));
+    box_sizer_5->Add(box_sizer_13, wxSizerFlags().Bottom().Border(wxALL));
 
     auto* box_sizer_9 = new wxBoxSizer(wxVERTICAL);
 

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -2954,7 +2954,7 @@
                   inc="0.5"
                   initial="9"
                   max="72"
-                  min="4"
+                  min="-1"
                   var_name="m_spinCustomPointSize"
                   wxEVT_SPINCTRLDOUBLE="OnPointSize"
                   wxEVT_TEXT="OnEditPointSize" />
@@ -2962,7 +2962,8 @@
               <node
                 class="wxBoxSizer"
                 orientation="wxVERTICAL"
-                var_name="box_sizer_13">
+                var_name="box_sizer_13"
+                alignment="wxALIGN_BOTTOM">
                 <node
                   class="spacer"
                   height="20" />

--- a/tests/sdi/cpp/maintestdialog.cpp
+++ b/tests/sdi/cpp/maintestdialog.cpp
@@ -77,7 +77,7 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     auto* grid_sizer2 = new wxGridSizer(2, 0, 0);
 
-    static_text = new wxStaticText(page_2, wxID_ANY, "12-pt default font");
+    static_text = new wxStaticText(page_2, wxID_ANY, "11.5-pt default font");
     {
         wxFontInfo font_info(11.5);
         font_info.FaceName("Segoe UI");
@@ -85,9 +85,9 @@ bool MainTestDialog::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     }
     grid_sizer2->Add(static_text, wxSizerFlags().Border(wxALL));
 
-    m_static_text = new wxStaticText(page_2, wxID_ANY, "Comic Sans MS");
+    m_static_text = new wxStaticText(page_2, wxID_ANY, "Comic Sans MS -1 pt size");
     {
-        wxFontInfo font_info(10.5);
+        wxFontInfo font_info(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT).GetPointSize());
         font_info.FaceName("Comic Sans MS");
         m_static_text->SetFont(wxFont(font_info));
     }

--- a/tests/sdi/python/main_test_dlg.py
+++ b/tests/sdi/python/main_test_dlg.py
@@ -87,14 +87,13 @@ class MainTestDialog(wx.Dialog):
 
         grid_sizer2 = wx.GridSizer(2, 0, 0)
 
-        self.static_text = wx.StaticText(page_2, wx.ID_ANY, "12-pt default font")
-        font_info = wx.FontInfo(11.5)
-        font_info.FaceName("Segoe UI")
+        self.static_text = wx.StaticText(page_2, wx.ID_ANY, "11.5-pt default font")
+        font_info = wx.FontInfo(11.5).FaceName("Segoe UI")
         self.static_text.SetFont(wx.Font(font_info))
         grid_sizer2.Add(self.static_text, wx.SizerFlags().Border(wx.ALL))
 
-        self.static_text = wx.StaticText(page_2, wx.ID_ANY, "Comic Sans MS")
-        font_info = wx.FontInfo(10.5)
+        self.static_text = wx.StaticText(page_2, wx.ID_ANY, "Comic Sans MS -1 pt size")
+        font_info = wx.FontInfo(wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT).GetPointSize())
         font_info.FaceName("Comic Sans MS")
         self.static_text.SetFont(wx.Font(font_info))
         grid_sizer2.Add(self.static_text, wx.SizerFlags().Border(wx.ALL))
@@ -107,8 +106,8 @@ class MainTestDialog(wx.Dialog):
 
         self.static_text3 = wx.StaticText(page_2, wx.ID_ANY,
             "bold, underlined Times New Roman, 12.5")
-        font_info = wx.FontInfo(12.5)
-        font_info.FaceName("Times New Roman").Weight(wx.FONTWEIGHT_BOLD).Underlined()
+        font_info = wx.FontInfo(12.5).FaceName("Times New Roman").Weight(
+            wx.FONTWEIGHT_BOLD).Underlined()
         self.static_text3.SetFont(wx.Font(font_info))
         grid_sizer2.Add(self.static_text3, wx.SizerFlags().Border(wx.ALL))
 
@@ -704,7 +703,7 @@ class MainTestDialog(wx.Dialog):
         box_sizer_17.Add(self.banner_left, wx.SizerFlags().Border(wx.ALL))
 
         self.banner_top = wx.adv.BannerWindow(page_7, wx.ID_ANY, wx.TOP)
-        self.banner_top.SetGradient(wx.Colour("#2B2B2B"), wx.Colour("#777777"))
+        self.banner_top.SetGradient(wx.Colour("#BFCDDB"), wx.Colour("#0078D7"))
         self.banner_top.SetText("Top Banner", "This is the top banner message")
         box_sizer_17.Add(self.banner_top, wx.SizerFlags().Border(wx.ALL))
 

--- a/tests/sdi/ruby/main_test_dlg.rb
+++ b/tests/sdi/ruby/main_test_dlg.rb
@@ -48,14 +48,15 @@ class MainTestDialog < Wx::Dialog
 
     grid_sizer2 = Wx::GridSizer.new(2, 0, 0)
 
-    @static_text = Wx::StaticText.new(page_2, Wx::ID_ANY, '12-pt default font')
-    font_info = Wx::FontInfo.new(11.5)
-    font_info.face_name('Segoe UI')
+    @static_text = Wx::StaticText.new(page_2, Wx::ID_ANY, '11.5-pt default font')
+    font_info = Wx::FontInfo.new(11.5).face_name('Segoe UI')
     @static_text.set_font(Wx::Font.new(font_info))
     grid_sizer2.add(@static_text, Wx::SizerFlags.new.border(Wx::ALL))
 
-    @static_text = Wx::StaticText.new(page_2, Wx::ID_ANY, 'Comic Sans MS')
-    font_info = Wx::FontInfo.new(10.5)
+    @static_text = Wx::StaticText.new(page_2, Wx::ID_ANY,
+      'Comic Sans MS -1 pt size')
+    font_info = Wx::FontInfo.new(Wx::SystemSettings.get_font(
+      Wx::SYS_DEFAULT_GUI_FONT).get_point_size())
     font_info.face_name('Comic Sans MS')
     @static_text.set_font(Wx::Font.new(font_info))
     grid_sizer2.add(@static_text, Wx::SizerFlags.new.border(Wx::ALL))
@@ -68,8 +69,8 @@ class MainTestDialog < Wx::Dialog
 
     @static_text3 = Wx::StaticText.new(page_2, Wx::ID_ANY,
       'bold, underlined Times New Roman, 12.5')
-    font_info = Wx::FontInfo.new(12.5)
-    font_info.face_name('Times New Roman').weight(Wx::FONTWEIGHT_BOLD).underlined()
+    font_info = Wx::FontInfo.new(12.5).face_name('Times New Roman').weight(
+      Wx::FONTWEIGHT_BOLD).underlined()
     @static_text3.set_font(Wx::Font.new(font_info))
     grid_sizer2.add(@static_text3, Wx::SizerFlags.new.border(Wx::ALL))
 
@@ -695,7 +696,7 @@ class MainTestDialog < Wx::Dialog
     box_sizer_17.add(@banner_left, Wx::SizerFlags.new.border(Wx::ALL))
 
     @banner_top = Wx::BannerWindow.new(page_7, Wx::ID_ANY, Wx::TOP)
-    @banner_top.set_gradient(Wx::Colour.new('#2B2B2B'), Wx::Colour.new('#777777'))
+    @banner_top.set_gradient(Wx::Colour.new('#BFCDDB'), Wx::Colour.new('#0078D7'))
     @banner_top.set_text('Top Banner', 'This is the top banner message')
     box_sizer_17.add(@banner_top, Wx::SizerFlags.new.border(Wx::ALL))
 

--- a/tests/sdi/sdi_test.wxui
+++ b/tests/sdi/sdi_test.wxui
@@ -358,14 +358,14 @@
                 var_name="grid_sizer2">
                 <node
                   class="wxStaticText"
-                  label="12-pt default font"
+                  label="11.5-pt default font"
                   var_name="static_text"
                   font="Segoe UI,11.5" />
                 <node
                   class="wxStaticText"
-                  label="Comic Sans MS"
+                  label="Comic Sans MS -1 pt size"
                   var_name="m_static_text"
-                  font="Comic Sans MS,10.5" />
+                  font="Comic Sans MS,-1" />
                 <node
                   class="wxStaticText"
                   label="italic"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes font handling to support a point size of -1 to indicate that a default point size should be used. It also fixes code generation in C++ for when a default point size is requested.

The Custom font dialog now allows a minimum size of -1.0 instead of 4.0. If the sets anything between 0.0 and -1.0 then a point size of -1 will be used.
