### PR TITLE
Replace SetSizerAndFit() with SetSizer() if prop_size is set.

### DIFF
--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxBoxSizer generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -76,7 +76,10 @@ bool BoxSizerGenerator::AfterChildrenCode(Code& code)
             }
             else
             {
-                code.FormFunction("SetSizerAndFit(");
+                if (parent->as_wxSize(prop_size) == wxDefaultSize)
+                    code.FormFunction("SetSizerAndFit(");
+                else  // Don't call Fit() if size has been specified
+                    code.FormFunction("SetSizer(");
             }
             code.NodeName().EndFunction();
         }

--- a/src/generate/gen_dialog.cpp
+++ b/src/generate/gen_dialog.cpp
@@ -183,7 +183,7 @@ bool DialogFormGenerator::AfterChildrenCode(Code& code)
     const auto min_size = form->as_wxSize(prop_minimum_size);
     const auto max_size = form->as_wxSize(prop_maximum_size);
 
-    if (min_size == wxDefaultSize && max_size == wxDefaultSize)
+    if (min_size == wxDefaultSize && max_size == wxDefaultSize && form->as_wxSize(prop_size) == wxDefaultSize)
     {
         code.FormFunction("SetSizerAndFit(").NodeName(child_node).EndFunction();
     }
@@ -198,8 +198,11 @@ bool DialogFormGenerator::AfterChildrenCode(Code& code)
         {
             code.Eol().FormFunction("SetMaxSize(").WxSize(prop_maximum_size).EndFunction();
         }
-        // EndFunction() will remove the opening paren if Ruby code
-        code.Eol().FormFunction("Fit(").EndFunction();
+
+        if (form->as_wxSize(prop_size) == wxDefaultSize)
+        {
+            code.Eol().FormFunction("Fit(").EndFunction();
+        }
     }
 
     bool is_focus_set = false;

--- a/src/generate/gen_dialog.cpp
+++ b/src/generate/gen_dialog.cpp
@@ -44,6 +44,7 @@ wxObject* DialogFormGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool DialogFormGenerator::ConstructionCode(Code& code)
 {
+    bool dialog_units = code.node()->as_string(prop_size).contains("d", tt::CASE::either);
     if (code.is_cpp())
     {
         code.Str("bool ").as_string(prop_class_name);
@@ -63,7 +64,11 @@ bool DialogFormGenerator::ConstructionCode(Code& code)
             code.as_string(prop_derived_class);
         else
             code += "wxDialog";
-        code += "::Create(parent, id, title, pos, size, style, name))";
+        code += "::Create(parent, id, title, pos, ";
+        if (dialog_units)
+            code += "ConvertDialogToPixels(size), style, name))";
+        else
+            code += "size, style, name))";
         code.Eol().Tab() += "return false;\n";
     }
     else if (code.is_python())

--- a/src/generate/gen_flexgrid_sizer.cpp
+++ b/src/generate/gen_flexgrid_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxFlexGridSizer generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -163,12 +163,16 @@ bool FlexGridSizerGenerator::AfterChildrenCode(Code& code)
         {
             if (GetParentName(code.node()) != "this")
             {
-                code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
+                code.ValidParentName().Function("SetSizerAndFit(");
             }
             else
             {
-                code.FormFunction("SetSizerAndFit(").NodeName().EndFunction();
+                if (parent->as_wxSize(prop_size) == wxDefaultSize)
+                    code.FormFunction("SetSizerAndFit(");
+                else  // Don't call Fit() if size has been specified
+                    code.FormFunction("SetSizer(");
             }
+            code.NodeName().EndFunction();
         }
     }
 

--- a/src/generate/gen_grid_sizer.cpp
+++ b/src/generate/gen_grid_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxGridSizer generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -75,12 +75,16 @@ bool GridSizerGenerator::AfterChildrenCode(Code& code)
         {
             if (GetParentName(code.node()) != "this")
             {
-                code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
+                code.ValidParentName().Function("SetSizerAndFit(");
             }
             else
             {
-                code.FormFunction("SetSizerAndFit(").NodeName().EndFunction();
+                if (parent->as_wxSize(prop_size) == wxDefaultSize)
+                    code.FormFunction("SetSizerAndFit(");
+                else  // Don't call Fit() if size has been specified
+                    code.FormFunction("SetSizer(");
             }
+            code.NodeName().EndFunction();
         }
     }
 

