### PR TITLE
Add new Different Project menu item/tool

### DIFF
--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -268,6 +268,7 @@ protected:
     void OnCopy(wxCommandEvent& event) override;
     void OnCut(wxCommandEvent& event) override;
     void OnDelete(wxCommandEvent& event) override;
+    void OnDifferentProject(wxCommandEvent& event) override;
     void OnDuplicate(wxCommandEvent& event) override;
     void OnEditCustomIds(wxCommandEvent& event) override;
     void OnFindDialog(wxCommandEvent& event) override;
@@ -277,8 +278,8 @@ protected:
     void OnInsertWidget(wxCommandEvent&) override;
     void OnNewProject(wxCommandEvent& event);
     void OnOpenRecentProject(wxCommandEvent& event);
-    void OnPreferencesDlg(wxCommandEvent& event) override;
     void OnPaste(wxCommandEvent& event) override;
+    void OnPreferencesDlg(wxCommandEvent& event) override;
     void OnSaveAsProject(wxCommandEvent& event) override;
     void OnToggleExpandLayout(wxCommandEvent&) override;
     void OnUpdateBrowseDocs(wxUpdateUIEvent& event) override;

--- a/src/ui/startup_dlg.cpp
+++ b/src/ui/startup_dlg.cpp
@@ -163,7 +163,6 @@ bool StartupDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     dlg_sizer->Add(box_sizer_7, wxSizerFlags().Expand().Border(wxALL));
 
     SetSizerAndFit(dlg_sizer);
-    Centre(wxBOTH);
 
     // Event handlers
     hyperlink_2->Bind(wxEVT_HYPERLINK, &StartupDlg::OnOpen, this);
@@ -180,7 +179,7 @@ bool StartupDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 // Code below this comment block will be preserved
 // if the code for this class is re-generated.
 //
-// clang-format on
+// ***********************************************
 // ***********************************************
 
 /////////////////////////////////////////////////////////////////////////////
@@ -192,8 +191,24 @@ bool StartupDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
 #include "mainframe.h"  // MainFrame -- Main window frame
 
+#include <wx/display.h>  // wxDisplay: represents a display/monitor attached to the system
+
 void StartupDlg::OnInit(wxInitDialogEvent& event)
 {
+    if (!GetParent())
+    {
+        wxDisplay desktop(this);
+        wxRect rect_parent(desktop.GetClientArea());
+        wxRect rect_this(GetSize());
+        rect_this.x = rect_parent.x + (rect_parent.width - rect_this.width) / 2;
+        rect_this.y = rect_parent.y + (rect_parent.height - rect_this.height) / 3;
+        SetSize(rect_this, wxSIZE_ALLOW_MINUS_ONE);
+    }
+    else
+    {
+        Center(wxHORIZONTAL);
+    }
+
     m_name_version->SetLabel(txtVersion);
 
     auto& history = wxGetMainFrame()->getFileHistory();

--- a/src/ui/startup_dlg.cpp
+++ b/src/ui/startup_dlg.cpp
@@ -18,7 +18,11 @@
 
 #include "../wxui/ui_images.h"
 
+#include <wx/display.h>
+
 #include "startup_dlg.h"
+
+#include "../mainframe.h"
 
 #include <wx/mstream.h>  // memory stream classes
 #include <wx/zstream.h>  // zlib stream classes
@@ -180,7 +184,6 @@ bool StartupDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 // if the code for this class is re-generated.
 //
 // ***********************************************
-// ***********************************************
 
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog to display if wxUiEditor is launched with no arguments
@@ -189,9 +192,7 @@ bool StartupDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "mainframe.h"  // MainFrame -- Main window frame
-
-#include <wx/display.h>  // wxDisplay: represents a display/monitor attached to the system
+// clang-format on
 
 void StartupDlg::OnInit(wxInitDialogEvent& event)
 {

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -77,17 +77,14 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     m_toolbar = new wxToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTB_FLAT|wxTB_HORIZONTAL|wxTB_NODIVIDER);
 
     m_toolbar->AddSeparator();
-    m_toolbar->AddTool(id_NewProject, "New",
-        wxueBundleSVG(wxue_img::new_project_svg, 921, 2208, FromDIP(wxSize(24, 24))), "New Project (Ctrl+N)");
-
-    m_toolbar->AddTool(id_OpenProject, "Open", wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN, wxART_TOOLBAR),
-        "Open Project (Ctrl+O)");
+    m_toolbar->AddTool(id_DifferentProject, "Different Project...",
+        wxue_img::bundle_wxUiEditor_svg(FromDIP(24), FromDIP(24)), "Different Project... (Ctrl+D)");
 
     m_toolbar->AddTool(wxID_SAVE, "Save",
         wxueBundleSVG(wxue_img::save_svg, 717, 2603, FromDIP(wxSize(24, 24))), "Save current project");
 
