### PR TITLE
Optimize use of Images List header file

### DIFF
--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -214,6 +214,7 @@ private:
 
     Node* m_form_node { nullptr };
     Node* m_ImagesForm { nullptr };
+    tt_string m_include_images_statement;
 
     PANEL_PAGE m_panel_type { NOT_PANEL };
 

--- a/src/panels/nav_toolbar.cpp
+++ b/src/panels/nav_toolbar.cpp
@@ -12,14 +12,12 @@
 #include <wx/icon.h>
 #include <wx/image.h>
 
+#include "../wxui/ui_images.h"
+
 #include "nav_toolbar.h"
 
 #include "mainframe.h"
 #include "project_handler.h"
-
-// Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size);
 
 NavToolbar::NavToolbar(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style,
     const wxString& name) : wxToolBar(parent, id, pos, size, style, name)

--- a/src/ui/startup_dlg.cpp
+++ b/src/ui/startup_dlg.cpp
@@ -8,9 +8,11 @@
 // clang-format off
 
 #include <wx/artprov.h>
+#include <wx/bitmap.h>
 #include <wx/bmpbndl.h>
 #include <wx/button.h>
 #include <wx/icon.h>
+#include <wx/image.h>
 #include <wx/statbmp.h>
 #include <wx/statline.h>
 

--- a/src/ui/startup_dlg.h
+++ b/src/ui/startup_dlg.h
@@ -9,15 +9,12 @@
 
 #pragma once
 
-#include <wx/bitmap.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/font.h>
 #include <wx/gdicmn.h>
 #include <wx/hyperlink.h>
 #include <wx/generic/hyperlink.h>
-#include <wx/icon.h>
-#include <wx/image.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
@@ -59,8 +56,8 @@ private:
 // Code below this comment block will be preserved
 // if the code for this class is re-generated.
 //
-    // clang-format on
-    // ***********************************************
+// clang-format on
+// ***********************************************
 
 public:
     enum : size_t

--- a/src/wxui/import_base.cpp
+++ b/src/wxui/import_base.cpp
@@ -9,11 +9,9 @@
 
 #include <wx/icon.h>
 
-#include "import_base.h"
+#include "ui_images.h"
 
-// Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size);
+#include "import_base.h"
 
 namespace wxue_img
 {

--- a/src/wxui/import_base.h
+++ b/src/wxui/import_base.h
@@ -9,15 +9,12 @@
 
 #pragma once
 
-#include <wx/bitmap.h>
 #include <wx/button.h>
 #include <wx/checklst.h>
 #include <wx/combobox.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
-#include <wx/icon.h>
-#include <wx/image.h>
 #include <wx/radiobut.h>
 #include <wx/sizer.h>
 #include <wx/statbox.h>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR optimizes C++ code generation when an Images List file is part of the project. Previously, this would access the file system to get the relative path to the header file for every property in every node that had a `type_image`. This PR now gets the relative path once per form.

When an Images List file is used, then all of the `wxue` image loading functions are placed in that file, and as long as the header file is included in the form's generated source file then it isn't necessary to add either the `wxue` definition or declaration. The PR now removes all definitions/declarations of the `wxue` functions if an Image List header file is generated in the #include section of the source file.
