### PR TITLE
Special-case non-Center() wxSizerFlags function

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1677,7 +1677,20 @@ Code& Code::GenSizerFlags()
 
     if (auto& prop = m_node->as_string(prop_alignment); prop.size())
     {
-        if (prop.contains("wxALIGN_CENTER"))
+        if (prop.contains("wxALIGN_CENTER_HORIZONTAL") &&
+            (m_node->getParent()->isGen(gen_wxGridSizer) || m_node->getParent()->isGen(gen_wxFlexGridSizer) ||
+             m_node->getParent()->isGen(gen_wxGridBagSizer)))
+        {
+            SizerFlagsFunction("CenterHorizontal") += ')';
+        }
+        else if (prop.contains("wxALIGN_CENTER_VERTICAL") &&
+                 (m_node->getParent()->isGen(gen_wxGridSizer) || m_node->getParent()->isGen(gen_wxFlexGridSizer) ||
+                  m_node->getParent()->isGen(gen_wxGridBagSizer)))
+
+        {
+            SizerFlagsFunction("CenterVertical") += ')';
+        }
+        else if (prop.contains("wxALIGN_CENTER"))
         {
             // Note that CenterHorizontal() and CenterVertical() require wxWidgets 3.1 or higher. Their advantage is
             // generating an assert if you try to use one that is invalid if the sizer parent's orientation doesn't

--- a/src/internal/convert_img_base.cpp
+++ b/src/internal/convert_img_base.cpp
@@ -171,7 +171,8 @@ bool ConvertImageBase::Create(wxWindow* parent, wxWindowID id, const wxString& t
 
     m_staticOriginal = new wxStaticText(this, wxID_ANY, "Source");
     m_staticOriginal->Hide();
-    grid_sizer2->Add(m_staticOriginal, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
+    grid_sizer2->Add(m_staticOriginal,
+        wxSizerFlags().CenterHorizontal().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
 
     m_staticOutput = new wxStaticText(this, wxID_ANY, "Current");
     m_staticOutput->Hide();

--- a/src/newdialogs/new_mdi.cpp
+++ b/src/newdialogs/new_mdi.cpp
@@ -110,7 +110,7 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     flex_grid_sizer->SetFlexibleDirection(wxHORIZONTAL);
 
     auto* staticText_2 = new wxStaticText(static_box_3->GetStaticBox(), wxID_ANY, "&Description:");
-    flex_grid_sizer->Add(staticText_2, wxSizerFlags().Center().Border(wxALL));
+    flex_grid_sizer->Add(staticText_2, wxSizerFlags().CenterVertical().Border(wxALL));
 
     auto* description = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, wxEmptyString);
     description->SetHint("Text");
@@ -121,7 +121,7 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     auto* staticText_10 = new wxStaticText(static_box_3->GetStaticBox(), wxID_ANY, "Class name:");
     staticText_10->SetToolTip("Change this to something unique to your project.");
-    flex_grid_sizer->Add(staticText_10, wxSizerFlags().Center().Border(wxALL));
+    flex_grid_sizer->Add(staticText_10, wxSizerFlags().CenterVertical().Border(wxALL));
 
     auto* doc_classname = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, "DocumentTextCtrlBase");
     doc_classname->SetValidator(wxTextValidator(wxFILTER_NONE, &m_doc_class));
@@ -130,7 +130,7 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     flex_grid_sizer->Add(doc_classname, wxSizerFlags(1).Border(wxALL));
 
     auto* staticText_5 = new wxStaticText(static_box_3->GetStaticBox(), wxID_ANY, "&Extension:");
-    flex_grid_sizer->Add(staticText_5, wxSizerFlags().Center().Border(wxALL));
+    flex_grid_sizer->Add(staticText_5, wxSizerFlags().CenterVertical().Border(wxALL));
 
     auto* extension = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, wxEmptyString);
     extension->SetHint("txt");
@@ -139,7 +139,7 @@ bool NewMdiForm::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     flex_grid_sizer->Add(extension, wxSizerFlags().Expand().Border(wxALL));
 
     auto* staticText_4 = new wxStaticText(static_box_3->GetStaticBox(), wxID_ANY, "&Filter:");
-    flex_grid_sizer->Add(staticText_4, wxSizerFlags().Center().Border(wxALL));
+    flex_grid_sizer->Add(staticText_4, wxSizerFlags().CenterVertical().Border(wxALL));
 
     auto* filter = new wxTextCtrl(static_box_3->GetStaticBox(), wxID_ANY, wxEmptyString);
     filter->SetHint("*.txt");

--- a/src/wxui/gridbag_item_base.cpp
+++ b/src/wxui/gridbag_item_base.cpp
@@ -24,26 +24,26 @@ bool GridBagItemBase::Create(wxWindow* parent, wxWindowID id, const wxString& ti
     auto* flex_grid_sizer = new wxFlexGridSizer(4, 0, 5);
 
     auto* staticText = new wxStaticText(this, wxID_ANY, "&Column:");
-    flex_grid_sizer->Add(staticText, wxSizerFlags().Center().Border(wxALL));
+    flex_grid_sizer->Add(staticText, wxSizerFlags().CenterVertical().Border(wxALL));
 
     m_spin_column = new wxSpinCtrl(this);
     flex_grid_sizer->Add(m_spin_column, wxSizerFlags().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     auto* staticText_2 = new wxStaticText(this, wxID_ANY, "Span c&olumns:");
-    flex_grid_sizer->Add(staticText_2, wxSizerFlags().Center().Border(wxALL));
+    flex_grid_sizer->Add(staticText_2, wxSizerFlags().CenterVertical().Border(wxALL));
 
     m_spin_span_column = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1,
         100, 1);
     flex_grid_sizer->Add(m_spin_span_column, wxSizerFlags().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     auto* staticText_3 = new wxStaticText(this, wxID_ANY, "&Row:");
-    flex_grid_sizer->Add(staticText_3, wxSizerFlags().Center().Border(wxALL));
+    flex_grid_sizer->Add(staticText_3, wxSizerFlags().CenterVertical().Border(wxALL));
 
     m_spin_row = new wxSpinCtrl(this);
     flex_grid_sizer->Add(m_spin_row, wxSizerFlags().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     auto* staticText_4 = new wxStaticText(this, wxID_ANY, "Span ro&ws:");
-    flex_grid_sizer->Add(staticText_4, wxSizerFlags().Center().Border(wxALL));
+    flex_grid_sizer->Add(staticText_4, wxSizerFlags().CenterVertical().Border(wxALL));
 
     m_spin_span_row = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 100,
         1);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes when Center() is used versus CenterHorizontal() and CenterVertical(). Using Center() in a child of a sizer that has orientation means the child will be correctly centered in a way that matches what the sizer's orientation allows. However, the various grid sizers don't have any orientation so children must specifically set whether to center vertically or horizontally.