### PR TITLE
Change filename to varname algorithm, add try/catch blocks around image processing thread

### DIFF
--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -891,7 +891,15 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
 
     m_source->writeLine();
 
-    thrd_collect_img_headers.join();
+    try
+    {
+        thrd_collect_img_headers.join();
+    }
+    catch (const std::system_error& err)
+    {
+        MSG_ERROR(err.what());
+    }
+
     if (m_embedded_images.size())
     {
         std::sort(m_embedded_images.begin(), m_embedded_images.end(),

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -293,7 +293,15 @@ void BaseCodeGenerator::GeneratePythonClass(PANEL_PAGE panel_type)
     if (m_form_node->isGen(gen_Images))
     {
         thrd_get_events.join();
-        thrd_collect_img_headers.join();
+        try
+        {
+            thrd_collect_img_headers.join();
+        }
+        catch (const std::system_error& err)
+        {
+            MSG_ERROR(err.what());
+        }
+
         GeneratePythonImagesForm();
         return;
     }
@@ -362,7 +370,15 @@ void BaseCodeGenerator::GeneratePythonClass(PANEL_PAGE panel_type)
         }
     }
 
-    thrd_collect_img_headers.join();
+    try
+    {
+        thrd_collect_img_headers.join();
+    }
+    catch (const std::system_error& err)
+    {
+        MSG_ERROR(err.what());
+    }
+
     if (m_embedded_images.size())
     {
         m_source->writeLine();

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -363,7 +363,15 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
         m_source->writeLine();
 
         thrd_get_events.join();
-        thrd_collect_img_headers.join();
+        try
+        {
+            thrd_collect_img_headers.join();
+        }
+        catch (const std::system_error& err)
+        {
+            MSG_ERROR(err.what());
+        }
+
         thrd_need_img_func.join();
         GenerateRubyImagesForm();
         return;
@@ -447,7 +455,15 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
         }
     }
 
-    thrd_collect_img_headers.join();
+    try
+    {
+        thrd_collect_img_headers.join();
+    }
+    catch (const std::system_error& err)
+    {
+        MSG_ERROR(err.what());
+    }
+
     if (m_embedded_images.size())
     {
         m_source->writeLine();

--- a/src/generate/gen_rust.cpp
+++ b/src/generate/gen_rust.cpp
@@ -280,7 +280,15 @@ void BaseCodeGenerator::GenerateRustClass(PANEL_PAGE panel_type)
     if (m_form_node->isGen(gen_Images))
     {
         thrd_get_events.join();
-        thrd_collect_img_headers.join();
+        try
+        {
+            thrd_collect_img_headers.join();
+        }
+        catch (const std::system_error& err)
+        {
+            MSG_ERROR(err.what());
+        }
+
         // GenerateRustImagesForm();
         return;
     }
@@ -308,7 +316,15 @@ void BaseCodeGenerator::GenerateRustClass(PANEL_PAGE panel_type)
         }
     }
 
-    thrd_collect_img_headers.join();
+    try
+    {
+        thrd_collect_img_headers.join();
+    }
+    catch (const std::system_error& err)
+    {
+        MSG_ERROR(err.what());
+    }
+
     if (m_embedded_images.size())
     {
         m_source->writeLine();

--- a/src/internal/msg_logging.cpp
+++ b/src/internal/msg_logging.cpp
@@ -126,6 +126,8 @@ void MsgLogging::AddErrorMsg(tt_string_view msg)
     auto& str = m_Msgs.emplace_back("Error: ");
     str << msg << '\n';
 
+    FAIL_MSG(str);
+
     if ((UserPrefs.GetDebugFlags() & Prefs::PREFS_MSG_WINDOW) && !m_isFirstShown)
     {
         m_isFirstShown = true;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The main focus of this PR is to change the filename to varname conversion. I encountered a situation where the entire filename was UTF8, and conversion failed completely, creating a varname of `_svg`. Part os this was due to `wxString::Format`, but even fixing that resulted in tripling the varname instead of the expected doubling. The new algorithm solves makes the varname a bit shorter, and also solves the UTF8 issue. The name is unique, but for UTF8, it will off course bear no resemblance to the original filename.

The second part of this PR adds try/catch around `thrd_collect_img_headers.join();` -- I'm running into a crash in the thread. This won't solve the crash, but should help to find the source of the problem. Once found, it still makes sense to leave the try/catch in place since it won't have any noticeable effect on performance.
