### PR TITLE
Track file modification time in Data List

### DIFF
--- a/src/project/data_handler.h
+++ b/src/project/data_handler.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <wx/datetime.h>  // declarations of time/date related classes (wxDateTime,
+
 #include <map>
 
 #include "node_classes.h"  // Forward defintions of Node classes
@@ -27,6 +29,7 @@ struct EmbeddedData
     size_t array_size;
     std::unique_ptr<unsigned char[]> array_data;
     size_t type;         // 0 = string, 1 = xml, tt::npos = not_found
+    wxDateTime m_DateTime;
     bool xml_condensed;  // true if node->as_bool(prop_xml_condensed_format) is true
 };
 
@@ -51,11 +54,6 @@ public:
 
     // Only call this when the datalist code needs to be generated.
     void Initialize();
-
-    // Generate extern references to all the data variables.
-    //
-    // This will call code.clear() before writing any code.
-    void WriteDataPreConstruction(Code& code);
 
     // Generate data list construction code in source
     //

--- a/src/project/data_handler.h
+++ b/src/project/data_handler.h
@@ -28,7 +28,7 @@ struct EmbeddedData
     tt_string filename;
     size_t array_size;
     std::unique_ptr<unsigned char[]> array_data;
-    size_t type;         // 0 = string, 1 = xml, tt::npos = not_found
+    size_t type;  // 0 = string, 1 = xml, tt::npos = not_found
     wxDateTime m_DateTime;
     bool xml_condensed;  // true if node->as_bool(prop_xml_condensed_format) is true
 };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a wxDataTime field to each embedded data list file structure. Before generating the file either in the C++ src panel, or when code is generated to disk, the wxDateTime is checked, and if it has changed the file will be reloaded before being generated. This allows the user to change the file while wxUiEditor is running, and have the change correctly generated.