### PR TITLE
Add python and ruby support for wxGenericStaticBitmap 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Dark Mode and High Contrast Dark Mode are now available in the Prefences dialog on Windows.
 - XPM files are now supported in wxPython and wxRuby3
+- Setting a static bitmap's scale mode will now use wxGenericStaticBitmap in wxPython (4.2.1) and wxRuby3 (0/9/3) to ensure that all platforms will support the scaling.
 
 ### Changed
 

--- a/src/generate/gen_static_bmp.cpp
+++ b/src/generate/gen_static_bmp.cpp
@@ -52,10 +52,14 @@ bool StaticBitmapGenerator::ConstructionCode(Code& code)
     {
         if (code.hasValue(prop_bitmap))
         {
+            bool use_generic_version = (code.node()->as_string(prop_scale_mode) != "None");
             if (code.is_python())
             {
                 bool is_list_created = PythonBitmapList(code, prop_bitmap);
-                code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
+                if (!use_generic_version)
+                    code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
+                else
+                    code.NodeName().CreateClass("GenericStaticBitmap").ValidParentName().Comma().as_string(prop_id).Comma();
 
                 if (is_list_created)
                 {
@@ -68,7 +72,6 @@ bool StaticBitmapGenerator::ConstructionCode(Code& code)
             }
             else if (code.is_ruby())
             {
-                bool use_generic_version = (code.node()->as_string(prop_scale_mode) != "None");
                 if (!use_generic_version)
                     code.NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id).Comma();
                 else
@@ -207,7 +210,11 @@ bool StaticBitmapGenerator::SettingsCode(Code& code)
 {
     if (code.node()->as_string(prop_scale_mode) != "None")
     {
-        code.NodeName().Function("SetScaleMode(").Add("wxStaticBitmap");
+        // C++ and wxRuby3 use wxStaticBitmap::ScaleMode, wxPython uses wxGenericStaticBitmap::ScaleMode
+        if (!code.is_python())
+            code.NodeName().Function("SetScaleMode(").Add("wxStaticBitmap");
+        else
+            code.NodeName().Function("SetScaleMode(").Add("wxGenericStaticBitmap");
         if (code.is_cpp())
         {
             code += "::Scale_";


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR supports wxGenericStaticBitmap now that wxPython 4.2.1 and wxRuby3 0.9.3 support it. When the user specifies a scaling mode, wxGenericStaticBitmap is now used in all three languages to ensure that the platform will support the scaling.