### PR TITLE
Replace some calls to wxMessageBox with wxMessageDialog

### DIFF
--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -307,6 +307,7 @@ set (file_list
     project/loadproject.cpp     # Load wxUiEditor project
     project/saveproject.cpp     # Save a wxUiEditor project file
 
+    utils/dlg_msgs.cpp          # wxMessageDialog dialogs
     utils/font_prop.cpp         # FontProperty class
     utils/utils.cpp             # Utility functions that work with properties
 

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Generate Python code files
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -12,6 +12,7 @@
 
 #include "base_generator.h"   // BaseGenerator -- Base widget generator class
 #include "code.h"             // Code -- Helper class for generating code
+#include "dlg_msgs.h"         // wxMessageDialog dialogs
 #include "file_codewriter.h"  // FileCodeWriter -- Classs to write code to disk
 #include "gen_base.h"         // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "gen_common.h"       // Common component functions
@@ -177,9 +178,7 @@ bool GeneratePythonFiles(GenResults& results, std::vector<tt_string>* pClassList
         catch (const std::exception& TESTING_PARAM(e))
         {
             MSG_ERROR(e.what());
-            wxMessageBox(tt_string("An internal error occurred generating code files for ")
-                             << form->as_string(prop_python_file),
-                         "Code generation");
+            dlgGenInternalError(e, path, form->as_std(prop_class_name));
             continue;
         }
     }

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -12,6 +12,7 @@
 
 #include "base_generator.h"   // BaseGenerator -- Base widget generator class
 #include "code.h"             // Code -- Helper class for generating code
+#include "dlg_msgs.h"         // wxMessageDialog dialogs
 #include "file_codewriter.h"  // FileCodeWriter -- Classs to write code to disk
 #include "gen_base.h"         // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "gen_common.h"       // Common component functions
@@ -187,9 +188,7 @@ bool GenerateRubyFiles(GenResults& results, std::vector<tt_string>* pClassList)
         catch (const std::exception& TESTING_PARAM(e))
         {
             MSG_ERROR(e.what());
-            wxMessageBox(tt_string("An internal error occurred generating code files for ")
-                             << form->as_string(prop_ruby_file),
-                         "Code generation");
+            dlgGenInternalError(e, path, form->as_std(prop_class_name));
             continue;
         }
     }

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -304,7 +304,9 @@ bool GenerateXrcFiles(GenResults& results, tt_string out_file, std::vector<tt_st
         GenXrcObject(Project.getProjectNode(), root, false);
         if (!doc.save_file(out_file.c_str(), "\t"))
         {
-            wxMessageBox(wxString("An unexpected error occurred exporting ") << out_file, "Export XRC");
+            std::string msg("Unable to save\n    \"" + out_file + "\"\n");
+            wxMessageDialog dlg(nullptr, msg, "", wxICON_ERROR | wxOK);
+            dlg.ShowModal();
         }
         return true;
     }

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Import a DialogBlocks project
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2023-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -31,6 +31,7 @@
 
 #include "import_dialogblocks.h"
 
+#include "dlg_msgs.h"      // wxMessageDialog dialogs
 #include "node.h"          // Node class
 #include "node_creator.h"  // NodeCreator class
 
@@ -41,8 +42,6 @@ bool DialogBlocks::Import(const tt_string& filename, bool write_doc)
     auto result = LoadDocFile(filename);
     if (!result)
     {
-        wxMessageBox(wxString() << "Unable to load " << filename << " -- was it saved as a binary file?",
-                     "Import DialogBlocks project");
         return false;
     }
 
@@ -50,7 +49,7 @@ bool DialogBlocks::Import(const tt_string& filename, bool write_doc)
 
     if (!tt::is_sameas(root.name(), "anthemion-project", tt::CASE::either))
     {
-        wxMessageBox(wxString() << filename << " is not a DialogBlocks file", "Import DialogBlocks project");
+        dlgInvalidProject(filename, "DialogBlocks", "Import DialogBlocks project");
         return false;
     }
 
@@ -138,9 +137,7 @@ bool DialogBlocks::Import(const tt_string& filename, bool write_doc)
     catch (const std::exception& TESTING_PARAM(e))
     {
         MSG_ERROR(e.what());
-        wxMessageBox(wxString("This DialogBlocks project file is invalid and cannot be loaded: ")
-                         << filename.make_wxString(),
-                     "Import DialogBlocks project");
+        dlgImportError(e, filename, "Import DialogBlocks project");
         return false;
     }
 
@@ -153,8 +150,8 @@ bool DialogBlocks::Import(const tt_string& filename, bool write_doc)
             MSG_ERROR(iter);
             errMsg << iter << '\n';
         }
