### PR TITLE
Add single form code generation for Internal/Debug use

### DIFF
--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -31,6 +31,8 @@
 using namespace code;
 using namespace GenEnum;
 
+static bool GeneratePythonForm(Node* form, GenResults& results, std::vector<tt_string>* pClassList = nullptr);
+
 // clang-format off
 
 inline constexpr const auto txt_PyPerlRubyCmtBlock =
@@ -53,6 +55,48 @@ extern const char* python_perl_ruby_end_cmt_line;  // "# ************* End of ge
 int GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags);
 
 #if defined(_DEBUG) || defined(INTERNAL_TESTING)
+
+void MainFrame::OnGenSinglePython(wxCommandEvent& WXUNUSED(event))
+{
+    auto form = wxGetMainFrame()->getSelectedNode();
+    if (form && !form->isForm())
+    {
+        form = form->getForm();
+    }
+    if (!form)
+    {
+        wxMessageBox("You must select a form before you can generate code.", "Code Generation");
+        return;
+    }
+
+    GenResults results;
+    GeneratePythonForm(form, results);
+
+    tt_string msg;
+    if (results.updated_files.size())
+    {
+        if (results.updated_files.size() == 1)
+            msg << "1 file was updated";
+        else
+            msg << results.updated_files.size() << " files were updated";
+        msg << '\n';
+    }
+    else
+    {
+        msg << "Generated file is current";
+    }
+
+    if (results.msgs.size())
+    {
+        for (auto& iter: results.msgs)
+        {
+            msg << '\n';
+            msg << iter;
+        }
+    }
+
+    wxMessageBox(msg, "Python Code Generation", wxOK | wxICON_INFORMATION);
+}
 
 void MainFrame::OnGeneratePython(wxCommandEvent& WXUNUSED(event))
 {

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -93,6 +93,10 @@ enum
     id_GeneratePython,
     id_GenerateRuby,
     id_GenerateRust,
+    id_GenSingleCpp,
+    id_GenSinglePython,
+    id_GenSingleRuby,
+    id_GenSingleRust,
     id_NodeMemory,
     id_ShowLogger,
     id_XrcPreviewDlg,
@@ -188,9 +192,14 @@ MainFrame::MainFrame() :
     menuInternal->Append(id_ShowLogger, "Show &Log Window", "Show window containing debug messages");
     menuInternal->Append(id_DebugPreferences, "Test &Settings...", "Settings to use in testing builds");
     menuInternal->AppendSeparator();
-    menuInternal->Append(id_GeneratePython, "&Generate Python", "Generate all python files from current project.");
-    menuInternal->Append(id_GenerateRuby, "&Generate Ruby", "Generate all ruby files from current project.");
-    menuInternal->Append(id_GenerateRust, "&Generate Rust", "Generate all rust files from current project.");
+    menuInternal->Append(id_GenSingleCpp, "&Generate Single C++", "Generate C++ src/hdr files for seletected form.");
+    menuInternal->Append(id_GenSinglePython, "&Generate Single Python", "Generate Python file for seletected form.");
+    menuInternal->Append(id_GenSingleRuby, "&Generate Single Ruby", "Generate Ruby file for seletected form.");
+    menuInternal->Append(id_GenSingleRust, "&Generate Single Rust", "Generate Rust file for seletected form.");
+
+    // menuInternal->Append(id_GeneratePython, "&Generate Python", "Generate all python files from current project.");
+    // menuInternal->Append(id_GenerateRuby, "&Generate Ruby", "Generate all ruby files from current project.");
+    // menuInternal->Append(id_GenerateRust, "&Generate Rust", "Generate all rust files from current project.");
     menuInternal->Append(id_DebugCurrentTest, "&Current Test", "Current debugging test");
 
     ////////////////////// Debug-only menu items //////////////////////
@@ -402,9 +411,14 @@ MainFrame::MainFrame() :
         },
         id_DebugPreferences);
 
