### PR TITLE
Add another option for custom control placeholder in Mockup panel

### DIFF
--- a/src/customprops/edit_custom_mockup_base.h
+++ b/src/customprops/edit_custom_mockup_base.h
@@ -9,10 +9,15 @@
 
 #pragma once
 
+#include <wx/checkbox.h>
+#include <wx/choice.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
+#include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
+#include <wx/textctrl.h>
 
 class EditCustomMockupBase : public wxDialog
 {
@@ -44,6 +49,7 @@ protected:
 
     void OnInit(wxInitDialogEvent& event);
     void OnOK(wxCommandEvent& event);
+    void OnSelect(wxCommandEvent& event);
 
     // Validator variables
 
@@ -53,8 +59,13 @@ protected:
 
     // Class member variables
 
+    wxCheckBox* m_check_centered;
+    wxChoice* m_widget_types;
+    wxStaticBoxSizer* m_static_box;
     wxStaticText* m_static_text2;
+    wxStaticText* m_static_text3;
     wxStaticText* m_static_text;
+    wxTextCtrl* m_text_static;
 
     wxString m_result;
 };

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -33,18 +33,18 @@ set (file_list
 
     customprops/code_string_prop.cpp    # Derived wxStringProperty class for code
     customprops/custom_colour_prop.cpp  # Property editor for colour
-    customprops/edit_custom_mockup.cpp  # Custom Property editor for pop_custom_mockup
     customprops/custom_param_prop.cpp   # Derived wxStringProperty class for custom control parameters
     customprops/directory_prop.cpp      # Derived wxStringProperty class for choosing a directory
+    customprops/edit_custom_mockup.cpp  # Custom Property editor for pop_custom_mockup
     customprops/evt_string_prop.cpp     # Derived wxStringProperty class for event function
     customprops/font_string_prop.cpp    # Derived wxStringProperty class for font property
     customprops/html_string_prop.cpp    # Derived wxStringProperty class for HTML
-    customprops/include_files_prop.cpp  # Derived wxStringProperty class for Include Files
+    customprops/id_prop.cpp             # Uses IDEditorDlg to edit a custom ID
     customprops/img_string_prop.cpp     # Derived wxStringProperty class for handling wxImage files or art
+    customprops/include_files_prop.cpp  # Derived wxStringProperty class for Include Files
     customprops/rearrange_prop.cpp      # wxRearangeList contents editor
     customprops/sb_fields_prop.cpp      # Property editor for status bar fields
     customprops/txt_string_prop.cpp     # Derived wxStringProperty class for single-line text
-    customprops/id_prop.cpp             # Uses IDEditorDlg to edit a custom ID
 
     customprops/eventhandler_dlg.cpp    # Dialog for editing event handlers
     customprops/font_prop_dlg.cpp       # Dialog for editing Font Property

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -3201,14 +3201,42 @@
             var_name="static_text3" />
           <node
             class="wxChoice"
-            class_access="none"
-            contents="&quot;wxBitmap&quot;"
+            contents="&quot;wxBitmap&quot; &quot;wxStaticText&quot;"
             selection_string="wxBitmap"
-            var_name="widget_type"
+            var_name="m_widget_types"
             get_function="get_WidgetType"
             set_function="set_WidgetType"
             validator_variable="m_widget_type"
-            flags="wxEXPAND" />
+            flags="wxEXPAND"
+            wxEVT_CHOICE="OnSelect" />
+          <node
+            class="wxStaticBoxSizer"
+            class_access="protected:"
+            hidden="1"
+            label="wxStaticText options"
+            var_name="m_static_box"
+            flags="wxEXPAND">
+            <node
+              class="wxBoxSizer"
+              flags="wxEXPAND">
+              <node
+                class="wxStaticText"
+                label="Text:"
+                var_name="m_static_text3"
+                alignment="wxALIGN_CENTER_VERTICAL" />
+              <node
+                class="wxTextCtrl"
+                var_name="m_text_static" />
+            </node>
+            <node
+              class="wxBoxSizer"
+              var_name="box_sizer2">
+              <node
+                class="wxCheckBox"
+                label="Centered"
+                var_name="m_check_centered" />
+            </node>
+          </node>
           <node
             class="wxFlexGridSizer">
             <node


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds wxStaticText as a custom Mockup control. When chosen, a wxStaticText control with a simple border will be used to represent the custom control. The dialog to edit this will allow for entering optional text, and optionally centering the text.

See #1316

Attn: @rossanoparis