### PR TITLE
Improve node selection handling in language panels

### DIFF
--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -601,6 +601,11 @@ void CodeDisplay::OnNodeSelected(Node* node)
         OnEmbedImageSelected(node);
         return;
     }
+    else if (node->isGen(gen_ribbonTool) || node->isGen(gen_ribbonButton))
+    {
+        OnRibbonToolSelected(node);
+        return;
+    }
 
     if (!node->hasProp(prop_var_name) && m_panel_type != GEN_LANG_XRC && !node->isGen(gen_ribbonTool) &&
         !node->isGen(gen_ribbonButton))
@@ -743,6 +748,37 @@ void CodeDisplay::OnNodeSelected(Node* node)
 
     // Unlike GetLineVisible(), this function does ensure that the line is visible.
     m_scintilla->ScrollToLine(line);
+}
+
+void CodeDisplay::OnRibbonToolSelected(Node* node)
+{
+    tt_string search;
+    if (auto parent = node->getParent(); parent)
+    {
+        if (parent->isGen(gen_wxRibbonButtonBar))
+        {
+            search << '"' << node->as_string(prop_label) << '"';
+        }
+        else if (parent->isGen(gen_wxRibbonToolBar))
+        {
+            search << parent->as_string(prop_var_name) << "->AddTool(" << node->as_string(prop_id) << ",";
+            if (m_panel_type == GEN_LANG_PYTHON)
+                search.Replace("->", ".");
+            else if (m_panel_type == GEN_LANG_RUBY)
+                search.Replace("->AddTool(", ".add_tool($");
+        }
+    }
+
+    if (search.size())
+    {
+        if (auto line = (to_int) m_view.FindLineContaining(search); line >= 0)
+        {
+            m_scintilla->MarkerDeleteAll(node_marker);
+            m_scintilla->MarkerAdd(line, node_marker);
+            m_scintilla->ScrollToLine(line);
+        }
+        return;
+    }
 }
 
 void CodeDisplay::OnEmbedImageSelected(Node* node)

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -39,6 +39,7 @@ public:
     wxStyledTextCtrl* GetTextCtrl() { return m_scintilla; };
 
 protected:
+    void OnRibbonToolSelected(Node* node);
     void OnEmbedImageSelected(Node* node);
     void OnFind(wxFindDialogEvent& event);
 

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Display code in scintilla control
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -16,10 +16,11 @@
 class wxFindDialogEvent;
 class Node;
 
-// CodeDisplayBase creates and initializes a wxStyledTextCtrl (scintilla) control, and places it in a sizer.
-//
-// WriteCode expects a class to override the doWrite() method, which in this case sends the text to the scinitilla control
-// created by CodeDisplayBase.
+// CodeDisplayBase creates and initializes a wxStyledTextCtrl (scintilla) control, and places
+// it in a sizer.
+
+// WriteCode expects a class to override the doWrite() method, which in this case sends the
+// text to the scinitilla control created by CodeDisplayBase.
 
 class CodeDisplay : public CodeDisplayBase, public WriteCode
 {
@@ -38,9 +39,10 @@ public:
     wxStyledTextCtrl* GetTextCtrl() { return m_scintilla; };
 
 protected:
+    void OnEmbedImageSelected(Node* node);
     void OnFind(wxFindDialogEvent& event);
 
-    // The following two functions are required to inherit from WriteCode
+    // The following function is required to inherit from WriteCode
 
     void doWrite(tt_string_view code) override;
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR creates special functions for handling a selected node when one of the Language panels is displayed. Using functions means there can be a lot more logic for specific nodes such as Image List images and Ribbon tools and buttons. Otherwise, the main search functions would become increasingly long and complex, making it harder to find the code for handling a specific node type.

Closes #1377