### PR TITLE
Remove inline functions to fix Unix build

### DIFF
--- a/src/generate/gen_initialize.cpp
+++ b/src/generate/gen_initialize.cpp
@@ -9,10 +9,10 @@
 #include "node_creator.h"  // NodeCreator
 
 #include "dataview_widgets.h"  // DataViewCtrl -- wxDataView component classes
-#include "gen_images_list.h"       // ImagesGenerator -- Embedded images generator
+#include "gen_images_list.h"   // ImagesGenerator -- Embedded images generator
+#include "gen_project.h"       // Project generator
+#include "gen_styled_text.h"   // StyledTextGenerator -- wxStyledText (scintilla) generate
 #include "menu_widgets.h"      // Menu component classes
-#include "gen_project.h"           // Project generator
-#include "gen_styled_text.h"       // StyledTextGenerator -- wxStyledText (scintilla) generate
 #include "window_widgets.h"    // Splitter and Scroll component classes
 
 #include "gen_activity.h"            // ActivityIndicatorGenerator -- wxActivityIndicator generator

--- a/src/nodes/tool_creator.cpp
+++ b/src/nodes/tool_creator.cpp
@@ -9,7 +9,7 @@
 
 #include "../panels/nav_panel.h"     // NavigationPanel -- Navigation Panel
 #include "../panels/ribbon_tools.h"  // RibbonPanel -- Displays component tools in a wxRibbonBar
-#include "gen_images_list.h"             // ImagesGenerator -- Images List Embedded images generator
+#include "gen_images_list.h"         // ImagesGenerator -- Images List Embedded images generator
 #include "mainframe.h"               // MainFrame -- Main window frame
 #include "node_creator.h"            // NodeCreator class
 #include "node_decl.h"               // NodeDeclaration class

--- a/src/panels/doc_view.cpp
+++ b/src/panels/doc_view.cpp
@@ -22,15 +22,8 @@
 #include <memory>  // for std::make_unique
 
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size)
-{
-    auto str = std::make_unique<char[]>(size_svg);
-    wxMemoryInputStream stream_in(data, size_data);
-    wxZlibInputStream zlib_strm(stream_in);
-    zlib_strm.Read(str.get(), size_svg);
-    return wxBitmapBundle::FromSVG(str.get(), def_size);
-};
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size);
 
 namespace wxue_img
 {

--- a/src/panels/nav_toolbar.cpp
+++ b/src/panels/nav_toolbar.cpp
@@ -23,15 +23,8 @@
 #include <memory>  // for std::make_unique
 
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size)
-{
-    auto str = std::make_unique<char[]>(size_svg);
-    wxMemoryInputStream stream_in(data, size_data);
-    wxZlibInputStream zlib_strm(stream_in);
-    zlib_strm.Read(str.get(), size_svg);
-    return wxBitmapBundle::FromSVG(str.get(), def_size);
-};
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size);
 
 NavToolbar::NavToolbar(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style,
     const wxString& name) : wxToolBar(parent, id, pos, size, style, name)

--- a/src/ui/startup_dlg.cpp
+++ b/src/ui/startup_dlg.cpp
@@ -24,15 +24,8 @@
 #include <memory>  // for std::make_unique
 
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size)
-{
-    auto str = std::make_unique<char[]>(size_svg);
-    wxMemoryInputStream stream_in(data, size_data);
-    wxZlibInputStream zlib_strm(stream_in);
-    zlib_strm.Read(str.get(), size_svg);
-    return wxBitmapBundle::FromSVG(str.get(), def_size);
-};
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size);
 
 namespace wxue_img
 {

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -27,15 +27,8 @@
 #include <memory>  // for std::make_unique
 
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size)
-{
-    auto str = std::make_unique<char[]>(size_svg);
-    wxMemoryInputStream stream_in(data, size_data);
-    wxZlibInputStream zlib_strm(stream_in);
-    zlib_strm.Read(str.get(), size_svg);
-    return wxBitmapBundle::FromSVG(str.get(), def_size);
-};
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size);
 
 namespace wxue_img
 {

--- a/src/wxui/import_base.cpp
+++ b/src/wxui/import_base.cpp
@@ -17,15 +17,8 @@
 #include <memory>  // for std::make_unique
 
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size)
-{
-    auto str = std::make_unique<char[]>(size_svg);
-    wxMemoryInputStream stream_in(data, size_data);
-    wxZlibInputStream zlib_strm(stream_in);
-    zlib_strm.Read(str.get(), size_svg);
-    return wxBitmapBundle::FromSVG(str.get(), def_size);
-};
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size);
 
 namespace wxue_img
 {

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -23,15 +23,8 @@
 #include <memory>  // for std::make_unique
 
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size)
-{
-    auto str = std::make_unique<char[]>(size_svg);
-    wxMemoryInputStream stream_in(data, size_data);
-    wxZlibInputStream zlib_strm(stream_in);
-    zlib_strm.Read(str.get(), size_svg);
-    return wxBitmapBundle::FromSVG(str.get(), def_size);
-};
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size);
 
 namespace wxue_img
 {

--- a/src/wxui/ribbonpanel_base.cpp
+++ b/src/wxui/ribbonpanel_base.cpp
@@ -21,13 +21,7 @@ using namespace GenEnum;
 #include <wx/mstream.h>  // memory stream classes
 
 // Convert a data array into a wxImage
-inline wxImage wxueImage(const unsigned char* data, size_t size_data)
-{
-    wxMemoryInputStream strm(data, size_data);
-    wxImage image;
-    image.LoadFile(strm);
-    return image;
-};
+wxImage wxueImage(const unsigned char* data, size_t size_data);
 
 namespace wxue_img
 {

--- a/src/wxui/ui_images.cpp
+++ b/src/wxui/ui_images.cpp
@@ -15,7 +15,7 @@
 #include <memory>  // for std::make_unique
 
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
     size_t size_data, size_t size_svg, wxSize def_size)
 {
     auto str = std::make_unique<char[]>(size_svg);
@@ -26,7 +26,7 @@ inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
 };
 
 // Convert a data array into a wxImage
-inline wxImage wxueImage(const unsigned char* data, size_t size_data)
+wxImage wxueImage(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
@@ -35,7 +35,7 @@ inline wxImage wxueImage(const unsigned char* data, size_t size_data)
 };
 
 // Convert multiple bitmaps into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleBitmaps(const wxBitmap& bmp1, const wxBitmap& bmp2, const wxBitmap& bmp3)
+wxBitmapBundle wxueBundleBitmaps(const wxBitmap& bmp1, const wxBitmap& bmp2, const wxBitmap& bmp3)
 {
     wxVector<wxBitmap> bitmaps;
     if (bmp1.IsOk())


### PR DESCRIPTION
gcc 11.4 doesn't support this -- it results in duplicate functions.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR temporarily hard-codes changes into the generated files for wxUiEditor to remove the `inline` keyword from the image functions. This was breaking Unix builds because the github action uses g++ version 11.4 which doesn't support the `inline` keyword for functions (it doesn't create them as a single linkage function).

While this hard-coding is in place, the wxUiEditor code can _not_ be regenerated. I have a branch that I'm working on which will generate the correct code, but it's turning out to be quite complicated, and I want Unix builds to work in the meantime.