### PR TITLE
Conditionalize char/short in tt_string::Format

### DIFF
--- a/src/tt/tt_string.cpp
+++ b/src/tt/tt_string.cpp
@@ -942,10 +942,15 @@ tt_string& tt_string::Format(std::string_view format, ...)
             if (format.at(pos) == 'c')
             {
                 if (width != WIDTH_LONG)
+                {
+                    FAIL_MSG("%c should not be used, since it only works when compiled with MSVC");
+#if defined(_WIN32)
                     buffer << va_arg(args, char);
+#endif
+                }
                 else
                 {
-                    FAIL_MSG("%lc should not be used, since it only works on Windows");
+                    FAIL_MSG("%lc should not be used, since it only works with MSVC compiler.");
 #if defined(_WIN32)
                     std::wstring str16;
                     str16 += va_arg(args, wchar_t);
@@ -993,11 +998,17 @@ tt_string& tt_string::Format(std::string_view format, ...)
                         break;
 
                     case WIDTH_CHAR:
+                        FAIL_MSG("%lc should not be used, since it only works with MSVC compiler.");
+#if defined(_WIN32)
                         buffer << va_arg(args, signed char);
+#endif
                         break;
 
                     case WIDTH_SHORT:
+                        FAIL_MSG("%lh should not be used, since it only works with MSVC compiler.");
+#if defined(_WIN32)
                         buffer << va_arg(args, short);
+#endif
                         break;
 
                     case WIDTH_LONG:
@@ -1058,11 +1069,17 @@ tt_string& tt_string::Format(std::string_view format, ...)
                         break;
 
                     case WIDTH_CHAR:
+                        FAIL_MSG("%luc should not be used, since it only works with MSVC compiler.");
+#if defined(_WIN32)
                         buffer << va_arg(args, unsigned char);
+#endif
                         break;
 
                     case WIDTH_SHORT:
+                        FAIL_MSG("%lh should not be used, since it only works with MSVC compiler.");
+#if defined(_WIN32)
                         buffer << va_arg(args, unsigned short);
+#endif
                         break;
 
                     case WIDTH_LONG:


### PR DESCRIPTION
Neither char or short work as currently coded when compiled with gcc.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR conditionalizes use of char and short in tt_string::Format. This generate a warning when compiled with gcc since using them will cause a GPF. These now all generate a `FAIL_MSG` under Debug builds and are conditionalized to only be available when building on Windows. As far as I know, this isn't ever used, but for now I'm leaving it in place until I've verified that it's never called, while at the same time ignoring it on Linux builds.