### PR TITLE
Fix Clang format problems with generated headers that have user supplied closing brace

### DIFF
--- a/src/generate/file_codewriter.h
+++ b/src/generate/file_codewriter.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   Classs to write code to disk
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -15,8 +15,9 @@ namespace code
     enum
     {
         flag_none = 0,
-        flag_test_only = 1 << 0,  // Don't write the file, just return the result
-        flag_no_ui = 1 << 1,      // Don't display any UI (cannot create missing folder)
+        flag_test_only = 1 << 0,          // Don't write the file, just return the result
+        flag_no_ui = 1 << 1,              // Don't display any UI (cannot create missing folder)
+        flag_add_closing_brace = 1 << 2,  // Set when no_closing_brace property is set
     };
 
     enum

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -138,6 +138,8 @@ void GenThreadCpp(GenData& gen_data, Node* form)
     int flags = flag_no_ui;
     if (gen_data.pClassList)
         flags |= flag_test_only;
+    if (form->as_bool(prop_no_closing_brace))
+        flags |= flag_add_closing_brace;
     auto retval = h_cw->WriteFile(GEN_LANG_CPLUSPLUS, flags);
 
     if (retval > 0)
@@ -403,7 +405,10 @@ void GenInhertedClass(GenResults& results)
             }
 
             // If we get here, the source file exists, but the header file does not.
-            retval = h_cw->WriteFile(GEN_LANG_CPLUSPLUS, flag_no_ui);
+            int flags = flag_no_ui;
+            if (form->as_bool(prop_no_closing_brace))
+                flags |= flag_add_closing_brace;
+            retval = h_cw->WriteFile(GEN_LANG_CPLUSPLUS, flags);
             if (retval == result::fail)
             {
                 results.msgs.emplace_back() << "Cannot create or write to the file " << path << '\n';
@@ -426,9 +431,17 @@ void GenInhertedClass(GenResults& results)
 
         path.replace_extension(header_ext);
         if (path.file_exists())
+        {
             retval = result::exists;
+        }
         else
-            retval = h_cw->WriteFile(GEN_LANG_CPLUSPLUS, flag_no_ui);
+        {
+            int flags = flag_no_ui;
+            if (form->as_bool(prop_no_closing_brace))
+                flags |= flag_add_closing_brace;
+
+            retval = h_cw->WriteFile(GEN_LANG_CPLUSPLUS, flags);
+        }
 
         if (retval == result::fail)
         {

--- a/src/panels/doc_view.h
+++ b/src/panels/doc_view.h
@@ -70,8 +70,9 @@ private:
 // Code below this comment block will be preserved
 // if the code for this class is re-generated.
 //
-// clang-format on
 // ***********************************************
+
+    // clang-format on
 
 public:
     DocViewPanel(wxWindow* parent, MainFrame* frame);

--- a/src/ui/startup_dlg.h
+++ b/src/ui/startup_dlg.h
@@ -62,8 +62,9 @@ private:
 // Code below this comment block will be preserved
 // if the code for this class is re-generated.
 //
-// clang-format on
 // ***********************************************
+
+    // clang-format on
 
 public:
     enum : size_t


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how a new header file is written if the user sets the no_closing_brace property to true. The new file will no longer have a `// clang_format on` line within the comment block, placing it after the block instead. In addition, a default `};` will be added at the end of the file.

Closes #1201

Note that this PR has no impact on existing generated code, other than allowing the user to move the `// clang_format on` line so that it is no longer within the comment block. Theoretically, we could write a special case to look for the old style, but I doubt there are enough people using this feature to make it worthwhile.