### PR TITLE
Add m_internal_data and getInternalData() to Node

### DIFF
--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -1320,3 +1320,10 @@ Node* Node::getPlatformContainer()
 
     return nullptr;
 }
+
+std::vector<tt_string>* Node::getInternalData()
+{
+    if (!m_internal_data)
+        m_internal_data = std::make_unique<std::vector<tt_string>>();
+    return m_internal_data.get();
+}

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -444,6 +444,9 @@ public:
     void setMockupObject(wxObject* object) { m_mockup_object = object; }
     const wxObject* getMockupObject() const { return m_mockup_object; }
 
+    // This will create a std::unique_ptr<std::vector<tt_string>> if one doesn't already exist.
+    std::vector<tt_string>* getInternalData();
+
 protected:
     void findAllChildProperties(std::vector<NodeProperty*>& list, PropName name);
 
@@ -465,6 +468,7 @@ private:
     NodeDeclaration* m_declaration;
 
     wxObject* m_mockup_object { nullptr };
+    std::unique_ptr<std::vector<tt_string>> m_internal_data;
 };
 
 using NodeMapEvents = std::unordered_map<std::string, NodeEvent, str_view_hash, std::equal_to<>>;


### PR DESCRIPTION
See PR for description

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR looks fairly simple, but years from now when I or someone else tries to figure out why Nodes have a `std::unique_ptr<std::vector<tt_string>>` they might be able to find this PR for when it was added and get an explanation of the rationale.

I have often wished there was a way to store data in a Node that would _not_ get written to the project. For example, once a project is read, it would be really helpful to know if an image file has been changed before the project gets generated, but without having to reread the file. Storing size and/or timedate stamp would solve that problem, but there is no reason to store it in the project file since all image files are read in when the project is loaded.

The issue has always been that sometimes I need to store a size_t, or wxSize, or a string, or something else entirely. There can be thousands of nodes in a project, so adding more members to every single node is not a good idea. All project data is stored as strings no matter what it is used for, so we're already using strings to store non-string data. Adding a vector of strings might be inefficient for storing data, but is the most flexible way to store unknown data types.
