### PR TITLE
Change the order of Image Types

### DIFF
--- a/src/customprops/img_props.h
+++ b/src/customprops/img_props.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Handles property grid image properties
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -13,7 +13,7 @@
 
 class NodeProperty;
 
-inline constexpr std::array<const char*, 5> s_type_names = { "Art", "Embed", "SVG", "XPM" };
+inline constexpr std::array<const char*, 4> s_type_names = { "Embed", "SVG", "Art", "XPM" };
 
 struct ImageProperties
 {

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -30,6 +30,11 @@ using namespace wxue_img;
 
 #include "art_ids.cpp"  // wxART_ strings
 
+#define EMBED_INDEX 0
+#define SVG_INDEX   1
+#define ART_INDEX   2
+#define XPM_INDEX   3
+
 wxIMPLEMENT_ABSTRACT_CLASS(PropertyGrid_Image, wxPGProperty);
 
 PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop) : wxPGProperty(label, wxPG_LABEL)
@@ -42,24 +47,24 @@ PropertyGrid_Image::PropertyGrid_Image(const wxString& label, NodeProperty* prop
     }
     else if (UserPrefs.is_SvgImages())
     {
-        m_img_props.type = s_type_names[2];  // SVG
+        m_img_props.type = s_type_names[SVG_INDEX];  // SVG
     }
 
     wxPGChoices types;
 
     if (prop->getNode()->isGen(gen_embedded_image))
     {
-        types.Add(s_type_names[1]);  // Embed
-        types.Add(s_type_names[2]);  // SVG
+        types.Add(s_type_names[EMBED_INDEX]);
+        types.Add(s_type_names[SVG_INDEX]);
         m_isEmbeddedImage = true;
     }
     else
     {
         // These need to match the array in img_props.h
-        types.Add(s_type_names[0]);  // Art
-        types.Add(s_type_names[1]);  // Embed
-        types.Add(s_type_names[2]);  // SVG
-        types.Add(s_type_names[3]);  // XPM
+        types.Add(s_type_names[EMBED_INDEX]);
+        types.Add(s_type_names[SVG_INDEX]);
+        types.Add(s_type_names[ART_INDEX]);
+        types.Add(s_type_names[XPM_INDEX]);
     }
 
     AddPrivateChild(new wxEnumProperty("type", wxPG_LABEL, types, 0));
@@ -216,7 +221,7 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
     ImageProperties img_props;
     if (UserPrefs.is_SvgImages())
     {
-        img_props.type = s_type_names[2];  // SVG
+        img_props.type = s_type_names[SVG_INDEX];
         img_props.SetWidth(24);
         img_props.SetHeight(24);
     }
@@ -234,7 +239,7 @@ wxVariant PropertyGrid_Image::ChildChanged(wxVariant& thisValue, int childIndex,
             {
                 if (m_isEmbeddedImage && index > 0)
                 {
-                    img_props.type = s_type_names[2];  // SVG image type
+                    img_props.type = s_type_names[SVG_INDEX];  // SVG image type
                 }
                 else
                 {


### PR DESCRIPTION
In the Property Grid, the Image Type drop down is now:

"Embed",
"SVG"
"Art"
"XPM"

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This changes the order of the drop down list of image types accessed in the PropertyGrid panel. In particular, it moves the `ART` type to _after_ the `SVG` type. The reason for this is because we need to truncate the array when used in an Image List. Previously, this was starting with an offset of 1 in order to skip ART, but the actual drop down referenced an index of 0 which was the `ART` property. Since we don't allow Art images to be added to the Image List, this was breaking the property.

Closes #1430