### PR TITLE
Improve handling of wxWidgets Project version

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -2075,7 +2075,7 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
 
         if (point_size != static_cast<int>(point_size))  // is there a fractional value?
         {
-            if (is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (is_cpp() && Project.is_wxWidgets31())
             {
                 Eol().Str("#if !wxCHECK_VERSION(3, 1, 2)").Eol().Tab();
 
@@ -2092,7 +2092,7 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
             }
             else
             {
-                if (is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+                if (is_cpp() && Project.is_wxWidgets31())
                 {
                     Eol().Str("#else // fractional point sizes are new to wxWidgets 3.1.2").Eol().Tab();
                 }
@@ -2106,7 +2106,7 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
 
                 // REVIEW: [Randalphwa - 12-30-2022] We don't output anything if std::to_chars() results in an error
 
-                if (is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+                if (is_cpp() && Project.is_wxWidgets31())
                 {
                     Eol().Str("#endif");
                 }

--- a/src/generate/gen_book_utils.cpp
+++ b/src/generate/gen_book_utils.cpp
@@ -114,7 +114,7 @@ void BookCtorAddImagelist(Code& code)
     if ((code.IsTrue(prop_display_images) || code.IsGen(gen_wxToolbook)) && isBookHasImage(code.node()))
     {
         code.OpenBrace();
-        if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+        if (code.is_cpp() && Project.is_wxWidgets31())
         {
             if (code.back() == '\t')
             {
@@ -183,7 +183,7 @@ void BookCtorAddImagelist(Code& code)
 
         code.Eol().NodeName().Function("SetImages(bundle_list").EndFunction();
 
-        if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+        if (code.is_cpp() && Project.is_wxWidgets31())
         {
             // Don't use Eol() here, because we want to insert the #if at the beginning of the line
             code << "\n\n#else  // older version of wxWidgets that don't support bitmap bundles\n";

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -297,7 +297,7 @@ bool GenBtnBimapCode(Node* node, tt_string& code, bool is_single)
     if (code.size())
         code << '\n';
 
-    bool is_old_widgets = (Project.as_string(prop_wxWidgets_version) == "3.1");
+    bool is_old_widgets = (Project.is_wxWidgets31());
     if (is_old_widgets)
     {
         if (code.size() && !(code.back() == '\n'))
@@ -722,7 +722,7 @@ bool GenerateVectorCode(const tt_string& description, tt_string& code)
     // If we get here, then we need to first put the bitmaps into a wxVector in order for wxBitmapBundle to load them.
 
     code << "{\n";
-    if (Project.as_string(prop_wxWidgets_version) == "3.1")
+    if (Project.is_wxWidgets31())
     {
         code << "#if wxCHECK_VERSION(3, 1, 6)\n";
     }
@@ -752,7 +752,7 @@ bool GenerateVectorCode(const tt_string& description, tt_string& code)
             code << "\tbitmaps.push_back(wxueImage(" << name << ", sizeof(" << name << ")));\n";
         }
     }
-    if (Project.as_string(prop_wxWidgets_version) == "3.1")
+    if (Project.is_wxWidgets31())
     {
         code << "#endif\n";
     }
@@ -1049,7 +1049,7 @@ tt_string GenerateIconCode(const tt_string& description)
         return code;
     }
 
-    if (Project.as_string(prop_wxWidgets_version) == "3.1" && !parts[IndexType].is_sameas("SVG"))
+    if (Project.is_wxWidgets31() && !parts[IndexType].is_sameas("SVG"))
     {
         code << "#if wxCHECK_VERSION(3, 1, 6)\n";
     }
@@ -1139,7 +1139,7 @@ tt_string GenerateIconCode(const tt_string& description)
         }
     }
 
-    if (Project.as_string(prop_wxWidgets_version) == "3.1")
+    if (Project.is_wxWidgets31())
     {
         code << "#else\n";
         auto image_code = GenerateBitmapCode(description);
@@ -1227,14 +1227,14 @@ void GenToolCode(Code& code)
         }
         else
         {
-            if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (code.is_cpp() && Project.is_wxWidgets31())
             {
                 code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t";
             }
 
             GenerateBundleParameter(code, parts);
 
-            if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (code.is_cpp() && Project.is_wxWidgets31())
             {
                 code.Eol() += "#else\n\t";
                 code << "wxBitmap(" << GenerateBitmapCode(node->as_string(prop_bitmap)) << ")";
@@ -1343,7 +1343,7 @@ bool BitmapList(Code& code, const GenEnum::PropName prop)
     }
 
     //////////////// C++ code starts here ////////////////
-    if (Project.as_string(prop_wxWidgets_version) == "3.1")
+    if (Project.is_wxWidgets31())
     {
         code.Add("#if wxCHECK_VERSION(3, 1, 6)");
     }

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -357,7 +357,7 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
     // wxBitmap if older. We need to conditionalize the header output by removing the "#include <wx/bmpbndl.h>" entry and
     // creating our own conditionalized header.
 
-    if (Project.as_string(prop_wxWidgets_version) == "3.1")
+    if (Project.is_wxWidgets31())
     {
         if (auto bmpbndl_hdr = src_includes.find("#include <wx/bmpbndl.h>"); bmpbndl_hdr != src_includes.end())
         {
@@ -626,7 +626,7 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
 
         if (m_NeedSVGFunction)
         {
-            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (Project.is_wxWidgets31())
             {
                 m_source->writeLine();
                 m_source->writeLine("#if !wxCHECK_VERSION(3, 1, 6)", indent::none);
@@ -763,7 +763,7 @@ void BaseCodeGenerator::GenerateCppClassHeader()
 
         if (m_NeedSVGFunction && Project.getForm_BundleSVG() != m_form_node)
         {
-            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (Project.is_wxWidgets31())
             {
                 m_header->writeLine();
                 m_header->writeLine("#if !wxCHECK_VERSION(3, 1, 6)", indent::none);

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -518,7 +518,7 @@ void BaseCodeGenerator::GenHdrEvents()
             }
             if ((event->get_name() == "wxEVT_WEBVIEW_FULL_SCREEN_CHANGED" ||
                  event->get_name() == "wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED") &&
-                Project.as_string(prop_wxWidgets_version) == "3.1")
+                Project.is_wxWidgets31())
             {
                 code << "\n#if wxCHECK_VERSION(3, 1, 5)\n";
                 if (m_form_node->as_bool(prop_use_derived_class))

--- a/src/generate/gen_grid.cpp
+++ b/src/generate/gen_grid.cpp
@@ -182,7 +182,7 @@ bool GridGenerator::SettingsCode(Code& code)
     {
         if (code.isPropValue(prop_cell_fit, "clip"))
         {
-            if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (code.is_cpp() && Project.is_wxWidgets31())
             {
                 code.Eol().Str("#if wxCHECK_VERSION(3, 1, 4)");
                 code.Eol().Tab().NodeName().Function("SetDefaultCellFitMode(");
@@ -197,7 +197,7 @@ bool GridGenerator::SettingsCode(Code& code)
         }
         else if (code.isPropValue(prop_cell_fit, "ellipsize"))
         {
-            if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (code.is_cpp() && Project.is_wxWidgets31())
             {
                 code.Eol().Str("#if wxCHECK_VERSION(3, 1, 4)");
                 code.Eol().Tab().NodeName().Function("SetDefaultCellFitMode(");
@@ -214,11 +214,11 @@ bool GridGenerator::SettingsCode(Code& code)
 
     if (code.IntValue(prop_selection_mode) != 0)
     {
-        if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+        if (code.is_cpp() && Project.is_wxWidgets31())
         {
             if (code.isPropValue(prop_selection_mode, "wxGridSelectNone"))
             {
-                if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+                if (code.is_cpp() && Project.is_wxWidgets31())
                 {
                     code.Eol().Str("#if wxCHECK_VERSION(3, 1, 5)");
                     code.Eol().Tab().NodeName().Function("SetSelectionMode(");

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -169,7 +169,7 @@ void BaseCodeGenerator::GenerateImagesForm()
         }
     }
 
-    bool is_old_widgets = (Project.as_string(prop_wxWidgets_version) == "3.1");
+    bool is_old_widgets = (Project.is_wxWidgets31());
 
     if (m_panel_type != HDR_PANEL)
     {

--- a/src/generate/gen_menuitem.cpp
+++ b/src/generate/gen_menuitem.cpp
@@ -113,7 +113,7 @@ bool MenuItemGenerator::SettingsCode(Code& code)
             // auto_indent = indent::auto_keep_whitespace;
             code.OpenBrace().Add("wxAcceleratorEntry entry;").Eol();
 
-            bool is_old_widgets = (Project.as_string(prop_wxWidgets_version) == "3.1");
+            bool is_old_widgets = (Project.is_wxWidgets31());
             if (is_old_widgets)
             {
                 code += "#if wxCHECK_VERSION(3, 1, 6)\n";
@@ -167,7 +167,7 @@ bool MenuItemGenerator::SettingsCode(Code& code)
             if (!is_vector_code)
             {
                 code.NodeName().Function("SetBitmap(");
-                if (Project.as_string(prop_wxWidgets_version) != "3.1")
+                if (!Project.is_wxWidgets31())
                 {
                     GenerateBundleCode(description, code.GetCode());
                     code.EndFunction();
@@ -186,7 +186,7 @@ bool MenuItemGenerator::SettingsCode(Code& code)
             else
             {
                 code.Tab().NodeName().Function("SetBitmap(");
-                if (Project.as_string(prop_wxWidgets_version) != "3.1")
+                if (!Project.is_wxWidgets31())
                 {
                     code += "wxBitmapBundle::FromBitmaps(bitmaps)";
                     code.UpdateBreakAt();
@@ -241,7 +241,7 @@ bool MenuItemGenerator::SettingsCode(Code& code)
             if (!is_vector_code)
             {
                 code.NodeName().Function("SetBitmap(");
-                if (Project.as_string(prop_wxWidgets_version) != "3.1")
+                if (!Project.is_wxWidgets31())
                 {
                     GenerateBundleCode(description, code.GetCode());
                     code.UpdateBreakAt();
@@ -261,7 +261,7 @@ bool MenuItemGenerator::SettingsCode(Code& code)
             else
             {
                 code.Tab().NodeName().Function("SetBitmap(");
-                if (Project.as_string(prop_wxWidgets_version) != "3.1")
+                if (!Project.is_wxWidgets31())
                 {
                     code += "wxBitmapBundle::FromBitmaps(bitmaps)";
                     code.UpdateBreakAt();

--- a/src/generate/gen_prop_grid_mgr.cpp
+++ b/src/generate/gen_prop_grid_mgr.cpp
@@ -138,7 +138,7 @@ bool PropertyGridPageGenerator::ConstructionCode(Code& code)
         code.Comma();
         if (is_bitmaps_list)
         {
-            if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (code.is_cpp() && Project.is_wxWidgets31())
             {
                 code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t";
             }
@@ -146,7 +146,7 @@ bool PropertyGridPageGenerator::ConstructionCode(Code& code)
                 code += "wxBitmapBundle::FromBitmaps(bitmaps)";
             else
                 code += "wx.BitmapBundle.FromBitmaps(bitmaps)";
-            if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (code.is_cpp() && Project.is_wxWidgets31())
             {
                 code.Eol().Str("#else").Eol();
                 tt_string bundle_code;

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -144,7 +144,7 @@ bool StaticCheckboxBoxSizerGenerator::ConstructionCode(Code& code)
             parent_name += "()";
         code.NodeName() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY";
         code.Comma();
-        if (Project.as_string(prop_wxWidgets_version) == "3.1")
+        if (Project.is_wxWidgets31())
         {
             code.Eol().Str("#if wxCHECK_VERSION(3, 1, 1)").Eol().Tab();
             code.as_string(prop_checkbox_var_name) << "),";

--- a/src/generate/gen_static_bmp.cpp
+++ b/src/generate/gen_static_bmp.cpp
@@ -120,14 +120,14 @@ void StaticBitmapGenerator::GenCppConstruction(Code& gen_code)
         if (!is_vector_code)
         {
             tt_string bundle_code;
-            if (Project.as_string(prop_wxWidgets_version) != "3.1")
+            if (!Project.is_wxWidgets31())
             {
                 GenerateBundleCode(description, bundle_code);
                 code << bundle_code;
             }
             else
             {
-                if (Project.as_string(prop_wxWidgets_version) == "3.1")
+                if (Project.is_wxWidgets31())
                 {
                     code.insert(0, "\t");
                     code += "\n#if wxCHECK_VERSION(3, 1, 6)\n\t\t";
@@ -154,7 +154,7 @@ void StaticBitmapGenerator::GenCppConstruction(Code& gen_code)
         }
         else
         {
-            if (Project.as_string(prop_wxWidgets_version) != "3.1")
+            if (!Project.is_wxWidgets31())
             {
                 code += "wxBitmapBundle::FromBitmaps(bitmaps)";
             }

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -136,7 +136,7 @@ bool StaticRadioBtnBoxSizerGenerator::ConstructionCode(Code& code)
             parent_name += "()";
         code.AddAuto().NodeName() << " = new wxStaticBoxSizer(new wxStaticBox(" << parent_name << ", wxID_ANY";
         code.Comma();
-        if (Project.as_string(prop_wxWidgets_version) == "3.1")
+        if (Project.is_wxWidgets31())
         {
             code.Eol().Str("#if wxCHECK_VERSION(3, 1, 1)").Eol().Tab();
             code.as_string(prop_radiobtn_var_name) << "),";

--- a/src/generate/gen_submenu.cpp
+++ b/src/generate/gen_submenu.cpp
@@ -56,7 +56,7 @@ bool SubMenuGenerator::AfterChildrenCode(Code& code)
             if (!is_vector_code)
             {
                 code.Str(submenu_item_name).Function("SetBitmap(");
-                if (Project.as_string(prop_wxWidgets_version) != "3.1")
+                if (!Project.is_wxWidgets31())
                 {
                     GenerateBundleCode(description, code.GetCode());
                     code.EndFunction();
@@ -75,7 +75,7 @@ bool SubMenuGenerator::AfterChildrenCode(Code& code)
             else
             {
                 code.Tab().Str(submenu_item_name).Function("SetBitmap(");
-                if (Project.as_string(prop_wxWidgets_version) != "3.1")
+                if (!Project.is_wxWidgets31())
                 {
                     code += "wxBitmapBundle::FromBitmaps(bitmaps)";
                     code.UpdateBreakAt();

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -178,7 +178,7 @@ bool TextCtrlGenerator::SettingsCode(Code& code)
     {
         if (code.is_cpp())
         {
-            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (Project.is_wxWidgets31())
             {
                 code.Eol(eol_if_needed) << "#if wxCHECK_VERSION(3, 1, 6)";
                 code.Eol().Tab().NodeName() << "->EnableProofCheck(wxTextProofOptions::Default()";

--- a/src/generate/gen_web_view.cpp
+++ b/src/generate/gen_web_view.cpp
@@ -77,7 +77,7 @@ void WebViewGenerator::GenEvent(Code& code, NodeEvent* event, const std::string&
     }
     if ((event->get_name() == "wxEVT_WEBVIEW_FULL_SCREEN_CHANGED" ||
          event->get_name() == "wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED") &&
-        Project.as_string(prop_wxWidgets_version) == "3.1")
+        Project.is_wxWidgets31())
     {
         code.Add("\n#if wxCHECK_VERSION(3, 1, 5)\n");
         BaseGenerator::GenEvent(code, event, class_name);

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -149,7 +149,7 @@ bool WizardFormGenerator::SettingsCode(Code& code)
         {
             code.Eol(eol_if_needed).Str("if not self.Create(parent, id, title").Comma();
         }
-        if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+        if (code.is_cpp() && Project.is_wxWidgets31())
         {
             code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t\t";
         }
@@ -177,7 +177,7 @@ bool WizardFormGenerator::SettingsCode(Code& code)
         if (code.is_cpp())
         {
             code.Comma().Str("pos").Comma().Str("style))");
-            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            if (Project.is_wxWidgets31())
             {
                 code.Eol() += "#else\n\t\t";
                 code << "wxBitmap(" << GenerateBitmapCode(code.node()->as_string(prop_bitmap)) << ")";
@@ -498,14 +498,14 @@ bool WizardPageGenerator::ConstructionCode(Code& code)
         {
             if (code.is_cpp())
             {
-                if (Project.as_string(prop_wxWidgets_version) == "3.1")
+                if (Project.is_wxWidgets31())
                 {
                     code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t";
                 }
 
                 code += "wxBitmapBundle::FromBitmaps(bitmaps)";
 
-                if (Project.as_string(prop_wxWidgets_version) == "3.1")
+                if (Project.is_wxWidgets31())
                 {
                     code += "\n#else\n\t";
                     code += GenerateBitmapCode(code.node()->as_string(prop_bitmap));
@@ -519,7 +519,7 @@ bool WizardPageGenerator::ConstructionCode(Code& code)
         {
             if (code.is_cpp())
             {
-                if (Project.as_string(prop_wxWidgets_version) == "3.1")
+                if (Project.is_wxWidgets31())
                 {
                     code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t";
                     tt_string bundle_code;

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -530,7 +530,7 @@ void AddPythonImageName(Code& code, const EmbeddedImage* embed)
 
 static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool get_bitmap)
 {
-    if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+    if (code.is_cpp() && Project.is_wxWidgets31())
     {
         code.Eol().Tab().Str("wxNullBitmap /* SVG images require wxWidgets 3.2 or higher */").Eol().Tab();
         return;
@@ -641,7 +641,7 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
 static void GenerateARTBundle(Code& code, const tt_string_vector& parts, bool get_bitmap)
 {
     code.Add("wxArtProvider");
-    if (get_bitmap || (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1"))
+    if (get_bitmap || (code.is_cpp() && Project.is_wxWidgets31()))
     {
         code.ClassMethod("GetBitmap(");
     }
@@ -929,7 +929,7 @@ void GenerateBundleParameter(Code& code, const tt_string_vector& parts, bool get
 
     if (parts[IndexType].starts_with("SVG"))
     {
-        if (code.is_cpp() && Project.as_string(prop_wxWidgets_version) == "3.1")
+        if (code.is_cpp() && Project.is_wxWidgets31())
         {
             code += "wxNullBitmap";
         }

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -840,6 +840,11 @@ void MainFrame::ProjectLoaded()
              });
     }
 
+    if (!Project.hasValue(prop_wxWidgets_version))
+    {
+        Project.set_value(prop_wxWidgets_version, UserPrefs.get_CppWidgetsVersion());
+    }
+
     m_selected_node = Project.getProjectNode()->getSharedPtr();
 }
 

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -146,7 +146,7 @@ bool ProjectHandler::LoadProject(const tt_string& file, bool allow_ui)
     // This should NOT be necessary if all alignment in the project file has been set
     // correctly. However, it it has not been set correctly, this will correct it and issue a
     // MSG_WARNING about what got fixed.
-    FinalImportCheck(project.get());
+    RecursiveNodeCheck(project.get());
 #endif
     // Calling this will also initialize the ImageHandler class
     Project.Initialize(project);
@@ -1493,7 +1493,10 @@ void ProjectHandler::FinalImportCheck(Node* parent, bool set_line_length)
         parent->set_value(prop_cpp_line_length, UserPrefs.get_CppLineLength());
         parent->set_value(prop_python_line_length, UserPrefs.get_PythonLineLength());
         parent->set_value(prop_ruby_line_length, UserPrefs.get_RubyLineLength());
-        parent->set_value(prop_wxWidgets_version, UserPrefs.get_CppWidgetsVersion());
+        if (!parent->hasValue(prop_wxWidgets_version))
+        {
+            parent->set_value(prop_wxWidgets_version, "3.1");
+        }
     }
 
     RecursiveNodeCheck(parent);

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -108,6 +108,8 @@ public:
 
     bool isUiAllowed() const { return m_allow_ui; }
 
+    bool is_wxWidgets31() const { return m_project_node->as_string(prop_wxWidgets_version) == "3.1"; }
+
     size_t getChildCount() const { return m_project_node->getChildCount(); }
 
     // Returns a GEN_LANG_... enum value. Specify a node if you want to check for a folder
@@ -174,6 +176,22 @@ public:
     // This will assume any ImagesList class will be the first child of the project, and will
     // either return that Node* or nullptr if no ImagesList class is found.
     Node* getImagesForm();
+
+    // Sets project property value only if the property exists, returns false if it doesn't
+    // exist.
+    template <typename T>
+    bool set_value(PropName name, T value)
+    {
+        if (auto prop = m_project_node->getPropPtr(name); prop)
+        {
+            prop->set_value(value);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
 
 private:
     NodeSharedPtr m_project_node { nullptr };

--- a/src/ui/preferences_dlg.cpp
+++ b/src/ui/preferences_dlg.cpp
@@ -294,7 +294,6 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
     UserPrefs.set_CppWidgetsVersion(m_choice_cpp_version->GetStringSelection().ToStdString());
     if (is_cpp_preferences_changed)
     {
-        // Project.getProjectNode()->set_value(prop_wxWidgets_version, UserPrefs.get_CppWidgetsVersion());
         Project.getProjectNode()->modifyProperty(prop_wxWidgets_version, UserPrefs.get_CppWidgetsVersion());
     }
 

--- a/src/xml/project_interfaces_xml.xml
+++ b/src/xml/project_interfaces_xml.xml
@@ -6,7 +6,6 @@ inline const char* project_interfaces_xml = R"===(<?xml version="1.0"?>
 			help="If you specify a control or property that requires a wxWidgets version later than this number, then the code will be generated within a conditional block.">
 			<option name="3.1" />
 			<option name="3.2" />
-			3.1
 		</property>
 		<property name="base_directory" type="path"
 			help="The generated base class output directory. If a form's base_file contains only a filename (without a path), the files will be generated in this directory. Leave blank to generate the in the same directory as the project file." />


### PR DESCRIPTION
This removes the 3.1 default setting making it possible to set the value without having Preferences override it.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how the wxWidgets version is set. It removes the default "3.1" setting so that it can be overridden with a specific setting. If it's not set, and the UI is loaded, it will default to the User's preference (defaults to 3.2). The exception to this is Imported projects -- since all other designers (as of 12/2023) are generating 3.1 code, the default is set to 3.1 for imported projects.

Note that this has no effect on wxPython or wxRuby code generation, since they are both built on top of wxWidgets 3.2.

This second part of the PR adds a Project.is_wxWidgets31() which can replace `Project.as_string(prop_wxWidgets_version) == "3.1"` to make the code more readable.