### PR TITLE
Fix code generating when wxWidgets 3.1 is set

### DIFF
--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -196,7 +196,18 @@ bool WizardFormGenerator::SettingsCode(Code& code)
     {
         if (code.is_cpp())
         {
+            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            {
+                code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t\t";
+            }
             code.Eol(eol_if_needed).FormFunction("if (!Create(").Str("parent, id, title, wxBitmapBundle(), pos, style))");
+
+            if (Project.as_string(prop_wxWidgets_version) == "3.1")
+            {
+                code.Eol() += "#else\n\t\t";
+                code.Eol(eol_if_needed).FormFunction("if (!Create(").Str("parent, id, title, wxNullBitmap, pos, style))");
+                code.Eol() += "#endif";
+            }
             code.Eol().Tab().Str("return;");
         }
         else if (code.is_python())
@@ -204,6 +215,7 @@ bool WizardFormGenerator::SettingsCode(Code& code)
             code.Eol(eol_if_needed).Str("if not self.Create(parent, id, title, wx.BitmapBundle(), pos, style):");
             code.Eol().Tab().Str("return");
         }
+        // wxRuby3 code generation doesn't use 2-step construction.
     }
 
     return true;

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -196,18 +196,7 @@ bool WizardFormGenerator::SettingsCode(Code& code)
     {
         if (code.is_cpp())
         {
-            if (Project.as_string(prop_wxWidgets_version) == "3.1")
-            {
-                code.Eol() += "#if wxCHECK_VERSION(3, 1, 6)\n\t\t";
-            }
-            code.Eol(eol_if_needed).FormFunction("if (!Create(").Str("parent, id, title, wxBitmapBundle(), pos, style))");
-
-            if (Project.as_string(prop_wxWidgets_version) == "3.1")
-            {
-                code.Eol() += "#else\n\t\t";
-                code.Eol(eol_if_needed).FormFunction("if (!Create(").Str("parent, id, title, wxNullBitmap, pos, style))");
-                code.Eol() += "#endif";
-            }
+            code.Eol(eol_if_needed).FormFunction("if (!Create(").Str("parent, id, title, wxNullBitmap, pos, style))");
             code.Eol().Tab().Str("return;");
         }
         else if (code.is_python())

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -716,7 +716,17 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
     name.make_relative(path);
     name.backslashestoforward();
 
-    if (bundle->lst_filenames.size() == 1)
+    if (code.is_cpp() && get_bitmap)
+    {
+        code.Eol().Tab() << "wxueImage(";
+
+        name = "wxue_img::" + embed->array_name;
+
+        code << name << ", sizeof(" << name << "))";
+        code << ".Rescale(";
+        code.Eol() << "\tFromDIP(" << embed->size.x << "), FromDIP(" << embed->size.y << "), wxIMAGE_QUALITY_BILINEAR)";
+    }
+    else if (bundle->lst_filenames.size() == 1)
     {
         if (code.is_cpp())
         {
@@ -725,12 +735,6 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
             name = "wxue_img::" + embed->array_name;
 
             code << name << ", sizeof(" << name << "))";
-            if (get_bitmap)
-            {
-                code << ".Rescale(";
-                code.Eol() << "\tFromDIP(" << embed->size.x << "), FromDIP(" << embed->size.y
-                           << "), wxIMAGE_QUALITY_BILINEAR)";
-            }
         }
         else if (code.is_python())
         {
@@ -766,13 +770,6 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
             else
             {
                 code << "wxNullBitmap))";
-            }
-
-            if (get_bitmap)
-            {
-                code.CheckLineLength(sizeof(".GetBitmap(wxSize(FromDIP(32), FromDIP(32)))"));
-                code << ".GetBitmap(wxSize(";
-                code.Eol().Tab() << "FromDIP(" << embed->size.x << "), FromDIP(" << embed->size.y << ")))";
             }
         }
         else if (code.is_python())
@@ -826,10 +823,6 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
             code.Str("return wxBitmapBundle::FromBitmaps(bitmaps);").CloseBrace();
             code.pop_back();  // remove the linefeed
             code.Str("()");
-            if (get_bitmap)
-            {
-                code << ".GetBitmap(wxSize(FromDIP(" << embed->size.x << "), FromDIP(" << embed->size.y << ")))";
-            }
         }
         else if (code.is_python())
         {

--- a/wxWidgets/src/stc/lexilla/lexers/LexCPP.cxx
+++ b/wxWidgets/src/stc/lexilla/lexers/LexCPP.cxx
@@ -1343,7 +1343,9 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 							// as that means that it contributed to the result.
 							if (!preproc.CurrentIfTaken()) {
 								// Inactive, may become active if parent scope active
-								assert(sc.state == (SCE_C_PREPROCESSOR|inactiveFlag));
+								// [Randalphwa - 12-03-2023] I commented out the assert because I was hitting
+								// it non-stop while working on wxUiEditor-generated code.
+								// assert(sc.state == (SCE_C_PREPROCESSOR|inactiveFlag));
 								preproc.InvertCurrentLevel();
 								activitySet = preproc.ActiveState();
 								// If following is active then show "else" as active


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a number of problems when generating code with wxWidgets 3.1 selected, mostly related to how images are loaded (wxImage versus wxBitmapBundle).