### PR TITLE
Inline functions

### DIFF
--- a/src/assertion_dlg.h
+++ b/src/assertion_dlg.h
@@ -17,7 +17,7 @@
 
 #if 0
 
-#include <source_location>
+    #include <source_location>
 
 // #if defined(__cpp_consteval)
 

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -734,26 +734,6 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
                 if (parts.size() < IndexImage + 1)
                     continue;
 
-                // If this is an Images List, then we need to see if the image property refers
-                // to an image within the Images List. If so, a function call will be made to
-                // the Image List's source code to load the image and therefore we don't need
-                // to generate any special header files or generate the general purpose image
-                // loading function.
-
-                if (m_ImagesForm && m_form_node != m_ImagesForm)
-                {
-                    if (auto bundle = ProjectImages.GetPropertyImageBundle(parts); bundle && bundle->lst_filenames.size())
-                    {
-                        if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed)
-                        {
-                            if (embed->form == m_ImagesForm)
-                            {
-                                continue;
-                            }
-                        }
-                    }
-                }
-
                 if (parts[IndexType] == "Embed")
                 {
                     if (iter.type() == type_animation)

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -261,6 +261,7 @@ bool GenerateCodeFiles(GenResults& results, std::vector<tt_string>* pClassList)
 
     std::vector<Node*> forms;
     Project.CollectForms(forms);
+    Project.FindWxueFunctions(forms);
 
     GenData gen_data(results, pClassList);
     gen_data.source_ext = source_ext;

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -199,6 +199,20 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
 
     CollectIncludes(m_form_node, src_includes, hdr_includes);
 
+    bool has_images_list_header = false;
+    if (auto images_form = Project.getImagesForm(); images_form && images_form != m_form_node)
+    {
+        tt_string image_file = Project.getBaseDirectory(images_form);
+        image_file.append_filename(images_form->as_string(prop_base_file));
+        image_file.replace_extension(m_header_ext);
+        image_file.make_relative(Project.getBaseDirectory(m_form_node->getForm()).make_absolute());
+        image_file.backslashestoforward();
+        if (src_includes.contains(tt_string() << "#include \"" << image_file << '\"'))
+        {
+            has_images_list_header = true;
+        }
+    }
+
     if (m_form_node->as_bool(prop_persist))
     {
         src_includes.insert("#include <wx/persist.h>");
@@ -582,19 +596,23 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
             m_source->writeLine();
             m_source->writeLine("#include <memory>  // for std::make_unique", indent::none);
         }
+        m_source->writeLine();
 
         // Now generate the functions
 
         if (m_NeedImageFunction || m_NeedHeaderFunction)
         {
-            tt_string_vector function;
-            function.ReadString(Project.getForm_Image() == m_form_node ? txt_wxueImageFunction :
-                                                                         txt_extern_wxueImageFunction);
-            for (auto& iter: function)
+            if (Project.getForm_Image() == m_form_node || !has_images_list_header)
             {
-                m_source->writeLine(iter, indent::none);
+                tt_string_vector function;
+                function.ReadString(Project.getForm_Image() == m_form_node ? txt_wxueImageFunction :
+                                                                             txt_extern_wxueImageFunction);
+                for (auto& iter: function)
+                {
+                    m_source->writeLine(iter, indent::none);
+                }
+                m_source->writeLine();
             }
-            m_source->writeLine();
         }
 
         if (m_NeedSVGFunction)
@@ -610,24 +628,30 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
                 m_source->writeLine("#endif", indent::none);
             }
 
-            tt_string_vector function;
-            function.ReadString(Project.getForm_BundleSVG() == m_form_node ? txt_GetBundleFromSVG :
-                                                                             txt_extern_GetBundleFromSVG);
-            for (auto& iter: function)
+            if (Project.getForm_BundleSVG() == m_form_node || !has_images_list_header)
             {
-                m_source->writeLine(iter, indent::none);
+                tt_string_vector function;
+                function.ReadString(Project.getForm_BundleSVG() == m_form_node ? txt_GetBundleFromSVG :
+                                                                                 txt_extern_GetBundleFromSVG);
+                for (auto& iter: function)
+                {
+                    m_source->writeLine(iter, indent::none);
+                }
+                m_source->writeLine();
             }