--- a/src/generate/gen_gridbag_sizer.cpp
+++ b/src/generate/gen_gridbag_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxGridBagSizer generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -235,12 +235,16 @@ bool GridBagSizerGenerator::AfterChildrenCode(Code& code)
         {
             if (GetParentName(code.node()) != "this")
             {
-                code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
+                code.ValidParentName().Function("SetSizerAndFit(");
             }
             else
             {
-                code.FormFunction("SetSizerAndFit(").NodeName().EndFunction();
+                if (parent->as_wxSize(prop_size) == wxDefaultSize)
+                    code.FormFunction("SetSizerAndFit(");
+                else  // Don't call Fit() if size has been specified
+                    code.FormFunction("SetSizer(");
             }
+            code.NodeName().EndFunction();
         }
     }
 

--- a/src/generate/gen_panel_form.cpp
+++ b/src/generate/gen_panel_form.cpp
@@ -154,14 +154,17 @@ bool PanelFormGenerator::AfterChildrenCode(Code& code)
     const auto max_size = panel->as_wxSize(prop_maximum_size);
     const auto size = panel->as_wxSize(prop_size);
 
-    if (min_size == wxDefaultSize && max_size == wxDefaultSize)
+    if (min_size == wxDefaultSize && max_size == wxDefaultSize && size == wxDefaultSize)
     {
         code.FormFunction("SetSizerAndFit(").NodeName(node).EndFunction();
     }
     else
     {
         code.FormFunction("SetSizer(").NodeName(node).EndFunction();
-        code.Eol().FormFunction("Fit(").EndFunction();
+        if (size == wxDefaultSize)
+        {
+            code.Eol().FormFunction("Fit(").EndFunction();
+        }
     }
 
     if (size != wxDefaultSize)

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -222,12 +222,16 @@ bool StaticCheckboxBoxSizerGenerator::AfterChildrenCode(Code& code)
             if (GetParentName(code.node()) != "this")
             {
                 code.ParentName().Add(".");
-                code.Function("SetSizerAndFit(").NodeName().EndFunction();
+                code.Function("SetSizerAndFit(");
             }
             else
             {
-                code.FormFunction("SetSizerAndFit(").NodeName().EndFunction();
+                if (parent->as_wxSize(prop_size) == wxDefaultSize)
+                    code.FormFunction("SetSizerAndFit(");
+                else  // Don't call Fit() if size has been specified
+                    code.FormFunction("SetSizer(");
             }
+            code.NodeName().EndFunction();
         }
     }
 

--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxStaticBoxSizer generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -119,12 +119,16 @@ bool StaticBoxSizerGenerator::AfterChildrenCode(Code& code)
         {
             if (GetParentName(code.node()) != "this")
             {
-                code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
+                code.ValidParentName().Function("SetSizerAndFit(");
             }
             else
             {
-                code.FormFunction("SetSizerAndFit(").NodeName().EndFunction();
+                if (parent->as_wxSize(prop_size) == wxDefaultSize)
+                    code.FormFunction("SetSizerAndFit(");
+                else  // Don't call Fit() if size has been specified
+                    code.FormFunction("SetSizer(");
             }
+            code.NodeName().EndFunction();
         }
     }
 

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -209,12 +209,16 @@ bool StaticRadioBtnBoxSizerGenerator::AfterChildrenCode(Code& code)
         {
             if (GetParentName(code.node()) != "this")
             {
-                code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
+                code.ValidParentName().Function("SetSizerAndFit(");
             }
             else
             {
-                code.FormFunction("SetSizerAndFit(").NodeName().EndFunction();
+                if (parent->as_wxSize(prop_size) == wxDefaultSize)
+                    code.FormFunction("SetSizerAndFit(");
+                else  // Don't call Fit() if size has been specified
+                    code.FormFunction("SetSizer(");
             }
+            code.NodeName().EndFunction();
         }
     }
 

--- a/src/generate/gen_wrap_sizer.cpp
+++ b/src/generate/gen_wrap_sizer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxWrapSizer generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -72,12 +72,16 @@ bool WrapSizerGenerator::AfterChildrenCode(Code& code)
         {
             if (GetParentName(code.node()) != "this")
             {
-                code.ParentName().Function("SetSizerAndFit(").NodeName().EndFunction();
+                code.ValidParentName().Function("SetSizerAndFit(");
             }
             else
             {
-                code.FormFunction("SetSizerAndFit(").NodeName().EndFunction();
+                if (parent->as_wxSize(prop_size) == wxDefaultSize)
+                    code.FormFunction("SetSizerAndFit(");
+                else  // Don't call Fit() if size has been specified
+                    code.FormFunction("SetSizer(");
             }
+            code.NodeName().EndFunction();
         }
     }
 

--- a/src/panels/doc_view.h
+++ b/src/panels/doc_view.h
@@ -65,8 +65,8 @@ private:
 // Code below this comment block will be preserved
 // if the code for this class is re-generated.
 //
