### PR TITLE
Fix code generation for wxStyledTextCtrl::SetTabWidth()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - The Context Help button in wxStdDialogButtonSizer did not have a label. This now generates a `wxContextHelpButton` which uses a bitmap rather than a label, and automatically places the dialog in context-help mode when clicked.
 - Fixed wxPython and wxRuby3 code generation for creating a wxPropertySheetDialog class.
 - When importing XRC files, a form's class name is correctly set if specified in the XRC file.
+- wxStyledTextCtrl::SetTabWidth() now generates code correctly (generated if tabs are enabled and tab width is not the default value of 8)
 
 ## [Released (1.2.0)]
 

--- a/src/generate/gen_styled_text.cpp
+++ b/src/generate/gen_styled_text.cpp
@@ -906,11 +906,10 @@ bool StyledTextGenerator::SettingsCode(Code& code)
     if (code.IsFalse(prop_use_tabs))
     {
         code.Eol(eol_if_needed).NodeName().Function("SetUseTabs(").False().EndFunction();
-
-        if (code.IntValue(prop_tab_width) != 8)
-        {
-            code.Eol().NodeName().Function("SetTabWidth(").as_string(prop_tab_width).EndFunction();
-        }
+    }
+    else if (code.IntValue(prop_tab_width) != 8)
+    {
+        code.Eol().NodeName().Function("SetTabWidth(").as_string(prop_tab_width).EndFunction();
     }
 
     // Default is true, so only set if false

--- a/src/internal/msgframe_base.cpp
+++ b/src/internal/msgframe_base.cpp
@@ -159,6 +159,7 @@ bool MsgFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& title
         m_scintilla->MarkerDefine(wxSTC_MARKNUM_FOLDERMIDTAIL, wxSTC_MARK_BACKGROUND);
         m_scintilla->MarkerDefine(wxSTC_MARKNUM_FOLDERSUB, wxSTC_MARK_BACKGROUND);
         m_scintilla->MarkerDefine(wxSTC_MARKNUM_FOLDERTAIL, wxSTC_MARK_BACKGROUND);
+        m_scintilla->SetTabWidth(4);
         m_scintilla->SetBackSpaceUnIndents(true);
     }
     box_sizer_3->Add(m_scintilla, wxSizerFlags(1).Expand().Border(wxALL));

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -142,6 +142,7 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
         m_scintilla->MarkerDefine(wxSTC_MARKNUM_FOLDERMIDTAIL, wxSTC_MARK_BACKGROUND);
         m_scintilla->MarkerDefine(wxSTC_MARKNUM_FOLDERSUB, wxSTC_MARK_BACKGROUND);
         m_scintilla->MarkerDefine(wxSTC_MARKNUM_FOLDERTAIL, wxSTC_MARK_BACKGROUND);
+        m_scintilla->SetTabWidth(4);
         m_scintilla->SetBackSpaceUnIndents(true);
     }
     box_sizer_3->Add(m_scintilla, wxSizerFlags(1).Expand().Border(wxALL));
@@ -202,6 +203,7 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     #include "gen_xrc.h"                   // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
     #include "mainframe.h"                 // MainFrame -- Main window frame
     #include "node.h"                      // Node class
+    #include "preferences.h"               // Prefs -- Set/Get wxUiEditor preferences
     #include "project_handler.h"           // ProjectHandler class
     #include "undo_cmds.h"                 // InsertNodeAction -- Undoable command classes derived from UndoAction
 
@@ -345,13 +347,6 @@ void XrcPreview::OnInit(wxInitDialogEvent& event)
     m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_xrc_keywords);
 
     m_scintilla->StyleSetBold(wxSTC_H_TAG, true);
-    m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#E91AFF"));
-    m_scintilla->StyleSetForeground(wxSTC_H_TAG, *wxBLUE);
-    m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour(0, 128, 0));
-    m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, *wxRED);
-    m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, *wxRED);
-    m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
-    m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
     if (UserPrefs.is_DarkMode())
     {
         auto fg = UserPrefs.GetColour(wxSYS_COLOUR_WINDOWTEXT);

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -352,6 +352,34 @@ void XrcPreview::OnInit(wxInitDialogEvent& event)
     m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, *wxRED);
     m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
     m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