-            m_source->writeLine();
         }
 
         if (m_NeedAnimationFunction)
         {
-            tt_string_vector function;
-            function.ReadString(Project.getForm_Animation() == m_form_node ? txt_GetAnimFromHdrFunction :
-                                                                             txt_extern_GetAnimFromHdrFunction);
-            for (auto& iter: function)
+            if (Project.getForm_Animation() == m_form_node || !has_images_list_header)
             {
-                m_source->writeLine(iter, indent::none);
+                tt_string_vector function;
+                function.ReadString(Project.getForm_Animation() == m_form_node ? txt_GetAnimFromHdrFunction :
+                                                                                 txt_extern_GetAnimFromHdrFunction);
+                for (auto& iter: function)
+                {
+                    m_source->writeLine(iter, indent::none);
+                }
             }
         }
 

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -44,6 +44,11 @@ wxImage wxueImage(const unsigned char* data, size_t size_data)
 };
 )===";
 
+inline constexpr const auto txt_extern_wxueImageFunction = R"===(
+// Convert a data array into a wxImage
+wxImage wxueImage(const unsigned char* data, size_t size_data);
+)===";
+
 inline constexpr const auto txt_GetBundleFromSVG = R"===(
 // Convert compressed SVG string into a wxBitmapBundle
 wxBitmapBundle wxueBundleSVG(const unsigned char* data,
@@ -56,6 +61,11 @@ wxBitmapBundle wxueBundleSVG(const unsigned char* data,
     return wxBitmapBundle::FromSVG(str.get(), def_size);
 };
 )===";
+inline constexpr const auto txt_extern_GetBundleFromSVG = R"===(
+// Convert compressed SVG string into a wxBitmapBundle
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size);
+)===";
 
 inline constexpr const auto txt_GetAnimFromHdrFunction = R"===(
 // Convert a data array into a wxAnimation
@@ -66,6 +76,11 @@ wxAnimation wxueAnimation(const unsigned char* data, size_t size_data)
     animation.Load(strm);
     return animation;
 };
+)===";
+
+inline constexpr const auto txt_extern_GetAnimFromHdrFunction = R"===(
+// Convert a data array into a wxAnimation
+wxAnimation wxueAnimation(const unsigned char* data, size_t size_data);
 )===";
 
 inline constexpr const auto txt_BaseCmtBlock =
