### PR TITLE
Darkmode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [unreleased (1.2.1)]
+
+### Added
+
+- Dark Mode and High Contrast Dark Mode are now available in the Prefences dialog on Windows.
+
+### Changed
+
+- The `hide_children` property in the wxStaticBoxSizer has been removed since the `hidden` property does exactly the same thing. Projects where `hide_children` was set will be automatically converted to use `hidden` instead.
+
+### Fixed
+
+- The Show Hidden on the toolbar now shows (in the Mockup panel) the children of sizers that have their children hidden.
+- Setting `hidden` in a wxStaticBoxSizer did not generate any code to hide the wxStaticBox and it's children (you had to check `hide_children` to get the code). This has been fixed.
+
 ## [Released (1.2.0)]
 
 ### Added

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -31,7 +31,9 @@ void BoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/
     if (node->as_bool(prop_hide_children))
     {
         if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
-            sizer->ShowItems(false);
+        {
+            sizer->ShowItems(getMockup()->IsShowingHidden());
+        }
     }
 }
 

--- a/src/generate/gen_flexgrid_sizer.cpp
+++ b/src/generate/gen_flexgrid_sizer.cpp
@@ -144,6 +144,15 @@ bool FlexGridSizerGenerator::ConstructionCode(Code& code)
     return true;
 }
 
+void FlexGridSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
+{
+    if (node->as_bool(prop_hide_children))
+    {
+        if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
+            sizer->ShowItems(getMockup()->IsShowingHidden());
+    }
+}
+
 bool FlexGridSizerGenerator::AfterChildrenCode(Code& code)
 {
     if (code.IsTrue(prop_hide_children))
@@ -177,15 +186,6 @@ bool FlexGridSizerGenerator::AfterChildrenCode(Code& code)
     }
 
     return true;
-}
-
-void FlexGridSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
-{
-    if (node->as_bool(prop_hide_children))
-    {
-        if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
-            sizer->ShowItems(false);
-    }
 }
 
 bool FlexGridSizerGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr,

--- a/src/generate/gen_grid_sizer.cpp
+++ b/src/generate/gen_grid_sizer.cpp
@@ -35,7 +35,7 @@ void GridSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*
     if (node->as_bool(prop_hide_children))
     {
         if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
-            sizer->ShowItems(false);
+            sizer->ShowItems(getMockup()->IsShowingHidden());
     }
 }
 

--- a/src/generate/gen_gridbag_sizer.cpp
+++ b/src/generate/gen_gridbag_sizer.cpp
@@ -40,7 +40,7 @@ void GridBagSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpare
     if (node->as_bool(prop_hide_children))
     {
         if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
-            sizer->ShowItems(false);
+            sizer->ShowItems(getMockup()->IsShowingHidden());
     }
 
     // For storing objects whose postion needs to be determined

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -69,7 +69,7 @@ void StaticCheckboxBoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow
     if (node->as_bool(prop_hidden))
     {
         if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
-            sizer->ShowItems(false);
+            sizer->ShowItems(getMockup()->IsShowingHidden());
     }
 }
 

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -63,7 +63,7 @@ void StaticRadioBtnBoxSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow
     if (node->as_bool(prop_hidden))
     {
         if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
-            sizer->ShowItems(false);
+            sizer->ShowItems(getMockup()->IsShowingHidden());
     }
 }
 

--- a/src/generate/gen_wrap_sizer.cpp
+++ b/src/generate/gen_wrap_sizer.cpp
@@ -32,7 +32,7 @@ void WrapSizerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*
     if (node->as_bool(prop_hide_children))
     {
         if (auto sizer = wxStaticCast(wxobject, wxSizer); sizer)
-            sizer->ShowItems(false);
+            sizer->ShowItems(getMockup()->IsShowingHidden());
     }
 }
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -69,7 +69,7 @@ wxIMPLEMENT_APP(App);
 
 tt_string tt_empty_cstr;
 
