### PR TITLE
Change when to generate wxue function declaration/definition

### DIFF
--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -611,7 +611,7 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
 
         if (m_NeedImageFunction || m_NeedHeaderFunction)
         {
-            if (Project.getForm_Image() == m_form_node && !has_images_list_header)
+            if (!has_images_list_header)
             {
                 tt_string_vector function;
                 function.ReadString(Project.getForm_Image() == m_form_node ? txt_wxueImageFunction :
@@ -637,7 +637,7 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
                 m_source->writeLine("#endif", indent::none);
             }
 
-            if (Project.getForm_BundleSVG() == m_form_node && !has_images_list_header)
+            if (!has_images_list_header)
             {
                 tt_string_vector function;
                 function.ReadString(Project.getForm_BundleSVG() == m_form_node ? txt_GetBundleFromSVG :
@@ -652,7 +652,7 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
 
         if (m_NeedAnimationFunction)
         {
-            if (Project.getForm_Animation() == m_form_node && !has_images_list_header)
+            if (!has_images_list_header)
             {
                 tt_string_vector function;
                 function.ReadString(Project.getForm_Animation() == m_form_node ? txt_GetAnimFromHdrFunction :

--- a/src/ui/startup_dlg.h
+++ b/src/ui/startup_dlg.h
@@ -56,8 +56,8 @@ private:
 // Code below this comment block will be preserved
 // if the code for this class is re-generated.
 //
-// clang-format on
-// ***********************************************
+    // clang-format on
+    // ***********************************************
 
 public:
     enum : size_t


### PR DESCRIPTION
If there is an Image List file, then all wxue functions are in that file, and declared in the header file that is #included in the source file.

If there is no Image List file, then either a declaration or definition must be generated.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a regression caused by #1323. While that PR improved code generation if there is an Image List file, it broke code generation if there is no Image List file. This PR fixes that regression.

Create a copy of sdi called sdi_31 which does _not_ have an Image List file and is set to generate 3.1 compatible code. This would provide testing for the more common scenario of no Image List file, while at the same time verifying that code generation for wxWidgets 3.1 is working correctly.

KeyWorksRW/wxUiTesting#19 was created in part to track any potential problems between projects with and without Image List files.