### PR TITLE
Fix StaticRadioBtnBoxSizer for wxGTK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Fixed wxPython and wxRuby3 code generation for creating a wxPropertySheetDialog class.
 - When importing XRC files, a form's class name is correctly set if specified in the XRC file.
 - wxStyledTextCtrl::SetTabWidth() now generates code correctly (generated if tabs are enabled and tab width is not the default value of 8)
+- wxStaticBoxSizers that use a wxRadioButton now work correctly in wxUiEditor's UI on Linux, and code generation has been updated to work on wxGTK allowing the button to be unchecked when the app is built with wxWidgets 3.3 or later.
 
 ## [Released (1.2.0)]
 

--- a/src/customprops/id_editor_dlg.cpp
+++ b/src/customprops/id_editor_dlg.cpp
@@ -20,7 +20,8 @@ bool IDEditorDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     auto* dlg_sizer = new wxBoxSizer(wxVERTICAL);
 
-    m_radioBtn_Standard = new wxRadioButton(this, wxID_ANY, "&wxWidgets Standard ID");
+    m_radioBtn_Standard = new wxRadioButton(this, wxID_ANY, "&wxWidgets Standard ID", wxDefaultPosition, wxDefaultSize,
+        wxRB_SINGLE);
     m_std_id_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radioBtn_Standard), wxVERTICAL);
 
     m_standard_ids = new wxChoice(m_std_id_box->GetStaticBox(), wxID_ANY);
@@ -44,7 +45,7 @@ bool IDEditorDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     dlg_sizer->Add(m_std_id_box, wxSizerFlags().Expand().Border(wxALL));
 
-    m_radioBtn_Custom = new wxRadioButton(this, wxID_ANY, "&Custom ID");
+    m_radioBtn_Custom = new wxRadioButton(this, wxID_ANY, "&Custom ID", wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
     m_cstm_id_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radioBtn_Custom), wxVERTICAL);
 
     auto* box_sizer = new wxBoxSizer(wxHORIZONTAL);

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -83,7 +83,8 @@ bool StaticRadioBtnBoxSizerGenerator::ConstructionCode(Code& code)
     if (code.is_cpp())
     {
         code.as_string(prop_radiobtn_var_name) << " = new wxRadioButton(";
-        code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label).EndFunction();
+        code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
+        code.Comma().Pos().Comma().WxSize().Comma().Add("wxRB_SINGLE").EndFunction();
 
         auto cur_size = code.size();
         if (GenValidatorSettings(code); code.size() > cur_size)

--- a/src/ui/generate_xrc_dlg.cpp
+++ b/src/ui/generate_xrc_dlg.cpp
@@ -23,7 +23,7 @@ bool GenerateXrcDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     auto* dlg_sizer = new wxBoxSizer(wxVERTICAL);
 
-    m_radio_combined = new wxRadioButton(this, wxID_ANY, "Combined File");
+    m_radio_combined = new wxRadioButton(this, wxID_ANY, "Combined File", wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
     m_radio_combined->SetValidator(wxGenericValidator(&m_create_combined));
 
     m_combined_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radio_combined), wxVERTICAL);
@@ -35,7 +35,7 @@ bool GenerateXrcDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     dlg_sizer->Add(m_combined_box, wxSizerFlags().Expand().Border(wxALL));
 
-    m_radio_separate = new wxRadioButton(this, wxID_ANY, "Separate Files");
+    m_radio_separate = new wxRadioButton(this, wxID_ANY, "Separate Files", wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
     m_separate_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radio_separate), wxVERTICAL);
 
     auto* staticText = new wxStaticText(m_separate_box->GetStaticBox(), wxID_ANY,

--- a/src/wxui/colourprop_base.cpp
+++ b/src/wxui/colourprop_base.cpp
@@ -49,7 +49,7 @@ bool ColourPropBase::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     dlg_sizer->AddSpacer(5 + wxSizerFlags::GetDefaultBorder());
 
-    m_radio_custom = new wxRadioButton(this, wxID_ANY, "Custom Colour");
+    m_radio_custom = new wxRadioButton(this, wxID_ANY, "Custom Colour", wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
     m_staticbox_custom = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radio_custom), wxVERTICAL);
     m_staticbox_custom->GetStaticBox()->Enable(false);
 

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -48,7 +48,8 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     auto* page_sizer = new wxBoxSizer(wxVERTICAL);
 
