### PR TITLE
Add wxRuby3 validator support, fix misc C++ validator problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Dark Mode and High Contrast Dark Mode are now available in the Prefences dialog on Windows.
-- XPM files are now supported in wxPython and wxRuby3
-- Setting a static bitmap's scale mode will now use wxGenericStaticBitmap in wxPython (4.2.1) and wxRuby3 (0/9/3) to ensure that all platforms will support the scaling.
-- Added wxBitmapToggleButton for all languages
-- Added wxContextHelpButton for all languages
+- XPM files are now supported in wxPython and wxRuby3.
+- Setting a static bitmap's scale mode will now use wxGenericStaticBitmap in wxPython (4.2.1) and wxRuby3 (0.9.3) to ensure that all platforms will support the scaling.
+- Added wxBitmapToggleButton for all languages.
+- Added wxContextHelpButton for all languages.
+- Added support for all four validators in wxRuby3 0.9.3 and up.
 
 ### Changed
 
 - The `hide_children` property in the `wxStaticBoxSizer` has been removed since the `hidden` property does exactly the same thing. Projects where `hide_children` was set will be automatically converted to use `hidden` instead.
 - The Image List file now includes wxue_img::image_ functions for each image in the list, replacing the `extern` declarations that were previously used. A new `add_externs` property has been added -- check that if you still need the extern declarations.
+- wxIntegerValidator and wxFloatingPointValidator now support setting either min or max, and are generated as separate calls. Previously, you had to set both of them to have either one generated.
 
 ### Fixed
 

--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -419,15 +419,13 @@ void BaseCodeGenerator::GenSettings(Node* node, bool within_brace)
 
     if (node->getPropPtr(prop_window_extra_style))
     {
-        if (m_language == GEN_LANG_CPLUSPLUS)
+        GenValidatorSettings(code);
+        if (code.size())
         {
-            GenValidatorSettings(code);
-            if (code.size())
-            {
-                m_source->writeLine(code);
-                code.clear();
-            }
+            m_source->writeLine(code);
+            code.clear();
         }
+
         code.GenWindowSettings();
         if (code.size())
             m_source->writeLine(code);

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -254,6 +254,8 @@ bool TextCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, 
     {
         if (auto val_type = node->getValidatorType(); val_type.size())
         {
+            if (node->as_string(prop_validator_data_type) == "wxFileName")
+                set_hdr.insert("#include <wx/filename.h>");
             if (val_type == "wxGenericValidator")
                 set_src.insert("#include <wx/valgen.h>");
             else if (val_type == "wxTextValidator")


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds support for wxRuby3 validators. It also updates C++ code generation for validators:

- wxGenericValidator will ignore any validator styles
- wxFILTER_NONE is no longer added as a style if other styles are specified
- wx/filename.h is added to header file if validator_data_type is wxFileName
- it is no longer necessary to set both min and max values for numeric validators in order for either of them to be used.
