### PR TITLE
Change code-generation for Context Help in wxStdDialogButtonSizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- The `hide_children` property in the wxStaticBoxSizer has been removed since the `hidden` property does exactly the same thing. Projects where `hide_children` was set will be automatically converted to use `hidden` instead.
+- The `hide_children` property in the `wxStaticBoxSizer` has been removed since the `hidden` property does exactly the same thing. Projects where `hide_children` was set will be automatically converted to use `hidden` instead.
 - The Image List file now includes wxue_img::image_ functions for each image in the list, replacing the `extern` declarations that were previously used. A new `add_externs` property has been added -- check that if you still need the extern declarations.
 
 ### Fixed
 
 - The Show Hidden on the toolbar now shows (in the Mockup panel) the children of sizers that have their children hidden.
-- Setting `hidden` in a wxStaticBoxSizer did not generate any code to hide the wxStaticBox and it's children (you had to check `hide_children` to get the code). This has been fixed.
+- Setting `hidden` in a `wxStaticBoxSizer` did not generate any code to hide the wxStaticBox and it's children (you had to check `hide_children` to get the code). This has been fixed.
+- The Context Help button in wxStdDialogButtonSizer did not have a label. This now generates a `wxContextHelpButton` which uses a bitmap rather than a label, and automatically places the dialog in context-help mode when clicked.
 
 ## [Released (1.2.0)]
 

--- a/src/generate/gen_std_dlgbtn_sizer.cpp
+++ b/src/generate/gen_std_dlgbtn_sizer.cpp
@@ -6,6 +6,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include <wx/button.h>
+#include <wx/cshelp.h>  // Context-sensitive help support classes
 #include <wx/sizer.h>
 #include <wx/statline.h>
 
@@ -62,7 +63,8 @@ wxObject* StdDialogButtonSizerGenerator::CreateMockup(Node* node, wxObject* pare
     if (node->as_bool(prop_Help))
         sizer->AddButton(new wxButton(wxStaticCast(parent, wxWindow), wxID_HELP));
     else if (node->as_bool(prop_ContextHelp))
-        sizer->AddButton(new wxButton(wxStaticCast(parent, wxWindow), wxID_CONTEXT_HELP));
+        // sizer->AddButton(new wxButton(wxStaticCast(parent, wxWindow), wxID_CONTEXT_HELP, "?"));
+        sizer->AddButton(new wxContextHelpButton(wxStaticCast(parent, wxWindow), wxID_CONTEXT_HELP));
 
     sizer->Realize();
 
@@ -212,7 +214,7 @@ bool StdDialogButtonSizerGenerator::ConstructionCode(Code& code)
     else if (node->as_bool(prop_ContextHelp))
     {
         code.Eol().NodeName().Function("AddButton(");
-        code += "new wxButton(this, wxID_CONTEXT_HELP));";
+        code += "new wxContextHelpButton(this, wxID_CONTEXT_HELP));";
     }
 
     if (def_btn_name == "OK" || def_btn_name == "Yes" || def_btn_name == "Save")
@@ -318,7 +320,7 @@ void StdDialogButtonSizerGenerator::GenPythonConstruction(Code& code)
     }
     else if (node->as_bool(prop_ContextHelp))
     {
-        code.Eol().NodeName().Add("_ContextHelp = wx.Button(self, wx.ID_CONTEXT_HELP)");
+        code.Eol().NodeName().Add("_ContextHelp = wx.ContextHelpButton(self, wx.ID_CONTEXT_HELP)");
         code.Eol().NodeName().Function("AddButton(").NodeName().Add("_ContextHelp").EndFunction();
     }
 
@@ -417,7 +419,8 @@ void StdDialogButtonSizerGenerator::GenRubyConstruction(Code& code)
     }
     else if (node->as_bool(prop_ContextHelp))
     {
-        gen_btn_code("ContextHelp", "context_help_btn", "Wx::ID_CONTEXT_HELP");
+        code.Eol().NodeName().Function("add_button(").Str("Wx::ContextHelpButton.new(self, Wx::ID_CONTEXT_HELP))");
+        // gen_btn_code("ContextHelp", "context_help_btn", "Wx::ID_CONTEXT_HELP");
     }
 
     code.Eol().NodeName().Function("realize");
@@ -579,6 +582,7 @@ int StdDialogButtonSizerGenerator::GenXrcObject(Node* node, pugi::xml_node& obje
         else if (node->as_bool(prop_ContextHelp))
         {
             button.append_attribute("name").set_value("wxID_CONTEXT_HELP");
+            button.append_child("label").text().set("?");
         }
     }
 
@@ -663,6 +667,8 @@ bool StdDialogButtonSizerGenerator::GetIncludes(Node* node, std::set<std::string
 {
     InsertGeneratorInclude(node, "#include <wx/button.h>", set_src, set_hdr);
     InsertGeneratorInclude(node, "#include <wx/sizer.h>", set_src, set_hdr);
+    if (node->as_bool(prop_ContextHelp))
+        set_src.insert("#include <wx/cshelp.h>");
 
     return true;
 }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes code generation for the Context Help button in a `wxStdDialogButtonSizer` to use a `wxContextHelpButton` instead of a `wxButton` (which was previously missing a label). This button is smaller than the other buttons since it uses a bitmap instead of text, and clicking on it will automatically place the dialog in context-help mode. This works for C++, wxPython and wxRuby3.

XRC does not support `wxContextHelpButton`, so the code generator will fall back to using a `wxButton` with "?" created for the label in the XRC file.

Closes #1335
