### PR TITLE
Update Preferences Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Dark Mode and High Contrast Dark Mode are now available in the Prefences dialog on Windows.
+- The font used in the code panels can now be set in the Preferences dialog.
 - XPM files are now supported in wxPython and wxRuby3.
 - Setting a static bitmap's scale mode will now use wxGenericStaticBitmap in wxPython (4.2.1) and wxRuby3 (0.9.3) to ensure that all platforms will support the scaling.
 - Added wxBitmapToggleButton for all languages.
@@ -17,6 +18,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- The graphics in the Navigation panel and the Ribbon toolbar have been replaced with new SVG images that will scale better on high DPI displays. Because the new graphics were created from scratch, they may look quite different from the old ones.
+- Additional colors for the Code display panels can be set in Preferences (support for C++, Python, Ruby and XRC).
 - The `hide_children` property in the `wxStaticBoxSizer` has been removed since the `hidden` property does exactly the same thing. Projects where `hide_children` was set will be automatically converted to use `hidden` instead.
 - The Image List file now includes wxue_img::image_ functions for each image in the list, replacing the `extern` declarations that were previously used. A new `add_externs` property has been added -- check that if you still need the extern declarations.
 - wxIntegerValidator and wxFloatingPointValidator now support setting either min or max, and are generated as separate calls. Previously, you had to set both of them to have either one generated.

--- a/src/customprops/font_prop_dlg.cpp
+++ b/src/customprops/font_prop_dlg.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog for editing Font Property
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -14,6 +14,16 @@
 FontPropDlg::FontPropDlg(wxWindow* parent, NodeProperty* prop) : FontPropDlgBase(parent)
 {
     m_value = prop->as_wxString();
+    Initialize();
+}
+
+FontPropDlg::FontPropDlg(wxWindow* parent, const wxString& font_description) : FontPropDlgBase(parent)
+{
+    m_value = font_description;
+    Initialize();
+}
+void FontPropDlg::Initialize()
+{
     if (m_value.size())
     {
         m_custom_font.Convert(m_value.utf8_string());
@@ -239,6 +249,7 @@ void FontPropDlg::OnOK(wxCommandEvent& event)
         m_system_font.Underlined(m_checkSystemUnderlined->GetValue());
         m_system_font.Strikethrough(m_checkSystemStrikeThrough->GetValue());
         m_value = m_system_font.as_wxString();
+        m_font_description = m_system_font.as_string();
     }
     else
     {
@@ -258,6 +269,7 @@ void FontPropDlg::OnOK(wxCommandEvent& event)
         else
             m_custom_font.FaceName(facename);
         m_value = m_custom_font.as_wxString();
+        m_font_description = m_custom_font.as_string();
     }
 
     event.Skip();

--- a/src/customprops/font_prop_dlg.h
+++ b/src/customprops/font_prop_dlg.h
@@ -19,9 +19,13 @@ class FontPropDlg : public FontPropDlgBase
 {
 public:
     FontPropDlg(wxWindow* parent, NodeProperty* prop);
+    FontPropDlg(wxWindow* parent, const wxString& font_description);
     const wxString& GetResults() { return m_value; }
+    tt_string_view GetFontDescription() { return m_font_description; }
 
 protected:
+    void Initialize();  // Call this from either of the constructors
+
     void UpdateFontInfo();
     // Handlers for FontPropDlgBase events
     void OnCustomRadio(wxCommandEvent& WXUNUSED(event)) override;
@@ -40,6 +44,7 @@ protected:
     void OnOK(wxCommandEvent& WXUNUSED(event)) override;
 
     wxString m_value;
+    tt_string m_font_description;
 
 private:
     wxFontEnumerator m_font_enum;

--- a/src/internal/msg_logging.cpp
+++ b/src/internal/msg_logging.cpp
@@ -157,7 +157,12 @@ void MsgLogging::AddErrorMsg(tt_string_view msg)
     auto& str = g_log_msgs.emplace_back("Error: ");
     str << msg << '\n';
 
-    FAIL_MSG(str);
+    // [Randalphwa - 03-04-2024]
+    // If AddErrorMsg is called during an event handler then FAIL_MSG can be called multiple
+    // times. While std::unique_lock prevents re-entrance, it can still result in a crash. If
+    // you really need to stop in this call, set a breakpoint and stop in the debugger. Do
+    // *not* call FAIL_MSG(str);
+    // FAIL_MSG(str);
 
     if (!g_pMsgLogging)  // g_pMsgLogging doesn't get created until the main window is created
     {

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1363,8 +1363,8 @@ wxWindow* MainFrame::CreateNoteBook(wxWindow* parent)
     m_mockupPanel = new MockupParent(m_notebook, this);
     m_notebook->AddPage(m_mockupPanel, "Mock Up", false, wxWithImages::NO_IMAGE);
 
-    m_generatedPanel = new BasePanel(m_notebook, this, GEN_LANG_CPLUSPLUS);
-    m_notebook->AddPage(m_generatedPanel, "C++", false, wxWithImages::NO_IMAGE);
+    m_cppPanel = new BasePanel(m_notebook, this, GEN_LANG_CPLUSPLUS);
+    m_notebook->AddPage(m_cppPanel, "C++", false, wxWithImages::NO_IMAGE);
 
     // Placing the Python panel first as it's the most commonly used language after C++
     m_pythonPanel = new BasePanel(m_notebook, this, GEN_LANG_PYTHON);

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -77,7 +77,16 @@ public:
     PropGridPanel* getPropPanel() { return m_property_panel; }
     NavigationPanel* getNavigationPanel() { return m_nav_panel; }
     RibbonPanel* getRibbonPanel() { return m_ribbon_panel; }
-    BasePanel* getGeneratedPanel() { return m_generatedPanel; }
+
+    BasePanel* GetCppPanel() { return m_cppPanel; }
+    BasePanel* GetPythonPanel() { return m_pythonPanel; }
+    BasePanel* GetRubyPanel() { return m_rubyPanel; }
+    BasePanel* GetXrcPanel() { return m_xrcPanel; }
+    BasePanel* GetGolangPanel() { return m_golangPanel; }
+    BasePanel* GetLuaPanel() { return m_luaPanel; }
+    BasePanel* GetPerlPanel() { return m_perlPanel; }
+    BasePanel* GetRustPanel() { return m_rustPanel; }
+
     wxAuiNotebook* getTopNotebook() { return m_notebook; }
     DocViewPanel* getDocViewPanel() { return m_docviewPanel; }
 
@@ -354,7 +363,7 @@ private:
     MockupParent* m_mockupPanel;
     DocViewPanel* m_docviewPanel { nullptr };
 
-    BasePanel* m_generatedPanel { nullptr };
+    BasePanel* m_cppPanel { nullptr };
     BasePanel* m_derivedPanel { nullptr };
 
     // Language panels

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -290,7 +290,7 @@ wxColour NodeProperty::as_color() const
             return wxColour(result->second);
         else
         {
-            FAIL_MSG(tt_string("Unknown CSS color: ") << m_value);
+            MSG_ERROR(tt_string("Unknown CSS color: ") << m_value);
             return wxNullColour;
         }
     }

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -40,7 +40,7 @@ const char* g_u8_cpp_keywords = "alignas alignof and and_eq atomic_cancel atomic
 
 const char* g_python_keywords = "False None True and as assert async break class continue def del elif else except finally "
                                 "for from global if import in is lambda "
-                                "nonlocal not or pass raise return try while with yield";
+                                "nonlocal not or pass raise return self try while with yield";
 
 const char* g_ruby_keywords = "ENCODING LINE FILE BEGIN END alias and begin break case class def defined do else"
                               " elsif end ensure false for if in module next nil not or redo require rescue retry"
@@ -456,4 +456,10 @@ void BasePanel::SetColor(int style, const wxColour& color)
 {
     m_cppPanel->SetColor(style, color);
     m_hPanel->SetColor(style, color);
+}
+
+void BasePanel::SetCodeFont(const wxFont& font)
+{
+    m_cppPanel->SetCodeFont(font);
+    m_hPanel->SetCodeFont(font);
 }

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -451,3 +451,9 @@ void BasePanel::OnNodeSelected(CustomEvent& event)
         }
     }
 }
+
+void BasePanel::SetColor(int style, const wxColour& color)
+{
+    m_cppPanel->SetColor(style, color);
+    m_hPanel->SetColor(style, color);
+}

--- a/src/panels/base_panel.h
+++ b/src/panels/base_panel.h
@@ -43,10 +43,12 @@ public:
 
     void OnNodeSelected(CustomEvent& event);
 
+    void SetColor(int style, const wxColour& color);
+
 protected:
 private:
     CodeDisplay* m_cppPanel;
-    CodeDisplay* m_hPanel;
+    CodeDisplay* m_hPanel;  // Header, inherit, info panel
     CodeDisplay* m_derived_src_panel { nullptr };
     CodeDisplay* m_derived_hdr_panel { nullptr };
     wxAuiNotebook* m_notebook;

--- a/src/panels/base_panel.h
+++ b/src/panels/base_panel.h
@@ -44,6 +44,7 @@ public:
     void OnNodeSelected(CustomEvent& event);
 
     void SetColor(int style, const wxColour& color);