+    if (UserPrefs.is_DarkMode())
+    {
+        auto fg = UserPrefs.GetColour(wxSYS_COLOUR_WINDOWTEXT);
+        auto bg = UserPrefs.GetColour(wxSYS_COLOUR_WINDOW);
+        for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+        {
+            m_scintilla->StyleSetForeground(idx, fg);
+            m_scintilla->StyleSetBackground(idx, bg);
+        }
+
+        m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#FF00FF"));
+        m_scintilla->StyleSetForeground(wxSTC_H_TAG, wxColour("#80ccff"));
+        m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour("#85e085"));
+        m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, wxColour("#ff6666"));
+        m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, wxColour("#ff6666"));
+        m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour("#85e085"));
+        m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour("#85e085"));
+    }
+    else
+    {
+        m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#FF00FF"));
+        m_scintilla->StyleSetForeground(wxSTC_H_TAG, *wxBLUE);
+        m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, *wxRED);
+        m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, *wxRED);
+        m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
+        m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
+    }
 
     wxFont font(10, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
     m_scintilla->StyleSetFont(wxSTC_STYLE_DEFAULT, font);

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -249,7 +249,7 @@ MainFrame::MainFrame() :
     m_menubar->Append(menuInternal, "&Internal");
 
     #if defined(_DEBUG)
-    m_toolbar->AddTool(id_XrcPreviewDlg, "XRC Tests", bundle_import_svg(24, 24), "Test Tests");
+    m_toolbar->AddTool(id_XrcPreviewDlg, "XRC Tests", bundle_import_svg(24, 24), "Dialog with multiple XRC tests");
     #endif
 
     m_toolbar->Realize();
@@ -258,7 +258,7 @@ MainFrame::MainFrame() :
     // For version 1.1.0.0, preview isn't reliable enough to be included in the release version
     m_menuTools->Delete(m_mi_preview);
     m_toolbar->DeleteTool(id_PreviewForm);
-#endif
+#endif  // defined(_DEBUG) || defined(INTERNAL_TESTING)
 
     CreateStatusBar(StatusPanels);
     SetStatusBarPane(1);  // specifies where menu and toolbar help content is displayed

--- a/src/wxui/codedisplay_base.cpp
+++ b/src/wxui/codedisplay_base.cpp
@@ -40,7 +40,6 @@ bool CodeDisplayBase::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos
         m_scintilla->SetMarginSensitive(0, false);
         m_scintilla->SetIndentationGuides(wxSTC_IV_REAL);
         m_scintilla->SetUseTabs(false);
-        m_scintilla->SetTabWidth(4);
         m_scintilla->SetBackSpaceUnIndents(true);
     }
     parent_sizer->Add(m_scintilla, wxSizerFlags(1).Expand().Border(wxALL));

--- a/src/wxui/edit_html_dialog_base.cpp
+++ b/src/wxui/edit_html_dialog_base.cpp
@@ -49,7 +49,6 @@ bool EditHtmlDialogBase::Create(wxWindow* parent, wxWindowID id, const wxString&
         m_scintilla->SetMarginSensitive(0, false);
         m_scintilla->SetIndentationGuides(wxSTC_IV_LOOKFORWARD);
         m_scintilla->SetUseTabs(false);
-        m_scintilla->SetTabWidth(4);
         m_scintilla->SetBackSpaceUnIndents(true);
     }
     {

--- a/src/wxui/editcodedialog_base.cpp
+++ b/src/wxui/editcodedialog_base.cpp
@@ -44,7 +44,6 @@ bool EditCodeDialogBase::Create(wxWindow* parent, wxWindowID id, const wxString&
         m_stc->SetMarginSensitive(0, false);
         m_stc->SetIndentationGuides(wxSTC_IV_LOOKFORWARD);
         m_stc->SetUseTabs(false);
-        m_stc->SetTabWidth(4);
         m_stc->SetBackSpaceUnIndents(true);
     }
     parent_sizer->Add(m_stc, wxSizerFlags(1).Expand().DoubleBorder(wxALL));

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -126,7 +126,6 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
         m_cpp_stc_lambda->SetMarginSensitive(0, false);
         m_cpp_stc_lambda->SetIndentationGuides(wxSTC_IV_LOOKFORWARD);
         m_cpp_stc_lambda->SetUseTabs(false);
-        m_cpp_stc_lambda->SetTabWidth(4);
         m_cpp_stc_lambda->SetBackSpaceUnIndents(true);
     }
     m_cpp_stc_lambda->SetMinSize(ConvertDialogToPixels(wxSize(200, -1)));
@@ -207,7 +206,6 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
         m_ruby_stc_lambda->SetMarginSensitive(0, false);
         m_ruby_stc_lambda->SetIndentationGuides(wxSTC_IV_LOOKFORWARD);
         m_ruby_stc_lambda->SetUseTabs(false);
-        m_ruby_stc_lambda->SetTabWidth(4);
         m_ruby_stc_lambda->SetBackSpaceUnIndents(true);
     }
     m_ruby_stc_lambda->SetMinSize(ConvertDialogToPixels(wxSize(200, -1)));

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -6128,6 +6128,7 @@
               <node
                 class="wxStyledTextCtrl"
                 fold_margin="1"
+                indentation_size="0"
                 lexer="XML"
                 flags="wxEXPAND"
                 proportion="1" />


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes broken logic around generating `wxStyledTextCtrl::SetTabWidth()` -- previously the tab was only set if `use_tabs` was false. Now it is set if `use_tabs` is true and tab width is not equal to 8.