### PR TITLE
Fix code that caused internal compiler error in MSVC

### DIFF
--- a/src/id_lists.h
+++ b/src/id_lists.h
@@ -7,13 +7,11 @@
 
 #pragma once
 
-// This file is designed to be #included into propgrid_panel.cpp, so it doesn't have the normal precompiled header.
-
 #include <array>
 
 // clang-format off
 
-auto inline list_wx_ids = std::to_array({
+constexpr auto list_wx_ids = std::to_array({
 
     "wxID_ABORT",
     "wxID_ABOUT",
@@ -148,7 +146,7 @@ auto inline list_wx_ids = std::to_array({
 
 });
 
-auto inline lst_stock_ids = std::to_array({
+constexpr auto lst_stock_ids = std::to_array({
     "wxID_ABOUT",
     "wxID_ADD",
     "wxID_APPLY",


### PR DESCRIPTION
This also places the "auto" keyword after the constexpr -- it's likely that the compiler error in #1312 was caused by the order, i.e. "auto inline" instead of "inline auto".

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes #1312 by replacing "auto inline" with "constexpr auto" to avoid an internal msvc compiler error with one of the earlier versions of MSVC 2019 (so far 12 versions have been released, so unknown which compiler versions fixed the bug). I verified that gcc 11.4 works with this change so this should not affect the daily builds or the compilers used to create the DEB/RPM packages.