+    void SetCodeFont(const wxFont& font);
 
 protected:
 private:

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -50,6 +50,10 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
     if (panel_type == GEN_LANG_XRC)
     {
         m_scintilla->SetLexer(wxSTC_LEX_XML);
+        // [Randalphwa - 03-04-2024] Default tab width for wxSTC_LEX_XML appears to be 8 at
+        // least in wxWidgets 3.3, but we want 4 for XRC to improve readability.
+        m_scintilla->SetTabWidth(4);
+
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_xrc_keywords);
 

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -526,8 +526,12 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
 
     // TODO: [KeyWorks - 01-02-2022] We do this because currently font selection uses a facename which is not cross-platform.
     // See issue #597.
-    wxFont font(10, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
-    m_scintilla->StyleSetFont(wxSTC_STYLE_DEFAULT, font);
+
+    FontProperty font_prop(UserPrefs.get_CodeDisplayFont().ToStdView());
+    m_scintilla->StyleSetFont(wxSTC_STYLE_DEFAULT, font_prop.GetFont());
+
+    // wxFont font(10, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+    // m_scintilla->StyleSetFont(wxSTC_STYLE_DEFAULT, font);
 
     m_scintilla->MarkerDefine(node_marker, wxSTC_MARK_BOOKMARK, wxNullColour, *wxGREEN);
 
@@ -832,4 +836,9 @@ void CodeDisplay::OnEmbedImageSelected(Node* node)
 void CodeDisplay::SetColor(int style, const wxColour& color)
 {
     m_scintilla->StyleSetForeground(style, color);
+}
+
+void CodeDisplay::SetCodeFont(const wxFont& font)
+{
+    m_scintilla->StyleSetFont(wxSTC_STYLE_DEFAULT, font);
 }

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -13,6 +13,7 @@
 
 #include "base_panel.h"      // BasePanel -- Code generation panel
 #include "code.h"            // Code -- Helper class for generating code
+#include "font_prop.h"       // FontProp -- Font properties
 #include "image_handler.h"   // ImageHandler class
 #include "mainframe.h"       // MainFrame -- Main window frame
 #include "node.h"            // Node class
@@ -68,25 +69,21 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
                 m_scintilla->StyleSetBackground(idx, bg);
             }
 
-            m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#FF00FF"));
-            m_scintilla->StyleSetForeground(wxSTC_H_TAG, wxColour("#80ccff"));
             m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour("#85e085"));
             m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, wxColour("#ff6666"));
             m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, wxColour("#ff6666"));
-            m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour("#85e085"));
             m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour("#85e085"));
         }
         else
         {
-            m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, wxColour("#FF00FF"));
-            m_scintilla->StyleSetForeground(wxSTC_H_TAG, *wxBLUE);
             m_scintilla->StyleSetForeground(wxSTC_H_COMMENT, wxColour(0, 128, 0));
             m_scintilla->StyleSetForeground(wxSTC_H_NUMBER, *wxRED);
             m_scintilla->StyleSetForeground(wxSTC_H_ENTITY, *wxRED);
-            m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
             m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
         }
         m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, UserPrefs.get_XrcAttributeColour());
+        m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, UserPrefs.get_XrcDblStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_H_TAG, UserPrefs.get_XrcTagColour());
     }
     else if (panel_type == GEN_LANG_PYTHON)
     {
@@ -94,7 +91,7 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_python_keywords);
 
-        tt_string wxPython_keywords("ToolBar MenuBar BitmapBundle Bitmap MemoryInputStream Window");
+        tt_string wxPython_keywords("ToolBar MenuBar BitmapBundle Bitmap SizerFlags MemoryInputStream Window");
 
         for (auto iter: NodeCreation.getNodeDeclarationArray())
         {
@@ -112,7 +109,6 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
 
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) wxPython_keywords.c_str());
-        m_scintilla->StyleSetForeground(wxSTC_P_WORD2, UserPrefs.get_PythonColour());
 
         if (UserPrefs.is_DarkMode())
         {
@@ -129,21 +125,17 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
             luminance = .80;
             auto light_green = HSLToWxColour(hue, saturation, luminance);
 
-            m_scintilla->StyleSetForeground(wxSTC_P_WORD, wxColour("#80ccff"));
-            // m_scintilla->StyleSetForeground(wxSTC_P_STRING, wxColour("#85e085"));
-            m_scintilla->StyleSetForeground(wxSTC_P_STRING, light_green);
             m_scintilla->StyleSetForeground(wxSTC_P_STRINGEOL, wxColour("#85e085"));
-            m_scintilla->StyleSetForeground(wxSTC_P_COMMENTLINE, wxColour("#85e085"));
-            m_scintilla->StyleSetForeground(wxSTC_P_NUMBER, wxColour("#ff6666"));
         }
         else
         {
-            m_scintilla->StyleSetForeground(wxSTC_P_WORD, *wxBLUE);
-            m_scintilla->StyleSetForeground(wxSTC_P_STRING, wxColour(0, 128, 0));
             m_scintilla->StyleSetForeground(wxSTC_P_STRINGEOL, wxColour(0, 128, 0));
-            m_scintilla->StyleSetForeground(wxSTC_P_COMMENTLINE, wxColour(0, 128, 0));
-            m_scintilla->StyleSetForeground(wxSTC_P_NUMBER, *wxRED);
         }
+        m_scintilla->StyleSetForeground(wxSTC_P_WORD2, UserPrefs.get_PythonColour());
+        m_scintilla->StyleSetForeground(wxSTC_P_WORD, UserPrefs.get_PythonKeywordColour());
+        m_scintilla->StyleSetForeground(wxSTC_P_NUMBER, UserPrefs.get_PythonNumberColour());
+        m_scintilla->StyleSetForeground(wxSTC_P_STRING, UserPrefs.get_PythonStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_P_COMMENTLINE, UserPrefs.get_PythonCommentColour());
     }
     else if (panel_type == GEN_LANG_RUBY)
     {
@@ -152,7 +144,9 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // We don't set ruby keywords because we can't colorize them differently from the
         // wxWidgets keywords.
 
-        tt_string wxRuby_keywords("ToolBar MenuBar BitmapBundle Bitmap Window Wx");
+        tt_string wxRuby_keywords("ALL LEFT RIGHT TOP BOTTOM DEFAULT_POSITION DEFAULT_SIZE HORIZONTAL VERTICAL Colour "
+                                  "ToolBar MenuBar BitmapBundle Bitmap ID_ANY ID_OK ID_CANCEL ID_SAVE ID_YES ID_NO "
+                                  "TAB_TRAVERSAL FILTER_DIGITS SizerFlags TextValidator Window Wx");
 
         // clang-format on
 
@@ -176,7 +170,6 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
         // the wxWidgets keywords.
 
         m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) wxRuby_keywords.c_str());
-        m_scintilla->StyleSetForeground(wxSTC_RB_WORD, UserPrefs.get_RubyColour());
 
         if (UserPrefs.is_DarkMode())
         {
@@ -187,17 +180,16 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
                 m_scintilla->StyleSetForeground(idx, fg);
                 m_scintilla->StyleSetBackground(idx, bg);
             }
-
-            m_scintilla->StyleSetForeground(wxSTC_RB_STRING, wxColour("#85e085"));
-            m_scintilla->StyleSetForeground(wxSTC_RB_COMMENTLINE, wxColour("#85e085"));
-            m_scintilla->StyleSetForeground(wxSTC_RB_NUMBER, wxColour("#ff6666"));
         }
-        else
-        {
-            m_scintilla->StyleSetForeground(wxSTC_RB_STRING, wxColour(0, 128, 0));
-            m_scintilla->StyleSetForeground(wxSTC_RB_COMMENTLINE, wxColour(0, 128, 0));
-            m_scintilla->StyleSetForeground(wxSTC_RB_NUMBER, *wxRED);
-        }
+        m_scintilla->StyleSetForeground(wxSTC_RB_WORD, UserPrefs.get_RubyColour());
+        m_scintilla->StyleSetForeground(wxSTC_RB_STRING, UserPrefs.get_RubyStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_RB_STRING_Q, UserPrefs.get_RubyStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_RB_STRING_QQ, UserPrefs.get_RubyStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_RB_STRING_QX, UserPrefs.get_RubyStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_RB_STRING_QR, UserPrefs.get_RubyStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_RB_STRING_QW, UserPrefs.get_RubyStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_RB_COMMENTLINE, UserPrefs.get_RubyCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_RB_NUMBER, UserPrefs.get_RubyNumberColour());
     }
 #if defined(_DEBUG)
     // The following language panels are experimental and only appear in a Debug build
@@ -494,17 +486,9 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
                 wxColour(0, 192, 0);
             }
         }