-#if wxCHECK_VERSION(3, 3, 0) && defined(_WIN32)
+#if defined(_WIN32)
     #include <wx/msw/darkmode.h>
 
 class DarkSettings : public wxDarkModeSettings

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -56,7 +56,6 @@ void Prefs::WriteConfig()
     config->Write("fullpath_title", m_fullpath_title);
 
     config->Write("enable_wakatime", m_enable_wakatime);
-    config->Write("dark_mode", m_dark_mode);
     config->Write("high_contrast", m_high_constrast);
     config->Write("load_last_project", m_is_load_last_project);
     config->Write("right_propgrid", m_is_right_propgrid);
@@ -71,6 +70,11 @@ void Prefs::WriteConfig()
     config->Write("cpp_line_length", m_cpp_line_length);
     config->Write("python_line_length", m_python_line_length);
     config->Write("ruby_line_length", m_ruby_line_length);
+
+    if (m_dark_mode_pending & PENDING_DARK_MODE_ENABLE)
+    {
+        config->Write("dark_mode", m_dark_mode_pending & PENDING_DARK_MODE_ON ? true : false);
+    }
 
     config->SetPath("/");
 }

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -43,7 +43,9 @@ public:
     bool is_WakaTimeEnabled() const { return m_enable_wakatime; }
 
     bool is_DarkMode() const { return m_dark_mode; }
+    bool is_DarkModePending() const { return m_dark_mode_pending; }
     void set_DarkMode(bool value) { m_dark_mode = value; }
+    void set_DarkModePending(size_t value) { m_dark_mode_pending = value; }
     bool is_HighContrast() const { return m_high_constrast; }
     void set_HighContrast(bool value) { m_high_constrast = value; }
 
@@ -128,6 +130,13 @@ public:
         PREFS_PJT_MEMBER_PREFIX = 1 << 1,
     };
 
+    enum : size_t
+    {
+        PENDING_DARK_MODE_ENABLE = 1,
+        PENDING_DARK_MODE_ON = 1 << 1,
+        PENDING_DARK_MODE_OFF = 1 << 2,
+    };
+
     // clang-format on
 
 private:
@@ -143,6 +152,8 @@ private:
     wxColour m_colour_cpp { wxColour("#FF00FF") };
     wxColour m_colour_python { wxColour("#FF00FF") };
     wxColour m_colour_ruby { wxColour("#FF00FF") };
+
+    size_t m_dark_mode_pending { 0 };  // 0 = no change, 1 = dark_mode_on, 2 = dark_mode_off
 
     int m_cpp_line_length { 110 };
     int m_python_line_length { 90 };