-// clang-format on
-// ***********************************************
+    // clang-format on
+    // ***********************************************
 
 public:
     DocViewPanel(wxWindow* parent, MainFrame* frame);

--- a/src/wxui/edit_html_dialog_base.cpp
+++ b/src/wxui/edit_html_dialog_base.cpp
@@ -64,7 +64,7 @@ bool EditHtmlDialogBase::Create(wxWindow* parent, wxWindowID id, const wxString&
     auto* stdBtn_2 = CreateStdDialogButtonSizer(wxOK|wxCANCEL);
     parent_sizer->Add(CreateSeparatedSizer(stdBtn_2), wxSizerFlags().Expand().Border(wxALL));
 
-    SetSizerAndFit(parent_sizer);
+    SetSizer(parent_sizer);
     Centre(wxBOTH);
 
     wxPersistentRegisterAndRestore(this, "EditHtmlDialogBase");

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -154,7 +154,7 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     m_right_panel_sizer = new wxBoxSizer(wxVERTICAL);
     m_panel_right->SetSizerAndFit(m_right_panel_sizer);
     m_MainSplitter->SplitVertically(m_nav_panel, m_panel_right);
-    SetSizerAndFit(m_mainframe_sizer);
+    SetSizer(m_mainframe_sizer);
 
     m_menubar = new wxMenuBar();
 

--- a/tests/sdi/cpp/testformpanel.cpp
+++ b/tests/sdi/cpp/testformpanel.cpp
@@ -42,7 +42,7 @@ bool TestFormPanel::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos, 
     m_panel2->SetSizerAndFit(parent_sizer3);
     m_splitter->SplitVertically(panel, m_panel2);
 
-    SetSizerAndFit(parent_sizer);
+    SetSizer(parent_sizer);
     SetSize(wxSize(500, 300));
 
     return true;

--- a/tests/sdi/python/testformpanel.py
+++ b/tests/sdi/python/testformpanel.py
@@ -46,7 +46,7 @@ class TestFormPanel(wx.Panel):
         panel2.SetSizerAndFit(parent_sizer3)
         self.splitter.SplitVertically(panel, panel2)
 
-        self.SetSizerAndFit(parent_sizer)
+        self.SetSizer(parent_sizer)
         self.SetSize(wx.Size(500, 300))
 # ************* End of generated code ***********
 # DO NOT EDIT THIS COMMENT BLOCK!

--- a/tests/sdi/ruby/tools_dlg.rb
+++ b/tests/sdi/ruby/tools_dlg.rb
@@ -112,6 +112,31 @@ class ToolBarsDialog < Wx::Dialog
     evt_init_dialog(:on_init)
     evt_tool(@tool_svg.get_id, :OnTool)
   end
+
+  # Loads image(s) from a string and returns a Wx::BitmapBundle object.
+  def wxue_get_bundle(image_name1, image_name2 = nil, image_name3 = nil)
+    image1 = Wx::Image.new
+    image1.load_stream(StringIO.new(image_name1))
+    if (image_name2)
+      image2 = Wx::Image.new
+      image2.load_stream(StringIO.new(image_name2))
+      if (image_name3)
+        image3 = Wx::Image.new
+        image3.load_stream(StringIO.new(image_name3))
+        bitmaps = [Wx::Bitmap.new(image1),
+                   Wx::Bitmap.new(image2),
+                   Wx::Bitmap.new(image3)]
+        bundle = Wx::BitmapBundle.from_bitmaps(bitmaps)
+        return bundle
+      else
+        bundle = Wx::BitmapBundle.from_bitmaps(Wx::Bitmap.new(image1),
+                                               Wx::Bitmap.new(image2))
+        return bundle
+      end
+    end
+    bundle = Wx::BitmapBundle.from_image(image1)
+    return bundle
+  end
 end
 
 $left_svg = (


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes code generation so that specifying a size for a form will no longer call SetSizerAndFit(). Instead it will just call SetSizer() so that the forms size will be exactly what was specified rather then resizing the form to fit the controls within the form. While this does mean that the form may clip some of it's content on a high resolution display with scaling over 100% set, that's the dev's prerogative for setting size instead of minimum_size. It also ensure that older projects like wxFormBuilder which don't support high-dpi displays will have dialogs and other forms look the same size as they did in the original project.

This also changes wxDialog so that it will use `ConvertDialogToPixels()` on the size parameter in the Create function if dialog units have been specified. Note that Mockup does _not_ reflect this, making it trial and error to get the dialog units correct. Currently, only the C++ code generation is updated to reflect this change.