### PR TITLE
Image loading overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - The `hide_children` property in the wxStaticBoxSizer has been removed since the `hidden` property does exactly the same thing. Projects where `hide_children` was set will be automatically converted to use `hidden` instead.
+- The Image List file now includes wxue_img::image_ functions for each image in the list, replacing the `extern` declarations that were previously used. This allows the Image List to be used in multiple projects without having to copy the source files.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - The `hide_children` property in the wxStaticBoxSizer has been removed since the `hidden` property does exactly the same thing. Projects where `hide_children` was set will be automatically converted to use `hidden` instead.
-- The Image List file now includes wxue_img::image_ functions for each image in the list, replacing the `extern` declarations that were previously used. This allows the Image List to be used in multiple projects without having to copy the source files.
+- The Image List file now includes wxue_img::image_ functions for each image in the list, replacing the `extern` declarations that were previously used. A new `add_externs` property has been added -- check that if you still need the extern declarations.
 
 ### Fixed
 

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -162,7 +162,7 @@ void PropertyGrid_Image::RefreshChildren()
             }
 
             if (!bundle.IsOk())
-                bundle = wxBitmapBundle::FromBitmap(LoadHeaderImage(empty_png, sizeof(empty_png)).Scale(15, 15));
+                bundle = wxue_img::bundle_empty_png();
 
             Item(IndexImage)->SetValueImage(bundle);
 

--- a/src/gen_enums.cpp
+++ b/src/gen_enums.cpp
@@ -77,6 +77,7 @@ std::map<GenEnum::PropName, const char*> GenEnum::map_PropNames = {
     { prop_TopDockable, "TopDockable" },
     { prop_Yes, "Yes" },
     { prop_add_default_border, "add_default_border" },
+    { prop_add_externs, "add_externs" },
     { prop_additional_carets_blink, "additional_carets_blink" },
     { prop_additional_carets_visible, "additional_carets_visible" },
     { prop_additional_inheritance, "additional_inheritance" },

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -96,6 +96,7 @@ namespace GenEnum
         prop_TopDockable,
         prop_Yes,
         prop_add_default_border,
+        prop_add_externs,
         prop_additional_carets_blink,
         prop_additional_carets_visible,
         prop_additional_inheritance,

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -127,7 +127,10 @@ bool AnimationGenerator::ConstructionCode(Code& code)
         code.Eol(eol_if_needed).NodeName().Function("SetInactiveBitmap(");
         if (code.is_cpp())
         {
-            code << GenerateBitmapCode(code.node()->as_string(prop_inactive_bitmap));
+            tt_string bundle_code;
+            GenerateBundleCode(code.node()->as_string(prop_inactive_bitmap), bundle_code);
+            code.CheckLineLength(bundle_code.size());
+            code += bundle_code;
         }
         else if (code.is_python())
         {

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -724,9 +724,40 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
                 if (parts[IndexType] == "Embed")
                 {
                     if (iter.type() == type_animation)
+                    {
                         m_NeedAnimationFunction = true;
+                    }
                     else
-                        m_NeedImageFunction = true;
+                    {
+                        if (!m_ImagesForm)
+                        {
+                            m_NeedImageFunction = true;
+                        }
+
+                        // If we haven't already encountered an image that requires a function,
+                        // then check to see if this image is in the Images List file and has a
+                        // bundle function to access it. If it does, then we still don't need
+                        // to generate an image function in the class file.
+                        else if (!m_NeedImageFunction)
+                        {
+                            if (auto bundle = ProjectImages.GetPropertyImageBundle(parts);
+                                bundle && bundle->lst_filenames.size())
+                            {
+                                if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed)
+                                {
+#if defined(_DEBUG)
+                                    auto name = ProjectImages.GetBundleFuncName(embed);
+                                    if (name.empty())
+#else
+                                    if (ProjectImages.GetBundleFuncName(embed).empty())
+#endif  // _DEBUG
+                                    {
+                                        m_NeedImageFunction = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
                 else if ((parts[IndexType] == "Art"))
                 {
@@ -734,7 +765,29 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
                 }
                 else if ((parts[IndexType] == "SVG"))
                 {
-                    m_NeedSVGFunction = true;
+                    if (!m_ImagesForm)
+                    {
+                        m_NeedSVGFunction = true;
+                    }
+                    else if (!m_NeedSVGFunction)
+                    {
+                        if (auto bundle = ProjectImages.GetPropertyImageBundle(parts);
+                            bundle && bundle->lst_filenames.size())
+                        {
+                            if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed)
+                            {
+#if defined(_DEBUG)
+                                auto name = ProjectImages.GetBundleFuncName(embed);
+                                if (name.empty())
+#else
+                                if (ProjectImages.GetBundleFuncName(embed).empty())
+#endif  // _DEBUG
+                                {
+                                    m_NeedSVGFunction = true;
+                                }
+                            }
+                        }
+                    }
                 }
                 else if (parts[IndexType] == "Header")
                 {

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -35,7 +35,11 @@ extern std::map<wxBitmapType, std::string> g_map_types;
 
 inline constexpr const auto txt_wxueImageFunction = R"===(
 // Convert a data array into a wxImage
-wxImage wxueImage(const unsigned char* data, size_t size_data)
+#ifdef __cpp_inline_variables
+inline wxImage wxueImage(const unsigned char* data, size_t size_data)
+#else
+static wxImage wxueImage(const unsigned char* data, size_t size_data)
+#endif
 {
     wxMemoryInputStream strm(data, size_data);
     wxImage image;
@@ -44,15 +48,15 @@ wxImage wxueImage(const unsigned char* data, size_t size_data)
 };
 )===";
 
-inline constexpr const auto txt_extern_wxueImageFunction = R"===(
-// Convert a data array into a wxImage
-wxImage wxueImage(const unsigned char* data, size_t size_data);
-)===";
-
 inline constexpr const auto txt_GetBundleFromSVG = R"===(
 // Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+#ifdef __cpp_inline_variables
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
     size_t size_data, size_t size_svg, wxSize def_size)
+#else
+static wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#endif
 {
     auto str = std::make_unique<char[]>(size_svg);
     wxMemoryInputStream stream_in(data, size_data);
@@ -61,26 +65,20 @@ wxBitmapBundle wxueBundleSVG(const unsigned char* data,
     return wxBitmapBundle::FromSVG(str.get(), def_size);
 };
 )===";
-inline constexpr const auto txt_extern_GetBundleFromSVG = R"===(
-// Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size);
-)===";
 
 inline constexpr const auto txt_GetAnimFromHdrFunction = R"===(
 // Convert a data array into a wxAnimation
-wxAnimation wxueAnimation(const unsigned char* data, size_t size_data)
+#ifdef __cpp_inline_variables
+inline wxAnimation wxueAnimation(const unsigned char* data, size_t size_data)
+#else
+static wxAnimation wxueAnimation(const unsigned char* data, size_t size_data)
+#endif
 {
     wxMemoryInputStream strm(data, size_data);
     wxAnimation animation;
     animation.Load(strm);
     return animation;
 };
-)===";
-
-inline constexpr const auto txt_extern_GetAnimFromHdrFunction = R"===(
-// Convert a data array into a wxAnimation
-wxAnimation wxueAnimation(const unsigned char* data, size_t size_data);
 )===";
 
 inline constexpr const auto txt_BaseCmtBlock =
@@ -593,13 +591,21 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
         if (m_NeedAnimationFunction)
         {
             m_source->writeLine("#include <wx/animate.h>", indent::none);
+            m_source->writeLine("\n#include <wx/mstream.h>  // memory stream classes", indent::none);
+            if (!m_NeedSVGFunction)
+            {
+                m_source->writeLine("#include <wx/zstream.h>  // zlib stream classes", indent::none);
+
+                m_source->writeLine();
+                m_source->writeLine("#include <memory>  // for std::make_unique", indent::none);
+            }
         }
-        if (!Project.getImagesForm() &&
-            (m_NeedImageFunction || m_NeedHeaderFunction || m_NeedSVGFunction || m_NeedAnimationFunction))
+        else if (m_NeedImageFunction || m_NeedHeaderFunction || m_NeedSVGFunction)
         {
             m_source->writeLine("\n#include <wx/mstream.h>  // memory stream classes", indent::none);
         }
-        if (!Project.getImagesForm() && m_NeedSVGFunction)
+
+        if (m_NeedSVGFunction)
         {
             m_source->writeLine("#include <wx/zstream.h>  // zlib stream classes", indent::none);
             m_source->writeLine();
@@ -611,17 +617,13 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
 
         if (m_NeedImageFunction || m_NeedHeaderFunction)
         {
-            if (!has_images_list_header)
+            tt_string_vector function;
+            function.ReadString(txt_wxueImageFunction);
+            for (auto& iter: function)
             {
-                tt_string_vector function;
-                function.ReadString(Project.getForm_Image() == m_form_node ? txt_wxueImageFunction :
-                                                                             txt_extern_wxueImageFunction);
-                for (auto& iter: function)
-                {
-                    m_source->writeLine(iter, indent::none);
-                }
-                m_source->writeLine();
+                m_source->writeLine(iter, indent::none);
             }
+            m_source->writeLine();
         }
 
         if (m_NeedSVGFunction)
@@ -637,31 +639,28 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
                 m_source->writeLine("#endif", indent::none);
             }
 
-            if (!has_images_list_header)
+            tt_string_vector function;
+            function.ReadString(txt_GetBundleFromSVG);
+            for (auto& iter: function)
             {
-                tt_string_vector function;
-                function.ReadString(Project.getForm_BundleSVG() == m_form_node ? txt_GetBundleFromSVG :
-                                                                                 txt_extern_GetBundleFromSVG);
-                for (auto& iter: function)
-                {
-                    m_source->writeLine(iter, indent::none);
-                }
-                m_source->writeLine();
+                m_source->writeLine(iter, indent::none);
             }
+            m_source->writeLine();
         }
 
         if (m_NeedAnimationFunction)
         {
-            if (!has_images_list_header)
+            // Note that we write the function even if the Image List file also has the
+            // function. It won't matter for C++17, and for C++14 the animation isn't likely to
+            // appear in a lot of forms, so any duplication of the function won't matter very
+            // much.
+            tt_string_vector function;
+            function.ReadString(txt_GetAnimFromHdrFunction);
+            for (auto& iter: function)
             {
-                tt_string_vector function;
-                function.ReadString(Project.getForm_Animation() == m_form_node ? txt_GetAnimFromHdrFunction :
-                                                                                 txt_extern_GetAnimFromHdrFunction);
-                for (auto& iter: function)
-                {
-                    m_source->writeLine(iter, indent::none);
-                }
+                m_source->writeLine(iter, indent::none);
             }
+            m_source->writeLine();
         }
 
         if (m_embedded_images.size())

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -613,7 +613,8 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
         }
         m_source->writeLine();
 
-        // Now generate the functions
+        // m_NeedImageFunction and m_NeedSVGFunction will be set to true if there is an image
+        // that is not added to an Image List where it can be loaded via a wxue_img:: function.
 
         if (m_NeedImageFunction || m_NeedHeaderFunction)
         {
@@ -760,7 +761,7 @@ void BaseCodeGenerator::GenerateCppClassHeader()
             m_header->writeLine();
         }
 
