### PR TITLE
Dialog units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,26 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [Uneleased (1.1.3)]
+## [Uneleased (1.2.0)]
 
 ### Added
 
 - Code can now be generated for wxRuby3 -- see https://github.com/mcorino/wxRuby3
-- New Doc panel will display a URL containing documentation for the currently selected widget. A toolbar in this panel lets you choose between C++, Python and Ruby documentation.
+- New Doc panel (Windows version only) will display a URL containing documentation for the currently selected widget. A toolbar in this panel lets you choose between C++, Python and Ruby documentation.
 - New Preferences dialog available under the File menu lets you set several global preferences
-- wxTimer is now supported as a child of a diloag, frame or form version of wxPanel
+- wxTimer is now supported as a child of a dialag, frame or form version of wxPanel
 - DialogBlocks projects saved as XML can be imported
 - wxAuiToolBar can now be created as a form (it creates a class instead of a child widget)
 - Added support for additional integer and floating point validators for wxTextCtrl
 - Folders now have their own code language preference that can override the Project's code preference
 - Added support for wxPropertySheetDialog as a form
-- tooltips set in wxAuiNotebook pages are now displayed when hovering over the tab display rather than the page itself
+- Tooltips set in wxAuiNotebook pages are now displayed when hovering over the tab display rather than the page itself
 - You can now set selected and non-selected fonts for wxAuiNotebook tabs
+- Added `dialog_units` property to the Project properties list to change default units for new dimensions
 
 ### Changed
 
-- controls that have one or more default window styles set (e.g., wxPanel has wxTAB_TRAVERSAL set) can now have that style unchecked and that state will be stored with the project file.
+- Controls that have one or more default window styles set (e.g., wxPanel has wxTAB_TRAVERSAL set) can now have that style unchecked and that state will be stored with the project file.
 - Color properties dialog now supports _all_ CSS color names
 - Generated code for colors now uses a CSS HTML String (#RRGGBB) instead of numerical values for red, green and blue.
 - Generated code for wxRibbonToolBar images are now scaled on high DPI displays
@@ -32,7 +33,7 @@ All notable changes to this project will be documented in this file.
 
 - You can now change the Window styles in a wxRichTextCtrl without generating an invalid constructor.
 - Color properties are correctly saved in a project
-- widgets set to specific platforms will also place events in a conditional block
+- Widgets set to specific platforms will also place events in a conditional block
 - For C++, widgets set to specific platforms will have the header member declarations in a conditional block
 - C++ code generation for fonts with a negative point size fixed
 

--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Custom property grid class for wxPoint
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -9,8 +9,9 @@
 
 #include "pg_point.h"
 
-#include "node.h"   // Node -- Node class
-#include "utils.h"  // Utility functions that work with properties
+#include "node.h"             // Node -- Node class
+#include "project_handler.h"  // ProjectHandler class
+#include "utils.h"            // Utility functions that work with properties
 
 wxIMPLEMENT_ABSTRACT_CLASS(CustomPointProperty, wxPGProperty);
 
@@ -103,7 +104,7 @@ void CustomPointProperty::InitValues(tt_string_view value)
     {
         m_point.x = -1;
         m_point.y = -1;
-        m_dialog_units = true;
+        m_dialog_units = Project.as_bool(prop_dialog_units);
     }
     else
     {
@@ -117,7 +118,7 @@ void CustomPointProperty::InitValues(tt_string_view value)
         {
             m_point.x = -1;
             m_point.y = -1;
-            m_dialog_units = true;
+            m_dialog_units = Project.as_bool(prop_dialog_units);
             return;
         }
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -176,6 +176,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_derived_file, "derived_file" },
     { prop_derived_header, "derived_header" },
     { prop_derived_params, "derived_params" },
+    { prop_dialog_units, "dialog_units" },
     { prop_digits, "digits" },
     { prop_direction, "direction" },
     { prop_disable_rubo_cop, "disable_rubo_cop" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -194,6 +194,7 @@ namespace GenEnum
         prop_derived_file,
         prop_derived_header,
         prop_derived_params,
+        prop_dialog_units,
         prop_digits,
         prop_direction,
         prop_disable_rubo_cop,

--- a/src/xml/project_xml.xml
+++ b/src/xml/project_xml.xml
@@ -20,6 +20,8 @@ inline const char* project_xml = R"===(<?xml version="1.0"?>
 		</property>
 		<property name="art_directory" type="path"
 			help="The directory containing your images (png, ico, xpm, etc.).">./</property>
+		<property name="dialog_units" type="bool"
+			help="When checked, dimensions will default to using dialog units. You can turn on or off dialog units for each individual dimension -- this just sets the default for new dimensions.">1</property>
 		<property name="internationalize" type="bool"
 			help="Wrap strings in a _() macro.">0</property>
 		<property name="help_provider" type="option"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a project-wide `dialog_units` property (check box below the `art_directory` property). It defaults to checked to match existing behavior in the 1.1 release. Unchecking it will only affect new dimensions (size, position, etc.) and even then only affects the default. The user can still turn the units on or off for each dimension individually.

Closes #1295
