### PR TITLE
Fix C++ codegen of forms with derived class

### DIFF
--- a/src/generate/gen_dialog.cpp
+++ b/src/generate/gen_dialog.cpp
@@ -58,7 +58,12 @@ bool DialogFormGenerator::ConstructionCode(Code& code)
             code.EndFunction();
         }
 
-        code.Eol(eol_if_needed) += "if (!wxDialog::Create(parent, id, title, pos, size, style, name))";
+        code.Eol(eol_if_needed) += "if (!";
+        if (code.node()->hasValue(prop_derived_class))
+            code.as_string(prop_derived_class);
+        else
+            code += "wxDialog";
+        code += "::Create(parent, id, title, pos, size, style, name))";
         code.Eol().Tab() += "return false;\n";
     }
     else if (code.is_python())

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -118,7 +118,12 @@ bool FrameFormGenerator::SettingsCode(Code& code)
 
     if (code.is_cpp())
     {
-        code.Eol(eol_if_needed).FormFunction("if (!wxFrame::Create(").Str("parent, id, title, pos, size, style, name))");
+        code.Eol(eol_if_needed) += "if (!";
+        if (code.node()->hasValue(prop_derived_class))
+            code.as_string(prop_derived_class);
+        else
+            code += "wxFrame";
+        code += "::Create(parent, id, title, pos, size, style, name))";
         code.Eol().Tab().Str("return false;");
     }
     else if (code.is_python())

--- a/src/generate/gen_panel_form.cpp
+++ b/src/generate/gen_panel_form.cpp
@@ -104,7 +104,12 @@ bool PanelFormGenerator::SettingsCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.Eol(eol_if_needed).FormFunction("if (!wxPanel::Create(").Str("parent, id, pos, size, style, name))");
+        code.Eol(eol_if_needed) += "if (!";
+        if (code.node()->hasValue(prop_derived_class))
+            code.as_string(prop_derived_class);
+        else
+            code += "wxPanel";
+        code += "::Create(parent, id, pos, size, style, name))";
         code.Eol().Tab().Str("return false;\n");
     }
     else if (code.is_python())

--- a/src/generate/gen_propsheet_dlg.cpp
+++ b/src/generate/gen_propsheet_dlg.cpp
@@ -99,7 +99,12 @@ bool PropSheetDlgGenerator::ConstructionCode(Code& code)
             code.FormFunction("SetOuterBorder(").Add(prop_outer_border).EndFunction().Eol();
         }
 
-        code.Eol(eol_if_needed) += "if (!wxPropertySheetDialog::Create(parent, id, title, pos, size, style, name))";
+        code.Eol(eol_if_needed) += "if (!";
+        if (code.node()->hasValue(prop_derived_class))
+            code.as_string(prop_derived_class);
+        else
+            code += "wxPropertySheetDialog";
+        code += "::Create(parent, id, title, pos, size, style, name))";
         code.Eol().Tab() += "return false;\n";
 
         code.Eol().Str("CreateButtons(").Add(prop_buttons).EndFunction();


### PR DESCRIPTION
Call the derived class's Create() method instead of the Base class's Create method.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes C++ code generation for wxDialog, wxFrame, wxPanel (form version) and wxPropertySheetDialog when using a derived class. Instead of calling the base class Create() method, it calls the derived class's Create() method.

This only changes C++ code generation. Python and Ruby code will need a derived class to be created before I modify that code generation.

This is related to issue #1267