-
-        wxMessageBox(errMsg, "Import DialogBlocks project");
+        wxMessageDialog dlg(nullptr, errMsg, "Import DialogBlocks Project", wxICON_WARNING | wxOK);
+        dlg.ShowModal();
     }
 
     return true;

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Import a wxFormBuider project
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -17,6 +17,7 @@
 #include "import_formblder.h"
 
 #include "base_generator.h"  // BaseGenerator -- Base widget generator class
+#include "dlg_msgs.h"        // wxMessageDialog dialogs
 #include "font_prop.h"       // FontProperty class
 #include "mainframe.h"       // Main window frame
 #include "node.h"            // Node class
@@ -36,8 +37,7 @@ bool FormBuilder::Import(const tt_string& filename, bool write_doc)
 
     if (!tt::is_sameas(root.name(), "wxFormBuilder_Project", tt::CASE::either))
     {
-        wxMessageBox(wxString() << filename.make_wxString() << " is not a wxFormBuilder file",
-                     "Import wxFormBuilder project");
+        dlgInvalidProject(filename, "wxFormBuilder", "Import wxFormBuilder project");
         return false;
     }
 
@@ -73,9 +73,7 @@ bool FormBuilder::Import(const tt_string& filename, bool write_doc)
     catch (const std::exception& TESTING_PARAM(e))
     {
         MSG_ERROR(e.what());
-        wxMessageBox(wxString("This wxFormBuilder project file is invalid and cannot be loaded: ")
-                         << filename.make_wxString(),
-                     "Import wxFormBuilder project");
+        dlgImportError(e, filename, "Import wxFormBuilder Project");
         return false;
     }
 
@@ -86,10 +84,10 @@ bool FormBuilder::Import(const tt_string& filename, bool write_doc)
         for (auto& iter: m_errors)
         {
             MSG_ERROR(iter);
-            errMsg << iter << '\n';
+            errMsg += iter + '\n';
         }
-
-        wxMessageBox(errMsg, "Import wxFormBuilder project");
+        wxMessageDialog dlg(nullptr, errMsg, "Import wxFormBuilder project", wxICON_WARNING | wxOK);
+        dlg.ShowModal();
     }
 
     return true;

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Import a wxCrafter project
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -21,6 +21,7 @@
 #include "import_wxcrafter.h"  // This will include rapidjson/document.h
 
 #include "base_generator.h"  // BaseGenerator -- Base widget generator class
+#include "dlg_msgs.h"        // wxMessageDialog dialogs
 #include "font_prop.h"       // FontProperty class
 #include "gen_enums.h"       // Enumerations for generators
 #include "mainframe.h"       // Main window frame
@@ -72,7 +73,9 @@ bool WxCrafter::Import(const tt_string& filename, bool write_doc)
     std::ifstream input(filename, std::ifstream::binary);
     if (!input.is_open())
     {
-        wxMessageBox(wxString() << "Cannot open " << filename.make_wxString(), "Import wxCrafter project");
+        std::string msg("Unable to open\n    \"" + filename + "\"");
+        wxMessageDialog dlg(nullptr, msg, "Import wxCrafter project", wxICON_ERROR | wxOK);
+        dlg.ShowModal();
         return false;
     }
     std::string buffer(std::istreambuf_iterator<char>(input), {});
@@ -81,12 +84,12 @@ bool WxCrafter::Import(const tt_string& filename, bool write_doc)
     Document document;
     if (document.Parse(buffer).HasParseError())
     {
-        wxMessageBox(filename.make_wxString() << " is not a valid wxCrafter file", "Import wxCrafter project");
+        dlgInvalidProject(filename, "wxCrafter", "Import wxCrafter project");
         return false;
     }
     if (!document.IsObject())
     {
-        wxMessageBox(filename.make_wxString() << " is not a valid wxCrafter file", "Import wxCrafter project");
+        dlgInvalidProject(filename, "wxCrafter", "Import wxCrafter project");
         return false;
     }
 
@@ -139,9 +142,7 @@ bool WxCrafter::Import(const tt_string& filename, bool write_doc)
     {
         FAIL_MSG(e.what())
         MSG_ERROR(e.what());
-        wxMessageBox(tt_string("Internal error: ") << e.what(), "Import wxCrafter project");
-        wxMessageBox(wxString("This wxCrafter project file is invalid and cannot be loaded: ") << filename.make_wxString(),
-                     "Import wxCrafter project");
+        dlgImportError(e, filename, "Import wxCrafter Project");
         return false;
     }
 
