### PR TITLE
Fix problems with base_file containing a directory

### DIFF
--- a/src/customprops/include_files_dlg.cpp
+++ b/src/customprops/include_files_dlg.cpp
@@ -96,7 +96,7 @@ bool IncludeFilesDialog::Create(wxWindow* parent, wxWindowID id, const wxString&
 
 /////////////////// Non-generated Copyright/License Info ////////////////////
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2023-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -164,38 +164,14 @@ void IncludeFilesDialog::OnAdd(wxCommandEvent& WXUNUSED(event))
         m_prop->isProp(prop_python_import_list))
     {
         auto* form = m_prop->getNode();
-        GenEnum::PropName file_prop;
-        if (m_language == GEN_LANG_RUBY)
-            file_prop = prop_ruby_file;
-        else if (m_language == GEN_LANG_PYTHON)
-            file_prop = prop_python_file;
-        else
-            file_prop = prop_base_file;
-
-        if (auto& base_file = form->as_string(file_prop); base_file.size())
+        path = Project.GetOutputPath(form, m_language);
+        if (path.size())
         {
-            path = Project.getBaseDirectory(form, m_language);
-            if (path.size())
-            {
-                path.append_filename(base_file);
-            }
-            else
-            {
-                path = base_file;
-            }
-
-            path.make_absolute();
-            path.backslashestoforward();
-            cur_file = path;
+            cur_file = path.filename();
 
             // We only got the node's filename in case it includes a path. We don't want the
             // filename portion as part of the path.
             path.remove_filename();
-
-            // We need to know the current filename so that properties that import modules
-            // (Python, Ruby, etc) don't try to load the current file.
-            cur_file.make_relative(path);
-            cur_file.backslashestoforward();
         }
 
         if (path.empty())

--- a/src/customprops/include_files_dlg.cpp
+++ b/src/customprops/include_files_dlg.cpp
@@ -164,8 +164,9 @@ void IncludeFilesDialog::OnAdd(wxCommandEvent& WXUNUSED(event))
         m_prop->isProp(prop_python_import_list))
     {
         auto* form = m_prop->getNode();
-        path = Project.GetOutputPath(form, m_language);
-        if (path.size())
+        auto [output_path, has_base_file] = Project.GetOutputPath(form, m_language);
+        path = std::move(output_path);
+        if (has_base_file)
         {
             cur_file = path.filename();
 

--- a/src/generate/file_codewriter.cpp
+++ b/src/generate/file_codewriter.cpp
@@ -1,12 +1,13 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   Classs to write code to disk
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
 #include <wx/file.h>      // wxFile - encapsulates low-level "file descriptor"
 #include <wx/filename.h>  // wxFileName - encapsulates a file path
+#include <wx/msgdlg.h>    // common header and base class for wxMessageDialog
 
 #include "file_codewriter.h"
 
@@ -236,14 +237,18 @@ int FileCodeWriter::WriteFile(int language, int flags)
             return write_no_folder;
         }
 
-        if (wxMessageBox(wxString() << "The directory " << copy.make_wxString()
-                                    << " doesn't exist.\n\nWould you like it to be created?",
-                         "Generate Files", wxICON_WARNING | wxYES_NO) == wxYES)
+        // Use wxMessageDialog() rather than wxMessageBox() because it will correctly handle a
+        // long filename, whereas wxMessageBox() would truncate a long filename.
+
+        std::string msg("The directory:\n    \"" + copy + "\"\ndoesn't exist. Would you like it to be created?");
+        wxMessageDialog dlg(nullptr, wxString::FromUTF8(msg), "Generate Files", wxICON_WARNING | wxYES_NO);
+        if (dlg.ShowModal() == wxID_YES)
         {
             if (!tt_string::MkDir(copy))
             {
-                wxMessageBox(wxString() << "The directory " << copy.make_wxString() << "could not be created.",
-                             "Generate Files", wxICON_ERROR | wxOK);
+                msg = "The directory:\n    \"" + copy + "\"\ncould not be created.";
+                wxMessageDialog dlg_error(nullptr, wxString::FromUTF8(msg), "Generate Files", wxICON_ERROR | wxOK);
+                dlg_error.ShowModal();
                 return write_cant_create;
             }
         }

--- a/src/generate/file_codewriter.cpp
+++ b/src/generate/file_codewriter.cpp
@@ -231,8 +231,10 @@ int FileCodeWriter::WriteFile(int language, int flags)
     copy.remove_filename();
     if (copy.size() && !copy.dir_exists() && !wxGetApp().AskedAboutMissingDir(copy))
     {
-        if (flags & flag_no_ui)
+        if (wxGetApp().isGenerating())
+        {
             return write_no_folder;
+        }
 
         if (wxMessageBox(wxString() << "The directory " << copy.make_wxString()
                                     << " doesn't exist.\n\nWould you like it to be created?",

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   Auto-generate a .cmake file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -139,20 +139,13 @@ int WriteCMakeFile(Node* parent_node, std::vector<tt_string>& updated_files, std
                 }
             }
 
-            tt_string path;
-            if (auto& base_file = form->as_string(prop_base_file); base_file.size())
+            tt_string path = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
+            if (path.empty())
             {
-                path = Project.getBaseDirectory(form, GEN_LANG_CPLUSPLUS);
-                if (path.size())
-                {
-                    path.append_filename(base_file);
-                }
-                else
-                {
-                    path = base_file;
-                }
-
-                path.make_absolute();
+                // No file was specified. It's unlikely this would actually happen given the
+                // form->hasValue(prop_base_file) above, but it does serve as a template check
+                // -- an will prevent a problem if the above check is removed.
+                continue;
             }
 
             if (cmake_file_dir.size())

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -139,8 +139,8 @@ int WriteCMakeFile(Node* parent_node, std::vector<tt_string>& updated_files, std
                 }
             }
 
-            tt_string path = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
-            if (path.empty())
+            auto [path, has_base_file] = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
+            if (!has_base_file)
             {
                 // No file was specified. It's unlikely this would actually happen given the
                 // form->hasValue(prop_base_file) above, but it does serve as a template check

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Generate C++ Base code files
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -98,26 +98,16 @@ void GenThreadCpp(GenData& gen_data, Node* form)
     tt_string& source_ext = gen_data.source_ext;
     tt_string& header_ext = gen_data.header_ext;
 
-    tt_string path;
-
-    if (auto& base_file = form->as_string(prop_base_file); base_file.size())
+    tt_string path = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
+    if (path.empty())
     {
-        path = Project.getBaseDirectory(form, GEN_LANG_CPLUSPLUS);
-        if (path.size())
-        {
-            path.append_filename(base_file);
-        }
+        tt_string msg("No filename specified for ");
+        if (form->hasValue(prop_class_name))
+            msg += form->as_string(prop_class_name);
         else
-        {
-            path = base_file;
-        }
-
-        path.make_absolute();
-        path.backslashestoforward();
-    }
-    else
-    {
-        gen_data.AddResultMsg(tt_string() << "No filename specified for " << form->as_string(prop_class_name) << '\n');
+            msg += map_GenNames[form->getGenName()];
+        msg += '\n';
+        gen_data.AddResultMsg(msg);
         return;
     }
 
@@ -547,47 +537,7 @@ void GenerateTmpFiles(const std::vector<tt_string>& ClassList, pugi::xml_node ro
             if (class_name.is_sameas(iter_class))
             {
                 path.clear();
-
-                // Get the folder or project output directory, and if specified, set the path
-                // relative to that directory.
-                auto SetPath = [&](const tt_string& base_file)
-                {
-                    path = Project.getBaseDirectory(form, language);
-                    if (path.size())
-                    {
-                        path.append_filename(base_file);
-                    }
-                    else
-                    {
-                        path = base_file;
-                    }
-
-                    path.make_absolute();
-                    path.backslashestoforward();
-                };
-
-                if (language == GEN_LANG_CPLUSPLUS)
-                {
-                    if (auto& base_file = form->as_string(prop_base_file); base_file.size())
-                    {
-                        SetPath(base_file);
-                    }
-                }
-                else if (language == GEN_LANG_PYTHON)
-                {
-                    if (auto& base_file = form->as_string(prop_python_file); base_file.size())
-                    {
-                        SetPath(base_file);
-                    }
-                }
-                else if (language == GEN_LANG_RUBY)
-                {
-                    if (auto& base_file = form->as_string(prop_ruby_file); base_file.size())
-                    {
-                        SetPath(base_file);
-                    }
-                }
-
+                path = Project.GetOutputPath(form, language);
                 if (path.empty())
                     continue;
 

--- a/src/generate/gen_codefiles.cpp
+++ b/src/generate/gen_codefiles.cpp
@@ -98,8 +98,8 @@ void GenThreadCpp(GenData& gen_data, Node* form)
     tt_string& source_ext = gen_data.source_ext;
     tt_string& header_ext = gen_data.header_ext;
 
-    tt_string path = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
-    if (path.empty())
+    auto [path, has_base_file] = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
+    if (!has_base_file)
     {
         tt_string msg("No filename specified for ");
         if (form->hasValue(prop_class_name))
@@ -473,7 +473,6 @@ void GenerateTmpFiles(const std::vector<tt_string>& ClassList, pugi::xml_node ro
 {
     tt_cwd cwd(true);
     Project.ChangeDir();
-    tt_string path;
     std::vector<tt_string> results;
 
     tt_string source_ext(".cpp");
@@ -536,9 +535,8 @@ void GenerateTmpFiles(const std::vector<tt_string>& ClassList, pugi::xml_node ro
 
             if (class_name.is_sameas(iter_class))
             {
-                path.clear();
-                path = Project.GetOutputPath(form, language);
-                if (path.empty())
+                auto [path, has_base_file] = Project.GetOutputPath(form, language);
+                if (!has_base_file)
                     continue;
 
                 BaseCodeGenerator codegen(language, form);

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -332,12 +332,14 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
     SetImagesForm();
     if (m_ImagesForm && m_ImagesForm->hasValue(prop_base_file))
     {
-        tt_string image_file = Project.getBaseDirectory(m_ImagesForm);
-        image_file.append_filename(m_ImagesForm->as_string(prop_base_file));
-        image_file.replace_extension(m_header_ext);
-        image_file.make_relative(Project.getBaseDirectory(m_form_node).make_absolute());
-        image_file.backslashestoforward();
-        m_include_images_statement << "#include \"" << image_file << '\"';
+        auto [path, has_base_file] = Project.GetOutputPath(m_ImagesForm, GEN_LANG_CPLUSPLUS);
+        if (has_base_file)
+        {
+            path.make_relative(Project.getBaseDirectory(m_form_node).make_absolute());
+            path.backslashestoforward();
+            path.replace_extension(m_header_ext);
+            m_include_images_statement << "#include \"" << path << '\"';
+        }
     }
 
     // Initialize these values before calling ParseImageProperties

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Generate C++ and Python events
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -681,27 +681,11 @@ void BaseCodeGenerator::GenPythonEventHandlers(EventVector& events)
     if (m_panel_type == NOT_PANEL)
     {
         tt_view_vector org_file;
-        tt_string path;
+        tt_string path = Project.GetOutputPath(m_form_node, GEN_LANG_PYTHON);
 
-        // Set path to the output file
-        if (auto& base_file = m_form_node->as_string(prop_python_file); base_file.size())
+        if (path.size() && path.extension().empty())
         {
-            path = Project.getBaseDirectory(m_form_node, GEN_LANG_PYTHON);
-            if (path.size())
-            {
-                path.append_filename(base_file);
-            }
-            else
-            {
-                path = base_file;
-            }
-
-            if (path.extension().empty())
-            {
-                path += ".py";
-            }
-            path.make_absolute();
-            path.backslashestoforward();
+            path += ".py";
         }
 
         // If the user has defined any event handlers, add them to the code_lines set so we
@@ -857,27 +841,11 @@ void BaseCodeGenerator::GenRubyEventHandlers(EventVector& events)
     if (m_panel_type == NOT_PANEL)
     {
         tt_view_vector org_file;
-        tt_string path;
+        tt_string path = Project.GetOutputPath(m_form_node, GEN_LANG_RUBY);
 
-        // Set path to the output file
-        if (auto& base_file = m_form_node->as_string(prop_ruby_file); base_file.size())
+        if (path.size() && path.extension().empty())
         {
-            path = Project.getBaseDirectory(m_form_node, GEN_LANG_RUBY);
-            if (path.size())
-            {
-                path.append_filename(base_file);
-            }
-            else
-            {
-                path = base_file;
-            }
-
-            if (path.extension().empty())
-            {
-                path += ".rb";
-            }
-            path.make_absolute();
-            path.backslashestoforward();
+            path += ".rb";
         }
 
         // If the user has defined any event handlers, add them to the code_lines set so we

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -681,16 +681,16 @@ void BaseCodeGenerator::GenPythonEventHandlers(EventVector& events)
     if (m_panel_type == NOT_PANEL)
     {
         tt_view_vector org_file;
-        tt_string path = Project.GetOutputPath(m_form_node, GEN_LANG_PYTHON);
+        auto [path, has_base_file] = Project.GetOutputPath(m_form_node, GEN_LANG_PYTHON);
 
-        if (path.size() && path.extension().empty())
+        if (has_base_file && path.extension().empty())
         {
             path += ".py";
         }
 
         // If the user has defined any event handlers, add them to the code_lines set so we
         // don't generate them again.
-        if (path.size() && org_file.ReadFile(path))
+        if (has_base_file && org_file.ReadFile(path))
         {
             size_t line_index;
             for (line_index = 0; line_index < org_file.size(); ++line_index)
@@ -841,16 +841,16 @@ void BaseCodeGenerator::GenRubyEventHandlers(EventVector& events)
     if (m_panel_type == NOT_PANEL)
     {
         tt_view_vector org_file;
-        tt_string path = Project.GetOutputPath(m_form_node, GEN_LANG_RUBY);
+        auto [path, has_base_file] = Project.GetOutputPath(m_form_node, GEN_LANG_RUBY);
 
-        if (path.size() && path.extension().empty())
+        if (has_base_file && path.extension().empty())
         {
             path += ".rb";
         }
 
         // If the user has defined any event handlers, add them to the code_lines set so we
         // don't generate them again.
-        if (path.size() && org_file.ReadFile(path))
+        if (has_base_file && org_file.ReadFile(path))
         {
             size_t line_index;
             for (line_index = 0; line_index < org_file.size(); ++line_index)

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -99,7 +99,6 @@ bool GeneratePythonFiles(GenResults& results, std::vector<tt_string>* pClassList
     }
     tt_cwd cwd(true);
     Project.ChangeDir();
-    tt_string path;
 
     bool generate_result = true;
     std::vector<Node*> forms;
@@ -111,8 +110,8 @@ bool GeneratePythonFiles(GenResults& results, std::vector<tt_string>* pClassList
 
     for (const auto& form: forms)
     {
-        path = Project.GetOutputPath(form, GEN_LANG_PYTHON);
-        if (path.empty())
+        auto [path, has_base_file] = Project.GetOutputPath(form, GEN_LANG_PYTHON);
+        if (!has_base_file)
         {
 #if !defined(_DEBUG)
             // For a lot of wxPython testing of projects with multiple dialogs, there may
@@ -797,11 +796,11 @@ void PythonBtnBimapCode(Code& code, bool is_single)
 
 tt_string MakePythonPath(Node* node)
 {
-    auto path = Project.GetOutputPath(node->getForm(), GEN_LANG_PYTHON);
+    auto [path, has_base_file] = Project.GetOutputPath(node->getForm(), GEN_LANG_PYTHON);
 
     if (path.empty())
         path = "./";
-    else
+    else if (has_base_file)
         path.remove_filename();
     return path;
 }

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -111,22 +111,8 @@ bool GeneratePythonFiles(GenResults& results, std::vector<tt_string>* pClassList
 
     for (const auto& form: forms)
     {
-        if (auto& base_file = form->as_string(prop_python_file); base_file.size())
-        {
-            path = Project.getBaseDirectory(form, GEN_LANG_PYTHON);
-            if (path.size())
-            {
-                path.append_filename(base_file);
-            }
-            else
-            {
-                path = base_file;
-            }
-
-            path.make_absolute();
-            path.backslashestoforward();
-        }
-        else
+        path = Project.GetOutputPath(form, GEN_LANG_PYTHON);
+        if (path.empty())
         {
 #if !defined(_DEBUG)
             // For a lot of wxPython testing of projects with multiple dialogs, there may
@@ -811,28 +797,11 @@ void PythonBtnBimapCode(Code& code, bool is_single)
 
 tt_string MakePythonPath(Node* node)
 {
-    tt_string path;
-    Node* form = node->getForm();
-
-    if (auto& base_file = form->as_string(prop_python_file); base_file.size())
-    {
-        path = Project.getBaseDirectory(form, GEN_LANG_PYTHON);
-        if (path.size())
-        {
-            path.append_filename(base_file);
-        }
-        else
-        {
-            path = base_file;
-        }
-
-        path.make_absolute();
-        path.backslashestoforward();
-    }
+    auto path = Project.GetOutputPath(node->getForm(), GEN_LANG_PYTHON);
 
     if (path.empty())
         path = "./";
-    path.make_absolute();
-    path.remove_filename();
+    else
+        path.remove_filename();
     return path;
 }

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -105,7 +105,6 @@ bool GenerateRubyFiles(GenResults& results, std::vector<tt_string>* pClassList)
     }
     tt_cwd cwd(true);
     Project.ChangeDir();
-    tt_string path;
 
     bool generate_result = true;
     std::vector<Node*> forms;
@@ -462,7 +461,8 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
                 // We have to provide our own method, and that requires this library
                 if (!stringio_requirement_written)
                 {
-                    stringio_requirement_written = true;
+                    // No further check for this is needed
+                    // stringio_requirement_written = true;
                     m_source->writeLine("require 'stringio'");
                 }
             }

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -117,8 +117,8 @@ bool GenerateRubyFiles(GenResults& results, std::vector<tt_string>* pClassList)
 
     for (const auto& form: forms)
     {
-        path = Project.GetOutputPath(form, GEN_LANG_RUBY);
-        if (path.empty())
+        auto [path, has_base_file] = Project.GetOutputPath(form, GEN_LANG_RUBY);
+        if (!has_base_file)
         {
 #if !defined(_DEBUG)
             // For a lot of wxRuby testing of projects with multiple dialogs, there may
@@ -655,10 +655,10 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
 
 tt_string MakeRubyPath(Node* node)
 {
-    auto path = Project.GetOutputPath(node->getForm(), GEN_LANG_RUBY);
+    auto [path, has_base_file] = Project.GetOutputPath(node->getForm(), GEN_LANG_RUBY);
     if (path.empty())
         path = "./";
-    else
+    else if (has_base_file)
         path.remove_filename();
     return path;
 }

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Generate Ruby code files
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2023-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -117,22 +117,8 @@ bool GenerateRubyFiles(GenResults& results, std::vector<tt_string>* pClassList)
 
     for (const auto& form: forms)
     {
-        if (auto& base_file = form->as_string(prop_ruby_file); base_file.size())
-        {
-            path = Project.getBaseDirectory(form, GEN_LANG_RUBY);
-            if (path.size())
-            {
-                path.append_filename(base_file);
-            }
-            else
-            {
-                path = base_file;
-            }
-
-            path.make_absolute();
-            path.backslashestoforward();
-        }
-        else
+        path = Project.GetOutputPath(form, GEN_LANG_RUBY);
+        if (path.empty())
         {
 #if !defined(_DEBUG)
             // For a lot of wxRuby testing of projects with multiple dialogs, there may
@@ -669,29 +655,11 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
 
 tt_string MakeRubyPath(Node* node)
 {
-    tt_string path;
-    Node* form = node->getForm();
-
-    if (auto& base_file = form->as_string(prop_ruby_file); base_file.size())
-    {
-        path = Project.getBaseDirectory(form, GEN_LANG_RUBY);
-        if (path.size())
-        {
-            path.append_filename(base_file);
-        }
-        else
-        {
-            path = base_file;
-        }
-
-        path.make_absolute();
-        path.backslashestoforward();
-    }
-
+    auto path = Project.GetOutputPath(node->getForm(), GEN_LANG_RUBY);
     if (path.empty())
         path = "./";
-    path.make_absolute();
-    path.remove_filename();
+    else
+        path.remove_filename();
     return path;
 }
 

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Generate XRC file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -318,22 +318,8 @@ bool GenerateXrcFiles(GenResults& results, tt_string out_file, std::vector<tt_st
 
     for (auto& form: forms)
     {
-        if (auto& base_file = form->as_string(prop_xrc_file); base_file.size())
-        {
-            path = Project.getBaseDirectory(form, GEN_LANG_XRC);
-            if (path.size())
-            {
-                path.append_filename(base_file);
-            }
-            else
-            {
-                path = base_file;
-            }
-
-            path.make_absolute();
-            path.backslashestoforward();
-        }
-        else
+        path = Project.GetOutputPath(form, GEN_LANG_XRC);
+        if (path.empty())
         {
             // If the form type is supported, warn the user about not having an XRC file for it.
             if (!form->isGen(gen_Images) && !form->isGen(gen_wxPopupTransientWindow))

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -318,7 +318,7 @@ bool GenerateXrcFiles(GenResults& results, tt_string out_file, std::vector<tt_st
 
     for (auto& form: forms)
     {
-        path = Project.GetOutputPath(form, GEN_LANG_XRC);
+        auto [path, has_base_file] = Project.GetOutputPath(form, GEN_LANG_XRC);
         if (path.empty())
         {
             // If the form type is supported, warn the user about not having an XRC file for it.

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -310,7 +310,6 @@ bool GenerateXrcFiles(GenResults& results, tt_string out_file, std::vector<tt_st
     }
     std::vector<Node*> forms;
     Project.CollectForms(forms);
-    tt_string path;
 
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
     results.EndClock();

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -266,6 +266,7 @@ int App::OnRun()
         {
             if (generate_type != GEN_LANG_NONE)
             {
+                m_is_generating = true;
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
                 results.StartClock();
 #endif

--- a/src/mainapp.h
+++ b/src/mainapp.h
@@ -64,6 +64,8 @@ public:
 
     bool isTestingMenuEnabled() const noexcept { return m_TestingMenuEnabled; }
 
+    bool isGenerating() const noexcept { return m_is_generating; }
+
 protected:
     bool OnInit() override;
 
@@ -88,6 +90,7 @@ private:
     bool m_isMainFrameClosing { false };
     // bool m_isProject_updated { false };
     bool m_TestingMenuEnabled { false };
+    bool m_is_generating { false };  // true if generating code from the command line
 
 #if (DARK_MODE)
     bool m_isDarkMode { true };

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -169,11 +169,28 @@ tt_string ProjectHandler::getBaseDirectory(Node* node, int language) const
         return m_projectPath;
     }
 
-    return result.first;
+    if (!node->isForm() && !node->isFolder())
+    {
+        node = node->getForm();
+        if (!node)
+        {
+            return m_projectPath;
+        }
+    }
+
+    auto [path, has_base_file] = GetOutputPath(node, language);
+    if (has_base_file)
+    {
+        path.remove_filename();
+    }
+
+    return path;
 }
 
 std::pair<tt_string, bool> ProjectHandler::GetOutputPath(Node* form, int language) const
 {
+    ASSERT(form->isForm() || form->isFolder());
+
     tt_string result;
     Node* folder = form->getFolder();
     if (folder)
@@ -282,18 +299,8 @@ std::pair<tt_string, bool> ProjectHandler::GetOutputPath(Node* form, int languag
                 result.erase(result.size() - end_folder, end_folder);
             }
         }
-        else
-        {
-            result += '/';
-        }
-
-        result += base_file;
     }
-    else
-    {
-        result.append_filename(base_file);
-    }
-
+    result.append_filename(base_file);
     result.make_absolute();
     result.backslashestoforward();
 

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -164,13 +164,9 @@ tt_string ProjectHandler::ArtDirectory() const
 
 tt_string ProjectHandler::getBaseDirectory(Node* node, int language) const
 {
-    // GetOutputPath() will handle a situation where the base filename contains a directory
-    // prefix, which might or might not be a duplicate of any project or folder's output
-    // directory.
-    auto result = GetOutputPath(node, language);
-    if (result.second)
+    if (!node || node == m_project_node.get())
     {
-        result.first.remove_filename();
+        return m_projectPath;
     }
 
     return result.first;

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   ProjectHandler class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -80,6 +80,10 @@ public:
     // If the node is within a folder, and the folder specifies a directory, then that
     // directory is returned. Otherwise the project base directory is returned.
     tt_string getBaseDirectory(Node* node, int language = GEN_LANG_CPLUSPLUS) const;
+
+    // This will return the absolute path to the output file for this node, or an empty
+    // string if no output file was specified for the lanuage.
+    tt_string GetOutputPath(Node* form, int language = GEN_LANG_CPLUSPLUS) const;
 
     // If the node is within a folder, and the folder specifies a directory, then that
     // directory is returned. Otherwise the project derived directory is returned.

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -7,9 +7,7 @@
 
 #pragma once  // NOLINT(#pragma once in main file)
 
-#include <map>
-#include <mutex>
-#include <thread>
+#include <utility>  // for pair<>
 
 #include "gen_enums.h"  // Enumerations for generators
 #include "node.h"       // Node class
@@ -81,9 +79,9 @@ public:
     // directory is returned. Otherwise the project base directory is returned.
     tt_string getBaseDirectory(Node* node, int language = GEN_LANG_CPLUSPLUS) const;
 
-    // This will return the absolute path to the output file for this node, or an empty
-    // string if no output file was specified for the lanuage.
-    tt_string GetOutputPath(Node* form, int language = GEN_LANG_CPLUSPLUS) const;
+    // Returns the absolute path to the output file for this node. If no output filename is
+    // specified, first will still contain a path with no filename, and second will be false.
+    std::pair<tt_string, bool> GetOutputPath(Node* form, int language = GEN_LANG_CPLUSPLUS) const;
 
     // If the node is within a folder, and the folder specifies a directory, then that
     // directory is returned. Otherwise the project derived directory is returned.


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a new function to the `ProjectHandler` class that retrieves the full path to the output file for the specified form and language. This also eliminates a duplicate single-level folder. E.g., given a project output file called `generate` and a form base_file called `generate/my_form` this will remove the duplicate `generate` folder. The upside is that this will fix the most common error where the folder portion was entered by hand even though it wasn't needed. It will, however, prevent the user from specifying nested folders containing the same name (i.e., `generate/generate/my_form` won't work if project output directory is set to `generate/`).

The second part of this PR adds a `isGenerating()` to App and uses that in FileCodeWriter::WriteFile() to determine whether or not to ask the user permission to create a directory that was specified, but doesn't exist. This allows the code writer to create a missing directory as long as code generation is running from the command line.

See #1366