-        if (m_NeedSVGFunction && Project.getForm_BundleSVG() != m_form_node)
+        if (m_NeedSVGFunction)
         {
             if (Project.is_wxWidgets31())
             {

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -155,29 +155,6 @@ void BaseCodeGenerator::GenerateImagesForm()
         m_source->writeLine("namespace wxue_img\n{");
         m_source->Indent();
         m_source->SetLastLineBlank();
-
-        if (m_NeedSVGFunction)
-        {
-            if (is_old_widgets)
-            {
-                m_source->writeLine();
-                m_source->writeLine("#if !wxCHECK_VERSION(3, 1, 6)", indent::none);
-                m_source->Indent();
-                m_source->writeLine("#error \"You must build with wxWidgets 3.1.6 or later to use SVG images.\"",
-                                    indent::auto_no_whitespace);
-                m_source->Unindent();
-                m_source->writeLine("#endif", indent::none);
-            }
-
-            tt_string_vector function;
-            function.ReadString(txt_get_bundle_svg_function);
-            for (auto& iter: function)
-            {
-                m_source->writeLine(iter, indent::none);
-            }
-        }
-
-        if (m_NeedImageFunction || Project.getForm_Image() == m_form_node)
         {
             tt_string_vector function;
             function.ReadString(txt_get_image_function);
@@ -186,130 +163,26 @@ void BaseCodeGenerator::GenerateImagesForm()
                 m_source->writeLine(iter, indent::none);
             }
 
-            m_source->writeLine();
             if (is_old_widgets)
             {
+                m_source->writeLine();
                 m_source->writeLine("#if wxCHECK_VERSION(3, 1, 6)", indent::none);
             }
 
+            function.clear();
+            function.ReadString(txt_get_bundle_svg_function);
+            for (auto& iter: function)
+            {
+                m_source->writeLine(iter, indent::none);
+            }
+
             if (is_old_widgets)
             {
-                m_source->writeLine("#endif", indent::none);
+                m_source->writeLine("#endif // wxCHECK_VERSION(3, 1, 6)", indent::none);
             }
         }
 
-        if (m_NeedSVGFunction)
-        {
-            for (auto embed: m_embedded_images)
-            {
-                if (embed->form != m_form_node || embed->type != wxBITMAP_TYPE_INVALID)
-                    continue;
-                tt_string code("wxBitmapBundle bundle_");
-                code << embed->array_name << "(int width, int height)";
-                m_source->writeLine(code);
-                m_source->writeLine("{");
-                m_source->Indent();
-                code = "return get_bundle_svg(";
-                code << embed->array_name << ", " << (embed->array_size & 0xFFFFFFFF) << ", ";
-                code << (embed->array_size >> (to_size_t) 32) << ", wxSize(width, height));";
-                m_source->writeLine(code);
-                m_source->Unindent();
-                m_source->writeLine("}");
-                m_source->writeLine();
-            }
-        }
-
-        if (m_NeedImageFunction)
-        {
-            m_source->writeLine();
-
-            if (!m_NeedSVGFunction && is_old_widgets)
-            {
-                m_source->writeLine("#if wxCHECK_VERSION(3, 1, 6)", indent::none);
-                m_source->SetLastLineBlank();
-            }
-
-            for (const auto& child: m_form_node->getChildNodePtrs())
-            {
-                if (auto bundle = ProjectImages.GetPropertyImageBundle(child->as_string(prop_bitmap));
-                    bundle && bundle->lst_filenames.size())
-                {
-                    auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]);
-                    if (embed->type == wxBITMAP_TYPE_INVALID || embed->type == wxBITMAP_TYPE_ICO ||
-                        embed->type == wxBITMAP_TYPE_CUR || embed->type == wxBITMAP_TYPE_GIF ||
-                        embed->type == wxBITMAP_TYPE_ANI)
-                    {
-                        // Ignore types that can't be placed into a bundle. Technically, a .gif
-                        // file could be added to a bundle, but use of .git instead of .png
-                        // would be highly unusual. A more common scenario is that any .git
-                        // file is being used for an animation control, which doesn't use a
-                        // bundle.
-                        continue;
-                    }
-                    m_source->writeLine();
-                    tt_string code("wxBitmapBundle bundle_");
-                    code << embed->array_name << "()";
-                    m_source->writeLine(code);
-                    m_source->writeLine("{");
-                    m_source->Indent();
-                    if (bundle->lst_filenames.size() == 1)
-                    {
-                        code = "return wxBitmapBundle::FromBitmap(wxBitmap(get_image(";
-                        code << embed->array_name << ", " << embed->array_size << ")));";
-                        m_source->writeLine(code);
-                    }
-                    else
-                    {
-                        code = "wxVector<wxBitmap> bitmaps;\n";
-                        for (auto& iter: bundle->lst_filenames)
-                        {
-                            // tt_string name(iter.filename());
-                            // name.remove_extension();
-                            // name.Replace(".", "_", true);  // fix wxFormBuilder header files
-                            embed = ProjectImages.GetEmbeddedImage(iter);
-                            ASSERT_MSG(embed, tt_string("Unable to locate embedded image for ") << iter);
-                            if (embed)
-                            {
-                                code << "\t\tbitmaps.push_back(get_image(" << embed->array_name << ", sizeof(" << embed->array_name << ")));\n";
-                            }
-                        }
-                        code += "return wxBitmapBundle::FromBitmaps(bitmaps);";
-                        m_source->writeLine(code);
-                    }
-                    m_source->Unindent();  // end function block
-                    m_source->writeLine("}");
-                }
-            }
-
-            if (!m_NeedSVGFunction && is_old_widgets)
-            {
-                m_source->writeLine("#else", indent::none);
-                m_source->writeLine();
-                for (auto embed: m_embedded_images)
-                {
-                    if (embed->form != m_form_node || embed->type == wxBITMAP_TYPE_INVALID)
-                        continue;
-                    m_source->writeLine();
-                    tt_string code("wxImage image_");
-                    code << embed->array_name << "()";
-                    m_source->writeLine(code);
-                    m_source->writeLine("{");
-                    m_source->Indent();
-                    code = "return get_image(";
-                    code << embed->array_name << ", " << embed->array_size << ");";
-                    m_source->writeLine(code);
-                    m_source->Unindent();
-                    m_source->writeLine("}");
-                }
-            }
-        }
-
-        if (!m_NeedSVGFunction && is_old_widgets)
-        {
-            m_source->writeLine("#endif", indent::none);
-        }
-
-        // Now add all of the image data
+        // Write all of the image data followed by the functions to access them.
 
         for (auto iter_array: m_embedded_images)
         {
@@ -341,6 +214,108 @@ void BaseCodeGenerator::GenerateImagesForm()
         }
 
         m_source->writeLine();
+
+        if (is_old_widgets)
+        {
+            m_source->writeLine("#if wxCHECK_VERSION(3, 1, 6)", indent::none);
+            m_source->SetLastLineBlank();
+        }
+
+        for (const auto& child: m_form_node->getChildNodePtrs())
+        {
+            if (auto bundle = ProjectImages.GetPropertyImageBundle(child->as_string(prop_bitmap));
+                bundle && bundle->lst_filenames.size())
+            {
+                auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]);
+                if (embed->type == wxBITMAP_TYPE_ICO || embed->type == wxBITMAP_TYPE_CUR ||
+                    embed->type == wxBITMAP_TYPE_GIF || embed->type == wxBITMAP_TYPE_ANI)
+                {
+                    // Ignore types that can't be placed into a bundle. Technically, a .gif
+                    // file could be added to a bundle, but use of .git instead of .png
+                    // would be highly unusual. A more common scenario is that any .git
+                    // file is being used for an animation control, which doesn't use a
+                    // bundle.
+                    continue;
+                }
+
+                m_source->writeLine();
+                tt_string code("wxBitmapBundle bundle_");
+
+                if (embed->type == wxBITMAP_TYPE_INVALID)
+                {
+                    code << embed->array_name << "(int width, int height)";
+                    m_source->writeLine(code);
+                    m_source->writeLine("{");
+                    m_source->Indent();
+                    code = "return get_bundle_svg(";
+                    code << embed->array_name << ", " << (embed->array_size & 0xFFFFFFFF) << ", ";
+                    code << (embed->array_size >> (to_size_t) 32) << ", wxSize(width, height));";
+                    m_source->writeLine(code);
+                    m_source->Unindent();
+                    m_source->writeLine("}");
+                    m_source->writeLine();
+                }
+                else
+                {
+                    code << embed->array_name << "()";
+                    m_source->writeLine(code);
+                    m_source->writeLine("{");
+                    m_source->Indent();
+                    if (bundle->lst_filenames.size() == 1)
+                    {
+                        code = "return wxBitmapBundle::FromBitmap(wxBitmap(get_image(";
+                        code << embed->array_name << ", " << embed->array_size << ")));";
+                        m_source->writeLine(code);
+                    }
+                    else
+                    {
+                        code = "wxVector<wxBitmap> bitmaps;\n";
+                        for (auto& iter: bundle->lst_filenames)
+                        {
+                            // tt_string name(iter.filename());
+                            // name.remove_extension();
+                            // name.Replace(".", "_", true);  // fix wxFormBuilder header files
+                            embed = ProjectImages.GetEmbeddedImage(iter);
+                            ASSERT_MSG(embed, tt_string("Unable to locate embedded image for ") << iter);
+                            if (embed)
+                            {
+                                code << "\t\tbitmaps.push_back(get_image(" << embed->array_name << ", sizeof("
+                                     << embed->array_name << ")));\n";
+                            }
+                        }
+                        code += "return wxBitmapBundle::FromBitmaps(bitmaps);";
+                        m_source->writeLine(code);
+                    }
+                    m_source->Unindent();  // end function block
+                    m_source->writeLine("}");
+                }
+            }
+        }
+
+        if (is_old_widgets)
+        {
+            m_source->writeLine("#endif  // wxCHECK_VERSION(3, 1, 6)", indent::none);
+        }
+
+        for (auto embed: m_embedded_images)
+        {
+            if (embed->type == wxBITMAP_TYPE_INVALID || embed->type == wxBITMAP_TYPE_ICO ||
+                embed->type == wxBITMAP_TYPE_CUR || embed->type == wxBITMAP_TYPE_GIF || embed->type == wxBITMAP_TYPE_ANI)
+                continue;
+
+            m_source->writeLine();
+            tt_string code("wxImage image_");
+            code << embed->array_name << "()";
+            m_source->writeLine(code);
+            m_source->writeLine("{");
+            m_source->Indent();
+            code = "return get_image(";
+            code << embed->array_name << ", " << embed->array_size << ");";
+            m_source->writeLine(code);
+            m_source->Unindent();
+            m_source->writeLine("}");
+        }
+
         m_source->Unindent();
         m_source->writeLine("}\n");
     }
@@ -377,30 +352,13 @@ void BaseCodeGenerator::GenerateImagesForm()
         m_header->Indent();
         m_header->SetLastLineBlank();
         m_header->writeLine("wxImage get_image(const unsigned char* data, size_t size_data);");
-        if (m_NeedSVGFunction && !is_old_widgets)
-        {
-            m_header->writeLine("wxBitmapBundle get_bundle_svg(const unsigned char* data, size_t size_data, size_t "
-                                "size_svg, wxSize def_size);");
-        }
-        m_header->writeLine();
-
-        if (m_NeedSVGFunction)
-        {
-            for (auto embed: m_embedded_images)
-            {
-                // wxBITMAP_TYPE_INVALID is used to indicate an SVG file since wxWidgets doesn't define it.
-                if (embed->form != m_form_node || embed->type != wxBITMAP_TYPE_INVALID)
-                    continue;
-                tt_string code("wxBitmapBundle bundle_");
-                code << embed->array_name << "(int width, int height);";
-                m_header->writeLine(code);
-            }
-        }
 
         m_header->writeLine();
-        if (!m_NeedSVGFunction && is_old_widgets)
+        if (is_old_widgets)
         {
             m_header->writeLine("#if wxCHECK_VERSION(3, 1, 6)", indent::none);
+            m_header->writeLine("wxBitmapBundle get_bundle_svg(const unsigned char* data, size_t size_data, size_t "
+                                "size_svg, wxSize def_size);");
         }
 
         for (const auto& child: m_form_node->getChildNodePtrs())
@@ -409,46 +367,47 @@ void BaseCodeGenerator::GenerateImagesForm()
                 bundle && bundle->lst_filenames.size())
             {
                 auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]);
-                if (embed->type == wxBITMAP_TYPE_INVALID || embed->type == wxBITMAP_TYPE_ICO ||
-                    embed->type == wxBITMAP_TYPE_CUR || embed->type == wxBITMAP_TYPE_GIF || embed->type == wxBITMAP_TYPE_ANI)
+                if (embed->type == wxBITMAP_TYPE_ICO || embed->type == wxBITMAP_TYPE_CUR ||
+                    embed->type == wxBITMAP_TYPE_GIF || embed->type == wxBITMAP_TYPE_ANI)
                 {
                     // Don't generate bundle functions for image types that are probably being used for something else
                     continue;
                 }
-                tt_string code("wxBitmapBundle bundle_");
-                code << embed->array_name << "();";
-                if (bundle->lst_filenames[0].size())
-                {
-                    code << "  // " << bundle->lst_filenames[0].filename();
-                }
 
+                tt_string code("wxBitmapBundle bundle_");
+                if (embed->type == wxBITMAP_TYPE_INVALID)
+                {
+                    code << embed->array_name << "(int width, int height);";
+                }
+                else
+                {
+                    code << embed->array_name << "();";
+                    if (bundle->lst_filenames[0].size())
+                    {
+                        code << "  // " << bundle->lst_filenames[0].filename();
+                    }
+                }
                 m_header->writeLine(code);
             }
         }
 