@@ -154,8 +155,8 @@ bool WxCrafter::Import(const tt_string& filename, bool write_doc)
             MSG_ERROR(iter);
             errMsg << iter << '\n';
         }
-
-        wxMessageBox(errMsg, "Import wxCrafter project");
+        wxMessageDialog dlg(nullptr, errMsg, "Import wxCrafter project", wxICON_WARNING | wxOK);
+        dlg.ShowModal();
     }
 
     return true;

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -1,13 +1,14 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Import a WxGlade file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
 #include "import_wxglade.h"
 
 #include "base_generator.h"  // BaseGenerator -- Base Generator class
+#include "dlg_msgs.h"        // wxMessageDialog dialogs
 #include "node.h"            // Node class
 #include "node_creator.h"    // NodeCreator class
 #include "utils.h"           // Utility functions that work with properties
@@ -25,7 +26,7 @@ bool WxGlade::Import(const tt_string& filename, bool write_doc)
 
     if (!tt::is_sameas(root.name(), "application", tt::CASE::either))
     {
-        wxMessageBox(filename.make_wxString() << " is not a wxGlade file", "Import");
+        dlgInvalidProject(filename, "wxGlade", "Import wxGlade project");
         return false;
     }
 
@@ -162,8 +163,7 @@ bool WxGlade::Import(const tt_string& filename, bool write_doc)
     catch (const std::exception& TESTING_PARAM(e))
     {
         MSG_ERROR(e.what());
-        wxMessageBox(wxString("This project file is invalid and cannot be loaded: ") << filename.make_wxString(),
-                     "Import Project");
+        dlgImportError(e, filename, "Import wxGlade project");
         return false;
     }
 

--- a/src/import/import_wxsmith.cpp
+++ b/src/import/import_wxsmith.cpp
@@ -1,13 +1,14 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Import a wxSmith or XRC file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
 #include "import_wxsmith.h"
 
 #include "base_generator.h"  // BaseGenerator -- Base Generator class
+#include "dlg_msgs.h"        // wxMessageDialog dialogs
 #include "node.h"            // Node class
 #include "node_creator.h"    // NodeCreator class
 #include "utils.h"           // Utility functions that work with properties
@@ -26,7 +27,7 @@ bool WxSmith::Import(const tt_string& filename, bool write_doc)
     if (!tt::is_sameas(root.name(), "wxsmith", tt::CASE::either) &&
         !tt::is_sameas(root.name(), "resource", tt::CASE::either))
     {
-        wxMessageBox(wxString() << filename.make_wxString() << " is not a wxSmith or XRC file", "Import");
+        dlgInvalidProject(filename, "wxSmith or XRC", "Import project");
         return false;
     }
 
@@ -54,7 +55,7 @@ bool WxSmith::Import(const tt_string& filename, bool write_doc)
     catch (const std::exception& TESTING_PARAM(e))
     {
         MSG_ERROR(e.what());
-        wxMessageBox(wxString("This project file is invalid and cannot be loaded: ") << filename, "Import Project");
+        dlgImportError(e, filename, "Import Project");
         return false;
     }
 
@@ -68,7 +69,8 @@ bool WxSmith::Import(const tt_string& filename, bool write_doc)
             errMsg << iter << '\n';
         }
 
-        wxMessageBox(errMsg, "Import project");
+        wxMessageDialog dlg(nullptr, errMsg, "Import Project", wxICON_WARNING | wxOK);
+        dlg.ShowModal();
     }
 
     return true;

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -10,6 +10,7 @@
 #include "import_xml.h"
 
 #include "base_generator.h"  // BaseGenerator -- Base Generator class
+#include "dlg_msgs.h"        // wxMessageDialog dialogs
 #include "gen_enums.h"       // Enumerations for generators
 #include "mainframe.h"       // Main window frame
 #include "node.h"            // Node class
@@ -137,9 +138,7 @@ std::optional<pugi::xml_document> ImportXML::LoadDocFile(const tt_string& file)
 
     if (auto result = doc.load_file(file.c_str()); !result)
     {
-        wxMessageBox(wxString("Cannot open ") << file.make_wxString() << "\n\n"
-                                              << result.description(),
-                     "Import wxFormBuilder project");
+        dlgCannotParse(result, file, "Import project");
         return {};
     }
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -278,6 +278,14 @@ public:
             return tt_empty_cstr;
     }
 