-        m_scintilla->StyleSetForeground(wxSTC_C_STRING, clr_green);
-        m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, clr_green);
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, clr_green);
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, clr_green);
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, clr_green);
-        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, clr_green);
 
         if (UserPrefs.is_DarkMode())
         {
-            m_scintilla->StyleSetForeground(wxSTC_C_WORD2, wxColourToDarkForeground(UserPrefs.get_CppColour()));
-            m_scintilla->StyleSetForeground(wxSTC_C_WORD, wxColourToDarkForeground(*wxBLUE));
             if (UserPrefs.is_HighContrast())
             {
                 m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour("#569CD6"));
@@ -513,15 +497,21 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
             {
                 m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
             }
-            m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, wxColour("#ff6666"));
         }
         else
         {
-            m_scintilla->StyleSetForeground(wxSTC_C_WORD2, UserPrefs.get_CppColour());
-            m_scintilla->StyleSetForeground(wxSTC_C_WORD, *wxBLUE);
             m_scintilla->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
-            m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, *wxRED);
         }
+
+        m_scintilla->StyleSetForeground(wxSTC_C_STRING, UserPrefs.get_CppStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_C_STRINGEOL, UserPrefs.get_CppStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENT, UserPrefs.get_CppCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINE, UserPrefs.get_CppCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTDOC, UserPrefs.get_CppCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, UserPrefs.get_CppCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_C_WORD2, UserPrefs.get_CppColour());
+        m_scintilla->StyleSetForeground(wxSTC_C_WORD, UserPrefs.get_CppKeywordColour());
+        m_scintilla->StyleSetForeground(wxSTC_C_NUMBER, UserPrefs.get_CppNumberColour());
     }
 
     // TODO: [KeyWorks - 01-02-2022] We do this because currently font selection uses a facename which is not cross-platform.

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -618,7 +618,7 @@ void CodeDisplay::OnNodeSelected(Node* node)
     }
 
     auto is_event = wxGetFrame().getPropPanel()->IsEventPageShowing();
-    PANEL_PAGE page = wxGetFrame().getGeneratedPanel()->GetPanelPage();
+    PANEL_PAGE page = wxGetFrame().GetCppPanel()->GetPanelPage();
 
     if (m_panel_type != GEN_LANG_CPLUSPLUS && page != CPP_PANEL)
         return;  // Nothing to search for in secondary pages of non-C++ languages

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -86,6 +86,7 @@ CodeDisplay::CodeDisplay(wxWindow* parent, int panel_type) : CodeDisplayBase(par
             m_scintilla->StyleSetForeground(wxSTC_H_DOUBLESTRING, wxColour(0, 128, 0));
             m_scintilla->StyleSetForeground(wxSTC_H_SINGLESTRING, wxColour(0, 128, 0));
         }
+        m_scintilla->StyleSetForeground(wxSTC_H_ATTRIBUTE, UserPrefs.get_XrcAttributeColour());
     }
     else if (panel_type == GEN_LANG_PYTHON)
     {
@@ -826,4 +827,9 @@ void CodeDisplay::OnEmbedImageSelected(Node* node)
             }
         }
     }
+}
+
+void CodeDisplay::SetColor(int style, const wxColour& color)
+{
+    m_scintilla->StyleSetForeground(style, color);
 }

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -27,6 +27,8 @@ class CodeDisplay : public CodeDisplayBase, public WriteCode
 public:
     CodeDisplay(wxWindow* parent, int panel_type);
 
+    void SetColor(int style, const wxColour& color);
+
     // Clears scintilla and internal buffer, removes read-only flag in scintilla
     void Clear() override;
 

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -28,6 +28,7 @@ public:
     CodeDisplay(wxWindow* parent, int panel_type);
 
     void SetColor(int style, const wxColour& color);
+    void SetCodeFont(const wxFont& font);
 
     // Clears scintilla and internal buffer, removes read-only flag in scintilla
     void Clear() override;

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -2317,7 +2317,7 @@ void PropGridPanel::OnAuiNotebookPageChanged(wxAuiNotebookEvent& /* event */)
 {
     CustomEvent custom_event(EVT_NodeSelected, wxGetFrame().getSelectedNode());
 
-    wxGetFrame().getGeneratedPanel()->OnNodeSelected(custom_event);
+    wxGetFrame().GetCppPanel()->OnNodeSelected(custom_event);
 }
 
 tt_string PropGridPanel::GetPropHelp(NodeProperty* prop) const

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -36,14 +36,35 @@ void Prefs::ReadConfig()
     m_is_cpp_snake_case = config->ReadBool("cpp_snake_case", true);
 
     m_cpp_widgets_version = config->Read("cpp_widgets_version", "3.2");
+    m_python_version = config->Read("python_version", "4.2");
+    m_ruby_version = config->Read("ruby_version", "0.9");
 
     m_colour_cpp = config->Read("cpp_colour", "#FF00FF");
+    m_colour_cpp_comment = config->Read("cpp_comment_colour", "#008000");
+    m_colour_cpp_keyword = config->Read("cpp_keyword_colour", "#0000FF");
+    m_colour_cpp_number = config->Read("cpp_number_colour", "#FF0000");
+    m_colour_cpp_string = config->Read("cpp_string_colour", "#008000");
+
     m_colour_python = config->Read("python_colour", "#FF00FF");
+    m_colour_python_comment = config->Read("python_comment_colour", "#008000");
+    m_colour_python_keyword = config->Read("python_keyword_colour", "#0000FF");
+    m_colour_python_number = config->Read("python_number_colour", "#FF0000");
+    m_colour_python_string = config->Read("python_string_colour", "#008000");
+
     m_colour_ruby = config->Read("ruby_colour", "#FF00FF");
+    m_colour_ruby_comment = config->Read("ruby_comment_colour", "#008000");
+    m_colour_ruby_number = config->Read("ruby_number_colour", "#FF0000");
+    m_colour_ruby_string = config->Read("ruby_string_colour", "#008000");
+
+    m_colour_xrc_attribute = config->Read("xrc_colour", "#FF00FF");
+    m_colour_xrc_dblstring = config->Read("xrc_dblstring_colour", "#008000");
+    m_colour_xrc_tag = config->Read("xrc_tag_colour", "#0000FF");
 
     m_cpp_line_length = config->Read("cpp_line_length", 110);
     m_python_line_length = config->Read("python_line_length", 90);
     m_ruby_line_length = config->Read("ruby_line_length", 80);
+
+    m_code_display_font = config->Read("code_display_font", "");
 
     config->SetPath("/");
 }
@@ -63,13 +84,33 @@ void Prefs::WriteConfig()
     config->Write("high_contrast", m_high_constrast);
     config->Write("load_last_project", m_is_load_last_project);
     config->Write("right_propgrid", m_is_right_propgrid);
+
     config->Write("cpp_snake_case", m_is_cpp_snake_case);
 
     config->Write("cpp_widgets_version", m_cpp_widgets_version.make_wxString());