-        if (!m_NeedSVGFunction && is_old_widgets)
+        if (is_old_widgets)
         {
-            if (m_NeedImageFunction)
-            {
-                m_header->writeLine("#else", indent::none);
-                m_header->writeLine();
-                for (auto embed: m_embedded_images)
-                {
-                    if (embed->form != m_form_node || embed->type == wxBITMAP_TYPE_INVALID)
-                        continue;
-                    tt_string code("wxImage image_");
-                    code << embed->array_name << "();";
-                    m_header->writeLine(code);
-                }
-            }
+            m_header->writeLine("#endif", indent::none);
+        }
+
+        m_header->writeLine();
+        for (auto embed: m_embedded_images)
+        {
+            if (embed->form != m_form_node || embed->type == wxBITMAP_TYPE_INVALID)
+                continue;
+            tt_string code("wxImage image_");
+            code << embed->array_name << "();";
+            m_header->writeLine(code);
         }
     }
 
-    if (!m_NeedSVGFunction && is_old_widgets)
-    {
-        m_header->writeLine("#endif", indent::none);
-    }
-
+#if 0
     m_header->writeLine();
     for (auto iter_array: m_embedded_images)
     {
@@ -457,16 +416,17 @@ void BaseCodeGenerator::GenerateImagesForm()
 
         tt_string line("extern const unsigned char ");
         line << iter_array->array_name << '[' << (iter_array->array_size & 0xFFFFFFFF) << "];";
-#if 0
+    #if 0
 // REVIEW: [Randalphwa - 12-08-2023] All the bundle functions have the filename lists, so adding them here is redundant
 // since the function name will be used when compiling for wxWidgets 3.2 or later.
         if (iter_array->filename.size())
         {
             line << "  // " << iter_array->filename;
         }
-#endif
+    #endif
         m_header->writeLine(line);
     }
+#endif
 
     m_header->Unindent();
     m_header->writeLine("}\n");

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -407,26 +407,23 @@ void BaseCodeGenerator::GenerateImagesForm()
         }
     }
 
-#if 0
-    m_header->writeLine();
-    for (auto iter_array: m_embedded_images)
+    if (m_form_node->as_bool(prop_add_externs))
     {
-        if (iter_array->form != m_form_node)
-            continue;
-
-        tt_string line("extern const unsigned char ");
-        line << iter_array->array_name << '[' << (iter_array->array_size & 0xFFFFFFFF) << "];";
-    #if 0
-// REVIEW: [Randalphwa - 12-08-2023] All the bundle functions have the filename lists, so adding them here is redundant
-// since the function name will be used when compiling for wxWidgets 3.2 or later.
-        if (iter_array->filename.size())
+        m_header->writeLine();
+        for (auto iter_array: m_embedded_images)
         {
-            line << "  // " << iter_array->filename;
+            if (iter_array->form != m_form_node)
+                continue;
+
+            tt_string line("extern const unsigned char ");
+            line << iter_array->array_name << '[' << (iter_array->array_size & 0xFFFFFFFF) << "];";
+            if (iter_array->filename.size())
+            {
+                line << "  // " << iter_array->filename;
+            }
+            m_header->writeLine(line);
         }
-    #endif
-        m_header->writeLine(line);
     }
-#endif
 
     m_header->Unindent();
     m_header->writeLine("}\n");