--- a/src/ui/preferences_dlg.cpp
+++ b/src/ui/preferences_dlg.cpp
@@ -31,7 +31,7 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     auto* page_general = new wxPanel(notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
     notebook->AddPage(page_general, "General", true);
 
-    auto* page_sizer_1 = new wxBoxSizer(wxVERTICAL);
+    m_general_page_sizer = new wxBoxSizer(wxVERTICAL);
 
     m_box_dark_settings = new wxBoxSizer(wxHORIZONTAL);
 
@@ -43,25 +43,25 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     m_check_high_contrast->SetToolTip("Only used if Dark Mode is selected");
     m_box_dark_settings->Add(m_check_high_contrast, wxSizerFlags().Border(wxALL));
     m_box_dark_settings->ShowItems(false);
-    page_sizer_1->Add(m_box_dark_settings,
+    m_general_page_sizer->Add(m_box_dark_settings,
     wxSizerFlags().Expand().Border(wxRIGHT|wxTOP|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
     m_check_right_propgrid = new wxCheckBox(page_general, wxID_ANY, "Property Panel on Right");
     m_check_right_propgrid->SetToolTip("If checked, the Property panel will be moved to the right side");
-    page_sizer_1->Add(m_check_right_propgrid, wxSizerFlags(1).Border(wxALL));
+    m_general_page_sizer->Add(m_check_right_propgrid, wxSizerFlags(1).Border(wxALL));
 
     m_check_load_last = new wxCheckBox(page_general, wxID_ANY, "Always load last project");
-    page_sizer_1->Add(m_check_load_last, wxSizerFlags(1).Border(wxALL));
+    m_general_page_sizer->Add(m_check_load_last, wxSizerFlags(1).Border(wxALL));
 
     m_check_fullpath = new wxCheckBox(page_general, wxID_ANY, "Full project path in title bar");
-    page_sizer_1->Add(m_check_fullpath, wxSizerFlags(1).Border(wxALL));
+    m_general_page_sizer->Add(m_check_fullpath, wxSizerFlags(1).Border(wxALL));
 
     auto* checkBox_wakatime = new wxCheckBox(page_general, wxID_ANY, "Enable WakaTime");
     checkBox_wakatime->SetValue(true);
     checkBox_wakatime->SetValidator(wxGenericValidator(&m_isWakaTimeEnabled));
     checkBox_wakatime->SetToolTip(
     "If you have WakaTime installed, checking this will record time spent in the editor as \"designing\". (See https://wakatime.com/about)");
-    page_sizer_1->Add(checkBox_wakatime, wxSizerFlags().Border(wxALL));
+    m_general_page_sizer->Add(checkBox_wakatime, wxSizerFlags().Border(wxALL));
 
     m_box_code_font = new wxBoxSizer(wxHORIZONTAL);
 
@@ -74,8 +74,8 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     m_code_font_picker->SetToolTip("This font will be used for all of the Code panels");
     m_box_code_font->Add(m_code_font_picker, wxSizerFlags(1).Expand().Border(wxALL));
 
-    page_sizer_1->Add(m_box_code_font, wxSizerFlags().Expand().Border(wxALL));
-    page_general->SetSizerAndFit(page_sizer_1);
+    m_general_page_sizer->Add(m_box_code_font, wxSizerFlags().Expand().Border(wxALL));
+    page_general->SetSizerAndFit(m_general_page_sizer);
 
     auto* page_cpp = new wxPanel(notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
     notebook->AddPage(page_cpp, "C++");
@@ -234,8 +234,9 @@ void PreferencesDlg::OnInit(wxInitDialogEvent& event)
     m_box_code_font->ShowItems(false);
     // m_code_font_picker = UserPrefs.get_CodeDisplayFont();
 
-#if !wxCHECK_VERSION(3, 3, 0) || !defined(_WIN32)
-    m_box_dark_settings->ShowItems(false);
+#if defined(__WXMSW__)
+    m_box_dark_settings->ShowItems(true);
+    m_general_page_sizer->Layout();
     Fit();
 #endif
 
@@ -274,7 +275,9 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
     if (m_check_fullpath->GetValue() != UserPrefs.is_FullPathTitle())
         is_fullpath_changed = true;
 
-    UserPrefs.set_DarkMode(m_check_dark_mode->GetValue());
+    UserPrefs.set_DarkModePending(
+        Prefs::PENDING_DARK_MODE_ENABLE |
+        (m_check_dark_mode->GetValue() ? Prefs::PENDING_DARK_MODE_ON : Prefs::PENDING_DARK_MODE_OFF));
     UserPrefs.set_HighContrast(m_check_high_contrast->GetValue());
     UserPrefs.set_FullPathTitle(m_check_fullpath->GetValue());
 

--- a/src/ui/preferences_dlg.h
+++ b/src/ui/preferences_dlg.h
@@ -52,6 +52,7 @@ protected:
 
     wxBoxSizer* m_box_code_font;
     wxBoxSizer* m_box_dark_settings;
+    wxBoxSizer* m_general_page_sizer;
     wxCheckBox* m_check_cpp_snake_case;
     wxCheckBox* m_check_dark_mode;
     wxCheckBox* m_check_fullpath;

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -6456,8 +6456,9 @@
             window_style="wxTAB_TRAVERSAL">
             <node
               class="wxBoxSizer"
+              class_access="protected:"
               orientation="wxVERTICAL"
-              var_name="page_sizer_1">
+              var_name="m_general_page_sizer">
               <node
                 class="wxBoxSizer"
                 class_access="protected:"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR sets a delay flag when dark mode is changed, and the actual value is not changed until the app is closed and `Prefs::WriteConfig()` is called. This avoids the crash called by turning off dark mode while dark colors are still in use.

The second part of this PR enables the Dark Mode setting on Windows in the Preferences dialog.

Closes #1273