-    Bind(wxEVT_MENU, &MainFrame::OnGeneratePython, this, id_GeneratePython);
-    Bind(wxEVT_MENU, &MainFrame::OnGenerateRuby, this, id_GenerateRuby);
-    Bind(wxEVT_MENU, &MainFrame::OnGenerateRust, this, id_GenerateRust);
+    Bind(wxEVT_MENU, &MainFrame::OnGenSingleCpp, this, id_GenSingleCpp);
+    Bind(wxEVT_MENU, &MainFrame::OnGenSinglePython, this, id_GenSinglePython);
+    Bind(wxEVT_MENU, &MainFrame::OnGenSingleRuby, this, id_GenSingleRuby);
+    Bind(wxEVT_MENU, &MainFrame::OnGenSingleRust, this, id_GenSingleRust);
+
+    // Bind(wxEVT_MENU, &MainFrame::OnGeneratePython, this, id_GeneratePython);
+    // Bind(wxEVT_MENU, &MainFrame::OnGenerateRuby, this, id_GenerateRuby);
+    // Bind(wxEVT_MENU, &MainFrame::OnGenerateRust, this, id_GenerateRust);
     Bind(wxEVT_MENU, &App::DbgCurrentTest, &wxGetApp(), id_DebugCurrentTest);
 #endif
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -252,6 +252,13 @@ public:
     void OnSaveProject(wxCommandEvent& event) override;
     void OnGenerateCode(wxCommandEvent& event) override;
 
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
+    void OnGenSingleCpp(wxCommandEvent& event);
+    void OnGenSinglePython(wxCommandEvent& event);
+    void OnGenSingleRuby(wxCommandEvent& event);
+    void OnGenSingleRust(wxCommandEvent& event);
+#endif
+
 protected:
     void OnAbout(wxCommandEvent& event) override;
     void OnAppendCrafter(wxCommandEvent& event) override;
@@ -301,10 +308,6 @@ protected:
     void OnGeneratePython(wxCommandEvent& event);
     void OnGenerateRuby(wxCommandEvent& event);
     void OnGenerateRust(wxCommandEvent& event);
-    void OnGenSingleCpp(wxCommandEvent& event);
-    void OnGenSinglePython(wxCommandEvent& event);
-    void OnGenSingleRuby(wxCommandEvent& event);
-    void OnGenSingleRust(wxCommandEvent& event);
 #endif
 
 #if defined(_DEBUG)  // Starts debug section.

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -301,6 +301,10 @@ protected:
     void OnGeneratePython(wxCommandEvent& event);
     void OnGenerateRuby(wxCommandEvent& event);
     void OnGenerateRust(wxCommandEvent& event);
+    void OnGenSingleCpp(wxCommandEvent& event);
+    void OnGenSinglePython(wxCommandEvent& event);
+    void OnGenSingleRuby(wxCommandEvent& event);
+    void OnGenSingleRust(wxCommandEvent& event);
 #endif
 
 #if defined(_DEBUG)  // Starts debug section.

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -292,6 +292,36 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
             ChangeSizer(gen_wxWrapSizer);
             break;
 
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
+        case MenuSingleGenCpp:
+            {
+                wxCommandEvent dummy;
+                wxGetMainFrame()->OnGenSingleCpp(dummy);
+            }
+            break;
+
+        case MenuSingleGenPython:
+            {
+                wxCommandEvent dummy;
+                wxGetMainFrame()->OnGenSinglePython(dummy);
+            }
+            break;
+
+        case MenuSingleGenRuby:
+            {
+                wxCommandEvent dummy;
+                wxGetMainFrame()->OnGenSingleRuby(dummy);
+            }
+            break;
+
+        case MenuSingleGenRust:
+            {
+                wxCommandEvent dummy;
+                wxGetMainFrame()->OnGenSingleRust(dummy);
+            }
+            break;
+#endif
+
         case MenuADD_PAGE:
             if (m_node->isGen(gen_BookPage))
             {
@@ -458,6 +488,17 @@ void NavPopupMenu::CreateCommonMenu(Node* node)
 
 void NavPopupMenu::MenuAddCommands(Node* node)
 {
+#if defined(_DEBUG) || defined(INTERNAL_TESTING)
+    if (node->isForm())
+    {
+        Append(MenuSingleGenCpp, "Generate C++ for this form");
+        Append(MenuSingleGenPython, "Generate Python for this form");
+        Append(MenuSingleGenRuby, "Generate Ruby for this form");
+        Append(MenuSingleGenRust, "Generate Rust for this form");
+        AppendSeparator();
+    }
+#endif
+
     if (node->isForm() || node->isGen(gen_Images) || node->isGen(gen_embedded_image) || node->isGen(gen_Data) ||
         node->isGen(gen_data_string))
     {

--- a/src/panels/navpopupmenu.h
+++ b/src/panels/navpopupmenu.h
@@ -151,6 +151,11 @@ public:
 
         MenuEXPAND_ALL,
 
+        // These are for Internal builds only
+        MenuSingleGenCpp,
+        MenuSingleGenPython,
+        MenuSingleGenRuby,
+        MenuSingleGenRust,
         MenuTESTING_INFO,
         MenuDEBUG_KEYHH,
     };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes Internal/Debug builds to allow for generating code for _only_ the currently selected from. On the Internal menu, this replaces the Generate Code options with Generate Single options. This also adds single code generation to the right-click popup menu.

While theoretically this could be exposed for non-Internal use, the main reason for adding it is for quick debug/feature checking when wxUiEditor is being worked on.

Note that while it is possible to generate Rust code, this is just a placeholder, as there are currently no active repositories that support Rust+wxWidgets.