### PR TITLE
Add construction to custom controls, update project importers to support it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Tooltips set in wxAuiNotebook pages are now displayed when hovering over the tab display rather than the page itself
 - You can now set selected and non-selected fonts for wxAuiNotebook tabs
 - Added `dialog_units` property to the Project properties list to change default units for new dimensions
+- Custom controls now have a `construction` property allowing you to replace the normal wxUiEditor-generated construction of the control with your own code.
 
 ### Changed
 
@@ -28,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Limiting the platforms for a container (such as a wxPanel) will now also limit the platforms for any child widgets.
 - C++ src_preamble contents is now placed at the top of the file instead of after the includes.
 - Custom font point size can be set to -1 to indicate that a default point size should be used.
+- Importing wxFormBuilder and wxGlade projects now supports converting a construction property for a custom control.
 
 ### Fixed
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -151,6 +151,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_combined_xrc_file, "combined_xrc_file" },
     { prop_compiler_standard, "compiler_standard" },
     { prop_const_values, "generate_const_values" },
+    { prop_construction, "construction" },
     { prop_contents, "contents" },
     { prop_context_help, "context_help" },
     { prop_context_menu, "context_menu" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -169,6 +169,7 @@ namespace GenEnum
         prop_combined_xrc_file,
         prop_compiler_standard,
         prop_const_values,
+        prop_construction,
         prop_contents,
         prop_context_help,
         prop_context_menu,

--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -189,3 +189,22 @@ bool CustomControl::GetIncludes(Node* node, std::set<std::string>& set_src, std:
     }
     return true;
 }
+
+void CustomControl::AddPropsAndEvents(NodeDeclaration* declaration)
+{
+    DeclAddVarNameProps(declaration, "m_custom");
+    DeclAddProp(declaration, prop_header, type_code_edit,
+                "The header file that declares the class. If the first line does not start with #include then the entire "
+                "contents will be placed in quotes and prefixed with #include. Python and Ruby code should use "
+                "python_import_list and ruby_require_list instead of this property.");
+    DeclAddProp(declaration, prop_namespace, type_string,
+                "C++ namespace the class is declared in. This property is ignored in any langauage besides C++.");
+    DeclAddProp(declaration, prop_class_name, type_string, "The name of the custom class.", "CustomClass");
+    DeclAddProp(declaration, prop_parameters, type_string_code_single,
+                "The parameters to use when the class is constructed. The macros ${id}, ${pos}, ${size}, "
+                "${window_extra_style}, ${window_name}, and ${window_style} will be replaced with the matching property. In "
+                "Python, this will be replaced with self.",
+                "(this)");
+    DeclAddProp(declaration, prop_settings_code, type_code_edit,
+                "Additional code to include after the class is constructed.");
+}

--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -31,6 +31,15 @@ wxObject* CustomControl::CreateMockup(Node* /* node */, wxObject* parent)
 
 bool CustomControl::ConstructionCode(Code& code)
 {
+    if (code.hasValue(prop_construction))
+    {
+        tt_string construction = code.view(prop_construction);
+        construction.BothTrim();
+        construction.Replace("@@", "\n", tt::REPLACE::all);
+        code += construction;
+        return true;
+    }
+
     code.AddAuto().NodeName();
     code.Str(" = ").AddIfCpp("new ");
     if (code.hasValue(prop_namespace) && code.is_cpp())
@@ -200,11 +209,16 @@ void CustomControl::AddPropsAndEvents(NodeDeclaration* declaration)
     DeclAddProp(declaration, prop_namespace, type_string,
                 "C++ namespace the class is declared in. This property is ignored in any langauage besides C++.");
     DeclAddProp(declaration, prop_class_name, type_string, "The name of the custom class.", "CustomClass");
+
+    DeclAddProp(declaration, prop_construction, type_code_edit,
+                "Optional code to construct the control instead of having wxUiEditor construct it. After this code is "
+                "placed into the generated file, the var_name property will be used to access the control.");
     DeclAddProp(declaration, prop_parameters, type_string_code_single,
                 "The parameters to use when the class is constructed. The macros ${id}, ${pos}, ${size}, "
                 "${window_extra_style}, ${window_name}, and ${window_style} will be replaced with the matching property. In "
                 "Python, this will be replaced with self.",
                 "(this)");
+
     DeclAddProp(declaration, prop_settings_code, type_code_edit,
                 "Additional code to include after the class is constructed.");
 }

--- a/src/generate/gen_custom_ctrl.h
+++ b/src/generate/gen_custom_ctrl.h
@@ -21,4 +21,6 @@ public:
                      int /* language */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