--- a/src/generate/gen_menuitem.cpp
+++ b/src/generate/gen_menuitem.cpp
@@ -161,46 +161,57 @@ bool MenuItemGenerator::SettingsCode(Code& code)
         if (code.is_cpp())
         {
             auto& description = node->as_string(prop_bitmap);
-            bool is_vector_code = GenerateVectorCode(description, code.GetCode());
-            code.UpdateBreakAt();
-
-            if (!is_vector_code)
+            if (auto function_name = ProjectImages.GetBundleFuncName(description); function_name.size())
             {
+                // We get here if there is an Image List that contains the function to retrieve this bundle.
                 code.NodeName().Function("SetBitmap(");
-                if (!Project.is_wxWidgets31())
-                {
-                    GenerateBundleCode(description, code.GetCode());
-                    code.EndFunction();
-                }
-                else
-                {
-                    code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t";
-                    GenerateBundleCode(description, code.GetCode());
-                    code.Eol() += "#else";
-                    code.Eol().Tab() << "wxBitmap(" << GenerateBitmapCode(description) << ")";
-                    code.Eol() += "#endif";
-                    code.Eol().EndFunction();
-                }
-                code.Eol();
+                code << function_name;
+                code.EndFunction();
             }
+
             else
             {
-                code.Tab().NodeName().Function("SetBitmap(");
-                if (!Project.is_wxWidgets31())
+                bool is_vector_code = GenerateVectorCode(description, code.GetCode());
+                code.UpdateBreakAt();
+
+                if (!is_vector_code)
                 {
-                    code += "wxBitmapBundle::FromBitmaps(bitmaps)";
-                    code.UpdateBreakAt();
-                    code.EndFunction().CloseBrace();
+                    code.NodeName().Function("SetBitmap(");
+                    if (!Project.is_wxWidgets31())
+                    {
+                        GenerateBundleCode(description, code.GetCode());
+                        code.EndFunction();
+                    }
+                    else
+                    {
+                        code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t";
+                        GenerateBundleCode(description, code.GetCode());
+                        code.Eol() += "#else";
+                        code.Eol().Tab() << "wxBitmap(" << GenerateBitmapCode(description) << ")";
+                        code.Eol() += "#endif";
+                        code.Eol().EndFunction();
+                    }
+                    code.Eol();
                 }
                 else
                 {
-                    code += "\n#if wxCHECK_VERSION(3, 1, 6)\n\t";
-                    code.Tab() += "wxBitmapBundle::FromBitmaps(bitmaps)";
-                    code += "\n#else\n\t";
-                    code.Tab() << "wxBitmap(" << GenerateBitmapCode(description) << ")\n";
-                    code << "#endif\n";
-                    code.UpdateBreakAt();
-                    code.Tab().EndFunction().CloseBrace();
+                    code.Tab().NodeName().Function("SetBitmap(");
+                    if (!Project.is_wxWidgets31())
+                    {
+                        code += "wxBitmapBundle::FromBitmaps(bitmaps)";
+                        code.UpdateBreakAt();
+                        code.EndFunction().CloseBrace();
+                    }
+                    else
+                    {
+                        code += "\n#if wxCHECK_VERSION(3, 1, 6)\n\t";
+                        code.Tab() += "wxBitmapBundle::FromBitmaps(bitmaps)";
+                        code += "\n#else\n\t";
+                        code.Tab() << "wxBitmap(" << GenerateBitmapCode(description) << ")\n";
+                        code << "#endif\n";
+                        code.UpdateBreakAt();
+                        code.Tab().EndFunction().CloseBrace();
+                    }
                 }
             }
         }

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -232,10 +232,14 @@ wxImage wxueImage(const unsigned char* data, size_t size_data)
 
 void BaseCodeGenerator::WriteImagePostHeader()
 {
+    auto images_form = Project.getImagesForm();
+    if (!images_form)
+        return;
+
     bool is_namespace_written = false;
     for (auto iter_array: m_embedded_images)
     {
-        if (iter_array->form != m_form_node)
+        if (iter_array->form != images_form)
             continue;
 
         if (!is_namespace_written)
@@ -260,7 +264,15 @@ void BaseCodeGenerator::WriteImagePostHeader()
             m_header->Indent();
             if (!m_form_node->isType(type_images))
             {
-                m_header->writeLine("// Images declared in this class module:");
+                tt_string comment("// Images defined in ");
+                comment << images_form->as_string(prop_base_file).filename();
+                tt_string source_ext(".cpp");
+                if (auto& extProp = Project.as_string(prop_source_ext); extProp.size())
+                {
+                    source_ext = extProp;
+                }
+                comment += source_ext;
+                m_header->writeLine(comment);
                 m_header->writeLine();
             }
             is_namespace_written = true;
@@ -272,6 +284,7 @@ void BaseCodeGenerator::WriteImagePostHeader()
         m_header->writeLine(tt_string("extern const unsigned char ")
                             << iter_array->array_name << '[' << (iter_array->array_size & 0xFFFFFFFF) << "];");
     }
+
     if (is_namespace_written)
     {
         m_header->Unindent();

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -72,9 +72,12 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
     // -12 to account for 8 indent + max 3 chars for number + comma
     size_t cpp_line_length = Project.as_size_t(prop_cpp_line_length) - 12;
 
+    auto images_form = Project.getImagesForm();
+
     for (auto iter_array: m_embedded_images)
     {
-        if (iter_array->form != m_form_node && code.is_cpp())
+        // The images form contains global images, so no need to generate code for them here.
+        if (iter_array->form == images_form)
             continue;
 
         if (code.is_cpp())

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -99,9 +99,9 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
                 if (!inlined_warning)
                 {
                     inlined_warning = true;
-                    code.Str("// WARNING: This will only work if compiled with C++17 or later.");
-                    code.Eol().Str("// Create an Images List and check auto_update to prevent the image");
-                    code.Eol().Str("// from being added to this header file.").Eol();
+                    code.Eol().Str("#if __cplusplus < 201703L");
+                    code.Eol().Str("#warning \"This code requires C++17 or later\"");
+                    code.Eol().Str("#endif");
                 }
                 // The header file can be included multiple times, so we need to set this to
                 // inline to avoid multiple definitions. Note that this requires C++17 --

--- a/src/internal/msgframe_base.cpp
+++ b/src/internal/msgframe_base.cpp
@@ -18,11 +18,6 @@
 
 #include "msgframe_base.h"
 
-namespace wxue_img
-{
-    extern const unsigned char hide_png[242];
-}
-
 bool MsgFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     const wxPoint& pos, const wxSize& size, long style, const wxString &name)
 {
@@ -47,7 +42,6 @@ bool MsgFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& title
     menu_file->Append(menu_item_clear);
     auto* menu_item_hide = new wxMenuItem(menu_file, id_hide, "&Hide");
     menu_item_hide->SetBitmap(wxue_img::bundle_hide_png());
-
     menu_file->Append(menu_item_hide);
     menubar->Append(menu_file, "&File");
 

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -442,7 +442,7 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // Add regular classes that have different generator class names
 
         tt_string widget_keywords(
-            "wxToolBar wxMenuBar wxBitmapBundle wxBitmap wxImage wxMemoryInputStream wxVector wxWindow");
+            "wxToolBar wxMenuBar wxBitmapBundle wxBitmap wxImage wxMemoryInputStream wxVector wxWindow wxZlibInputStream");
 
         for (auto iter: NodeCreation.getNodeDeclarationArray())
         {

--- a/src/panels/doc_view.cpp
+++ b/src/panels/doc_view.cpp
@@ -16,11 +16,29 @@
 
 #include "doc_view.h"
 
+#include <wx/mstream.h>  // memory stream classes
+#include <wx/zstream.h>  // zlib stream classes
+
+#include <memory>  // for std::make_unique
+
+// Convert compressed SVG string into a wxBitmapBundle
+#ifdef __cpp_inline_variables
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#else
+static wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#endif
+{
+    auto str = std::make_unique<char[]>(size_svg);
+    wxMemoryInputStream stream_in(data, size_data);
+    wxZlibInputStream zlib_strm(stream_in);
+    zlib_strm.Read(str.get(), size_svg);
+    return wxBitmapBundle::FromSVG(str.get(), def_size);
+};
+
 namespace wxue_img
 {
-    extern const unsigned char cpp_logo_svg[587];
-    // python-logo-only.svg
-    extern const unsigned char python_logo_only_svg[1648];
     extern const unsigned char ruby_logo_svg[1853];
 }
 

--- a/src/panels/doc_view.h
+++ b/src/panels/doc_view.h
@@ -19,6 +19,11 @@ class CustomEvent;
 class wxWebView;
 class MainFrame;
 
+namespace wxue_img
+{
+    extern const unsigned char ruby_logo_svg[1853];
+}
+
 class DocViewPanel : public wxPanel
 {
 public:
@@ -65,8 +70,8 @@ private:
 // Code below this comment block will be preserved
 // if the code for this class is re-generated.
 //
-    // clang-format on
-    // ***********************************************
+// clang-format on
+// ***********************************************
 
 public:
     DocViewPanel(wxWindow* parent, MainFrame* frame);

--- a/src/panels/nav_toolbar.cpp
+++ b/src/panels/nav_toolbar.cpp
@@ -19,6 +19,34 @@
 #include "mainframe.h"
 #include "project_handler.h"
 
+#include <wx/mstream.h>  // memory stream classes
+#include <wx/zstream.h>  // zlib stream classes
+
+#include <memory>  // for std::make_unique
+
+// Convert compressed SVG string into a wxBitmapBundle
+#ifdef __cpp_inline_variables
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#else
+static wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#endif
+{
+    auto str = std::make_unique<char[]>(size_svg);
+    wxMemoryInputStream stream_in(data, size_data);
+    wxZlibInputStream zlib_strm(stream_in);
+    zlib_strm.Read(str.get(), size_svg);
+    return wxBitmapBundle::FromSVG(str.get(), def_size);
+};
+
+namespace wxue_img
+{
+    extern const unsigned char nav_coll_expand_svg[249];
+    extern const unsigned char nav_collapse_svg[244];
+    extern const unsigned char nav_expand_svg[248];
+}
+
 NavToolbar::NavToolbar(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style,
     const wxString& name) : wxToolBar(parent, id, pos, size, style, name)
 {

--- a/src/panels/nav_toolbar.h
+++ b/src/panels/nav_toolbar.h
@@ -14,8 +14,6 @@
 
 namespace wxue_img
 {
-    // Images declared in this class module:
-
     extern const unsigned char nav_coll_expand_svg[249];
     extern const unsigned char nav_collapse_svg[244];
     extern const unsigned char nav_expand_svg[248];

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -1369,6 +1369,25 @@ tt_string ImageHandler::GetBundleFuncName(const tt_string_vector& parts)
     return name;
 }
 
+tt_string ImageHandler::GetBundleFuncName(const EmbeddedImage* embed, wxSize svg_size)
+{
+    tt_string name;
+    if (!embed || embed->form != Project.getImagesForm())
+    {
+        return name;
+    }
+    if (embed->type == wxBITMAP_TYPE_INVALID)
+    {
+        name << "wxue_img::bundle_" << embed->array_name << "(";
+        name << svg_size.x << ", " << svg_size.y << ")";
+    }
+    else
+    {
+        name << "wxue_img::bundle_" << embed->array_name << "()";
+    }
+    return name;
+}
+
 std::optional<tt_string> ImageHandler::FileNameToVarName(tt_string_view filename, size_t max_length)
 {
     ASSERT(max_length > sizeof("_name_truncated"))

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -94,6 +94,9 @@ public:
     // If there is an Image form containing this bundle, return it's name
     tt_string GetBundleFuncName(const tt_string_vector& parts);
 
+    // If there is an Image form containing this bundle, return it's name
+    tt_string GetBundleFuncName(const EmbeddedImage* embed, wxSize svg_size = wxDefaultSize);
+
     ImageBundle* ProcessBundleProperty(const tt_string_vector& parts, Node* node);
 
     inline ImageBundle* ProcessBundleProperty(const tt_string& description, Node* node)

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -166,10 +166,6 @@ public:
     Node* getForm_Image() const { return m_form_Image; }
 
     // After calling FindWxueFunctions(), this will return the form that should be used to
-    // generate the one copy of wxueBundleBitmaps() that is used by all forms.
-    Node* getForm_BundleBitmaps() const { return m_form_BundleBitmaps; }
-
-    // After calling FindWxueFunctions(), this will return the form that should be used to
     // generate the one copy of wxueAnimation() that is used by all forms.
     Node* getForm_Animation() const { return m_form_BundleBitmaps; }
 

--- a/src/ui/startup_dlg.cpp
+++ b/src/ui/startup_dlg.cpp
@@ -20,12 +20,30 @@
 
 #include "startup_dlg.h"
 
+#include <wx/mstream.h>  // memory stream classes
+#include <wx/zstream.h>  // zlib stream classes
+
+#include <memory>  // for std::make_unique
+
+// Convert compressed SVG string into a wxBitmapBundle
+#ifdef __cpp_inline_variables
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#else
+static wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#endif
+{
+    auto str = std::make_unique<char[]>(size_svg);
+    wxMemoryInputStream stream_in(data, size_data);
+    wxZlibInputStream zlib_strm(stream_in);
+    zlib_strm.Read(str.get(), size_svg);
+    return wxBitmapBundle::FromSVG(str.get(), def_size);
+};
+
 namespace wxue_img
 {
-    extern const unsigned char import_svg[418];
-    // new-project.svg
-    extern const unsigned char new_project_svg[921];
-    extern const unsigned char wxUiEditor_svg[1943];
+    extern const unsigned char new_project_svg[921];  // new-project.svg
 }
 
 bool StartupDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,

--- a/src/ui/startup_dlg.h
+++ b/src/ui/startup_dlg.h
@@ -18,6 +18,12 @@
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
+namespace wxue_img
+{
+    // new-project.svg
+    extern const unsigned char new_project_svg[921];
+}
+
 class StartupDlg : public wxDialog
 {
 public:
@@ -56,8 +62,8 @@ private:
 // Code below this comment block will be preserved
 // if the code for this class is re-generated.
 //
-    // clang-format on
-    // ***********************************************
+// clang-format on
+// ***********************************************
 
 public:
     enum : size_t

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -21,13 +21,30 @@
 
 #include "eventhandler_dlg_base.h"
 
+#include <wx/mstream.h>  // memory stream classes
+#include <wx/zstream.h>  // zlib stream classes
+
+#include <memory>  // for std::make_unique
+
+// Convert compressed SVG string into a wxBitmapBundle
+#ifdef __cpp_inline_variables
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#else
+static wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#endif
+{
+    auto str = std::make_unique<char[]>(size_svg);
+    wxMemoryInputStream stream_in(data, size_data);
+    wxZlibInputStream zlib_strm(stream_in);
+    zlib_strm.Read(str.get(), size_svg);
+    return wxBitmapBundle::FromSVG(str.get(), def_size);
+};
+
 namespace wxue_img
 {
-    extern const unsigned char cpp_logo_svg[587];
     extern const unsigned char ruby_logo_svg[1853];
-    extern const unsigned char wxPython_1_5x_png[765];
-    extern const unsigned char wxPython_2x_png[251];
-    extern const unsigned char wxPython_png[399];
 }
 
 bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,

--- a/src/wxui/eventhandler_dlg_base.h
+++ b/src/wxui/eventhandler_dlg_base.h
@@ -21,6 +21,11 @@
 #include <wx/stc/stc.h>
 #include <wx/textctrl.h>
 
+namespace wxue_img
+{
+    extern const unsigned char ruby_logo_svg[1853];
+}
+
 class EventHandlerDlgBase : public wxDialog
 {
 public:

--- a/src/wxui/import_base.cpp
+++ b/src/wxui/import_base.cpp
@@ -13,10 +13,26 @@
 
 #include "import_base.h"
 
-namespace wxue_img
+#include <wx/mstream.h>  // memory stream classes
+#include <wx/zstream.h>  // zlib stream classes
+
+#include <memory>  // for std::make_unique
+
+// Convert compressed SVG string into a wxBitmapBundle
+#ifdef __cpp_inline_variables
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#else
+static wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#endif
 {
-    extern const unsigned char import_svg[418];
-}
+    auto str = std::make_unique<char[]>(size_svg);
+    wxMemoryInputStream stream_in(data, size_data);
+    wxZlibInputStream zlib_strm(stream_in);
+    zlib_strm.Read(str.get(), size_svg);
+    return wxBitmapBundle::FromSVG(str.get(), def_size);
+};
 
 bool ImportBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     const wxPoint& pos, const wxSize& size, long style, const wxString &name)

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -17,14 +17,48 @@
 #include "mainframe.h"
 #include "project_handler.h"
 
+#include <wx/mstream.h>  // memory stream classes
+#include <wx/zstream.h>  // zlib stream classes
+
+#include <memory>  // for std::make_unique
+
+// Convert compressed SVG string into a wxBitmapBundle
+#ifdef __cpp_inline_variables
+inline wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#else
+static wxBitmapBundle wxueBundleSVG(const unsigned char* data,
+    size_t size_data, size_t size_svg, wxSize def_size)
+#endif
+{
+    auto str = std::make_unique<char[]>(size_svg);
+    wxMemoryInputStream stream_in(data, size_data);
+    wxZlibInputStream zlib_strm(stream_in);
+    zlib_strm.Read(str.get(), size_svg);
+    return wxBitmapBundle::FromSVG(str.get(), def_size);
+};
+
 namespace wxue_img
 {
-    extern const unsigned char import_svg[418];
-    extern const unsigned char redo_svg[919];
-    extern const unsigned char undo_svg[882];
-    extern const unsigned char wxPython_1_5x_png[765];
-    extern const unsigned char wxPython_2x_png[251];
-    extern const unsigned char wxPython_png[399];
+    extern const unsigned char alignbottom_svg[658];
+    extern const unsigned char aligncenter_svg[898];
+    extern const unsigned char alignleft_svg[688];
+    extern const unsigned char alignright_svg[690];
+    extern const unsigned char aligntop_svg[688];
+    extern const unsigned char alignvertcenter_svg[911];
+    extern const unsigned char bottom_svg[585];
+    extern const unsigned char expand_svg[819];
+    extern const unsigned char generate_svg[780];
+    extern const unsigned char hidden_svg[2111];
+    extern const unsigned char left_svg[585];
+    extern const unsigned char magnify_svg[3953];
+    extern const unsigned char new_project_svg[921];  // new-project.svg
+    extern const unsigned char right_svg[599];
+    extern const unsigned char ruby_logo_svg[1853];
+    extern const unsigned char save_svg[717];
+    extern const unsigned char top_svg[586];
+    extern const unsigned char wxlogo_svg[1331];
+    extern const unsigned char xrc_preview_svg[469];
 }
 
 bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
@@ -156,7 +190,6 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     m_menuFile->AppendSubMenu(m_submenu_recent, "Open &Recent");
     auto* menu_import = new wxMenuItem(m_menuFile, wxID_ANY, "&Import...");
     menu_import->SetBitmap(wxue_img::bundle_import_svg(16, 16));
-
     m_menuFile->Append(menu_import);
     m_menuFile->AppendSeparator();
     auto* menu_item = new wxMenuItem(m_menuFile, wxID_SAVE, "&Save\tCtrl+S", "Save current project", wxITEM_NORMAL);
@@ -207,11 +240,9 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     m_menuEdit = new wxMenu();
     auto* menu_undo = new wxMenuItem(m_menuEdit, wxID_UNDO, wxEmptyString);
     menu_undo->SetBitmap(wxue_img::bundle_undo_svg(16, 16));
-
     m_menuEdit->Append(menu_undo);
     auto* menu_redo = new wxMenuItem(m_menuEdit, wxID_REDO, wxEmptyString);
     menu_redo->SetBitmap(wxue_img::bundle_redo_svg(16, 16));
-
     m_menuEdit->Append(menu_redo);
     m_menuEdit->AppendSeparator();
     auto* menu_cut = new wxMenuItem(m_menuEdit, wxID_CUT, wxEmptyString);
@@ -356,14 +387,7 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     m_menuHelp->Append(menu_item_6);
     auto* menu_item_9 = new wxMenuItem(m_menuHelp, wxID_ANY, "wxPython Documentation",
         "Open wxPython documentation in your default browser.", wxITEM_NORMAL);
-    {
-        wxVector<wxBitmap> bitmaps;
-        bitmaps.push_back(wxueImage(wxue_img::wxPython_png, sizeof(wxue_img::wxPython_png)));
-        bitmaps.push_back(wxueImage(wxue_img::wxPython_1_5x_png, sizeof(wxue_img::wxPython_1_5x_png)));
-        bitmaps.push_back(wxueImage(wxue_img::wxPython_2x_png, sizeof(wxue_img::wxPython_2x_png)));
-        menu_item_9->SetBitmap(wxBitmapBundle::FromBitmaps(bitmaps));
-    }
-
+    menu_item_9->SetBitmap(wxue_img::bundle_wxPython_png());
     m_menuHelp->Append(menu_item_9);
     auto* menu_item_10 = new wxMenuItem(m_menuHelp, wxID_ANY, "wxRuby Documentation",
         "Open wxRuby documentation in your default browser.", wxITEM_NORMAL);

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -25,8 +25,6 @@ class NavigationPanel;
 
 namespace wxue_img
 {
-    // Images declared in this class module:
-
     extern const unsigned char alignbottom_svg[658];
     extern const unsigned char aligncenter_svg[898];
     extern const unsigned char alignleft_svg[688];

--- a/src/wxui/menu_auibar.cpp
+++ b/src/wxui/menu_auibar.cpp
@@ -16,18 +16,6 @@ using namespace GenEnum;
 
 #include "menu_auibar.h"
 
-namespace wxue_img
-{
-    extern const unsigned char slider_png[248];
-    extern const unsigned char spin_ctrl_png[300];
-    extern const unsigned char toolStretchable_png[578];
-    extern const unsigned char tool_png[629];
-    extern const unsigned char toolseparator_png[581];
-    extern const unsigned char toolspacer_png[459];
-    extern const unsigned char wxComboBox_png[233];
-    extern const unsigned char wxStaticText_png[290];
-}
-
 MenuAuiBar::MenuAuiBar() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menu_bartools.cpp
+++ b/src/wxui/menu_bartools.cpp
@@ -16,17 +16,6 @@ using namespace GenEnum;
 
 #include "menu_bartools.h"
 
-namespace wxue_img
-{
-    extern const unsigned char slider_png[248];
-    extern const unsigned char spin_ctrl_png[300];
-    extern const unsigned char toolStretchable_png[578];
-    extern const unsigned char tool_dropdown_png[447];
-    extern const unsigned char tool_png[629];
-    extern const unsigned char toolspacer_png[459];
-    extern const unsigned char wxComboBox_png[233];
-}
-
 MenuBarTools::MenuBarTools() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menubutton.cpp
+++ b/src/wxui/menubutton.cpp
@@ -16,15 +16,6 @@ using namespace GenEnum;
 
 #include "menubutton.h"
 
-namespace wxue_img
-{
-    extern const unsigned char close_btn_png[956];
-    extern const unsigned char stddialogbuttonsizer_png[524];
-    extern const unsigned char toggle_button_png[277];
-    extern const unsigned char wxButton_png[500];
-    extern const unsigned char wxCommandLinkButton_png[582];
-}
-
 MenuButton::MenuButton() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menucheckbox.cpp
+++ b/src/wxui/menucheckbox.cpp
@@ -16,12 +16,6 @@ using namespace GenEnum;
 
 #include "menucheckbox.h"
 
-namespace wxue_img
-{
-    extern const unsigned char check3state_png[194];
-    extern const unsigned char wxCheckBox_png[202];
-}
-
 MenuCheckbox::MenuCheckbox() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menucombobox.cpp
+++ b/src/wxui/menucombobox.cpp
@@ -16,13 +16,6 @@ using namespace GenEnum;
 
 #include "menucombobox.h"
 
-namespace wxue_img
-{
-    extern const unsigned char bmp_combo_box_png[492];
-    extern const unsigned char wxChoice_png[330];
-    extern const unsigned char wxComboBox_png[233];
-}
-
 MenuCombobox::MenuCombobox() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menudatactrl.cpp
+++ b/src/wxui/menudatactrl.cpp
@@ -16,13 +16,6 @@ using namespace GenEnum;
 
 #include "menudatactrl.h"
 
-namespace wxue_img
-{
-    extern const unsigned char dataview_ctrl_png[231];
-    extern const unsigned char dataviewlist_ctrl_png[685];
-    extern const unsigned char dataviewtree_ctrl_png[238];
-}
-
 MenuDataCtrl::MenuDataCtrl() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menulistbox.cpp
+++ b/src/wxui/menulistbox.cpp
@@ -16,16 +16,6 @@ using namespace GenEnum;
 
 #include "menulistbox.h"
 
-namespace wxue_img
-{
-    extern const unsigned char wxCheckListBox_png[498];
-    extern const unsigned char wxEditListBox_png[707];
-    extern const unsigned char wxListBox_png[310];
-    extern const unsigned char wxListView_png[356];
-    extern const unsigned char wxRearrangeCtrl_png[332];
-    extern const unsigned char wxSimpleHtmlListBox_png[676];
-}
-
 MenuListbox::MenuListbox() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menuribbontype.cpp
+++ b/src/wxui/menuribbontype.cpp
@@ -16,13 +16,6 @@ using namespace GenEnum;
 
 #include "menuribbontype.h"
 
-namespace wxue_img
-{
-    extern const unsigned char ribbon_bar_png[844];
-    extern const unsigned char ribbon_buttonbar_png[300];
-    extern const unsigned char ribbon_gallery_png[215];
-}
-
 MenuRibbonType::MenuRibbonType() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menuspin.cpp
+++ b/src/wxui/menuspin.cpp
@@ -16,13 +16,6 @@ using namespace GenEnum;
 
 #include "menuspin.h"
 
-namespace wxue_img
-{
-    extern const unsigned char spin_ctrl_double_png[219];
-    extern const unsigned char spin_ctrl_png[300];
-    extern const unsigned char spinbtn_png[192];
-}
-
 MenuSpin::MenuSpin() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/menustaticsizer.cpp
+++ b/src/wxui/menustaticsizer.cpp
@@ -16,13 +16,6 @@ using namespace GenEnum;
 
 #include "menustaticsizer.h"
 
-namespace wxue_img
-{
-    extern const unsigned char wxStaticBoxSizer_png[199];
-    extern const unsigned char wxStaticCheckBoxSizer_png[341];
-    extern const unsigned char wxStaticRadioBtnSizer_png[367];
-}
-
 MenuStaticSizer::MenuStaticSizer() : wxMenu()
 {
     if (!wxImage::FindHandler(wxBITMAP_TYPE_PNG))

--- a/src/wxui/ribbonpanel_base.cpp
+++ b/src/wxui/ribbonpanel_base.cpp
@@ -18,24 +18,101 @@ using namespace GenEnum;
 
 #include "ribbonpanel_base.h"
 
+#include <wx/mstream.h>  // memory stream classes
+
+// Convert a data array into a wxImage
+#ifdef __cpp_inline_variables
+inline wxImage wxueImage(const unsigned char* data, size_t size_data)
+#else
+static wxImage wxueImage(const unsigned char* data, size_t size_data)
+#endif
+{
+    wxMemoryInputStream strm(data, size_data);
+    wxImage image;
+    image.LoadFile(strm);
+    return image;
+};
+
 namespace wxue_img
 {
-    extern const unsigned char auitoolbar_png[476];
-    extern const unsigned char dataview_ctrl_png[231];
-    extern const unsigned char folder_png[641];
-    extern const unsigned char ribbon_bar_png[844];
-    extern const unsigned char ribbon_buttonbar_png[300];
-    extern const unsigned char scrollbar_png[214];
-    extern const unsigned char slider_png[248];
-    extern const unsigned char spin_ctrl_png[300];
-    extern const unsigned char stddialogbuttonsizer_png[524];
-    extern const unsigned char tool_png[629];
-    extern const unsigned char toolspacer_png[459];
-    extern const unsigned char wxButton_png[500];
-    extern const unsigned char wxListBox_png[310];
-    extern const unsigned char wxStaticBoxSizer_png[199];
-    extern const unsigned char wxStaticText_png[290];
-    extern const unsigned char wxTimer_png[1323];
+    extern const unsigned char WXPOPupTransientWindow_png[358];
+    extern const unsigned char auinotebook_png[284];
+    extern const unsigned char book_page_png[229];
+    extern const unsigned char calendar_png[937];
+    extern const unsigned char colourPickerIcon_png[534];
+    extern const unsigned char customControl_png[740];
+    extern const unsigned char dataviewlist_column_png[224];
+    extern const unsigned char datepicker_png[1047];
+    extern const unsigned char dirPicker_png[690];
+    extern const unsigned char doc_mdi_parent_frame_png[543];
+    extern const unsigned char filePicker_png[705];
+    extern const unsigned char flex_grid_sizer_png[139];
+    extern const unsigned char fontPicker_png[763];
+    extern const unsigned char gauge_png[260];
+    extern const unsigned char genericdir_ctrl_png[328];
+    extern const unsigned char grid_bag_sizer_png[145];
+    extern const unsigned char grid_png[171];
+    extern const unsigned char grid_sizer_png[127];
+    extern const unsigned char htmlwin_png[1053];
+    extern const unsigned char hyperlink_ctrl_png[329];
+    extern const unsigned char infobar_png[556];
+    extern const unsigned char menu_png[795];
+    extern const unsigned char menuitem_png[481];
+    extern const unsigned char pagectrl_png[601];
+    extern const unsigned char propgriditem_png[436];
+    extern const unsigned char propgridpage_png[237];
+    extern const unsigned char radio_box_png[488];
+    extern const unsigned char ribbon_button_png[220];
+    extern const unsigned char ribbon_gallery_item_png[679];
+    extern const unsigned char ribbon_page_png[368];
+    extern const unsigned char ribbon_panel_png[392];
+    extern const unsigned char richtextctrl_png[736];
+    extern const unsigned char scintilla_png[729];
+    extern const unsigned char search_png[800];
+    extern const unsigned char separator_png[306];
+    extern const unsigned char sizer_horizontal_png[129];
+    extern const unsigned char sizer_png[133];
+    extern const unsigned char spacer_png[183];
+    extern const unsigned char static_bitmap_png[778];
+    extern const unsigned char static_line_png[122];
+    extern const unsigned char statusbar_png[432];
+    extern const unsigned char submenu_png[760];
+    extern const unsigned char text_sizer_png[157];
+    extern const unsigned char timepicker_png[227];
+    extern const unsigned char tree_ctrl_png[246];
+    extern const unsigned char treelistctrl_png[425];
+    extern const unsigned char treelistctrlcolumn_png[504];
+    extern const unsigned char webview_png[1208];
+    extern const unsigned char wrap_sizer_png[145];
+    extern const unsigned char wxChoicebook_png[434];
+    extern const unsigned char wxCollapsiblePane_png[324];
+    extern const unsigned char wxDialog_png[636];
+    extern const unsigned char wxFrame_png[424];
+    extern const unsigned char wxListbook_png[357];
+    extern const unsigned char wxMenuBar_png[490];
+    extern const unsigned char wxNotebook_png[177];
+    extern const unsigned char wxPanel_png[156];
+    extern const unsigned char wxPropertyGridManager_png[225];
+    extern const unsigned char wxPropertyGrid_png[212];
+    extern const unsigned char wxToolBar_png[554];
+    extern const unsigned char wxToolbook_png[450];
+    extern const unsigned char wxTreebook_png[484];
+    extern const unsigned char wxWizardPageSimple_png[605];
+    extern const unsigned char wxWizard_png[1047];
+    extern const unsigned char wxactivityIndicator_png[796];
+    extern const unsigned char wxanimation_png[248];
+    extern const unsigned char wxbannerWindow_png[835];
+    extern const unsigned char wxcheckBox_png[202];
+    extern const unsigned char wxcomboBox_png[233];
+    extern const unsigned char wxfileCtrl_png[255];
+    extern const unsigned char wxmenuBar_png[490];
+    extern const unsigned char wxnotebook_png[177];
+    extern const unsigned char wxradioButton_png[268];
+    extern const unsigned char wxscrolledWindow_png[258];
+    extern const unsigned char wxsimplebook_png[249];
+    extern const unsigned char wxsplitterWindow_png[266];
+    extern const unsigned char wxtextCtrl_png[283];
+    extern const unsigned char wxtoolBar_png[554];
 }
 
 bool RibbonPanelBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style,

--- a/src/wxui/ribbonpanel_base.h
+++ b/src/wxui/ribbonpanel_base.h
@@ -24,8 +24,6 @@
 
 namespace wxue_img
 {
-    // Images declared in this class module:
-
     extern const unsigned char WXPOPupTransientWindow_png[358];
     extern const unsigned char auinotebook_png[284];
     extern const unsigned char book_page_png[229];

--- a/src/wxui/ui_images.cpp
+++ b/src/wxui/ui_images.cpp
@@ -14,342 +14,27 @@
 
 #include <memory>  // for std::make_unique
 
-// Convert compressed SVG string into a wxBitmapBundle
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size)
-{
-    auto str = std::make_unique<char[]>(size_svg);
-    wxMemoryInputStream stream_in(data, size_data);
-    wxZlibInputStream zlib_strm(stream_in);
-    zlib_strm.Read(str.get(), size_svg);
-    return wxBitmapBundle::FromSVG(str.get(), def_size);
-};
-
-// Convert a data array into a wxImage
-wxImage wxueImage(const unsigned char* data, size_t size_data)
-{
-    wxMemoryInputStream strm(data, size_data);
-    wxImage image;
-    image.LoadFile(strm);
-    return image;
-};
-
-// Convert multiple bitmaps into a wxBitmapBundle
-wxBitmapBundle wxueBundleBitmaps(const wxBitmap& bmp1, const wxBitmap& bmp2, const wxBitmap& bmp3)
-{
-    wxVector<wxBitmap> bitmaps;
-    if (bmp1.IsOk())
-        bitmaps.push_back(bmp1);
-    if (bmp2.IsOk())
-        bitmaps.push_back(bmp2);
-    if (bmp3.IsOk())
-        bitmaps.push_back(bmp3);
-    return wxBitmapBundle::FromBitmaps(bitmaps);
-};
-
-// Convert a data array into a wxAnimation
-wxAnimation wxueAnimation(const unsigned char* data, size_t size_data)
-{
-    wxMemoryInputStream strm(data, size_data);
-    wxAnimation animation;
-    animation.Load(strm);
-    return animation;
-};
-
 namespace wxue_img
 {
-    wxBitmapBundle bundle_cpp_logo_svg(int width, int height)
+    // Convert a data array into a wxImage
+    wxImage get_image(const unsigned char* data, size_t size_data)
     {
-        return wxueBundleSVG(wxue_img::cpp_logo_svg, 587, 1405, wxSize(width, height));
-    }
+        wxMemoryInputStream strm(data, size_data);
+        wxImage image;
+        image.LoadFile(strm);
+        return image;
+    };
 
-    wxBitmapBundle bundle_import_svg(int width, int height)
+    // Convert compressed SVG string into a wxBitmapBundle
+    wxBitmapBundle get_bundle_svg(const unsigned char* data,
+        size_t size_data, size_t size_svg, wxSize def_size)
     {
-        return wxueBundleSVG(wxue_img::import_svg, 418, 1013, wxSize(width, height));
-    }
-
-    wxBitmapBundle bundle_python_logo_only_svg(int width, int height)
-    {
-        return wxueBundleSVG(wxue_img::python_logo_only_svg, 1648, 6310, wxSize(width, height));
-    }
-
-    wxBitmapBundle bundle_redo_svg(int width, int height)
-    {
-        return wxueBundleSVG(wxue_img::redo_svg, 919, 2836, wxSize(width, height));
-    }
-
-    wxBitmapBundle bundle_undo_svg(int width, int height)
-    {
-        return wxueBundleSVG(wxue_img::undo_svg, 882, 2658, wxSize(width, height));
-    }
-
-    wxBitmapBundle bundle_wxUiEditor_svg(int width, int height)
-    {
-        return wxueBundleSVG(wxue_img::wxUiEditor_svg, 1943, 7265, wxSize(width, height));
-    }
-
-    wxBitmapBundle bundle_xrc_compare_svg(int width, int height)
-    {
-        return wxueBundleSVG(wxue_img::xrc_compare_svg, 260, 706, wxSize(width, height));
-    }
-
-    wxBitmapBundle bundle_auitoolbar_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(auitoolbar_png, 476)));
-    }
-
-    wxBitmapBundle bundle_bmp_combo_box_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(bmp_combo_box_png, 492)));
-    }
-
-    wxBitmapBundle bundle_check3state_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(check3state_png, 194)));
-    }
-
-    wxBitmapBundle bundle_close_btn_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(close_btn_png, 956)));
-    }
-
-    wxBitmapBundle bundle_dataview_ctrl_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(dataview_ctrl_png, 231)));
-    }
-
-    wxBitmapBundle bundle_dataviewlist_ctrl_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(dataviewlist_ctrl_png, 685)));
-    }
-
-    wxBitmapBundle bundle_dataviewtree_ctrl_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(dataviewtree_ctrl_png, 238)));
-    }
-
-    wxBitmapBundle bundle_debug_16_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(debug_16_png, 656)));
-    }
-
-    wxBitmapBundle bundle_debug_32_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(debug_32_png, 1701)));
-    }
-
-    wxBitmapBundle bundle_default_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(default_png, 518)));
-    }
-
-    wxBitmapBundle bundle_empty_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(empty_png, 101)));
-    }
-
-    wxBitmapBundle bundle_folder_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(folder_png, 641)));
-    }
-
-    wxBitmapBundle bundle_hide_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(hide_png, 242)));
-    }
-
-    wxBitmapBundle bundle_logo16_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(logo16_png, 639)));
-    }
-
-    wxBitmapBundle bundle_logo32_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(logo32_png, 1470)));
-    }
-
-    wxBitmapBundle bundle_logo64_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(logo64_png, 1718)));
-    }
-
-    wxBitmapBundle bundle_project_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(project_png, 899)));
-    }
-
-    wxBitmapBundle bundle_ribbon_bar_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(ribbon_bar_png, 844)));
-    }
-
-    wxBitmapBundle bundle_ribbon_buttonbar_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(ribbon_buttonbar_png, 300)));
-    }
-
-    wxBitmapBundle bundle_ribbon_gallery_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(ribbon_gallery_png, 215)));
-    }
-
-    wxBitmapBundle bundle_scrollbar_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(scrollbar_png, 214)));
-    }
-
-    wxBitmapBundle bundle_slider_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(slider_png, 248)));
-    }
-
-    wxBitmapBundle bundle_spin_ctrl_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(spin_ctrl_png, 300)));
-    }
-
-    wxBitmapBundle bundle_spin_ctrl_double_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(spin_ctrl_double_png, 219)));
-    }
-
-    wxBitmapBundle bundle_spinbtn_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(spinbtn_png, 192)));
-    }
-
-    wxBitmapBundle bundle_stddialogbuttonsizer_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(stddialogbuttonsizer_png, 524)));
-    }
-
-    wxBitmapBundle bundle_title_close_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(title_close_png, 144)));
-    }
-
-    wxBitmapBundle bundle_toggle_button_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(toggle_button_png, 277)));
-    }
-
-    wxBitmapBundle bundle_tool_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(tool_png, 629)));
-    }
-
-    wxBitmapBundle bundle_toolStretchable_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(toolStretchable_png, 578)));
-    }
-
-    wxBitmapBundle bundle_tool_dropdown_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(tool_dropdown_png, 447)));
-    }
-
-    wxBitmapBundle bundle_toolseparator_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(toolseparator_png, 581)));
-    }
-
-    wxBitmapBundle bundle_toolspacer_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(toolspacer_png, 459)));
-    }
-
-    wxBitmapBundle bundle_unknown_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(unknown_png, 1699)));
-    }
-
-    wxBitmapBundle bundle_wxButton_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxButton_png, 500)));
-    }
-
-    wxBitmapBundle bundle_wxCheckBox_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxCheckBox_png, 202)));
-    }
-
-    wxBitmapBundle bundle_wxCheckListBox_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxCheckListBox_png, 498)));
-    }
-
-    wxBitmapBundle bundle_wxChoice_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxChoice_png, 330)));
-    }
-
-    wxBitmapBundle bundle_wxComboBox_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxComboBox_png, 233)));
-    }
-
-    wxBitmapBundle bundle_wxCommandLinkButton_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxCommandLinkButton_png, 582)));
-    }
-
-    wxBitmapBundle bundle_wxEditListBox_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxEditListBox_png, 707)));
-    }
-
-    wxBitmapBundle bundle_wxListBox_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxListBox_png, 310)));
-    }
-
-    wxBitmapBundle bundle_wxListView_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxListView_png, 356)));
-    }
-
-    wxBitmapBundle bundle_wxPython_png()
-    {
-        return wxueBundleBitmaps(
-            wxBitmap(wxueImage(wxPython_png, 399)),
-            wxBitmap(wxueImage(wxPython_1_5x_png, 765)),
-            wxBitmap(wxueImage(wxPython_2x_png, 251)));
-    }
-
-    wxBitmapBundle bundle_wxRearrangeCtrl_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxRearrangeCtrl_png, 332)));
-    }
-
-    wxBitmapBundle bundle_wxSimpleHtmlListBox_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxSimpleHtmlListBox_png, 676)));
-    }
-
-    wxBitmapBundle bundle_wxStaticBoxSizer_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxStaticBoxSizer_png, 199)));
-    }
-
-    wxBitmapBundle bundle_wxStaticCheckBoxSizer_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxStaticCheckBoxSizer_png, 341)));
-    }
-
-    wxBitmapBundle bundle_wxStaticRadioBtnSizer_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxStaticRadioBtnSizer_png, 367)));
-    }
-
-    wxBitmapBundle bundle_wxStaticText_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxStaticText_png, 290)));
-    }
-
-    wxBitmapBundle bundle_wxTimer_png()
-    {
-        return wxBitmapBundle::FromBitmap(wxBitmap(wxueImage(wxTimer_png, 1323)));
-    }
+        auto str = std::make_unique<char[]>(size_svg);
+        wxMemoryInputStream stream_in(data, size_data);
+        wxZlibInputStream zlib_strm(stream_in);
+        zlib_strm.Read(str.get(), size_svg);
+        return wxBitmapBundle::FromSVG(str.get(), def_size);
+    };
 
     const unsigned char auitoolbar_png[476] {
     137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,22,0,0,0,22,8,6,0,0,0,196,180,108,59,0,0,0,9,112,72,89,115,0,0,11,
@@ -1580,6 +1265,564 @@ namespace wxue_img
     111,156,50,167,82,1,187,227,201,126,129,134,120,218,38,252,70,45,221,238,62,125,3,236,248,194,181
     };
 