+    config->Write("python_version", m_python_version.make_wxString());
+    config->Write("ruby_version", m_ruby_version.make_wxString());
 
     config->Write("cpp_colour", m_colour_cpp.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("cpp_comment_colour", m_colour_cpp_comment.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("cpp_keyword_colour", m_colour_cpp_keyword.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("cpp_number_colour", m_colour_cpp_number.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("cpp_string_colour", m_colour_cpp_string.GetAsString(wxC2S_HTML_SYNTAX));
+
     config->Write("python_colour", m_colour_python.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("python_comment_colour", m_colour_python_comment.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("python_keyword_colour", m_colour_python_keyword.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("python_number_colour", m_colour_python_number.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("python_string_colour", m_colour_python_string.GetAsString(wxC2S_HTML_SYNTAX));
+
     config->Write("ruby_colour", m_colour_ruby.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("ruby_comment_colour", m_colour_ruby_comment.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("ruby_number_colour", m_colour_ruby_number.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("ruby_string_colour", m_colour_ruby_string.GetAsString(wxC2S_HTML_SYNTAX));
+
+    config->Write("xrc_colour", m_colour_xrc_attribute.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("xrc_dblstring_colour", m_colour_xrc_dblstring.GetAsString(wxC2S_HTML_SYNTAX));
+    config->Write("xrc_tag_colour", m_colour_xrc_tag.GetAsString(wxC2S_HTML_SYNTAX));
 
     config->Write("cpp_line_length", m_cpp_line_length);
     config->Write("python_line_length", m_python_line_length);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -80,6 +80,8 @@ void Prefs::WriteConfig()
         config->Write("dark_mode", m_dark_mode_pending & PENDING_DARK_MODE_ON ? true : false);
     }
 
+    config->Write("code_display_font", m_code_display_font.make_wxString());
+
     config->SetPath("/");
 }
 

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -150,7 +150,7 @@ private:
     PREVIEW_TYPE m_preview_type { PREVIEW_TYPE_XRC };
 
     tt_string m_cpp_widgets_version { "3.2" };
-    tt_string m_code_display_font { "modern,10" };
+    tt_string m_code_display_font;
 
     wxColour m_colour_cpp { wxColour("#FF00FF") };
     wxColour m_colour_python { wxColour("#FF00FF") };

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -32,7 +32,6 @@ public:
 
     void ReadConfig();
     void WriteConfig();
-
     // Add borders around all new sizers
     bool is_SizersAllBorders() const { return m_sizers_all_borders; }
 
@@ -81,15 +80,48 @@ public:
 
     const tt_string& get_CppWidgetsVersion() const { return m_cpp_widgets_version; }
     void set_CppWidgetsVersion(const tt_string& version) { m_cpp_widgets_version = version; }
+    const tt_string& get_PythonVersion() const { return m_python_version; }
+    void set_PythonVersion(const tt_string& version) { m_python_version = version; }
+    const tt_string& get_RubyVersion() const { return m_ruby_version; }
+    void set_RubyVersion(const tt_string& version) { m_ruby_version = version; }
 
     const wxColour& get_CppColour() const { return m_colour_cpp; }
     void set_CppColour(const wxColour& colour) { m_colour_cpp = colour; }
+    const wxColour& get_CppCommentColour() const { return m_colour_cpp_comment; }
+    void set_CppCommentColour(const wxColour& colour) { m_colour_cpp_comment = colour; }
+    const wxColour& get_CppKeywordColour() const { return m_colour_cpp_keyword; }
+    void set_CppKeywordColour(const wxColour& colour) { m_colour_cpp_keyword = colour; }
+    const wxColour& get_CppNumberColour() const { return m_colour_cpp_number; }
+    void set_CppNumberColour(const wxColour& colour) { m_colour_cpp_number = colour; }
+    const wxColour& get_CppStringColour() const { return m_colour_cpp_string; }
+    void set_CppStringColour(const wxColour& colour) { m_colour_cpp_string = colour; }
 
     const wxColour& get_PythonColour() const { return m_colour_python; }
     void set_PythonColour(const wxColour& colour) { m_colour_python = colour; }
+    const wxColour& get_PythonKeywordColour() const { return m_colour_python_keyword; }
+    void set_PythonKeywordColour(const wxColour& colour) { m_colour_python_keyword = colour; }
+    const wxColour& get_PythonNumberColour() const { return m_colour_python_number; }
+    void set_PythonNumberColour(const wxColour& colour) { m_colour_python_number = colour; }
+    const wxColour& get_PythonStringColour() const { return m_colour_python_string; }
+    void set_PythonStringColour(const wxColour& colour) { m_colour_python_string = colour; }
+    const wxColour& get_PythonCommentColour() const { return m_colour_python_comment; }
+    void set_PythonCommentColour(const wxColour& colour) { m_colour_python_comment = colour; }
 
     const wxColour& get_RubyColour() const { return m_colour_ruby; }
     void set_RubyColour(const wxColour& colour) { m_colour_ruby = colour; }
+    const wxColour& get_RubyCommentColour() const { return m_colour_ruby_comment; }
+    void set_RubyCommentColour(const wxColour& colour) { m_colour_ruby_comment = colour; }
+    const wxColour& get_RubyNumberColour() const { return m_colour_ruby_number; }
+    void set_RubyNumberColour(const wxColour& colour) { m_colour_ruby_number = colour; }
+    const wxColour& get_RubyStringColour() const { return m_colour_ruby_string; }
+    void set_RubyStringColour(const wxColour& colour) { m_colour_ruby_string = colour; }
+
+    const wxColour& get_XrcAttributeColour() const { return m_colour_xrc_attribute; }
+    void set_XrcAttributeColour(const wxColour& colour) { m_colour_xrc_attribute = colour; }
+    const wxColour& get_XrcDblStringColour() const { return m_colour_xrc_dblstring; }
+    void set_XrcDblStringColour(const wxColour& colour) { m_colour_xrc_dblstring = colour; }
+    const wxColour& get_XrcTagColour() const { return m_colour_xrc_tag; }
+    void set_XrcTagColour(const wxColour& colour) { m_colour_xrc_tag = colour; }
 
     void set_SizersAllBorders(bool setting) { m_sizers_all_borders = setting; }
     void set_SizersExpand(bool setting) { m_sizers_always_expand = setting; }
@@ -150,11 +182,31 @@ private:
     PREVIEW_TYPE m_preview_type { PREVIEW_TYPE_XRC };
 
     tt_string m_cpp_widgets_version { "3.2" };
+    tt_string m_python_version { "4.2" };
+    tt_string m_ruby_version { "0.9" };
+
     tt_string m_code_display_font;
 
     wxColour m_colour_cpp { wxColour("#FF00FF") };
+    wxColour m_colour_cpp_comment { wxColour("#008000") };
+    wxColour m_colour_cpp_keyword { wxColour("#0000FF") };
+    wxColour m_colour_cpp_number { wxColour("#FF0000") };
+    wxColour m_colour_cpp_string { wxColour("#008000") };
+
     wxColour m_colour_python { wxColour("#FF00FF") };
+    wxColour m_colour_python_comment { wxColour("#008000") };
+    wxColour m_colour_python_keyword { wxColour("#0000FF") };
+    wxColour m_colour_python_number { wxColour("#FF0000") };
+    wxColour m_colour_python_string { wxColour("#008000") };
+
     wxColour m_colour_ruby { wxColour("#FF00FF") };
+    wxColour m_colour_ruby_comment { wxColour("#008000") };
+    wxColour m_colour_ruby_number { wxColour("#FF000000") };
+    wxColour m_colour_ruby_string { wxColour("#008000") };
+
+    wxColour m_colour_xrc_attribute { wxColour("#FF00FF") };
+    wxColour m_colour_xrc_dblstring { wxColour("#008000") };
+    wxColour m_colour_xrc_tag { wxColour("#0000FF") };
 
     size_t m_dark_mode_pending { 0 };  // 0 = no change, 1 = dark_mode_on, 2 = dark_mode_off
 

--- a/src/ui/preferences_dlg.cpp
+++ b/src/ui/preferences_dlg.cpp
@@ -7,7 +7,6 @@
 
 // clang-format off
 
-#include <wx/button.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
 #include <wx/stattext.h>
@@ -85,10 +84,8 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     staticText_2->Wrap(200);
     m_box_code_font->Add(staticText_2, wxSizerFlags().Center().Border(wxALL));
 
-    m_code_font_picker = new wxFontPickerCtrl(page_general, wxID_ANY, wxNullFont, wxDefaultPosition, wxDefaultSize,
-        wxFNTP_FONTDESC_AS_LABEL|wxFNTP_USEFONT_FOR_LABEL);
-    m_code_font_picker->SetToolTip("This font will be used for all of the Code panels");
-    m_box_code_font->Add(m_code_font_picker, wxSizerFlags(1).Expand().Border(wxALL));
+    m_btn_font = new wxButton(page_general, wxID_ANY, "Font");
+    m_box_code_font->Add(m_btn_font, wxSizerFlags().Border(wxALL));
 
     m_general_page_sizer->Add(m_box_code_font, wxSizerFlags().Expand().Border(wxALL));
     page_general->SetSizerAndFit(m_general_page_sizer);
@@ -104,7 +101,7 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     staticText_3->Wrap(200);
     box_sizer->Add(staticText_3, wxSizerFlags().Center().Border(wxALL));
 
-    auto* text_cpp_line_length = new wxTextCtrl(page_cpp, wxID_ANY, wxEmptyString);
+    auto* text_cpp_line_length = new wxTextCtrl(page_cpp, wxID_ANY, "110");
     text_cpp_line_length->SetValidator(wxTextValidator(wxFILTER_DIGITS, &m_cpp_line_length));
     text_cpp_line_length->SetToolTip(
     "Most generated code will not exceed this length. This will be the initial value when a new project is created.");
@@ -125,21 +122,46 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     m_choice_cpp_version = new wxChoice(page_cpp, wxID_ANY);
     m_choice_cpp_version->Append("3.1");
     m_choice_cpp_version->Append("3.2");
+    m_choice_cpp_version->Append("3.3");
     m_choice_cpp_version->SetStringSelection("3.2");
     m_choice_cpp_version->SetToolTip("Code requiring a newer version then this will be placed in a conditional block.");
     box_sizer_5->Add(m_choice_cpp_version, wxSizerFlags().Border(wxALL));
 
     page_sizer_2->Add(box_sizer_5, wxSizerFlags().Border(wxALL));
 
-    auto* box_sizer_8 = new wxBoxSizer(wxHORIZONTAL);
+    auto* grid_sizer3 = new wxGridSizer(2, 0, 0);
 
     auto* staticText_7 = new wxStaticText(page_cpp, wxID_ANY, "wxWidgets &keyword color:");
-    box_sizer_8->Add(staticText_7, wxSizerFlags().Center().Border(wxALL));
+    grid_sizer3->Add(staticText_7, wxSizerFlags().CenterVertical().Border(wxALL));
 
-    m_colour_cpp = new wxColourPickerCtrl(page_cpp, wxID_ANY, *wxBLACK);
-    box_sizer_8->Add(m_colour_cpp, wxSizerFlags().Border(wxALL));
+    m_colour_cpp = new wxColourPickerCtrl(page_cpp, wxID_ANY, wxColour("#FF00FF"));
+    grid_sizer3->Add(m_colour_cpp, wxSizerFlags().Border(wxALL));
 
-    page_sizer_2->Add(box_sizer_8, wxSizerFlags().Border(wxALL));
+    auto* staticText9 = new wxStaticText(page_cpp, wxID_ANY, "&C++ keyword color:");
+    grid_sizer3->Add(staticText9, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_cpp_keyword = new wxColourPickerCtrl(page_cpp, wxID_ANY, wxColour("#0000FF"));
+    grid_sizer3->Add(m_colour_cpp_keyword, wxSizerFlags().Border(wxALL));
+
+    auto* staticText10 = new wxStaticText(page_cpp, wxID_ANY, "&Comment color:");
+    grid_sizer3->Add(staticText10, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_cpp_comment = new wxColourPickerCtrl(page_cpp, wxID_ANY, wxColour("#008000"));
+    grid_sizer3->Add(m_colour_cpp_comment, wxSizerFlags().Border(wxALL));
+
+    auto* staticText11 = new wxStaticText(page_cpp, wxID_ANY, "&Number color:");
+    grid_sizer3->Add(staticText11, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_cpp_number = new wxColourPickerCtrl(page_cpp, wxID_ANY, wxColour("#FF0000"));
+    grid_sizer3->Add(m_colour_cpp_number, wxSizerFlags().Border(wxALL));
+
+    auto* staticText12 = new wxStaticText(page_cpp, wxID_ANY, "&String color:");
+    grid_sizer3->Add(staticText12, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_cpp_string = new wxColourPickerCtrl(page_cpp, wxID_ANY, wxColour("#008000"));
+    grid_sizer3->Add(m_colour_cpp_string, wxSizerFlags().Border(wxALL));
+
+    page_sizer_2->Add(grid_sizer3, wxSizerFlags().Border(wxALL));
     page_cpp->SetSizerAndFit(page_sizer_2);
 
     auto* page_python = new wxPanel(notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
@@ -153,7 +175,7 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     staticText_4->Wrap(200);
     box_sizer_3->Add(staticText_4, wxSizerFlags().Center().Border(wxALL));
 
-    auto* text_python_line_length = new wxTextCtrl(page_python, wxID_ANY, wxEmptyString);
+    auto* text_python_line_length = new wxTextCtrl(page_python, wxID_ANY, "90");
     text_python_line_length->SetValidator(wxTextValidator(wxFILTER_DIGITS, &m_python_line_length));
     text_python_line_length->SetToolTip(
     "Most generated code will not exceed this length. This will be the initial value when a new project is created.");
@@ -161,15 +183,52 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     page_sizer_3->Add(box_sizer_3, wxSizerFlags().Border(wxALL));
 
-    auto* box_sizer_6 = new wxBoxSizer(wxHORIZONTAL);
+    auto* box_sizer7 = new wxBoxSizer(wxHORIZONTAL);
 
-    auto* staticText = new wxStaticText(page_python, wxID_ANY, "wxWidgets &keyword color:");
-    box_sizer_6->Add(staticText, wxSizerFlags().Center().Border(wxALL));
+    auto* static_text3 = new wxStaticText(page_python, wxID_ANY, "wxPython version");
+    box_sizer7->Add(static_text3, wxSizerFlags().Border(wxALL));
 
-    m_colour_python = new wxColourPickerCtrl(page_python, wxID_ANY, *wxBLACK);
-    box_sizer_6->Add(m_colour_python, wxSizerFlags().Border(wxALL));
+    m_choice_python_version = new wxChoice(page_python, wxID_ANY);
+    m_choice_python_version->Append("4.2");
+    m_choice_python_version->SetStringSelection("4.2");
+    m_choice_python_version->SetToolTip("Code requiring a newer version then this will be placed in a conditional block.");
+    box_sizer7->Add(m_choice_python_version, wxSizerFlags().Border(wxALL));
 
-    page_sizer_3->Add(box_sizer_6, wxSizerFlags().Border(wxALL));
+    page_sizer_3->Add(box_sizer7, wxSizerFlags().Border(wxALL));
+
+    auto* grid_sizer2 = new wxGridSizer(2, 0, 0);
+
+    auto* staticText = new wxStaticText(page_python, wxID_ANY, "&wxWidgets keyword color:");
+    grid_sizer2->Add(staticText, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_python = new wxColourPickerCtrl(page_python, wxID_ANY, wxColour("#FF00FF"));
+    grid_sizer2->Add(m_colour_python, wxSizerFlags().Border(wxALL));
+
+    auto* staticText5 = new wxStaticText(page_python, wxID_ANY, "&wxWidgets keyword color:");
+    grid_sizer2->Add(staticText5, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_python_keyword = new wxColourPickerCtrl(page_python, wxID_ANY, wxColour("#0000FF"));
+    grid_sizer2->Add(m_colour_python_keyword, wxSizerFlags().Border(wxALL));
+
+    auto* staticText6 = new wxStaticText(page_python, wxID_ANY, "&Comment color:");
+    grid_sizer2->Add(staticText6, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_python_comment = new wxColourPickerCtrl(page_python, wxID_ANY, wxColour("#008000"));
+    grid_sizer2->Add(m_colour_python_comment, wxSizerFlags().Border(wxALL));
+
+    auto* staticText7 = new wxStaticText(page_python, wxID_ANY, "&Number color:");
+    grid_sizer2->Add(staticText7, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_python_number = new wxColourPickerCtrl(page_python, wxID_ANY, wxColour("#FF0000"));
+    grid_sizer2->Add(m_colour_python_number, wxSizerFlags().Border(wxALL));
+
+    auto* staticText8 = new wxStaticText(page_python, wxID_ANY, "&String color:");
+    grid_sizer2->Add(staticText8, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_python_string = new wxColourPickerCtrl(page_python, wxID_ANY, wxColour("#008000"));
+    grid_sizer2->Add(m_colour_python_string, wxSizerFlags().Border(wxALL));
+
+    page_sizer_3->Add(grid_sizer2, wxSizerFlags().Border(wxALL));
     page_python->SetSizerAndFit(page_sizer_3);
 
     auto* page_ruby = new wxPanel(notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
@@ -183,7 +242,7 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     staticText_5->Wrap(200);
     box_sizer_4->Add(staticText_5, wxSizerFlags().Center().Border(wxALL));
 
-    auto* text_ruby_line_length = new wxTextCtrl(page_ruby, wxID_ANY, wxEmptyString);
+    auto* text_ruby_line_length = new wxTextCtrl(page_ruby, wxID_ANY, "80");
     text_ruby_line_length->SetValidator(wxTextValidator(wxFILTER_DIGITS, &m_ruby_line_length));
     text_ruby_line_length->SetToolTip(
     "Most generated code will not exceed this length. This will be the initial value when a new project is created.");
@@ -191,16 +250,79 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     page_sizer_4->Add(box_sizer_4, wxSizerFlags().Border(wxALL));
 
-    auto* box_sizer_7 = new wxBoxSizer(wxHORIZONTAL);
+    auto* box_sizer6 = new wxBoxSizer(wxHORIZONTAL);
 
-    auto* staticText_6 = new wxStaticText(page_ruby, wxID_ANY, "wxWidgets &keyword color:");
-    box_sizer_7->Add(staticText_6, wxSizerFlags().Center().Border(wxALL));
+    auto* static_text2 = new wxStaticText(page_ruby, wxID_ANY, "wxRuby version");
+    box_sizer6->Add(static_text2, wxSizerFlags().Border(wxALL));
 
-    m_colour_ruby = new wxColourPickerCtrl(page_ruby, wxID_ANY, *wxBLACK);
-    box_sizer_7->Add(m_colour_ruby, wxSizerFlags().Border(wxALL));
+    m_choice_ruby_version = new wxChoice(page_ruby, wxID_ANY);
+    m_choice_ruby_version->Append("0.9");
+    m_choice_ruby_version->SetStringSelection("0.9");
+    m_choice_ruby_version->SetToolTip("Code requiring a newer version then this will be placed in a conditional block.");
+    box_sizer6->Add(m_choice_ruby_version, wxSizerFlags().Border(wxALL));
 
-    page_sizer_4->Add(box_sizer_7, wxSizerFlags().Border(wxALL));
+    page_sizer_4->Add(box_sizer6, wxSizerFlags().Border(wxALL));
+
+    auto* grid_sizer4 = new wxGridSizer(2, 0, 0);
+
+    auto* staticText13 = new wxStaticText(page_ruby, wxID_ANY, "wxWidgets &keyword color:");
+    grid_sizer4->Add(staticText13, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_ruby = new wxColourPickerCtrl(page_ruby, wxID_ANY, wxColour("#FF00FF"));
+    grid_sizer4->Add(m_colour_ruby, wxSizerFlags().Border(wxALL));
+
+    auto* staticText15 = new wxStaticText(page_ruby, wxID_ANY, "&Comment color:");
+    grid_sizer4->Add(staticText15, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_ruby_comment = new wxColourPickerCtrl(page_ruby, wxID_ANY, wxColour("#008000"));
+    grid_sizer4->Add(m_colour_ruby_comment, wxSizerFlags().Border(wxALL));
+
+    auto* staticText16 = new wxStaticText(page_ruby, wxID_ANY, "&Number color:");
+    grid_sizer4->Add(staticText16, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_ruby_number = new wxColourPickerCtrl(page_ruby, wxID_ANY, wxColour("#FF0000"));
+    grid_sizer4->Add(m_colour_ruby_number, wxSizerFlags().Border(wxALL));
+
+    auto* staticText17 = new wxStaticText(page_ruby, wxID_ANY, "&String color:");
+    grid_sizer4->Add(staticText17, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_ruby_string = new wxColourPickerCtrl(page_ruby, wxID_ANY, wxColour("#008000"));
+    grid_sizer4->Add(m_colour_ruby_string, wxSizerFlags().Border(wxALL));
+
+    page_sizer_4->Add(grid_sizer4, wxSizerFlags().Border(wxALL));
     page_ruby->SetSizerAndFit(page_sizer_4);
+
+    auto* page_xrc = new wxPanel(notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    notebook->AddPage(page_xrc, "XRC");
+
+    auto* page_sizer2 = new wxBoxSizer(wxVERTICAL);
+
+    auto* grid_sizer = new wxGridSizer(2, 0, 0);
+
+    auto* staticText3 = new wxStaticText(page_xrc, wxID_ANY, "&Attribute color:");
+    grid_sizer->Add(staticText3, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_xrc_attribute = new wxColourPickerCtrl(page_xrc, wxID_ANY, wxColour("#FF00FF"));
+    grid_sizer->Add(m_colour_xrc_attribute, wxSizerFlags().Border(wxALL));
+
+    auto* staticText4 = new wxStaticText(page_xrc, wxID_ANY, "&String color:");
+    grid_sizer->Add(staticText4, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_xrc_string = new wxColourPickerCtrl(page_xrc, wxID_ANY, wxColour("#008000"));
+    grid_sizer->Add(m_colour_xrc_string, wxSizerFlags().Border(wxALL));
+
+    auto* staticText2 = new wxStaticText(page_xrc, wxID_ANY, "&Tag color:");
+    grid_sizer->Add(staticText2, wxSizerFlags().CenterVertical().Border(wxALL));
+
+    m_colour_xrc_tag = new wxColourPickerCtrl(page_xrc, wxID_ANY, wxColour("#0000FF"));
+    grid_sizer->Add(m_colour_xrc_tag, wxSizerFlags().Border(wxALL));
+
+    page_sizer2->Add(grid_sizer, wxSizerFlags().Border(wxALL));
+
+    auto* box_sizer5 = new wxBoxSizer(wxHORIZONTAL);
+
+    page_sizer2->Add(box_sizer5, wxSizerFlags().Border(wxALL));
+    page_xrc->SetSizerAndFit(page_sizer2);
 
     auto* stdBtn = CreateStdDialogButtonSizer(wxOK|wxCANCEL);
     dlg_sizer->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));
@@ -210,6 +332,7 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     // Event handlers
     Bind(wxEVT_BUTTON, &PreferencesDlg::OnOK, this, wxID_OK);
+    m_btn_font->Bind(wxEVT_BUTTON, &PreferencesDlg::OnFontButton, this);
     Bind(wxEVT_INIT_DIALOG, &PreferencesDlg::OnInit, this);
 
     return true;
@@ -224,9 +347,21 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 // clang-format on
 // ***********************************************
 
-#include "mainframe.h"        // CMainFrame -- Main window frame
-#include "preferences.h"      // Set/Get wxUiEditor preferences
-#include "project_handler.h"  // ProjectHandler class
+/////////////////// Non-generated Copyright/License Info ////////////////////
+// Purpose:
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2024 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include <wx/stc/stc.h>  // A wxWidgets implementation of Scintilla.  This class is the
+
+#include "../customprops/font_prop_dlg.h"  // FontStringProperty class
+#include "../panels/base_panel.h"          // BasePanel class
+#include "font_prop.h"                     // FontProperty class
+#include "mainframe.h"                     // CMainFrame -- Main window frame
+#include "preferences.h"                   // Set/Get wxUiEditor preferences
+#include "project_handler.h"               // ProjectHandler class
 
 void PreferencesDlg::OnInit(wxInitDialogEvent& event)
 {
@@ -236,21 +371,43 @@ void PreferencesDlg::OnInit(wxInitDialogEvent& event)
     m_check_svg_bitmaps->SetValue(UserPrefs.is_SvgImages());
 
     m_check_cpp_snake_case->SetValue(UserPrefs.is_CppSnakeCase());
+
     m_check_load_last->SetValue(UserPrefs.is_LoadLastProject());
     m_check_right_propgrid->SetValue(UserPrefs.is_RightPropGrid());
     m_isWakaTimeEnabled = UserPrefs.is_WakaTimeEnabled();
+
     m_choice_cpp_version->SetStringSelection(UserPrefs.get_CppWidgetsVersion().make_wxString());
+    m_choice_python_version->SetStringSelection(UserPrefs.get_PythonVersion().make_wxString());
+    m_choice_ruby_version->SetStringSelection(UserPrefs.get_RubyVersion().make_wxString());
+
     m_colour_cpp->SetColour(UserPrefs.get_CppColour());
+    m_colour_cpp_comment->SetColour(UserPrefs.get_CppCommentColour());
+    m_colour_cpp_keyword->SetColour(UserPrefs.get_CppKeywordColour());
+    m_colour_cpp_number->SetColour(UserPrefs.get_CppNumberColour());
+    m_colour_cpp_string->SetColour(UserPrefs.get_CppStringColour());
+
     m_colour_python->SetColour(UserPrefs.get_PythonColour());
+    m_colour_python_comment->SetColour(UserPrefs.get_PythonCommentColour());
+    m_colour_python_keyword->SetColour(UserPrefs.get_PythonKeywordColour());
+    m_colour_python_number->SetColour(UserPrefs.get_PythonNumberColour());
+    m_colour_python_string->SetColour(UserPrefs.get_PythonStringColour());
+
     m_colour_ruby->SetColour(UserPrefs.get_RubyColour());
+    m_colour_ruby_comment->SetColour(UserPrefs.get_RubyCommentColour());
+    m_colour_ruby_number->SetColour(UserPrefs.get_RubyNumberColour());
+    m_colour_ruby_string->SetColour(UserPrefs.get_RubyStringColour());
+
+    m_colour_xrc_attribute->SetColour(UserPrefs.get_XrcAttributeColour());
+    m_colour_xrc_string->SetColour(UserPrefs.get_XrcDblStringColour());
+    m_colour_xrc_tag->SetColour(UserPrefs.get_XrcTagColour());
 
     m_cpp_line_length = std::to_string(UserPrefs.get_CppLineLength());
     m_python_line_length = std::to_string(UserPrefs.get_PythonLineLength());
     m_ruby_line_length = std::to_string(UserPrefs.get_RubyLineLength());
 
-    // We aren't ready for setting the font yet
-    m_box_code_font->ShowItems(false);
-    // m_code_font_picker = UserPrefs.get_CodeDisplayFont();
+    FontProperty font_prop(UserPrefs.get_CodeDisplayFont().ToStdView());
+    m_btn_font->SetLabel(font_prop.as_wxString());
+    m_btn_font->SetFont(font_prop.GetFont());
 
 #if defined(__WXMSW__)
     m_box_dark_settings->ShowItems(true);
@@ -262,6 +419,18 @@ void PreferencesDlg::OnInit(wxInitDialogEvent& event)
     event.Skip();
 }
 
+void PreferencesDlg::OnFontButton(wxCommandEvent& WXUNUSED(event))
+{
+    FontPropDlg dlg(this, m_btn_font->GetLabel());
+    if (dlg.ShowModal() == wxID_OK)
+    {
+        FontProperty font_prop(dlg.GetFontDescription());
+        m_btn_font->SetLabel(dlg.GetResults());
+        m_btn_font->SetFont(font_prop.GetFont());
+        Fit();
+    }
+}
+
 void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
 {
     if (!Validate() || !TransferDataFromWindow())
@@ -271,18 +440,9 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
         return;
     }
 
-    bool is_color_changed = false;
     bool is_prop_grid_changed = false;
     bool is_dark_changed = false;
     bool is_fullpath_changed = false;
-    bool is_cpp_preferences_changed = false;
-
-    if (m_colour_cpp->GetColour() != UserPrefs.get_CppColour())
-        is_color_changed = true;
-    if (m_colour_python->GetColour() != UserPrefs.get_PythonColour())
-        is_color_changed = true;
-    if (m_colour_ruby->GetColour() != UserPrefs.get_RubyColour())
-        is_color_changed = true;
 
     if (m_check_dark_mode->GetValue() != UserPrefs.is_DarkMode())
         is_dark_changed = true;
@@ -292,7 +452,22 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
         is_fullpath_changed = true;
 
     if (m_choice_cpp_version->GetStringSelection().ToStdString() != UserPrefs.get_CppWidgetsVersion())
-        is_cpp_preferences_changed = true;
+    {
+        UserPrefs.set_CppWidgetsVersion(m_choice_cpp_version->GetStringSelection().ToStdString());
+        Project.getProjectNode()->modifyProperty(prop_wxWidgets_version, UserPrefs.get_CppWidgetsVersion());
+    }
+
+    if (m_choice_python_version->GetStringSelection().ToStdString() != UserPrefs.get_PythonVersion())
+    {
+        UserPrefs.set_PythonVersion(m_choice_python_version->GetStringSelection().ToStdString());
+        Project.getProjectNode()->modifyProperty(prop_wxPython_version, UserPrefs.get_PythonVersion());
+    }
+
+    if (m_choice_ruby_version->GetStringSelection().ToStdString() != UserPrefs.get_RubyVersion())
+    {
+        UserPrefs.set_RubyVersion(m_choice_ruby_version->GetStringSelection().ToStdString());
+        Project.getProjectNode()->modifyProperty(prop_wxRuby_version, UserPrefs.get_RubyVersion());
+    }
 
     UserPrefs.set_DarkModePending(
         Prefs::PENDING_DARK_MODE_ENABLE |
@@ -306,15 +481,131 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
     UserPrefs.set_RightPropGrid(m_check_right_propgrid->GetValue());
     UserPrefs.set_WakaTimeEnabled(m_isWakaTimeEnabled);
 
-    UserPrefs.set_CppWidgetsVersion(m_choice_cpp_version->GetStringSelection().ToStdString());
-    if (is_cpp_preferences_changed)
-    {
-        Project.getProjectNode()->modifyProperty(prop_wxWidgets_version, UserPrefs.get_CppWidgetsVersion());
+    {  // C++ colors
+        if (UserPrefs.get_CppColour() != m_colour_cpp->GetColour())
+        {
+            UserPrefs.set_CppColour(m_colour_cpp->GetColour());
+            wxGetFrame().GetCppPanel()->SetColor(wxSTC_C_WORD2, m_colour_cpp->GetColour());
+        }
+
+        if (UserPrefs.get_CppCommentColour() != m_colour_cpp_comment->GetColour())
+        {
+            UserPrefs.set_CppCommentColour(m_colour_cpp_comment->GetColour());
+            wxGetFrame().GetCppPanel()->SetColor(wxSTC_C_COMMENTLINE, m_colour_cpp_comment->GetColour());
+        }
+
+        if (UserPrefs.get_CppKeywordColour() != m_colour_cpp_keyword->GetColour())
+        {
+            UserPrefs.set_CppKeywordColour(m_colour_cpp_keyword->GetColour());
+            wxGetFrame().GetCppPanel()->SetColor(wxSTC_C_WORD, m_colour_cpp_keyword->GetColour());
+        }
+
+        if (UserPrefs.get_CppNumberColour() != m_colour_cpp_number->GetColour())
+        {
+            UserPrefs.set_CppNumberColour(m_colour_cpp_number->GetColour());
+            wxGetFrame().GetCppPanel()->SetColor(wxSTC_C_NUMBER, m_colour_cpp_number->GetColour());
+        }
+
+        if (UserPrefs.get_CppStringColour() != m_colour_cpp_string->GetColour())
+        {
+            UserPrefs.set_CppStringColour(m_colour_cpp_string->GetColour());
+            wxGetFrame().GetCppPanel()->SetColor(wxSTC_C_STRING, m_colour_cpp_string->GetColour());
+        }
     }
 
-    UserPrefs.set_CppColour(m_colour_cpp->GetColour());
-    UserPrefs.set_PythonColour(m_colour_python->GetColour());
-    UserPrefs.set_RubyColour(m_colour_ruby->GetColour());
+    {  // Python colors
+        if (UserPrefs.get_PythonColour() != m_colour_python->GetColour())
+        {
+            UserPrefs.set_PythonColour(m_colour_python->GetColour());
+            wxGetFrame().GetPythonPanel()->SetColor(wxSTC_P_WORD2, m_colour_python->GetColour());
+        }
+
+        if (UserPrefs.get_PythonCommentColour() != m_colour_python_comment->GetColour())
+        {
+            UserPrefs.set_PythonCommentColour(m_colour_python_comment->GetColour());
+            wxGetFrame().GetPythonPanel()->SetColor(wxSTC_P_COMMENTLINE, m_colour_python_comment->GetColour());
+        }
+
+        if (UserPrefs.get_PythonKeywordColour() != m_colour_python_keyword->GetColour())
+        {
+            UserPrefs.set_PythonKeywordColour(m_colour_python_keyword->GetColour());
+            wxGetFrame().GetPythonPanel()->SetColor(wxSTC_P_WORD, m_colour_python_keyword->GetColour());
+        }
+
+        if (UserPrefs.get_PythonNumberColour() != m_colour_python_number->GetColour())
+        {
+            UserPrefs.set_PythonNumberColour(m_colour_python_number->GetColour());
+            wxGetFrame().GetPythonPanel()->SetColor(wxSTC_P_NUMBER, m_colour_python_number->GetColour());
+        }
+
+        if (UserPrefs.get_PythonStringColour() != m_colour_python_string->GetColour())
+        {
+            UserPrefs.set_PythonStringColour(m_colour_python_string->GetColour());
+            wxGetFrame().GetPythonPanel()->SetColor(wxSTC_P_STRING, m_colour_python_string->GetColour());
+        }
+    }
+
+    {  // Ruby colors
+        if (UserPrefs.get_RubyColour() != m_colour_ruby->GetColour())
+        {
+            UserPrefs.set_RubyColour(m_colour_ruby->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_WORD, m_colour_ruby->GetColour());
+        }
+
+        if (UserPrefs.get_RubyCommentColour() != m_colour_ruby_comment->GetColour())
+        {
+            UserPrefs.set_RubyCommentColour(m_colour_ruby_comment->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_COMMENTLINE, m_colour_ruby_comment->GetColour());
+        }
+
+        if (UserPrefs.get_RubyNumberColour() != m_colour_ruby_number->GetColour())
+        {
+            UserPrefs.set_RubyNumberColour(m_colour_ruby_number->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_NUMBER, m_colour_ruby_number->GetColour());
+        }
+
+        if (UserPrefs.get_RubyStringColour() != m_colour_ruby_string->GetColour())
+        {
+            UserPrefs.set_RubyStringColour(m_colour_ruby_string->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_STRING, m_colour_ruby_string->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_STRING_Q, m_colour_ruby_string->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_STRING_QQ, m_colour_ruby_string->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_STRING_QX, m_colour_ruby_string->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_STRING_QR, m_colour_ruby_string->GetColour());
+            wxGetFrame().GetRubyPanel()->SetColor(wxSTC_RB_STRING_QW, m_colour_ruby_string->GetColour());
+        }
+    }
+
+    {  // XRC colors
+        if (UserPrefs.get_XrcAttributeColour() != m_colour_xrc_attribute->GetColour())
+        {
+            UserPrefs.set_XrcAttributeColour(m_colour_xrc_attribute->GetColour());
+            wxGetFrame().GetXrcPanel()->SetColor(wxSTC_H_ATTRIBUTE, m_colour_xrc_attribute->GetColour());
+        }
+
+        if (UserPrefs.get_XrcDblStringColour() != m_colour_xrc_string->GetColour())
+        {
+            UserPrefs.set_XrcDblStringColour(m_colour_xrc_string->GetColour());
+            wxGetFrame().GetXrcPanel()->SetColor(wxSTC_H_DOUBLESTRING, m_colour_xrc_string->GetColour());
+        }
+
+        if (UserPrefs.get_XrcTagColour() != m_colour_xrc_tag->GetColour())
+        {
+            UserPrefs.set_XrcTagColour(m_colour_xrc_tag->GetColour());
+            wxGetFrame().GetXrcPanel()->SetColor(wxSTC_H_TAG, m_colour_xrc_tag->GetColour());
+        }
+    }
+
+    if (UserPrefs.get_CodeDisplayFont() != m_btn_font->GetLabel().utf8_string())
+    {
+        FontProperty font_prop(tt_string_view(m_btn_font->GetLabel().utf8_string()));
+        auto font = font_prop.GetFont();
+        UserPrefs.set_CodeDisplayFont(font_prop.as_string());
+        wxGetFrame().GetCppPanel()->SetCodeFont(font);
+        wxGetFrame().GetPythonPanel()->SetCodeFont(font);
+        wxGetFrame().GetRubyPanel()->SetCodeFont(font);
+        wxGetFrame().GetXrcPanel()->SetCodeFont(font);
+    }
 
     auto line_length = tt::atoi(m_cpp_line_length.ToStdString());
 
@@ -341,17 +632,11 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
 
     UserPrefs.WriteConfig();
 
-    if (is_color_changed || is_prop_grid_changed || is_dark_changed)
+    if (is_prop_grid_changed || is_dark_changed)
     {
         tt_string msg("You must close and reopen wxUiEditor for");
-        if (is_color_changed)
-            msg += " the color";
         if (is_prop_grid_changed)
         {
-            if (is_dark_changed)
-                msg += ", ";
-            else
-                msg += " and ";
             msg += " the Property Panel";
             if (is_dark_changed)
                 msg += " and Dark Mode";

--- a/src/ui/preferences_dlg.h
+++ b/src/ui/preferences_dlg.h
@@ -9,14 +9,15 @@
 
 #pragma once
 
+#include <wx/button.h>
 #include <wx/checkbox.h>
 #include <wx/choice.h>
 #include <wx/clrpicker.h>
+#include <wx/colour.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
-#include <wx/font.h>
-#include <wx/fontpicker.h>
 #include <wx/gdicmn.h>
+#include <wx/settings.h>
 #include <wx/sizer.h>
 
 class PreferencesDlg : public wxDialog
@@ -38,21 +39,23 @@ protected:
 
     // Event handlers
 
+    void OnFontButton(wxCommandEvent& event);
     void OnInit(wxInitDialogEvent& event);
     void OnOK(wxCommandEvent& event);
 
     // Validator variables
 
     bool m_isWakaTimeEnabled { true };
-    wxString m_cpp_line_length;
-    wxString m_python_line_length;
-    wxString m_ruby_line_length;
+    wxString m_cpp_line_length { "110" };
+    wxString m_python_line_length { "90" };
+    wxString m_ruby_line_length { "80" };
 
     // Class member variables
 
     wxBoxSizer* m_box_code_font;
     wxBoxSizer* m_box_dark_settings;
     wxBoxSizer* m_general_page_sizer;
+    wxButton* m_btn_font;
     wxCheckBox* m_check_cpp_snake_case;
     wxCheckBox* m_check_dark_mode;
     wxCheckBox* m_check_fullpath;
@@ -61,10 +64,25 @@ protected:
     wxCheckBox* m_check_right_propgrid;
     wxCheckBox* m_check_svg_bitmaps;
     wxChoice* m_choice_cpp_version;
+    wxChoice* m_choice_python_version;
+    wxChoice* m_choice_ruby_version;
     wxColourPickerCtrl* m_colour_cpp;
+    wxColourPickerCtrl* m_colour_cpp_comment;
+    wxColourPickerCtrl* m_colour_cpp_keyword;
+    wxColourPickerCtrl* m_colour_cpp_number;
+    wxColourPickerCtrl* m_colour_cpp_string;
     wxColourPickerCtrl* m_colour_python;
+    wxColourPickerCtrl* m_colour_python_comment;
+    wxColourPickerCtrl* m_colour_python_keyword;
+    wxColourPickerCtrl* m_colour_python_number;
+    wxColourPickerCtrl* m_colour_python_string;
     wxColourPickerCtrl* m_colour_ruby;
-    wxFontPickerCtrl* m_code_font_picker;
+    wxColourPickerCtrl* m_colour_ruby_comment;
+    wxColourPickerCtrl* m_colour_ruby_number;
+    wxColourPickerCtrl* m_colour_ruby_string;
+    wxColourPickerCtrl* m_colour_xrc_attribute;
+    wxColourPickerCtrl* m_colour_xrc_string;
+    wxColourPickerCtrl* m_colour_xrc_tag;
 };
 
 // ************* End of generated code ***********

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -6922,12 +6922,10 @@
                   wrap="200"
                   alignment="wxALIGN_CENTER_VERTICAL" />
                 <node
-                  class="wxFontPickerCtrl"
-                  var_name="m_code_font_picker"
-                  minimum_size="-1,-1d"
-                  tooltip="This font will be used for all of the Code panels"
-                  flags="wxEXPAND"
-                  proportion="1" />
+                  class="wxButton"
+                  label="Font"
+                  var_name="m_btn_font"
+                  wxEVT_BUTTON="OnFontButton" />
               </node>
             </node>
           </node>
@@ -6939,7 +6937,8 @@
             <node
               class="wxBoxSizer"
               orientation="wxVERTICAL"
-              var_name="page_sizer_2">
+              var_name="page_sizer_2"
+              flags="wxEXPAND">
               <node
                 class="wxBoxSizer">
                 <node
@@ -6952,6 +6951,7 @@
                 <node
                   class="wxTextCtrl"
                   class_access="none"
+                  value="110"
                   var_name="text_cpp_line_length"
                   validator_style="wxFILTER_DIGITS"
                   validator_variable="m_cpp_line_length"
@@ -6972,14 +6972,14 @@
                   var_name="static_text" />
                 <node
                   class="wxChoice"
-                  contents="&quot;3.1&quot; &quot;3.2&quot;"
+                  contents="&quot;3.1&quot; &quot;3.2&quot; &quot;3.3&quot;"
                   selection_string="3.2"
                   var_name="m_choice_cpp_version"
                   tooltip="Code requiring a newer version then this will be placed in a conditional block." />
               </node>
               <node
-                class="wxBoxSizer"
-                var_name="box_sizer_8">
+                class="wxGridSizer"
+                var_name="grid_sizer3">
                 <node
                   class="wxStaticText"
                   class_access="none"
@@ -6988,7 +6988,48 @@
                   alignment="wxALIGN_CENTER_VERTICAL" />
                 <node
                   class="wxColourPickerCtrl"
+                  colour="#FF00FF"
                   var_name="m_colour_cpp" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;C++ keyword color:"
+                  var_name="staticText9"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#0000FF"
+                  var_name="m_colour_cpp_keyword" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Comment color:"
+                  var_name="staticText10"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#008000"
+                  var_name="m_colour_cpp_comment" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Number color:"
+                  var_name="staticText11"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#FF0000"
+                  var_name="m_colour_cpp_number" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;String color:"
+                  var_name="staticText12"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#008000"
+                  var_name="m_colour_cpp_string" />
               </node>
             </node>
           </node>
@@ -7014,6 +7055,7 @@
                 <node
                   class="wxTextCtrl"
                   class_access="none"
+                  value="90"
                   var_name="text_python_line_length"
                   validator_style="wxFILTER_DIGITS"
                   validator_variable="m_python_line_length"
@@ -7021,16 +7063,72 @@
               </node>
               <node
                 class="wxBoxSizer"
-                var_name="box_sizer_6">
+                var_name="box_sizer7">
                 <node
                   class="wxStaticText"
                   class_access="none"
-                  label="wxWidgets &amp;keyword color:"
+                  label="wxPython version"
+                  var_name="static_text3" />
+                <node
+                  class="wxChoice"
+                  contents="&quot;4.2&quot;"
+                  selection_string="4.2"
+                  var_name="m_choice_python_version"
+                  tooltip="Code requiring a newer version then this will be placed in a conditional block." />
+              </node>
+              <node
+                class="wxGridSizer"
+                var_name="grid_sizer2">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;wxWidgets keyword color:"
                   var_name="staticText"
                   alignment="wxALIGN_CENTER_VERTICAL" />
                 <node
                   class="wxColourPickerCtrl"
+                  colour="#FF00FF"
                   var_name="m_colour_python" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;wxWidgets keyword color:"
+                  var_name="staticText5"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#0000FF"
+                  var_name="m_colour_python_keyword" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Comment color:"
+                  var_name="staticText6"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#008000"
+                  var_name="m_colour_python_comment" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Number color:"
+                  var_name="staticText7"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#FF0000"
+                  var_name="m_colour_python_number" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;String color:"
+                  var_name="staticText8"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#008000"
+                  var_name="m_colour_python_string" />
               </node>
             </node>
           </node>
@@ -7056,6 +7154,7 @@
                 <node
                   class="wxTextCtrl"
                   class_access="none"
+                  value="80"
                   var_name="text_ruby_line_length"
                   validator_style="wxFILTER_DIGITS"
                   validator_variable="m_ruby_line_length"
@@ -7063,17 +7162,110 @@
               </node>
               <node
                 class="wxBoxSizer"
-                var_name="box_sizer_7">
+                var_name="box_sizer6">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="wxRuby version"
+                  var_name="static_text2" />
+                <node
+                  class="wxChoice"
+                  contents="&quot;0.9&quot;"
+                  selection_string="0.9"
+                  var_name="m_choice_ruby_version"
+                  tooltip="Code requiring a newer version then this will be placed in a conditional block." />
+              </node>
+              <node
+                class="wxGridSizer"
+                var_name="grid_sizer4">
                 <node
                   class="wxStaticText"
                   class_access="none"
                   label="wxWidgets &amp;keyword color:"
-                  var_name="staticText_6"
+                  var_name="staticText13"
                   alignment="wxALIGN_CENTER_VERTICAL" />
                 <node
                   class="wxColourPickerCtrl"
+                  colour="#FF00FF"
                   var_name="m_colour_ruby" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Comment color:"
+                  var_name="staticText15"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#008000"
+                  var_name="m_colour_ruby_comment" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Number color:"
+                  var_name="staticText16"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#FF0000"
+                  var_name="m_colour_ruby_number" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;String color:"
+                  var_name="staticText17"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#008000"
+                  var_name="m_colour_ruby_string" />
               </node>
+            </node>
+          </node>
+          <node
+            class="BookPage"
+            label="XRC"
+            var_name="page_xrc"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="page_sizer2">
+              <node
+                class="wxGridSizer">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Attribute color:"
+                  var_name="staticText3"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#FF00FF"
+                  var_name="m_colour_xrc_attribute" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;String color:"
+                  var_name="staticText4"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#008000"
+                  var_name="m_colour_xrc_string" />
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Tag color:"
+                  var_name="staticText2"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxColourPickerCtrl"
+                  colour="#0000FF"
+                  var_name="m_colour_xrc_tag" />
+              </node>
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer5" />
             </node>
           </node>
         </node>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR expands the Preferences Dialog. It adds the ability to set the font to use in the various code display panels. It also expands the colors that can be set, while removing the need to restart wxUiEditor after the user changes one or more colors. It also adds versions to wxPython and wxRuby (currently only one version available for each, but could be expanded in the future). It adds 3.3 to the C++ wxWidgets versions.

Note that the Ruby lexer doesn't support a second set of keywords, and doesn't correctly set the color for quoted strings (any of the 6 variants of string types).
