### PR TITLE
Switch compiler standard to std:c++latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,9 @@ endif()
 
 ####################### General Settings #######################
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+# CMAKE_CXX_STANDARD is not set, using -std::c++latest instead. However, currently your compiler
+# *MUST* support C++20 or later.
+
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if (MSVC)
@@ -263,7 +264,7 @@ endif()
 if (MSVC)
     # /GL -- combined with the Linker flag /LTCG to perform whole program optimization in Release build
     # /FC -- Full path to source code file in diagnostics
-    target_compile_options(wxUiEditor PRIVATE "$<$<CONFIG:Release>:/GL>" "/FC" "/W4" "/Zc:__cplusplus" "/utf-8")
+    target_compile_options(wxUiEditor PRIVATE "$<$<CONFIG:Release>:/GL>" "/FC" "/W4" "/Zc:__cplusplus" "/utf-8" "/std:c++latest")
 
     target_link_options(wxUiEditor PRIVATE "$<$<CONFIG:Release>:/LTCG>")
     target_link_options(wxUiEditor PRIVATE "$<$<CONFIG:Debug>:/OPT:REF>")
@@ -271,7 +272,7 @@ if (MSVC)
     # Assume the manifest is in the resource file
     target_link_options(wxUiEditor PRIVATE "/manifest:no")
 elseif(UNIX)
-    target_compile_options(wxUiEditor PRIVATE "-fPIC")
+    target_compile_options(wxUiEditor PRIVATE "-fPIC" "-std:c++latest")
 endif()
 
 target_precompile_headers(wxUiEditor PRIVATE "src/pch.h")

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -42,7 +42,6 @@
 #include "project_handler.h"  // ProjectHandler class
 #include "undo_cmds.h"        // InsertNodeAction -- Undoable command classes derived from UndoAction
 #include "utils.h"            // Utility functions that work with properties
-#include "wakatime.h"         // WakaTime -- Updates WakaTime metrics
 #include "write_code.h"       // Write code to Scintilla or file
 
 #include "panels/base_panel.h"      // BasePanel -- C++ panel

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Main window frame
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -13,6 +13,7 @@
 #include "gen_enums.h"   // Enumerations for generators
 #include "mainapp.h"     // App class
 #include "undo_stack.h"  // UndoAction -- Maintain a undo and redo stack
+#include "wakatime.h"    // WakaTime -- Updates WakaTime metrics
 
 #include "wxui/mainframe_base.h"
 
@@ -27,7 +28,6 @@ class MockupPanel;
 class MockupParent;
 class NavigationPanel;
 class PropGridPanel;
-class WakaTime;
 class ImportPanel;
 
 class wxAuiNotebook;

--- a/src/pch.h
+++ b/src/pch.h
@@ -9,6 +9,14 @@
 
 #pragma once  // NOLINT(#pragma once in main file)
 
+#if defined(_MSVC_LANG)
+    #if (_MSVC_LANG < 202002L)
+        #error "This project requires C++20 or later"
+    #endif
+#elif (__cplusplus < 202002L)
+    #error "This project requires C++20 or later"
+#endif
+
 // Ensure that _DEBUG is defined in non-release builds
 #if !defined(NDEBUG) && !defined(_DEBUG)
     #define _DEBUG

--- a/src/tt/tt_string.h
+++ b/src/tt/tt_string.h
@@ -72,19 +72,11 @@ public:
     // Locates the position of a substring.
     size_t locate(std::string_view str, size_t posStart = 0, tt::CASE check = tt::CASE::exact) const;
 
-#if ((__cplusplus > 202002L || (defined(_MSVC_LANG) && _MSVC_LANG > 202002L)) && defined(__cpp_lib_string_contains))
-    // C++23 already has a contains() function, so we just declare our variation that supports
-    // case-insensitive (normal and utf8).
-
-    // Returns true if the sub string exists
-    bool contains(std::string_view sub, tt::CASE checkcase) const { return (locate(sub, 0, checkcase) != npos); }
-#else
     // Returns true if the sub string exists
     bool contains(std::string_view sub, tt::CASE checkcase = tt::CASE::exact) const
     {
         return (locate(sub, 0, checkcase) != npos);
     }
-#endif
 
     // Returns true if any string in the iteration list appears somewhere in the the main string.
     template <class iterT>

--- a/src/tt/tt_string_view.h
+++ b/src/tt/tt_string_view.h
@@ -55,19 +55,11 @@ public:
     /// Locates the position of a substring.
     size_t locate(std::string_view str, size_t posStart = 0, tt::CASE check = tt::CASE::exact) const;
 
-#if ((__cplusplus > 202002L || (defined(_MSVC_LANG) && _MSVC_LANG > 202002L)) && defined(__cpp_lib_string_contains))
-    // C++23 already has a contains() function, so we just declare our variation that supports
-    // case-insensitive (normal and utf8).
-
-    /// Returns true if the sub string exists
-    bool contains(std::string_view sub, tt::CASE checkcase) const { return (locate(sub, 0, checkcase) != npos); }
-#else
     /// Returns true if the sub string exists
     bool contains(std::string_view sub, tt::CASE checkcase = tt::CASE::exact) const
     {
         return (locate(sub, 0, checkcase) != npos);
     }
-#endif
 
     /// Returns true if any string in the iteration list appears somewhere in the the main string.
     template <class iterT>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes the C++20 requirement from CMakeLists.txt and places the check in the precompiled header instead. That made it possible to use -std::c++latest as the compiler. With MSVC, that's going to be C++23 which resulted in some errors that needed fixing. By always using the latest standard, we can avoid having compiler problems due to changing standards in the future.

Note that c++latest can _not_ be used currently for compiling the wxWidgets library -- that will require fixes to wxWidgets itself.