### PR TITLE
Get correct page for active tab

### DIFF
--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -78,6 +78,7 @@ public:
     NavigationPanel* getNavigationPanel() { return m_nav_panel; }
     RibbonPanel* getRibbonPanel() { return m_ribbon_panel; }
     BasePanel* getGeneratedPanel() { return m_generatedPanel; }
+    wxAuiNotebook* getTopNotebook() { return m_notebook; }
     DocViewPanel* getDocViewPanel() { return m_docviewPanel; }
 
 #if defined(INTERNAL_TESTING)

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -289,15 +289,18 @@ void BasePanel::OnFind(wxFindDialogEvent& event)
 
 PANEL_PAGE BasePanel::GetPanelPage() const
 {
-    if (auto page = m_notebook->GetCurrentPage(); page)
+    auto* top_notebook = wxGetFrame().getTopNotebook();
+    auto top_page_name = top_notebook->GetPageText(top_notebook->GetSelection());
+    auto* child_panel = static_cast<BasePanel*>(top_notebook->GetCurrentPage());
+    if (auto* page = child_panel->m_notebook->GetCurrentPage(); page)
     {
-        if (page == m_cppPanel)
+        if (page == child_panel->m_cppPanel)
             return CPP_PANEL;
-        else if (page == m_hPanel)
+        else if (page == child_panel->m_hPanel)
             return HDR_PANEL;
-        else if (page == m_derived_src_panel)
+        else if (page == child_panel->m_derived_src_panel)
             return DERIVED_SRC_PANEL;
-        else if (page == m_derived_hdr_panel)
+        else if (page == child_panel->m_derived_hdr_panel)
             return DERIVED_HDR_PANEL;
     }
     return CPP_PANEL;


### PR DESCRIPTION
The called BasePanel may not be the currently selected panel, so start with the top most notebook, find the active tab, then find out which page in the active tab is active.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how the active Language tab is determined. By starting with the active tab, the correct display page for the selected language is retrieved, which is necessary for bookmarking to work correctly.

Closes #1347