-    m_toolbar->AddTool(id_GenerateCode, wxEmptyString,
-        wxueBundleSVG(wxue_img::generate_svg, 780, 2716, FromDIP(wxSize(24, 24))), "Generate code");
+    m_toolbar->AddTool(id_GenerateCode, "Generate...",
+        wxueBundleSVG(wxue_img::generate_svg, 780, 2716, FromDIP(wxSize(24, 24))), "Generate code...");
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(wxID_UNDO, wxEmptyString,
@@ -176,19 +173,23 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     m_menubar = new wxMenuBar();
 
     m_menuFile = new wxMenu();
+    auto* menuItem3 = new wxMenuItem(m_menuFile, id_DifferentProject, "&Different Project...\tCtrl+D", "Open a project",
+        wxITEM_NORMAL);
+    menuItem3->SetBitmap(wxue_img::bundle_wxUiEditor_svg(16, 16));
+    m_menuFile->Append(menuItem3);
     auto* menuItem = new wxMenuItem(m_menuFile, id_NewProject, "&New Project...\tCtrl+N", "Create an empty project",
         wxITEM_NORMAL);
     menuItem->SetBitmap(wxueBundleSVG(wxue_img::new_project_svg, 921, 2208, wxSize(16, 16)));
 
     m_menuFile->Append(menuItem);
     auto* menuItem2 = new wxMenuItem(m_menuFile, id_OpenProject, "&Open Project...\tCtrl+O", "Open a project", wxITEM_NORMAL);
-    menuItem2->SetBitmap(wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN, wxART_OTHER));
+    menuItem2->SetBitmap(wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN, wxART_MENU));
 
     m_menuFile->Append(menuItem2);
 
     m_submenu_recent = new wxMenu();
     m_menuFile->AppendSubMenu(m_submenu_recent, "Open &Recent");
-    auto* menu_import = new wxMenuItem(m_menuFile, wxID_ANY, "&Import...");
+    auto* menu_import = new wxMenuItem(m_menuFile, wxID_ANY, "&Import Project...");
     menu_import->SetBitmap(wxue_img::bundle_import_svg(16, 16));
     m_menuFile->Append(menu_import);
     m_menuFile->AppendSeparator();
@@ -404,6 +405,7 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     Bind(wxEVT_CLOSE_WINDOW, &MainFrameBase::OnClose, this);
     Bind(wxEVT_MENU, &MainFrameBase::OnToggleExpandLayout, this, id_Expand);
     Bind(wxEVT_MENU, &MainFrameBase::OnGenerateCode, this, id_GenerateCode);
+    Bind(wxEVT_MENU, &MainFrameBase::OnDifferentProject, this, id_DifferentProject);
     Bind(wxEVT_MENU,
         [](wxCommandEvent&)
         {
@@ -419,14 +421,14 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
         },
         menu_import->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveProject, this, wxID_SAVE);