+
+    void AddPropsAndEvents(NodeDeclaration* declaration) override;
 };

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -312,8 +312,15 @@ void BaseCodeGenerator::GeneratePythonClass(PANEL_PAGE panel_type)
         list.SetString(m_form_node->as_string(prop_python_import_list));
         for (auto& iter: list)
         {
-            iter.remove_extension();
-            m_source->writeLine(tt_string("import ") << iter);
+            if (!iter.starts_with("import "))
+            {
+                iter.remove_extension();
+                m_source->writeLine(tt_string("import ") << iter);
+            }
+            else
+            {
+                m_source->writeLine(iter);
+            }
         }
         if (list.size())
         {

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -157,11 +157,16 @@ void FormBuilder::createProjectNode(pugi::xml_node& xml_obj, Node* new_node)
                 else if (prop_name.as_string() == "code_generation")
                 {
                     if (tt::contains(xml_prop.text().as_string(), "Python"))
-                        m_language = GEN_LANG_PYTHON;
+                        m_language |= GEN_LANG_PYTHON;
                     else if (tt::contains(xml_prop.text().as_string(), "C++"))
-                        m_language = GEN_LANG_CPLUSPLUS;
+                        m_language |= GEN_LANG_CPLUSPLUS;
                     else if (tt::contains(xml_prop.text().as_string(), "XRC"))
-                        m_language = GEN_LANG_XRC;
+                        m_language |= GEN_LANG_XRC;
+                    else if (tt::contains(xml_prop.text().as_string(), "Lua"))
+                        m_language |= GEN_LANG_LUA;
+
+                    // wxFormBuilder also generates PHP code, but wxUiEditor currently doesn't support that since
+                    // wxPHP is not being actively maintained.
                 }
             }
         }

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -440,7 +440,7 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
                     copy.erase_from(';');
                 }
 
-                newobject->set_value(prop_parameters, copy);
+                newobject->set_value(prop_construction, copy);
                 continue;
             }
             else if (prop_name == "settings")

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -452,8 +452,30 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
                 tt_string header;
                 header.ExtractSubString(xml_prop.text().as_sview().view_stepover());
                 if (header.size())
+                if (m_language & GEN_LANG_PYTHON)
                 {
-                    newobject->set_value(prop_header, header);
+                    tt_string header(xml_prop.text().as_sview());
+                    if (parent)
+                    {
+                        auto form = parent->getForm();
+                        tt_string cur_value = form->as_string(prop_python_import_list);
+                        if (cur_value.size())
+                        {
+                            cur_value += ';';
+                        }
+                        cur_value += header;
+                        form->set_value(prop_python_import_list, cur_value);
+                    }
+                    continue;
+                }
+                else
+                {
+                    tt_string header;
+                    header.ExtractSubString(xml_prop.text().as_sview());
+                    if (header.size())
+                    {
+                        newobject->set_value(prop_header, header);
+                    }
                 }
                 continue;
             }

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -567,6 +567,30 @@ bool WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
         // This is an option for dialogs -- no idea what it is supposed to do...
         return true;
     }
+    else if (node_name == "custom_constructor" && node->isGen(gen_CustomControl))
+    {
+        // wxGlade specifes the construction code on the right side of the = sign, so we need to
+        // insert what should be on the left side.
+        tt_string construction;
+        if (m_language == GEN_LANG_PYTHON)
+        {
+            construction = "self." + node->as_string(prop_var_name) + " = ";
+            construction += xml_obj.text().as_string();
+        }
+        else if (m_language == GEN_LANG_CPLUSPLUS)
+        {
+            construction = node->as_string(prop_var_name) + " = ";
+            construction += xml_obj.text().as_string();
+        }
+        else
+        {
+            // Construction is not supported in any other language
+            return true;
+        }
+
+        node->set_value(prop_construction, construction);
+        return true;
+    }
     return false;
 }
 

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -44,6 +44,11 @@ bool WxGlade::Import(const tt_string& filename, bool write_doc)
             m_language = GEN_LANG_CPLUSPLUS;
         }
     }
+    else
+    {
+        // We don't support Perl or Lisp
+        m_language = GEN_LANG_CPLUSPLUS;
+    }
 
     // Using a try block means that if at any point it becomes obvious the project file is invalid and we cannot recover,
     // then we can throw an error and give a standard response about an invalid file.

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -65,8 +65,7 @@ NavigationPanel::NavigationPanel(wxWindow* parent) : wxPanel(parent)
 {
     SetWindowStyle(wxBORDER_RAISED);
 
-    m_tree_ctrl = new wxTreeCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-                                 wxTR_DEFAULT_STYLE | wxBORDER_SUNKEN);
+    m_tree_ctrl = new wxTreeCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE | wxBORDER_SUNKEN);
 
     int index = 0;
     wxSize gen_image_size = parent->FromDIP(wxSize(GenImageSize, GenImageSize));

--- a/src/pch.h
+++ b/src/pch.h
@@ -108,19 +108,22 @@ enum class MoveDirection
     Right
 };
 