-    m_cpp_radio_use_function = new wxRadioButton(cpp_page, wxID_ANY, "Use function");
+    m_cpp_radio_use_function = new wxRadioButton(cpp_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+        wxRB_SINGLE);
     m_cpp_function_box = new wxStaticBoxSizer(new wxStaticBox(cpp_page, wxID_ANY, m_cpp_radio_use_function), wxVERTICAL);
 
     m_cpp_text_function = new wxTextCtrl(m_cpp_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
@@ -56,7 +57,8 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     page_sizer->Add(m_cpp_function_box, wxSizerFlags().Expand().Border(wxALL));
 
-    m_cpp_radio_use_lambda = new wxRadioButton(cpp_page, wxID_ANY, "Use lambda");
+    m_cpp_radio_use_lambda = new wxRadioButton(cpp_page, wxID_ANY, "Use lambda", wxDefaultPosition, wxDefaultSize,
+        wxRB_SINGLE);
     m_cpp_lambda_box = new wxStaticBoxSizer(new wxStaticBox(cpp_page, wxID_ANY, m_cpp_radio_use_lambda), wxVERTICAL);
 
     auto* box_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
@@ -109,7 +111,8 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     auto* page_sizer_2 = new wxBoxSizer(wxVERTICAL);
 
-    m_py_radio_use_function = new wxRadioButton(python_page, wxID_ANY, "Use function");
+    m_py_radio_use_function = new wxRadioButton(python_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+        wxRB_SINGLE);
     m_py_function_box = new wxStaticBoxSizer(new wxStaticBox(python_page, wxID_ANY, m_py_radio_use_function), wxVERTICAL);
 
     m_py_text_function = new wxTextCtrl(m_py_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
@@ -117,7 +120,8 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     page_sizer_2->Add(m_py_function_box, wxSizerFlags().Expand().Border(wxALL));
 
-    m_py_radio_use_lambda = new wxRadioButton(python_page, wxID_ANY, "Use lambda");
+    m_py_radio_use_lambda = new wxRadioButton(python_page, wxID_ANY, "Use lambda", wxDefaultPosition, wxDefaultSize,
+        wxRB_SINGLE);
     m_py_lambda_box = new wxStaticBoxSizer(new wxStaticBox(python_page, wxID_ANY, m_py_radio_use_lambda), wxVERTICAL);
 
     auto* staticText_2 = new wxStaticText(m_py_lambda_box->GetStaticBox(), wxID_ANY,
@@ -136,13 +140,15 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     auto* page_sizer_3 = new wxBoxSizer(wxVERTICAL);
 
-    m_ruby_radio_use_function = new wxRadioButton(ruby_page, wxID_ANY, "Use function");
+    m_ruby_radio_use_function = new wxRadioButton(ruby_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+        wxRB_SINGLE);
     m_ruby_function_box = new wxStaticBoxSizer(new wxStaticBox(ruby_page, wxID_ANY, m_ruby_radio_use_function), wxVERTICAL);
 
     m_ruby_text_function = new wxTextCtrl(m_ruby_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
     m_ruby_function_box->Add(m_ruby_text_function, wxSizerFlags().Expand().Border(wxALL));
 
-    m_ruby_radio_use_lambda = new wxRadioButton(m_ruby_function_box->GetStaticBox(), wxID_ANY, "Use lambda");
+    m_ruby_radio_use_lambda = new wxRadioButton(m_ruby_function_box->GetStaticBox(), wxID_ANY, "Use lambda",
+        wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
     m_ruby_lambda_box = new wxStaticBoxSizer(new wxStaticBox(m_ruby_function_box->GetStaticBox(), wxID_ANY,
         m_ruby_radio_use_lambda), wxVERTICAL);
 

--- a/src/wxui/fontpropdlg_base.cpp
+++ b/src/wxui/fontpropdlg_base.cpp
@@ -19,7 +19,7 @@ bool FontPropDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& ti
 
     auto* dlg_sizer = new wxBoxSizer(wxVERTICAL);
 
-    m_radioSystem = new wxRadioButton(this, wxID_ANY, "Default GUI Font");
+    m_radioSystem = new wxRadioButton(this, wxID_ANY, "Default GUI Font", wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
     m_system_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radioSystem), wxVERTICAL);
 
     auto* box_sizer_10 = new wxBoxSizer(wxHORIZONTAL);
@@ -86,7 +86,7 @@ bool FontPropDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& ti
 
     dlg_sizer->AddSpacer(20);
 
-    m_radioCustom = new wxRadioButton(this, wxID_ANY, "Custom Font");
+    m_radioCustom = new wxRadioButton(this, wxID_ANY, "Custom Font", wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
     m_custom_box = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, m_radioCustom), wxVERTICAL);
 
     auto* box_sizer_3 = new wxBoxSizer(wxHORIZONTAL);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the `wxRB_SINGLE` style to the `wxRadioButton` created by the `StaticRadioBtnBoxSizer`. The reason for this change is that wxGTK doesn't allow a radio button to be unchecked unless it's part of a group containing 2 or more buttons. If it is marked as `wxRB_SINGLE` then wxWidgets 3.3 will create a hidden button that becomes part of a group making it possible to deselect the button.