### PR TITLE
wxStaticBoxSizer changes

### DIFF
--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -37,10 +37,12 @@ wxObject* StaticBoxSizerGenerator::CreateMockup(Node* node, wxObject* parent)
 
 void StaticBoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
 {
-    if (node->as_bool(prop_hide_children))
+    if (!node->as_bool(prop_hidden) && node->as_bool(prop_hide_children) && !getMockup()->IsShowingHidden())
     {
         if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
+        {
             sizer->ShowItems(false);
+        }
     }
 }
 

--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -29,21 +29,12 @@ wxObject* StaticBoxSizerGenerator::CreateMockup(Node* node, wxObject* parent)
     if (min_size.x != -1 || min_size.y != -1)
         sizer->SetMinSize(min_size);
 
-    if (node->as_bool(prop_hidden) && !getMockup()->IsShowingHidden())
-        sizer->GetStaticBox()->Hide();
+    if (node->as_bool(prop_hidden))
+    {
+        sizer->GetStaticBox()->Show(getMockup()->IsShowingHidden());
+    }
 
     return sizer;
-}
-
-void StaticBoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
-{
-    if (!node->as_bool(prop_hidden) && node->as_bool(prop_hide_children) && !getMockup()->IsShowingHidden())
-    {
-        if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
-        {
-            sizer->ShowItems(false);
-        }
-    }
 }
 
 bool StaticBoxSizerGenerator::ConstructionCode(Code& code)

--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -90,16 +90,16 @@ bool StaticBoxSizerGenerator::SettingsCode(Code& code)
         code.NodeName().Function("GetStaticBox()->Enable(").False().EndFunction();
     }
 
+    if (code.IsTrue(prop_hidden))
+    {
+        code.NodeName().Function("GetStaticBox()").Function("Show(").False().EndFunction();
+    }
+
     return true;
 }
 
 bool StaticBoxSizerGenerator::AfterChildrenCode(Code& code)
 {
-    if (code.IsTrue(prop_hide_children))
-    {
-        code.NodeName().Function("ShowItems(").False().EndFunction();
-    }
-
     auto parent = code.node()->getParent();
     if (!parent->isSizer() && !parent->isGen(gen_wxDialog) && !parent->isGen(gen_PanelForm))
     {

--- a/src/generate/gen_staticbox_sizer.h
+++ b/src/generate/gen_staticbox_sizer.h
@@ -13,7 +13,6 @@ class StaticBoxSizerGenerator : public BaseGenerator
 {
 public:
     wxObject* CreateMockup(Node* node, wxObject* parent) override;
-    void AfterCreation(wxObject* /*wxobject*/, wxWindow* /*wxparent*/, Node* /* node */, bool /* is_preview */) override;
 
     bool ConstructionCode(Code&) override;
     bool SettingsCode(Code&) override;

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -304,6 +304,16 @@ NodeSharedPtr NodeCreator::createNodeFromXml(pugi::xml_node& xml_obj, Node* pare
                     }
                 };
 
+                // wxUiEditor 1.2.0 mistakenly added both prop_hidden and prop_hide_children.
+                // 1.2.1 removes the duplicate prop_hide_children, so this sets prop_hidden to
+                // true if prop_hide_children is true.
+                if (prop->get_name() == prop_hide_children && new_node->isGen(gen_wxStaticBoxSizer) && iter.as_bool())
+                {
+                    new_node->set_value(prop_hidden, true);
+                    prop->set_value(false);
+                    continue;
+                }
+
                 if (prop->type() == type_bool)
                 {
                     prop->set_value(iter.as_bool());

--- a/src/xml/sizers_xml.xml
+++ b/src/xml/sizers_xml.xml
@@ -68,7 +68,7 @@ inline const char* sizers_xml = R"===(<?xml version="1.0"?>
 			help="Hides the sizer and it's children.">0</property>
 		<event name="wxEVT_UPDATE_UI" class="wxUpdateUIEvent"
 			help="" />
-		<property name="hide_children" type="bool"
+		<property name="hide_children" type="bool" hide="1"
 			help="Hides all of the sizer's children.">0</property>
 	</gen>
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes wxStaticBoxSizer. It fixes three problems:

### hide_children

Adding this property was a mistake since the `hidden` property will do the same thing (hide the children). It isn't possible to hide just the children and not the entire static box since the children are added to a wxWindow, not the outer sizer.

To maintain compatibility, the `hide_children` property still exists but is now hidden. When a project is loaded, a check is made to see if the property was set to true, and if so, it will be set to false and the `hidden` property will be set to true.

### Mockup

The mockup was not always working correctly when the Show hidden controls toolbar button was pressed. Removing hide_children fixed most of the problems, the new commit simplifies the code and makes it reliable.

### Code generation

Previously, only code for the `hide_children` property was generated. Now code handling the `hidden` property is generated directly after the constructor code (if the property is set to true).