+    const std::string& as_std(PropName name) const
+    {
+        if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
+            return m_properties[result->second].as_string();
+        else
+            return tt_empty_cstr;
+    }
+
     // On Windows this will first convert to UTF-16 unless wxUSE_UNICODE_UTF8 is set.
     //
     // The string will be empty if the property doesn't exist.

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Load wxUiEditor project
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -9,6 +9,7 @@
 #include <wx/utils.h>    // Miscellaneous utilities
 
 #include "base_generator.h"   // BaseGenerator -- Base widget generator class
+#include "dlg_msgs.h"         // wxMessageDialog dialogs
 #include "gen_enums.h"        // Enumerations for generators
 #include "image_handler.h"    // ProjectImage class
 #include "mainframe.h"        // MainFrame -- Main window frame
@@ -46,7 +47,7 @@ bool ProjectHandler::LoadProject(const tt_string& file, bool allow_ui)
         ASSERT_MSG(result, tt_string() << "pugi failed trying to load " << file);
         if (allow_ui)
         {
-            wxMessageBox(wxString("Cannot open ") << file.make_wxString() << "\n\n" << result.description(), "Load Project");
+            dlgCannotParse(result, file, "Load Project");
         }
         return false;
     }
@@ -858,7 +859,7 @@ bool ProjectHandler::Import(ImportXML& import, tt_string& file, bool append, boo
                 ASSERT_MSG(result, tt_string() << "pugi failed trying to load " << file);
                 if (allow_ui)
                 {
-                    wxMessageBox(wxString("Cannot open ") << file << "\n\n" << result.description(), "Load Project");
+                    dlgCannotParse(result, file, "Load Project");
                 }
             }
             else

--- a/src/utils/dlg_msgs.cpp
+++ b/src/utils/dlg_msgs.cpp
@@ -1,0 +1,46 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   wxMessageDialog dialogs
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2024 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "dlg_msgs.h"
+
+//////////////// Import Project Dialogs ////////////////////////
+
+void dlgCannotParse(const pugi::xml_parse_result& result, const std::string& filename, const std::string& caption)
+{
+    std::string msg("Unable to load\n    \"" + filename + "\"\n" + result.description());
+    wxMessageDialog dlg(nullptr, msg, caption, wxICON_ERROR | wxOK);
+    dlg.ShowModal();
+}
+
+void dlgInvalidProject(const std::string& filename, std::string_view project_type, std::string_view caption)
+{
+#ifdef __cpp_lib_format
+    std::string msg = std::format("The file\n    \"{}\"\nis not a valid {} file.", filename, project_type);
+#else
+    tt_string msg;
+    msg << "The file\n    \"" << filename << "\"\nis not a valid " << project_type << " file.";
+#endif  // __cpp_lib_format
+    wxMessageDialog dlg(nullptr, msg, wxString(caption), wxICON_ERROR | wxOK);
+    dlg.ShowModal();
+}
+
+void dlgImportError(const std::exception& err, const std::string& filename, std::string_view caption)
+{
+    std::string msg("An internal error occurred (" + std::string(err.what()) + ") trying to import\n    \"" + filename +
+                    "\"\nThis project appears to be invalid and cannot be loaded.");
+    wxMessageDialog dlg(nullptr, msg, wxString(caption), wxICON_ERROR | wxOK);
+    dlg.ShowModal();
+}
+
+//////////////// Code Generation Dialogs ////////////////////////
+
+void dlgGenInternalError(const std::exception& err, const std::string& filename, const std::string& caption)
+{
+    std::string msg("An internal error occurred (" + std::string(err.what()) + ") generating\n    \"" + filename + "\"\n");
+    wxMessageDialog dlg(nullptr, msg, caption, wxICON_ERROR | wxOK);
+    dlg.ShowModal();
+}

--- a/src/utils/dlg_msgs.h
+++ b/src/utils/dlg_msgs.h
@@ -1,0 +1,20 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   wxMessageDialog dialogs
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2024 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <pugixml.hpp>
+
+//////////////// Import Project Dialogs ////////////////////////
+
+void dlgCannotParse(const pugi::xml_parse_result& result, const std::string& filename, const std::string& caption);
+void dlgInvalidProject(const std::string& filename, std::string_view project_type, std::string_view caption);
+void dlgImportError(const std::exception& err, const std::string& filename, std::string_view caption);
+
+//////////////// Code Generation Dialogs ////////////////////////
+
+void dlgGenInternalError(const std::exception& err, const std::string& filename, const std::string& caption);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR creates a new dlg_msgs src/hdr module which supplies functions for calling wxMessageDialog. These are used to replace some of the calls to wxMessageBox when a full file path needs to be displayed. This can be truncated in wxMessageBox, hence the switch to wxMessageDialog.

The rest of the changes are straightforward replacements of wxMessageBox with wxMessageDialog.