-// This is used to determine the type of file that is being generated
+// This is used to determine the type of file that is being generated. It is created as bit
+// flags so that code like that in ImportFormbuilder can track multiple languages. However the
+// Code class only supports a single language, and passing in multiple languages will cause it
+// to fail to generate any language.
 enum
 {
-    GEN_LANG_NONE,
-    GEN_LANG_CPLUSPLUS,
-    GEN_LANG_PYTHON,
-    GEN_LANG_RUBY,
-    GEN_LANG_XRC,
+    GEN_LANG_NONE = 0,
+    GEN_LANG_CPLUSPLUS = 1,
+    GEN_LANG_PYTHON = 1 << 1,
+    GEN_LANG_RUBY = 1 << 2,
+    GEN_LANG_XRC = 1 << 3,
 
-    GEN_LANG_GOLANG,  // experimental
-    GEN_LANG_LUA,     // experimental
-    GEN_LANG_PERL,    // experimental
-    GEN_LANG_RUST,    // experimental
+    GEN_LANG_GOLANG = 1 << 4,  // experimental
+    GEN_LANG_LUA = 1 << 5,     // experimental
+    GEN_LANG_PERL = 1 << 6,    // experimental
+    GEN_LANG_RUST = 1 << 7,    // experimental
 };
 
 // Used to index fields in a bitmap property

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -793,18 +793,13 @@ bool ProjectHandler::Import(ImportXML& import, tt_string& file, bool append, boo
 
         if (auto language = import.GetLanguage(); language != GEN_LANG_NONE)
         {
-            switch (language)
-            {
-                case GEN_LANG_CPLUSPLUS:
-                    project_node->set_value(prop_code_preference, "C++");
-                    break;
-                case GEN_LANG_PYTHON:
-                    project_node->set_value(prop_code_preference, "Python");
-                    break;
-                case GEN_LANG_XRC:
-                    project_node->set_value(prop_code_preference, "XRC");
-                    break;
-            }
+            if (language & GEN_LANG_CPLUSPLUS)
+                project_node->set_value(prop_code_preference, "C++");
+            else if (language & GEN_LANG_PYTHON)
+                project_node->set_value(prop_code_preference, "Python");
+            else if (language & GEN_LANG_XRC)
+                project_node->set_value(prop_code_preference, "XRC");
+
             SetLangFilenames();
         }
 

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -74,17 +74,6 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		</inherits>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
-		<property name="var_name" type="string">m_custom</property>
-		<property name="header" type="code_edit"
-			help="The header file that declares the class. If the first line does not start with #include then the entire contents will be placed in quotes and prefixed with #include. Python and Ruby code should use python_import_list and ruby_require_list instead of this property." />
-		<property name="namespace" type="string"
-			help="The namespace the class is declared in." />
-		<property name="class_name" type="string"
-			help="The name of the custom class.">CustomClass</property>
-		<property name="parameters" type="string_code_single"
-			help="The parameters to use when the class is constructed. The macros ${id}, ${pos}, ${size}, ${window_extra_style}, ${window_name}, and ${window_style} will be replaced with the matching property. In Python, this will be replaced with self.">(this)</property>
-		<property name="settings_code" type="code_edit"
-			help="Additional code to include after the class is constructed." />
 	</gen>
 
 	<gen class="wxRearrangeCtrl" image="wxRearrangeCtrl" type="widget">

--- a/src/xml/widgets_xml.xml
+++ b/src/xml/widgets_xml.xml
@@ -75,8 +75,8 @@ inline const char* widgets_xml = R"===(<?xml version="1.0"?>
 		<inherits class="Window Events" />
 		<inherits class="sizer_child" />
 		<property name="var_name" type="string">m_custom</property>
-		<property name="header" type="file"
-			help="The header file that declares the class." />
+		<property name="header" type="code_edit"
+			help="The header file that declares the class. If the first line does not start with #include then the entire contents will be placed in quotes and prefixed with #include. Python and Ruby code should use python_import_list and ruby_require_list instead of this property." />
 		<property name="namespace" type="string"
 			help="The namespace the class is declared in." />
 		<property name="class_name" type="string"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates how Custom Controls are generated, combined with changes to wxFormBuilder and wxGlade importers to improve importing of custom controls.

# wxFormBuilder changes

- import will now use the same filename for the first form in the wxFB project file, and will properly set that for Python and XRC files.
- `include` property in CustomControl will now place the contents in python_import_list if the language is Python.

# wxGlade changes

- `custom_constructor` property in CustomControl will now add a variable assignment prefix followed by the constructor code. (i.e., it will add `var_name = ` before the constructor code)

# Custom Control changes

- New `construction` property allows the dev to create their own code to construct the custom control. If used, the `parameters` property will be ignored.
- header property is now a multi-line property. If it contains just a single filename, it will work as before (filename placed in quotes, prefixed with `#include`). If the line does _not_ start with `#` followed by `include` (spaces between `#` and `include` are allowed), then the line will be inserted unchanged.