### PR TITLE
Remove TESTING_PARAM macro, making exception text available to Release builds

### DIFF
--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -175,10 +175,10 @@ bool GeneratePythonFiles(GenResults& results, std::vector<tt_string>* pClassList
                 ++results.file_count;
             }
         }
-        catch (const std::exception& TESTING_PARAM(e))
+        catch (const std::exception& err)
         {
-            MSG_ERROR(e.what());
-            dlgGenInternalError(e, path, form->as_std(prop_class_name));
+            MSG_ERROR(err.what());
+            dlgGenInternalError(err, path, form->as_std(prop_class_name));
             continue;
         }
     }

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -185,10 +185,10 @@ bool GenerateRubyFiles(GenResults& results, std::vector<tt_string>* pClassList)
                 ++results.file_count;
             }
         }
-        catch (const std::exception& TESTING_PARAM(e))
+        catch (const std::exception& err)
         {
-            MSG_ERROR(e.what());
-            dlgGenInternalError(e, path, form->as_std(prop_class_name));
+            MSG_ERROR(err.what());
+            dlgGenInternalError(err, path, form->as_std(prop_class_name));
             continue;
         }
     }

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -134,10 +134,10 @@ bool DialogBlocks::Import(const tt_string& filename, bool write_doc)
             m_project->createDoc(m_docOut);
     }
 
-    catch (const std::exception& TESTING_PARAM(e))
+    catch (const std::exception& err)
     {
-        MSG_ERROR(e.what());
-        dlgImportError(e, filename, "Import DialogBlocks project");
+        MSG_ERROR(err.what());
+        dlgImportError(err, filename, "Import DialogBlocks project");
         return false;
     }
 

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -70,10 +70,10 @@ bool FormBuilder::Import(const tt_string& filename, bool write_doc)
             m_project->createDoc(m_docOut);
     }
 
-    catch (const std::exception& TESTING_PARAM(e))
+    catch (const std::exception& err)
     {
-        MSG_ERROR(e.what());
-        dlgImportError(e, filename, "Import wxFormBuilder Project");
+        MSG_ERROR(err.what());
+        dlgImportError(err, filename, "Import wxFormBuilder Project");
         return false;
     }
 

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -160,10 +160,10 @@ bool WxGlade::Import(const tt_string& filename, bool write_doc)
             m_project->createDoc(m_docOut);
     }
 
-    catch (const std::exception& TESTING_PARAM(e))
+    catch (const std::exception& err)
     {
-        MSG_ERROR(e.what());
-        dlgImportError(e, filename, "Import wxGlade project");
+        MSG_ERROR(err.what());
+        dlgImportError(err, filename, "Import wxGlade project");
         return false;
     }
 

--- a/src/import/import_wxsmith.cpp
+++ b/src/import/import_wxsmith.cpp
@@ -52,10 +52,10 @@ bool WxSmith::Import(const tt_string& filename, bool write_doc)
             m_project->createDoc(m_docOut);
     }
 
-    catch (const std::exception& TESTING_PARAM(e))
+    catch (const std::exception& err)
     {
-        MSG_ERROR(e.what());
-        dlgImportError(e, filename, "Import Project");
+        MSG_ERROR(err.what());
+        dlgImportError(err, filename, "Import Project");
         return false;
     }
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -208,9 +208,6 @@ constexpr const char BMP_PROP_SEPARATOR = ';';
     #define MSG_WARNING(msg)
     #define MSG_ERROR(msg)
 
-    // Use this macro to comment out parameters that are not used in Release builds
-    #define TESTING_PARAM(param) /* param */
-
 #else
 
 // These messages can be individually enabled/disabled in the Preferences dialog (Debug tab).
@@ -234,9 +231,6 @@ constexpr const char BMP_PROP_SEPARATOR = ';';
         {                                    \
             g_pMsgLogging->AddErrorMsg(msg); \
         }
-
-    // Use this macro to comment out parameters that are not used in Release builds
-    #define TESTING_PARAM(param) param
 
 #endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)
 

--- a/src/previews.cpp
+++ b/src/previews.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Top level Preview functions
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -20,6 +20,7 @@
 
 #include "../tools/preview_settings.h"  // PreviewSettings
 #include "../ui/xrccompare.h"           // C++/XRC UI Comparison dialog
+#include "dlg_msgs.h"                   // wxMessageDialog dialogs
 #include "gen_common.h"                 // GeneratorLibrary -- Generator classes
 #include "generate/gen_xrc.h"           // Generate XRC file
 #include "mainapp.h"                    // App -- Main application class
@@ -294,10 +295,10 @@ void PreviewXrc(Node* form_node)
                 break;
         }
     }
-    catch (const std::exception& TESTING_PARAM(e))
+    catch (const std::exception& err)
     {
-        MSG_ERROR(e.what());
-        wxMessageBox("An internal error occurred generating XRC code", "XRC Dialog Preview");
+        MSG_ERROR(err.what());
+        dlgGenInternalError(err, "XRC code", "XRC Preview");
     }
 
     // Restore the original style if it was temporarily changed.
@@ -519,10 +520,10 @@ void MainFrame::PreviewCpp(Node* form_node)
                 break;
         }
     }
-    catch (const std::exception& TESTING_PARAM(e))
+    catch (const std::exception& err)
     {
-        MSG_ERROR(e.what());
-        wxMessageBox("An internal error occurred while creating the preview", "Preview");
+        MSG_ERROR(err.what());
+        dlgGenInternalError(err, "preview", "Preview");
     }
 
     // Restore the original style if it was temporarily changed.

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -197,11 +197,11 @@ NodeSharedPtr ProjectHandler::LoadProject(pugi::xml_document& doc, bool allow_ui
         }
         project = NodeCreation.createProjectNode(&node);
     }
-    catch (const std::exception& TESTING_PARAM(e))
+    catch (const std::exception& err)
     {
         if (allow_ui)
         {
-            MSG_ERROR(e.what());
+            MSG_ERROR(err.what());
             wxMessageBox("This wxUiEditor project file is invalid and cannot be loaded.", "Load Project");
         }
     }


### PR DESCRIPTION
exception text is now available in Release builds.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes the TESTING_PARAM macro which was used to ignore the exception variable in Release builds. With the new dlg_msgs module, it's worth displaying any text the exception may contain, even in Release builds.