@@ -572,7 +587,8 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
         if (m_NeedImageFunction || m_NeedHeaderFunction)
         {
             tt_string_vector function;
-            function.ReadString(txt_wxueImageFunction);
+            function.ReadString(Project.getForm_Image() == m_form_node ? txt_wxueImageFunction :
+                                                                         txt_extern_wxueImageFunction);
             for (auto& iter: function)
             {
                 m_source->writeLine(iter, indent::none);
@@ -594,7 +610,8 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
             }
 
             tt_string_vector function;
-            function.ReadString(txt_GetBundleFromSVG);
+            function.ReadString(Project.getForm_BundleSVG() == m_form_node ? txt_GetBundleFromSVG :
+                                                                             txt_extern_GetBundleFromSVG);
             for (auto& iter: function)
             {
                 m_source->writeLine(iter, indent::none);
@@ -605,7 +622,8 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
         if (m_NeedAnimationFunction)
         {
             tt_string_vector function;
-            function.ReadString(txt_GetAnimFromHdrFunction);
+            function.ReadString(Project.getForm_Animation() == m_form_node ? txt_GetAnimFromHdrFunction :
+                                                                             txt_extern_GetAnimFromHdrFunction);
             for (auto& iter: function)
             {
                 m_source->writeLine(iter, indent::none);
@@ -698,7 +716,7 @@ void BaseCodeGenerator::GenerateCppClassHeader()
             m_header->writeLine("#include <memory>  // for std::make_unique", indent::none);
         }
 
-        if (m_NeedImageFunction || m_NeedHeaderFunction)
+        if ((m_NeedImageFunction && Project.getForm_Image() == m_form_node) || m_NeedHeaderFunction)
         {
             tt_string_vector function;
             function.ReadString(txt_wxueImageFunction);
@@ -709,7 +727,7 @@ void BaseCodeGenerator::GenerateCppClassHeader()
             m_header->writeLine();
         }
 
-        if (m_NeedSVGFunction)
+        if (m_NeedSVGFunction && Project.getForm_BundleSVG() != m_form_node)
         {
             if (Project.as_string(prop_wxWidgets_version) == "3.1")
             {
@@ -731,7 +749,7 @@ void BaseCodeGenerator::GenerateCppClassHeader()
             m_header->writeLine();
         }
 
-        if (m_NeedAnimationFunction)
+        if (m_NeedAnimationFunction && Project.getForm_Animation() != m_form_node)
         {
             tt_string_vector function;
             function.ReadString(txt_GetAnimFromHdrFunction);

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -571,11 +571,12 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
         {
             m_source->writeLine("#include <wx/animate.h>", indent::none);
         }
-        if (m_NeedImageFunction || m_NeedHeaderFunction || m_NeedSVGFunction || m_NeedAnimationFunction)
+        if (!Project.getImagesForm() &&
+            (m_NeedImageFunction || m_NeedHeaderFunction || m_NeedSVGFunction || m_NeedAnimationFunction))
         {
             m_source->writeLine("\n#include <wx/mstream.h>  // memory stream classes", indent::none);
         }
-        if (m_NeedSVGFunction)
+        if (!Project.getImagesForm() && m_NeedSVGFunction)
         {
             m_source->writeLine("#include <wx/zstream.h>  // zlib stream classes", indent::none);
             m_source->writeLine();

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -35,7 +35,7 @@ extern std::map<wxBitmapType, std::string> g_map_types;
 
 inline constexpr const auto txt_wxueImageFunction = R"===(
 // Convert a data array into a wxImage
-inline wxImage wxueImage(const unsigned char* data, size_t size_data)
+wxImage wxueImage(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
@@ -46,7 +46,7 @@ inline wxImage wxueImage(const unsigned char* data, size_t size_data)
 
 inline constexpr const auto txt_GetBundleFromSVG = R"===(
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
     size_t size_data, size_t size_svg, wxSize def_size)
 {
     auto str = std::make_unique<char[]>(size_svg);
@@ -59,7 +59,7 @@ inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
 
 inline constexpr const auto txt_GetAnimFromHdrFunction = R"===(
 // Convert a data array into a wxAnimation
-inline wxAnimation wxueAnimation(const unsigned char* data, size_t size_data)
+wxAnimation wxueAnimation(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxAnimation animation;

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -73,7 +73,7 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
         }
 
         auto bmp = node->as_wxBitmapBundle(prop_bitmap);
-        ASSERT(bmp.IsOk());
+        ASSERT_MSG(bmp.IsOk(), tt_string("as_wxBitmapBundle(\"") << node->as_string(prop_bitmap) << "\") failed");
         if (!bmp.IsOk())
         {
             m_text_info->SetLabel("Cannot locate image!");

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -173,10 +173,6 @@ void BaseCodeGenerator::GenerateImagesForm()
 
     if (m_panel_type != HDR_PANEL)
     {
-        if (m_NeedAnimationFunction || Project.getForm_Animation() == m_form_node)
-        {
-            m_source->writeLine("#include <wx/animate.h>  // wxAnimation class", indent::none);
-        }
         m_source->writeLine("#include <wx/mstream.h>  // memory stream classes", indent::none);
 
         if (m_NeedSVGFunction || Project.getForm_BundleSVG() == m_form_node)
@@ -406,6 +402,11 @@ void BaseCodeGenerator::GenerateImagesForm()
 
     if (m_panel_type != CPP_PANEL)
     {
+        if (m_NeedAnimationFunction || Project.getForm_Animation() == m_form_node)
+        {
+            m_header->writeLine("#include <wx/animate.h>  // wxAnimation class", indent::none);
+        }
+
         if (m_NeedSVGFunction && is_old_widgets)
         {
             m_source->writeLine();

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -430,6 +430,16 @@ void BaseCodeGenerator::GenerateImagesForm()
         }
 
         m_header->writeLine();
+        if (m_NeedAnimationFunction || Project.getForm_Animation() == m_form_node)
+        {
+            m_header->writeLine("wxAnimation wxueAnimation(const unsigned char* data, size_t size_data);");
+        }
+        if (m_NeedSVGFunction || Project.getForm_BundleSVG() == m_form_node)
+        {
+            m_header->writeLine("wxBitmapBundle wxueBundleSVG(const unsigned char* data,\n\t"
+                                "size_t size_data, size_t size_svg, wxSize def_size);",
+                                indent::auto_keep_whitespace);
+        }
         m_header->writeLine("wxImage wxueImage(const unsigned char* data, size_t size_data);");
         m_header->writeLine();
         m_header->writeLine("namespace wxue_img\n{");

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -106,7 +106,7 @@ wxObject* ImagesGenerator::CreateMockup(Node* /* node */, wxObject* wxobject)
 
 inline constexpr const auto txt_wxueImageFunction = R"===(
 // Convert a data array into a wxImage
-inline wxImage wxueImage(const unsigned char* data, size_t size_data)
+wxImage wxueImage(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
@@ -117,7 +117,7 @@ inline wxImage wxueImage(const unsigned char* data, size_t size_data)
 
 inline constexpr const auto txt_GetBundleFromSVG = R"===(
 // Convert compressed SVG string into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
     size_t size_data, size_t size_svg, wxSize def_size)
 {
     auto str = std::make_unique<char[]>(size_svg);
@@ -130,7 +130,7 @@ inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
 
 inline constexpr const auto txt_GetBundleFromBitmaps = R"===(
 // Convert multiple bitmaps into a wxBitmapBundle
-inline wxBitmapBundle wxueBundleBitmaps(const wxBitmap& bmp1, const wxBitmap& bmp2, const wxBitmap& bmp3)
+wxBitmapBundle wxueBundleBitmaps(const wxBitmap& bmp1, const wxBitmap& bmp2, const wxBitmap& bmp3)
 {
     wxVector<wxBitmap> bitmaps;
     if (bmp1.IsOk())

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -219,7 +219,7 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
 
 inline constexpr const auto txt_wxueImageFunction = R"===(
 // Convert a data array into a wxImage
-inline wxImage wxueImage(const unsigned char* data, size_t size_data)
+wxImage wxueImage(const unsigned char* data, size_t size_data)
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;

--- a/src/panels/doc_view.cpp
+++ b/src/panels/doc_view.cpp
@@ -16,15 +16,6 @@
 
 #include "doc_view.h"
 
-#include <wx/mstream.h>  // memory stream classes
-#include <wx/zstream.h>  // zlib stream classes
-
-#include <memory>  // for std::make_unique
-
-// Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size);
-
 namespace wxue_img
 {
     extern const unsigned char cpp_logo_svg[587];

--- a/src/panels/nav_toolbar.cpp
+++ b/src/panels/nav_toolbar.cpp
@@ -17,11 +17,6 @@
 #include "mainframe.h"
 #include "project_handler.h"
 
-#include <wx/mstream.h>  // memory stream classes
-#include <wx/zstream.h>  // zlib stream classes
-
-#include <memory>  // for std::make_unique
-
 // Convert compressed SVG string into a wxBitmapBundle
 wxBitmapBundle wxueBundleSVG(const unsigned char* data,
     size_t size_data, size_t size_svg, wxSize def_size);

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -1006,13 +1006,10 @@ void ImageHandler::UpdateBundle(const tt_string_vector& parts, Node* node)
 
     tt_string lookup_str;
     lookup_str << parts[0] << ';' << parts[1].filename();
+    // ProcessBundleProperty() will add a new bundle, or replace an old bundle if the path has changed.
 
-    auto result = m_bundles.find(lookup_str);
-    if (result == m_bundles.end())
-    {
-        ProcessBundleProperty(parts, node);
-        result = m_bundles.find(lookup_str);
-    }
+    ProcessBundleProperty(parts, node);
+    auto result = m_bundles.find(ConvertToLookup(parts));
 
     if (result != m_bundles.end() && result->second.lst_filenames.size())
     {

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -53,6 +53,13 @@ inline tt_string ConvertToLookup(const tt_string& description)
     return lookup_str;
 }
 
+inline tt_string ConvertToLookup(const tt_string_vector& parts)
+{
+    tt_string lookup_str;
+    lookup_str << parts[0] << ';' << parts[1].filename();
+    return lookup_str;
+}
+
 void ImageHandler::Initialize(NodeSharedPtr project, bool allow_ui)
 {
     m_project_node = project;
@@ -589,8 +596,7 @@ bool ImageHandler::AddNewEmbeddedBundle(const tt_string_vector& parts, tt_string
 {
     ASSERT(parts.size() > 1)
 
-    tt_string lookup_str;
-    lookup_str << parts[0] << ';' << parts[1].filename();
+    auto lookup_str = ConvertToLookup(parts);
 
     ImageBundle img_bundle;
 
@@ -815,10 +821,7 @@ ImageBundle* ImageHandler::ProcessBundleProperty(const tt_string_vector& parts, 
 {
     ASSERT(parts.size() > 1)
 
-    tt_string lookup_str;
-    lookup_str << parts[0] << ';' << parts[1].filename();
-
-    ASSERT_MSG(!m_bundles.contains(lookup_str), "ProcessBundleProperty should not be called if bundle already exists!")
+    auto lookup_str = ConvertToLookup(parts);
 
     if (parts[IndexImage].empty())
     {
@@ -1004,8 +1007,6 @@ void ImageHandler::UpdateBundle(const tt_string_vector& parts, Node* node)
     if (parts.size() < 2 || node->isFormParent())
         return;
 
-    tt_string lookup_str;
-    lookup_str << parts[0] << ';' << parts[1].filename();
     // ProcessBundleProperty() will add a new bundle, or replace an old bundle if the path has changed.
 
     ProcessBundleProperty(parts, node);
@@ -1041,10 +1042,7 @@ wxBitmapBundle ImageHandler::GetPropertyBitmapBundle(tt_string_view description,
         return GetInternalImage("unknown");
     }
 
-    tt_string lookup_str;
-    lookup_str << parts[IndexType] << ';' << parts[IndexImage].filename();
-
-    if (auto result = m_bundles.find(lookup_str); result != m_bundles.end())
+    if (auto result = m_bundles.find(ConvertToLookup(parts)); result != m_bundles.end())
     {
         // At this point we know that the bundle has been stored, but the actual size for
         // display can change any time the property is used to retrieve the bundle.
@@ -1074,10 +1072,7 @@ const ImageBundle* ImageHandler::GetPropertyImageBundle(const tt_string_vector& 
         return nullptr;
     }
 
-    tt_string lookup_str;
-    lookup_str << parts[0] << ';' << parts[1].filename();
-
-    if (auto result = m_bundles.find(lookup_str); result != m_bundles.end())
+    if (auto result = m_bundles.find(ConvertToLookup(parts)); result != m_bundles.end())
     {
         return &result->second;
     }

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -403,20 +403,28 @@ void ProjectHandler::FindWxueFunctions(std::vector<Node*>& forms)
                         if (iter.type() == type_animation)
                         {
                             if (!m_form_Animation)
-                                m_form_Animation = child->getForm();
+                            {
+                                m_form_Animation = m_ImagesForm ? m_ImagesForm : child->getForm();
+                            }
                         }
                         else
                         {
                             if (!m_form_Image)
-                                m_form_Image = child->getForm();
+                            {
+                                m_form_Image = m_ImagesForm ? m_ImagesForm : child->getForm();
+                            }
                             if (!m_form_BundleBitmaps && ProjectImages.GetPropertyImageBundle(parts))
-                                m_form_BundleBitmaps = child->getForm();
+                            {
+                                m_form_BundleBitmaps = m_ImagesForm ? m_ImagesForm : child->getForm();
+                            }
                         }
                     }
                     else if ((parts[IndexType] == "SVG"))
                     {
                         if (!m_form_BundleSVG)
-                            m_form_BundleSVG = child->getForm();
+                        {
+                            m_form_BundleSVG = m_ImagesForm ? m_ImagesForm : child->getForm();
+                        }
                     }
 
                     if (m_form_Animation && m_form_BundleSVG && m_form_BundleBitmaps && m_form_Image)
@@ -441,9 +449,16 @@ void ProjectHandler::FindWxueFunctions(std::vector<Node*>& forms)
     m_form_BundleBitmaps = nullptr;
     m_form_Image = nullptr;
     m_form_Animation = nullptr;
+    m_ImagesForm = nullptr;
 
     for (auto form: forms)
     {
+        if (form->isGen(gen_Images))
+        {
+            m_ImagesForm = form;
+            continue;
+        }
+
         if (form->hasValue(prop_icon))
         {
             tt_string_vector parts(form->as_string(prop_icon), BMP_PROP_SEPARATOR, tt::TRIM::both);

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -486,3 +486,12 @@ void ProjectHandler::FindWxueFunctions(std::vector<Node*>& forms)
         }
     }
 }
+
+Node* ProjectHandler::getImagesForm()
+{
+    if (!m_ImagesForm && m_project_node->getChildCount() > 0 && m_project_node->getChild(0)->isGen(gen_Images))
+    {
+        m_ImagesForm = m_project_node->getChild(0);
+    }
+    return m_ImagesForm;
+}

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -178,6 +178,7 @@ private:
     Node* m_form_Image { nullptr };
     Node* m_form_BundleBitmaps { nullptr };
     Node* m_form_Animation { nullptr };
+    Node* m_ImagesForm { nullptr };
 
     tt_string m_projectFile;
     tt_string m_projectPath;

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -171,7 +171,9 @@ public:
     // generate the one copy of wxueAnimation() that is used by all forms.
     Node* getForm_Animation() const { return m_form_BundleBitmaps; }
 
-    Node* getImagesForm() const { return m_ImagesForm; }
+    // This will assume any ImagesList class will be the first child of the project, and will
+    // either return that Node* or nullptr if no ImagesList class is found.
+    Node* getImagesForm();
 
 private:
     NodeSharedPtr m_project_node { nullptr };

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -171,6 +171,8 @@ public:
     // generate the one copy of wxueAnimation() that is used by all forms.
     Node* getForm_Animation() const { return m_form_BundleBitmaps; }
 
+    Node* getImagesForm() const { return m_ImagesForm; }
+
 private:
     NodeSharedPtr m_project_node { nullptr };
 

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -151,8 +151,33 @@ public:
     // grandchildren, etc.
     void RecursiveNodeCheck(Node* node);
 
+    // Assumes CollectForms() has already been called. Finds out which form should be used
+    // to generate wxue() functions for embedded images.
+    void FindWxueFunctions(std::vector<Node*>& forms);
+
+    // After calling FindWxueFunctions(), this will return the form that should be used to
+    // generate the one copy of wxueBundleSVG() that is used by all forms.
+    Node* getForm_BundleSVG() const { return m_form_BundleSVG; }
+
+    // After calling FindWxueFunctions(), this will return the form that should be used to
+    // generate the one copy of wxueImage() that is used by all forms.
+    Node* getForm_Image() const { return m_form_Image; }
+
+    // After calling FindWxueFunctions(), this will return the form that should be used to
+    // generate the one copy of wxueBundleBitmaps() that is used by all forms.
+    Node* getForm_BundleBitmaps() const { return m_form_BundleBitmaps; }
+
+    // After calling FindWxueFunctions(), this will return the form that should be used to
+    // generate the one copy of wxueAnimation() that is used by all forms.
+    Node* getForm_Animation() const { return m_form_BundleBitmaps; }
+
 private:
     NodeSharedPtr m_project_node { nullptr };
+
+    Node* m_form_BundleSVG { nullptr };
+    Node* m_form_Image { nullptr };
+    Node* m_form_BundleBitmaps { nullptr };
+    Node* m_form_Animation { nullptr };
 
     tt_string m_projectFile;
     tt_string m_projectPath;

--- a/src/ui/startup_dlg.cpp
+++ b/src/ui/startup_dlg.cpp
@@ -18,15 +18,6 @@
 
 #include "startup_dlg.h"
 
-#include <wx/mstream.h>  // memory stream classes
-#include <wx/zstream.h>  // zlib stream classes
-
-#include <memory>  // for std::make_unique
-
-// Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size);
-
 namespace wxue_img
 {
     extern const unsigned char import_svg[418];

--- a/src/wxui/edit_html_dialog_base.cpp
+++ b/src/wxui/edit_html_dialog_base.cpp
@@ -17,7 +17,7 @@
 bool EditHtmlDialogBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     const wxPoint& pos, const wxSize& size, long style, const wxString &name)
 {
-    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+    if (!wxDialog::Create(parent, id, title, pos, ConvertDialogToPixels(size), style, name))
         return false;
 
     auto* parent_sizer = new wxBoxSizer(wxVERTICAL);

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -21,15 +21,6 @@
 
 #include "eventhandler_dlg_base.h"
 
-#include <wx/mstream.h>  // memory stream classes
-#include <wx/zstream.h>  // zlib stream classes
-
-#include <memory>  // for std::make_unique
-
-// Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size);
-
 namespace wxue_img
 {
     extern const unsigned char cpp_logo_svg[587];

--- a/src/wxui/import_base.cpp
+++ b/src/wxui/import_base.cpp
@@ -11,11 +11,6 @@
 
 #include "import_base.h"
 
-#include <wx/mstream.h>  // memory stream classes
-#include <wx/zstream.h>  // zlib stream classes
-
-#include <memory>  // for std::make_unique
-
 // Convert compressed SVG string into a wxBitmapBundle
 wxBitmapBundle wxueBundleSVG(const unsigned char* data,
     size_t size_data, size_t size_svg, wxSize def_size);

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -17,15 +17,6 @@
 #include "mainframe.h"
 #include "project_handler.h"
 
-#include <wx/mstream.h>  // memory stream classes
-#include <wx/zstream.h>  // zlib stream classes
-
-#include <memory>  // for std::make_unique
-
-// Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size);
-
 namespace wxue_img
 {
     extern const unsigned char import_svg[418];

--- a/src/wxui/ribbonpanel_base.cpp
+++ b/src/wxui/ribbonpanel_base.cpp
@@ -18,11 +18,6 @@ using namespace GenEnum;
 
 #include "ribbonpanel_base.h"
 
-#include <wx/mstream.h>  // memory stream classes
-
-// Convert a data array into a wxImage
-wxImage wxueImage(const unsigned char* data, size_t size_data);
-
 namespace wxue_img
 {
     extern const unsigned char auitoolbar_png[476];

--- a/src/wxui/ui_images.cpp
+++ b/src/wxui/ui_images.cpp
@@ -47,6 +47,15 @@ wxBitmapBundle wxueBundleBitmaps(const wxBitmap& bmp1, const wxBitmap& bmp2, con
     return wxBitmapBundle::FromBitmaps(bitmaps);
 };
 
+// Convert a data array into a wxAnimation
+wxAnimation wxueAnimation(const unsigned char* data, size_t size_data)
+{
+    wxMemoryInputStream strm(data, size_data);
+    wxAnimation animation;
+    animation.Load(strm);
+    return animation;
+};
+
 namespace wxue_img
 {
     wxBitmapBundle bundle_cpp_logo_svg(int width, int height)

--- a/src/wxui/ui_images.h
+++ b/src/wxui/ui_images.h
@@ -11,8 +11,12 @@
 
 #include <wx/gdicmn.h>
 
+#include <wx/animate.h>  // wxAnimation class
 #include <wx/bmpbndl.h>
 
+wxAnimation wxueAnimation(const unsigned char* data, size_t size_data);
+wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size);
 wxImage wxueImage(const unsigned char* data, size_t size_data);
 
 namespace wxue_img


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes code generation for wxueImage(), wxueBundleSVG() and wxueBundleBitmaps(). It removes the `inline` prefix, since some versions of Linux default to an old version of GCC which does not support this prefix as a way to indicate that the function should only have one linkage.

The solution for this is to only write the function in one source module. The `ProjectHandler` now has a function that parses all forms and determines which form needs which of the three functions.

Note that this changes a lot of the code generation, but should not change the actual functionality -- it just means that wxUiEditor must figure out the sole location of the image functions rather then relying on the compiler/linker to do so.

Closes #1285
