### PR TITLE
Fix image size display in wxRibbon tools and buttons

### DIFF
--- a/src/generate/gen_ribbon_button.cpp
+++ b/src/generate/gen_ribbon_button.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxRibbonBar -- form and regular
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -11,6 +11,7 @@
 #include "code.h"        // Code -- Helper class for generating code
 #include "gen_common.h"  // GeneratorLibrary -- Generator classes
 #include "image_gen.h"   // Functions for generating embedded images
+#include "mainframe.h"   // MainFrame -- Main window frame
 #include "node.h"        // Node class
 #include "utils.h"       // Utility functions that work with properties
 
@@ -32,11 +33,13 @@ void RibbonButtonBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxp
 
     for (const auto& child: node->getChildNodePtrs())
     {
-        auto bmp = child->as_wxBitmap(prop_bitmap);
-        if (!bmp.IsOk())
+        auto bundle = child->as_wxBitmapBundle(prop_bitmap);
+        wxBitmap bmp;
+        if (bundle.IsOk())
+            bmp = bundle.GetBitmapFor(wxGetMainFrame()->getWindow());
+        else
             bmp = GetInternalImage("default");
 
-        // REVIEW: This is still a bitmap rather then a bundle as of the 3.1.6 release
         btn_bar->AddButton(wxID_ANY, child->as_wxString(prop_label), bmp, child->as_wxString(prop_help),
                            (wxRibbonButtonKind) child->as_int(prop_kind));
     }

--- a/src/generate/gen_ribbon_tool.cpp
+++ b/src/generate/gen_ribbon_tool.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxRibbonToolBar generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -36,7 +36,7 @@ wxObject* RibbonToolBarGenerator::CreateMockup(Node* node, wxObject* parent)
 
 void RibbonToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxparent*/, Node* node, bool /* is_preview */)
 {
-    auto btn_bar = wxDynamicCast(wxobject, wxRibbonToolBar);
+    auto btn_bar = wxStaticCast(wxobject, wxRibbonToolBar);
 
     for (const auto& child: node->getChildNodePtrs())
     {
@@ -46,12 +46,14 @@ void RibbonToolBarGenerator::AfterCreation(wxObject* wxobject, wxWindow* /*wxpar
         }
         else
         {
-            auto bmp = child->as_wxBitmap(prop_bitmap);
-            if (!bmp.IsOk())
+            auto bundle = child->as_wxBitmapBundle(prop_bitmap);
+            wxBitmap bmp;
+            if (bundle.IsOk())
+                bmp = bundle.GetBitmapFor(wxGetMainFrame()->getWindow());
+            else
                 bmp = GetInternalImage("default");
-            auto scaled_bmp = child->as_wxBitmapBundle(prop_bitmap).GetBitmap(wxGetMainFrame()->FromDIP(bmp.GetSize()));
-            btn_bar->AddTool(wxID_ANY, scaled_bmp, child->as_wxString(prop_help),
-                             (wxRibbonButtonKind) child->as_int(prop_kind));
+
+            btn_bar->AddTool(wxID_ANY, bmp, child->as_wxString(prop_help), (wxRibbonButtonKind) child->as_int(prop_kind));
         }
     }
     btn_bar->Realize();


### PR DESCRIPTION
Retrieving a bundle and then calling bundle.GetBitmapFor() gets us correct scaling even for Ribbon tools and buttons that support wxBitmapBundle.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes problems with Mockup image size and display of wxRibbon tools and buttons. The Mockup now scales the images to match the DPI of wxUiEditor's mainframe window.