### PR TITLE
Prevent double-assignment in wxToolBar

### DIFF
--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -1304,6 +1304,11 @@ void GenToolCode(Code& code)
 {
     const auto* node = code.node();
     code.Eol(eol_if_needed);
+    bool need_variable_result =
+        (node->hasValue(prop_var_name) &&
+         ((node->as_string(prop_class_access) != "none") || node->isGen(gen_tool_dropdown) ||
+          (node->isGen(gen_auitool) && node->as_string(prop_initial_state) != "wxAUI_BUTTON_STATE_NORMAL")));
+
     if (node->as_bool(prop_disabled) || (node->as_string(prop_id) == "wxID_ANY" && node->getInUseEventCount()))
     {
         code.AddAuto().NodeName();
@@ -1311,11 +1316,8 @@ void GenToolCode(Code& code)
             code += " := ";
         else
             code += " = ";
+        need_variable_result = false;  // make certain we don't add this again
     }
-    bool need_variable_result =
-        (node->hasValue(prop_var_name) &&
-         ((node->as_string(prop_class_access) != "none") || node->isGen(gen_tool_dropdown) ||
-          (node->isGen(gen_auitool) && node->as_string(prop_initial_state) != "wxAUI_BUTTON_STATE_NORMAL")));
 
     if (need_variable_result)
     {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes the rare double assignment when adding a tool to a wxToolBar. The original issued said it was in wxRibbonToolBar, but that was incorrect.

Closes #1376