+    wxBitmapBundle bundle_auitoolbar_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(auitoolbar_png, 476)));
+    }
+
+    wxBitmapBundle bundle_bmp_combo_box_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(bmp_combo_box_png, 492)));
+    }
+
+    wxBitmapBundle bundle_check3state_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(check3state_png, 194)));
+    }
+
+    wxBitmapBundle bundle_close_btn_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(close_btn_png, 956)));
+    }
+
+    wxBitmapBundle bundle_cpp_logo_svg(int width, int height)
+    {
+        return get_bundle_svg(cpp_logo_svg, 587, 1405, wxSize(width, height));
+    }
+
+    wxBitmapBundle bundle_dataview_ctrl_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(dataview_ctrl_png, 231)));
+    }
+
+    wxBitmapBundle bundle_dataviewlist_ctrl_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(dataviewlist_ctrl_png, 685)));
+    }
+
+    wxBitmapBundle bundle_dataviewtree_ctrl_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(dataviewtree_ctrl_png, 238)));
+    }
+
+    wxBitmapBundle bundle_debug_16_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(debug_16_png, 656)));
+    }
+
+    wxBitmapBundle bundle_debug_32_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(debug_32_png, 1701)));
+    }
+
+    wxBitmapBundle bundle_default_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(default_png, 518)));
+    }
+
+    wxBitmapBundle bundle_empty_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(empty_png, 101)));
+    }
+
+    wxBitmapBundle bundle_folder_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(folder_png, 641)));
+    }
+
+    wxBitmapBundle bundle_hide_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(hide_png, 242)));
+    }
+
+    wxBitmapBundle bundle_import_svg(int width, int height)
+    {
+        return get_bundle_svg(import_svg, 418, 1013, wxSize(width, height));
+    }
+
+    wxBitmapBundle bundle_logo16_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(logo16_png, 639)));
+    }
+
+    wxBitmapBundle bundle_logo32_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(logo32_png, 1470)));
+    }
+
+    wxBitmapBundle bundle_logo64_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(logo64_png, 1718)));
+    }
+
+    wxBitmapBundle bundle_project_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(project_png, 899)));
+    }
+
+    wxBitmapBundle bundle_python_logo_only_svg(int width, int height)
+    {
+        return get_bundle_svg(python_logo_only_svg, 1648, 6310, wxSize(width, height));
+    }
+
+    wxBitmapBundle bundle_redo_svg(int width, int height)
+    {
+        return get_bundle_svg(redo_svg, 919, 2836, wxSize(width, height));
+    }
+
+    wxBitmapBundle bundle_ribbon_bar_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(ribbon_bar_png, 844)));
+    }
+
+    wxBitmapBundle bundle_ribbon_buttonbar_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(ribbon_buttonbar_png, 300)));
+    }
+
+    wxBitmapBundle bundle_ribbon_gallery_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(ribbon_gallery_png, 215)));
+    }
+
+    wxBitmapBundle bundle_scrollbar_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(scrollbar_png, 214)));
+    }
+
+    wxBitmapBundle bundle_slider_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(slider_png, 248)));
+    }
+
+    wxBitmapBundle bundle_spin_ctrl_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(spin_ctrl_png, 300)));
+    }
+
+    wxBitmapBundle bundle_spin_ctrl_double_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(spin_ctrl_double_png, 219)));
+    }
+
+    wxBitmapBundle bundle_spinbtn_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(spinbtn_png, 192)));
+    }
+
+    wxBitmapBundle bundle_stddialogbuttonsizer_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(stddialogbuttonsizer_png, 524)));
+    }
+
+    wxBitmapBundle bundle_title_close_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(title_close_png, 144)));
+    }
+
+    wxBitmapBundle bundle_toggle_button_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(toggle_button_png, 277)));
+    }
+
+    wxBitmapBundle bundle_tool_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(tool_png, 629)));
+    }
+
+    wxBitmapBundle bundle_toolStretchable_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(toolStretchable_png, 578)));
+    }
+
+    wxBitmapBundle bundle_tool_dropdown_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(tool_dropdown_png, 447)));
+    }
+
+    wxBitmapBundle bundle_toolseparator_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(toolseparator_png, 581)));
+    }
+
+    wxBitmapBundle bundle_toolspacer_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(toolspacer_png, 459)));
+    }
+
+    wxBitmapBundle bundle_undo_svg(int width, int height)
+    {
+        return get_bundle_svg(undo_svg, 882, 2658, wxSize(width, height));
+    }
+
+    wxBitmapBundle bundle_unknown_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(unknown_png, 1699)));
+    }
+
+    wxBitmapBundle bundle_wxButton_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxButton_png, 500)));
+    }
+
+    wxBitmapBundle bundle_wxCheckBox_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxCheckBox_png, 202)));
+    }
+
+    wxBitmapBundle bundle_wxCheckListBox_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxCheckListBox_png, 498)));
+    }
+
+    wxBitmapBundle bundle_wxChoice_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxChoice_png, 330)));
+    }
+
+    wxBitmapBundle bundle_wxComboBox_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxComboBox_png, 233)));
+    }
+
+    wxBitmapBundle bundle_wxCommandLinkButton_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxCommandLinkButton_png, 582)));
+    }
+
+    wxBitmapBundle bundle_wxEditListBox_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxEditListBox_png, 707)));
+    }
+
+    wxBitmapBundle bundle_wxListBox_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxListBox_png, 310)));
+    }
+
+    wxBitmapBundle bundle_wxListView_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxListView_png, 356)));
+    }
+
+    wxBitmapBundle bundle_wxPython_png()
+    {
+        wxVector<wxBitmap> bitmaps;
+        bitmaps.push_back(get_image(wxPython_png, sizeof(wxPython_png)));
+        bitmaps.push_back(get_image(wxPython_1_5x_png, sizeof(wxPython_1_5x_png)));
+        bitmaps.push_back(get_image(wxPython_2x_png, sizeof(wxPython_2x_png)));
+        return wxBitmapBundle::FromBitmaps(bitmaps);
+    }
+
+    wxBitmapBundle bundle_wxRearrangeCtrl_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxRearrangeCtrl_png, 332)));
+    }
+
+    wxBitmapBundle bundle_wxSimpleHtmlListBox_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxSimpleHtmlListBox_png, 676)));
+    }
+
+    wxBitmapBundle bundle_wxStaticBoxSizer_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxStaticBoxSizer_png, 199)));
+    }
+
+    wxBitmapBundle bundle_wxStaticCheckBoxSizer_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxStaticCheckBoxSizer_png, 341)));
+    }
+
+    wxBitmapBundle bundle_wxStaticRadioBtnSizer_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxStaticRadioBtnSizer_png, 367)));
+    }
+
+    wxBitmapBundle bundle_wxStaticText_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxStaticText_png, 290)));
+    }
+
+    wxBitmapBundle bundle_wxTimer_png()
+    {
+        return wxBitmapBundle::FromBitmap(wxBitmap(get_image(wxTimer_png, 1323)));
+    }
+
+    wxBitmapBundle bundle_wxUiEditor_svg(int width, int height)
+    {
+        return get_bundle_svg(wxUiEditor_svg, 1943, 7265, wxSize(width, height));
+    }
+
+    wxBitmapBundle bundle_xrc_compare_svg(int width, int height)
+    {
+        return get_bundle_svg(xrc_compare_svg, 260, 706, wxSize(width, height));
+    }
+
+    wxImage image_auitoolbar_png()
+    {
+        return get_image(auitoolbar_png, 476);
+    }
+
+    wxImage image_bmp_combo_box_png()
+    {
+        return get_image(bmp_combo_box_png, 492);
+    }
+
+    wxImage image_check3state_png()
+    {
+        return get_image(check3state_png, 194);
+    }
+
+    wxImage image_close_btn_png()
+    {
+        return get_image(close_btn_png, 956);
+    }
+
+    wxImage image_dataview_ctrl_png()
+    {
+        return get_image(dataview_ctrl_png, 231);
+    }
+
+    wxImage image_dataviewlist_ctrl_png()
+    {
+        return get_image(dataviewlist_ctrl_png, 685);
+    }
+
+    wxImage image_dataviewtree_ctrl_png()
+    {
+        return get_image(dataviewtree_ctrl_png, 238);
+    }
+
+    wxImage image_debug_16_png()
+    {
+        return get_image(debug_16_png, 656);
+    }
+
+    wxImage image_debug_32_png()
+    {
+        return get_image(debug_32_png, 1701);
+    }
+
+    wxImage image_default_png()
+    {
+        return get_image(default_png, 518);
+    }
+
+    wxImage image_empty_png()
+    {
+        return get_image(empty_png, 101);
+    }
+
+    wxImage image_folder_png()
+    {
+        return get_image(folder_png, 641);
+    }
+
+    wxImage image_hide_png()
+    {
+        return get_image(hide_png, 242);
+    }
+
+    wxImage image_logo16_png()
+    {
+        return get_image(logo16_png, 639);
+    }
+
+    wxImage image_logo32_png()
+    {
+        return get_image(logo32_png, 1470);
+    }
+
+    wxImage image_logo64_png()
+    {
+        return get_image(logo64_png, 1718);
+    }
+
+    wxImage image_project_png()
+    {
+        return get_image(project_png, 899);
+    }
+
+    wxImage image_ribbon_bar_png()
+    {
+        return get_image(ribbon_bar_png, 844);
+    }
+
+    wxImage image_ribbon_buttonbar_png()
+    {
+        return get_image(ribbon_buttonbar_png, 300);
+    }
+
+    wxImage image_ribbon_gallery_png()
+    {
+        return get_image(ribbon_gallery_png, 215);
+    }
+
+    wxImage image_scrollbar_png()
+    {
+        return get_image(scrollbar_png, 214);
+    }
+
+    wxImage image_slider_png()
+    {
+        return get_image(slider_png, 248);
+    }
+
+    wxImage image_spin_ctrl_double_png()
+    {
+        return get_image(spin_ctrl_double_png, 219);
+    }
+
+    wxImage image_spin_ctrl_png()
+    {
+        return get_image(spin_ctrl_png, 300);
+    }
+
+    wxImage image_spinbtn_png()
+    {
+        return get_image(spinbtn_png, 192);
+    }
+
+    wxImage image_stddialogbuttonsizer_png()
+    {
+        return get_image(stddialogbuttonsizer_png, 524);
+    }
+
+    wxImage image_title_close_png()
+    {
+        return get_image(title_close_png, 144);
+    }
+
+    wxImage image_toggle_button_png()
+    {
+        return get_image(toggle_button_png, 277);
+    }
+
+    wxImage image_toolStretchable_png()
+    {
+        return get_image(toolStretchable_png, 578);
+    }
+
+    wxImage image_tool_dropdown_png()
+    {
+        return get_image(tool_dropdown_png, 447);
+    }
+
+    wxImage image_tool_png()
+    {
+        return get_image(tool_png, 629);
+    }
+
+    wxImage image_toolseparator_png()
+    {
+        return get_image(toolseparator_png, 581);
+    }
+
+    wxImage image_toolspacer_png()
+    {
+        return get_image(toolspacer_png, 459);
+    }
+
+    wxImage image_unknown_png()
+    {
+        return get_image(unknown_png, 1699);
+    }
+
+    wxImage image_wxButton_png()
+    {
+        return get_image(wxButton_png, 500);
+    }
+
+    wxImage image_wxCheckBox_png()
+    {
+        return get_image(wxCheckBox_png, 202);
+    }
+
+    wxImage image_wxCheckListBox_png()
+    {
+        return get_image(wxCheckListBox_png, 498);
+    }
+
+    wxImage image_wxChoice_png()
+    {
+        return get_image(wxChoice_png, 330);
+    }
+
+    wxImage image_wxComboBox_png()
+    {
+        return get_image(wxComboBox_png, 233);
+    }
+
+    wxImage image_wxCommandLinkButton_png()
+    {
+        return get_image(wxCommandLinkButton_png, 582);
+    }
+
+    wxImage image_wxEditListBox_png()
+    {
+        return get_image(wxEditListBox_png, 707);
+    }
+
+    wxImage image_wxListBox_png()
+    {
+        return get_image(wxListBox_png, 310);
+    }
+
+    wxImage image_wxListView_png()
+    {
+        return get_image(wxListView_png, 356);
+    }
+
+    wxImage image_wxPython_1_5x_png()
+    {
+        return get_image(wxPython_1_5x_png, 765);
+    }
+
+    wxImage image_wxPython_2x_png()
+    {
+        return get_image(wxPython_2x_png, 251);
+    }
+
+    wxImage image_wxPython_png()
+    {
+        return get_image(wxPython_png, 399);
+    }
+
+    wxImage image_wxRearrangeCtrl_png()
+    {
+        return get_image(wxRearrangeCtrl_png, 332);
+    }
+
+    wxImage image_wxSimpleHtmlListBox_png()
+    {
+        return get_image(wxSimpleHtmlListBox_png, 676);
+    }
+
+    wxImage image_wxStaticBoxSizer_png()
+    {
+        return get_image(wxStaticBoxSizer_png, 199);
+    }
+
+    wxImage image_wxStaticCheckBoxSizer_png()
+    {
+        return get_image(wxStaticCheckBoxSizer_png, 341);
+    }
+
+    wxImage image_wxStaticRadioBtnSizer_png()
+    {
+        return get_image(wxStaticRadioBtnSizer_png, 367);
+    }
+
+    wxImage image_wxStaticText_png()
+    {
+        return get_image(wxStaticText_png, 290);
+    }
+
+    wxImage image_wxTimer_png()
+    {
+        return get_image(wxTimer_png, 1323);
+    }
 }
 
 // ************* End of generated code ***********

