### PR TITLE
Move where check for "Art" is made

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -271,6 +271,11 @@ void BaseCodeGenerator::GatherGeneratorIncludes(Node* node, std::set<std::string
                     set_src.insert(m_include_images_statement);
                 }
 
+                if (iter.as_string().starts_with("Art"))
+                {
+                    m_NeedArtProviderHeader = true;
+                }
+
                 if (auto function_name = ProjectImages.GetBundleFuncName(iter.as_string()); function_name.size())
                 {
                     continue;
@@ -764,10 +769,6 @@ void BaseCodeGenerator::ParseImageProperties(Node* node)
                             }
                         }
                     }
-                }
-                else if ((parts[IndexType] == "Art"))
-                {
-                    m_NeedArtProviderHeader = true;
                 }
                 else if ((parts[IndexType] == "SVG"))
                 {


### PR DESCRIPTION
Moved out of thread function into GatherGeneratorIncludes(). See issue #1367

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR moves the check for whether wx/artprov.h must be generated to the GatherGeneratorIncludes() function so that it is not dependent on thread completion for the flag to be set.

Closes #1367