-    Bind(wxEVT_MENU, &MainFrameBase::OnImportWindowsResource, this, id_AppendWinRes);
+    Bind(wxEVT_MENU, &MainFrameBase::OnPreviewXrc, this, id_PreviewForm);
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveAsProject, this, id_SaveProjectAs);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendCrafter, this, id_AppendCrafter);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendFormBuilder, this, id_AppendFormBuilder);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendGlade, this, id_AppendGlade);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendSmith, this, id_AppendSmith);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendDialogBlocks, this, id_AppendCrafter);
-    Bind(wxEVT_MENU, &MainFrameBase::OnPreviewXrc, this, id_PreviewForm);
+    Bind(wxEVT_MENU, &MainFrameBase::OnImportWindowsResource, this, id_AppendWinRes);
     Bind(wxEVT_MENU, &MainFrameBase::OnAppendXRC, this, id_AppendXRC);
     Bind(wxEVT_MENU, &MainFrameBase::OnPreferencesDlg, this, id_PreferencesDlg);
     Bind(wxEVT_MENU,

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -68,6 +68,7 @@ public:
         id_BorderLeft,
         id_BorderRight,
         id_BorderTop,
+        id_DifferentProject,
         id_Expand,
         id_GenerateCode,
         id_Magnify,
@@ -116,6 +117,7 @@ protected:
     virtual void OnCopy(wxCommandEvent& event) { event.Skip(); }
     virtual void OnCut(wxCommandEvent& event) { event.Skip(); }
     virtual void OnDelete(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnDifferentProject(wxCommandEvent& event) { event.Skip(); }
     virtual void OnDuplicate(wxCommandEvent& event) { event.Skip(); }
     virtual void OnEditCustomIds(wxCommandEvent& event) { event.Skip(); }
     virtual void OnFindDialog(wxCommandEvent& event) { event.Skip(); }

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -5178,6 +5178,8 @@
       icon="SVG;wxUiEditor.svg;[16,16]"
       title="Open, Import, or Create Project"
       base_file="..\ui\startup_dlg"
+      local_src_includes="../mainframe.h"
+      system_src_includes="wx/display.h"
       no_closing_brace="1"
       private_members="1"
       use_derived_class="0"

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -214,17 +214,11 @@
               class="toolSeparator" />
             <node
               class="tool"
-              bitmap="SVG;new-project.svg;[24,24]"
-              id="id_NewProject"
-              label="New"
-              tooltip="New Project (Ctrl+N)" />
-            <node
-              class="tool"
-              bitmap="Art;wxART_FILE_OPEN|wxART_TOOLBAR"
-              id="id_OpenProject"
-              label="Open"
-              tooltip="Open Project (Ctrl+O)"
-              var_name="tool2" />
+              bitmap="SVG;wxUiEditor.svg;[24,24]"
+              id="id_DifferentProject"
+              label="Different Project..."
+              tooltip="Different Project... (Ctrl+D)"
+              var_name="tool4" />
             <node
               class="tool"
               bitmap="SVG;save.svg;[24,24]"
@@ -236,8 +230,8 @@
               class="tool"
               bitmap="SVG;generate.svg;[24,24]"
               id="id_GenerateCode"
-              label=""
-              tooltip="Generate code"
+              label="Generate..."
+              tooltip="Generate code..."
               var_name="Generate"
               wxEVT_TOOL="OnGenerateCode" />
             <node
@@ -448,18 +442,29 @@
             var_name="m_menuFile">
             <node
               class="wxMenuItem"
+              bitmap="SVG;wxUiEditor.svg;[16,16]"
+              help="Open a project"
+              id="id_DifferentProject"
+              label="&amp;Different Project..."
+              shortcut="Ctrl+D"
+              var_name="menuItem3"
+              wxEVT_MENU="OnDifferentProject" />
+            <node
+              class="wxMenuItem"
               bitmap="SVG;new-project.svg;[16,16]"
               help="Create an empty project"
               id="id_NewProject"
-              label="&amp;New Project...&#09;Ctrl+N"
+              label="&amp;New Project..."
+              shortcut="Ctrl+N"
               var_name="menuItem"
               wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@Project.NewProject(true);@@}" />
             <node
               class="wxMenuItem"
-              bitmap="Art;wxART_FILE_OPEN|wxART_OTHER"
+              bitmap="Art;wxART_FILE_OPEN|wxART_MENU"
               help="Open a project"
               id="id_OpenProject"
-              label="&amp;Open Project...&#09;Ctrl+O"
+              label="&amp;Open Project..."
+              shortcut="Ctrl+O"
               var_name="menuItem2"
               wxEVT_MENU="OnOpenProject" />
             <node
@@ -470,7 +475,7 @@
             <node
               class="wxMenuItem"
               bitmap="SVG;import.svg;[16,16]"
-              label="&amp;Import..."
+              label="&amp;Import Project..."
               var_name="menu_import"
               wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@// Specifying false tells NewProject to import@@Project.NewProject(false);@@}" />
             <node
@@ -5168,6 +5173,7 @@
     </node>
     <node
       class="wxDialog"
+      center="no"
       class_name="StartupDlg"
       icon="SVG;wxUiEditor.svg;[16,16]"
       title="Open, Import, or Create Project"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new `Different Project` menu item (first item under the File menu) and replaces the New and Open toolbar tools with a single Different Project tool. The Different Project command launches the Startup Dialog, giving the user access to New, Open, Recent and Import project options.

This also slightly changes where the Startup Dialog appears when wxUiEditor is first loaded -- instead of being centered vertically on the screen, it's now moved up so that 1/3 of the remaining desktop space is above it instead of 1/2.