--- a/src/wxui/ui_images.h
+++ b/src/wxui/ui_images.h
@@ -11,75 +11,124 @@
 
 #include <wx/gdicmn.h>
 
-#include <wx/animate.h>  // wxAnimation class
 #include <wx/bmpbndl.h>
-
-wxAnimation wxueAnimation(const unsigned char* data, size_t size_data);
-wxBitmapBundle wxueBundleSVG(const unsigned char* data,
-    size_t size_data, size_t size_svg, wxSize def_size);
-wxImage wxueImage(const unsigned char* data, size_t size_data);
 
 namespace wxue_img
 {
+    wxImage get_image(const unsigned char* data, size_t size_data);
+
+    wxBitmapBundle bundle_auitoolbar_png();  // auitoolbar.png
+    wxBitmapBundle bundle_bmp_combo_box_png();  // bmp_combo_box.png
+    wxBitmapBundle bundle_check3state_png();  // check3state.png
+    wxBitmapBundle bundle_close_btn_png();  // close_btn.png
     wxBitmapBundle bundle_cpp_logo_svg(int width, int height);
+    wxBitmapBundle bundle_dataview_ctrl_png();  // dataview_ctrl.png
+    wxBitmapBundle bundle_dataviewlist_ctrl_png();  // dataviewlist_ctrl.png
+    wxBitmapBundle bundle_dataviewtree_ctrl_png();  // dataviewtree_ctrl.png
+    wxBitmapBundle bundle_debug_16_png();  // debug_16.png
+    wxBitmapBundle bundle_debug_32_png();  // debug_32.png
+    wxBitmapBundle bundle_default_png();  // default.png
+    wxBitmapBundle bundle_empty_png();  // empty.png
+    wxBitmapBundle bundle_folder_png();  // folder.png
+    wxBitmapBundle bundle_hide_png();  // hide.png
     wxBitmapBundle bundle_import_svg(int width, int height);
+    wxBitmapBundle bundle_logo16_png();  // logo16.png
+    wxBitmapBundle bundle_logo32_png();  // logo32.png
+    wxBitmapBundle bundle_logo64_png();  // logo64.png
+    wxBitmapBundle bundle_project_png();  // project.png
     wxBitmapBundle bundle_python_logo_only_svg(int width, int height);
     wxBitmapBundle bundle_redo_svg(int width, int height);
+    wxBitmapBundle bundle_ribbon_bar_png();  // ribbon_bar.png
+    wxBitmapBundle bundle_ribbon_buttonbar_png();  // ribbon_buttonbar.png
+    wxBitmapBundle bundle_ribbon_gallery_png();  // ribbon_gallery.png
+    wxBitmapBundle bundle_scrollbar_png();  // scrollbar.png
+    wxBitmapBundle bundle_slider_png();  // slider.png
+    wxBitmapBundle bundle_spin_ctrl_png();  // spin_ctrl.png
+    wxBitmapBundle bundle_spin_ctrl_double_png();  // spin_ctrl_double.png
+    wxBitmapBundle bundle_spinbtn_png();  // spinbtn.png
+    wxBitmapBundle bundle_stddialogbuttonsizer_png();  // stddialogbuttonsizer.png
+    wxBitmapBundle bundle_title_close_png();  // title_close.png
+    wxBitmapBundle bundle_toggle_button_png();  // toggle_button.png
+    wxBitmapBundle bundle_tool_png();  // tool.png
+    wxBitmapBundle bundle_toolStretchable_png();  // toolStretchable.png
+    wxBitmapBundle bundle_tool_dropdown_png();  // tool_dropdown.png
+    wxBitmapBundle bundle_toolseparator_png();  // toolseparator.png
+    wxBitmapBundle bundle_toolspacer_png();  // toolspacer.png
     wxBitmapBundle bundle_undo_svg(int width, int height);
+    wxBitmapBundle bundle_unknown_png();  // unknown.png
+    wxBitmapBundle bundle_wxButton_png();  // wxButton.png
+    wxBitmapBundle bundle_wxCheckBox_png();  // wxCheckBox.png
+    wxBitmapBundle bundle_wxCheckListBox_png();  // wxCheckListBox.png
+    wxBitmapBundle bundle_wxChoice_png();  // wxChoice.png
+    wxBitmapBundle bundle_wxComboBox_png();  // wxComboBox.png
+    wxBitmapBundle bundle_wxCommandLinkButton_png();  // wxCommandLinkButton.png
+    wxBitmapBundle bundle_wxEditListBox_png();  // wxEditListBox.png
+    wxBitmapBundle bundle_wxListBox_png();  // wxListBox.png
+    wxBitmapBundle bundle_wxListView_png();  // wxListView.png
+    wxBitmapBundle bundle_wxPython_png();  // wxPython.png
+    wxBitmapBundle bundle_wxRearrangeCtrl_png();  // wxRearrangeCtrl.png
+    wxBitmapBundle bundle_wxSimpleHtmlListBox_png();  // wxSimpleHtmlListBox.png
+    wxBitmapBundle bundle_wxStaticBoxSizer_png();  // wxStaticBoxSizer.png
+    wxBitmapBundle bundle_wxStaticCheckBoxSizer_png();  // wxStaticCheckBoxSizer.png
+    wxBitmapBundle bundle_wxStaticRadioBtnSizer_png();  // wxStaticRadioBtnSizer.png
+    wxBitmapBundle bundle_wxStaticText_png();  // wxStaticText.png
+    wxBitmapBundle bundle_wxTimer_png();  // wxTimer.png
     wxBitmapBundle bundle_wxUiEditor_svg(int width, int height);
     wxBitmapBundle bundle_xrc_compare_svg(int width, int height);
 
-    wxBitmapBundle bundle_auitoolbar_png();
-    wxBitmapBundle bundle_bmp_combo_box_png();
-    wxBitmapBundle bundle_check3state_png();
-    wxBitmapBundle bundle_close_btn_png();
-    wxBitmapBundle bundle_dataview_ctrl_png();
-    wxBitmapBundle bundle_dataviewlist_ctrl_png();
-    wxBitmapBundle bundle_dataviewtree_ctrl_png();
-    wxBitmapBundle bundle_debug_16_png();
-    wxBitmapBundle bundle_debug_32_png();
-    wxBitmapBundle bundle_default_png();
-    wxBitmapBundle bundle_empty_png();
-    wxBitmapBundle bundle_folder_png();
-    wxBitmapBundle bundle_hide_png();
-    wxBitmapBundle bundle_logo16_png();
-    wxBitmapBundle bundle_logo32_png();
-    wxBitmapBundle bundle_logo64_png();
-    wxBitmapBundle bundle_project_png();
-    wxBitmapBundle bundle_ribbon_bar_png();
-    wxBitmapBundle bundle_ribbon_buttonbar_png();
-    wxBitmapBundle bundle_ribbon_gallery_png();
-    wxBitmapBundle bundle_scrollbar_png();
-    wxBitmapBundle bundle_slider_png();
-    wxBitmapBundle bundle_spin_ctrl_png();
-    wxBitmapBundle bundle_spin_ctrl_double_png();
-    wxBitmapBundle bundle_spinbtn_png();
-    wxBitmapBundle bundle_stddialogbuttonsizer_png();
-    wxBitmapBundle bundle_title_close_png();
-    wxBitmapBundle bundle_toggle_button_png();
-    wxBitmapBundle bundle_tool_png();
-    wxBitmapBundle bundle_toolStretchable_png();
-    wxBitmapBundle bundle_tool_dropdown_png();
-    wxBitmapBundle bundle_toolseparator_png();
-    wxBitmapBundle bundle_toolspacer_png();
-    wxBitmapBundle bundle_unknown_png();
-    wxBitmapBundle bundle_wxButton_png();
-    wxBitmapBundle bundle_wxCheckBox_png();
-    wxBitmapBundle bundle_wxCheckListBox_png();
-    wxBitmapBundle bundle_wxChoice_png();
-    wxBitmapBundle bundle_wxComboBox_png();
-    wxBitmapBundle bundle_wxCommandLinkButton_png();
-    wxBitmapBundle bundle_wxEditListBox_png();
-    wxBitmapBundle bundle_wxListBox_png();
-    wxBitmapBundle bundle_wxListView_png();
-    wxBitmapBundle bundle_wxPython_png();
-    wxBitmapBundle bundle_wxRearrangeCtrl_png();
-    wxBitmapBundle bundle_wxSimpleHtmlListBox_png();
-    wxBitmapBundle bundle_wxStaticBoxSizer_png();
-    wxBitmapBundle bundle_wxStaticCheckBoxSizer_png();
-    wxBitmapBundle bundle_wxStaticRadioBtnSizer_png();
-    wxBitmapBundle bundle_wxStaticText_png();
-    wxBitmapBundle bundle_wxTimer_png();
+    wxImage image_auitoolbar_png();
+    wxImage image_bmp_combo_box_png();
+    wxImage image_check3state_png();
+    wxImage image_close_btn_png();
+    wxImage image_dataview_ctrl_png();
+    wxImage image_dataviewlist_ctrl_png();
+    wxImage image_dataviewtree_ctrl_png();
+    wxImage image_debug_16_png();
+    wxImage image_debug_32_png();
+    wxImage image_default_png();
+    wxImage image_empty_png();
+    wxImage image_folder_png();
+    wxImage image_hide_png();
+    wxImage image_logo16_png();
+    wxImage image_logo32_png();
+    wxImage image_logo64_png();
+    wxImage image_project_png();
+    wxImage image_ribbon_bar_png();
+    wxImage image_ribbon_buttonbar_png();
+    wxImage image_ribbon_gallery_png();
+    wxImage image_scrollbar_png();
+    wxImage image_slider_png();
+    wxImage image_spin_ctrl_double_png();
+    wxImage image_spin_ctrl_png();
+    wxImage image_spinbtn_png();
+    wxImage image_stddialogbuttonsizer_png();
+    wxImage image_title_close_png();
+    wxImage image_toggle_button_png();
+    wxImage image_toolStretchable_png();
+    wxImage image_tool_dropdown_png();
+    wxImage image_tool_png();
+    wxImage image_toolseparator_png();
+    wxImage image_toolspacer_png();
+    wxImage image_unknown_png();
+    wxImage image_wxButton_png();
+    wxImage image_wxCheckBox_png();
+    wxImage image_wxCheckListBox_png();
+    wxImage image_wxChoice_png();
+    wxImage image_wxComboBox_png();
+    wxImage image_wxCommandLinkButton_png();
+    wxImage image_wxEditListBox_png();
+    wxImage image_wxListBox_png();
+    wxImage image_wxListView_png();
+    wxImage image_wxPython_1_5x_png();
+    wxImage image_wxPython_2x_png();
+    wxImage image_wxPython_png();
+    wxImage image_wxRearrangeCtrl_png();
+    wxImage image_wxSimpleHtmlListBox_png();
+    wxImage image_wxStaticBoxSizer_png();
+    wxImage image_wxStaticCheckBoxSizer_png();
+    wxImage image_wxStaticRadioBtnSizer_png();
+    wxImage image_wxStaticText_png();
+    wxImage image_wxTimer_png();
 
     extern const unsigned char auitoolbar_png[476];
     extern const unsigned char bmp_combo_box_png[492];
@@ -100,8 +149,7 @@ namespace wxue_img
     extern const unsigned char logo32_png[1470];
     extern const unsigned char logo64_png[1718];
     extern const unsigned char project_png[899];
-    // python-logo-only.svg
-    extern const unsigned char python_logo_only_svg[1648];
+    extern const unsigned char python_logo_only_svg[1648];  // python-logo-only.svg
     extern const unsigned char redo_svg[919];
     extern const unsigned char ribbon_bar_png[844];
     extern const unsigned char ribbon_buttonbar_png[300];

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -9,6 +9,7 @@
     wxWidgets_version="3.2">
     <node
       class="Images"
+      add_externs="1"
       base_file="ui_images">
       <node
         class="embedded_image"

--- a/src/xml/lang_settings.xml
+++ b/src/xml/lang_settings.xml
@@ -8,7 +8,7 @@ inline const char* lang_settings_xml = R"===(<?xml version="1.0"?>
 		<property name="base_file" type="file"
 			help="The filename of the base class." />
 		<property name="generate_translation_unit" type="bool"
-			help="If checked, both a source file (translation unit) and a header file are generated. If not checked, all code is generated in the header file, and no source file is created.">
+			help="If checked, both a source file (translation unit) and a header file are generated. If not checked, all code is generated in the header file, and no source file is created. A header-only file with images requires a C++17 or later compiler.">
 			1</property>
 		<property name="source_preamble" type="code_edit"
 			help="This preamble is added in addition to any src_preamble specified for the entire project. It will be placed unchanged at the top of the generated base src file after any (optional) precompiled header file." />

--- a/src/xml/objects_xml.xml
+++ b/src/xml/objects_xml.xml
@@ -8,6 +8,8 @@ inline const char* objects_xml = R"===(<?xml version="1.0"?>
             help="The Python filename to store all the embedded images in.">images</property>
         <property name="ruby_file" type="file"
             help="The Ruby filename to store all the embedded images in.">images</property>
+        <property name="add_externs" type="bool"
+            help="If checked, each image data array will be added to the header file as an extern.">0</property>
         <!-- <property name="auto_update" type="bool"
             help="Automatically add any embedded or svg images specified for controls or forms. Will only add images in folders if the folder does not have its own image form.">0</property> -->
     </gen>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how the Image List file is generated, and how images are loaded with or without the existence of an Image File.

## No Images List file

wxueImage() and wxueBundleSVG() will be generated in any file that needs them whether or not that file actually contains the image data array. A conditional is now used to mark the functions as `inline` if compiling under C++17 or later, or `static` if compiling under C++14 or earlier. For C++17, only one copy of the function will be linked into the executable, and for older compilers that `static` will prevent name conflicts, though it does mean the function body will be added multiple times to the executable.

Each image data array is still unique to the project, and where it gets defined still depends on the order of the forms in the project. Each form's generated source file will have `externs` declared for any image that is needed. These are no longer generated in the header file, since the file containing the image definition could change any time the user changes form position.

## Images List file

The wxueImage() and wxueBundleSVG() functions have been removed from this file. In their place are get_image() and get_bundle_svg() which are within the `wxue_img` namespace. Normally, these will not be used by a dev, since there are both `bundle_...()` and `image_...()` functions for loading any image added to the list that can be loaded into a wxBitmapBundle or wxImage.

By default, the header file only contains the namespace and all of the available functions. A `add_extern` property has been added to the Images List node -- and if checked, `extern` declarations will be added to the header file after all of the function declarations.

## wxWidgets 3.1 code generation

This is still broken around images, and this PR probably makes it worse. A second branch is active with 3.1 code generation fixes, and after this PR is merged into it, work will continue on that branch. Chances are, if you mark your project as using wxWidgets 3.1, you will not be able to compile it.