### PR TITLE
Refactor ProjectImages class

### DIFF
--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -32,10 +32,10 @@ void ImageProperties::InitValues(tt_string_view value)
         }
         else
         {
-            auto img_bundle = ProjectImages.GetPropertyImageBundle(value);
-            if (img_bundle)
+            auto* embed = ProjectImages.GetEmbeddedImage(image);
+            if (embed)
             {
-                m_size = img_bundle->bundle.GetDefaultSize();
+                m_size = embed->size;
             }
             else
             {

--- a/src/customprops/img_props.h
+++ b/src/customprops/img_props.h
@@ -30,6 +30,7 @@ public:
     void SetWidth(int width) { m_size.x = width; }
     void SetHeight(int height) { m_size.y = height; }
     void SetSize(wxSize size) { m_size = size; }
+    wxSize GetSize() { return m_size; }
 
     void SetAnimationType() { m_isAnimationType = true; }
     bool IsAnimationType() { return m_isAnimationType; }

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -117,14 +117,10 @@ void PropertyGrid_Image::RefreshChildren()
             {
                 if (m_img_props.type != "XPM")
                 {
-                    if (auto img = ProjectImages.GetPropertyImageBundle(m_img_props.CombineValues(),
-                                                                        wxGetFrame().getSelectedNode());
-                        img)
+                    auto* embed = ProjectImages.FindEmbedded(m_img_props.CombineValues());
+                    if (embed)
                     {
-                        if (img->bundle.IsOk())
-                        {
-                            bundle = img->bundle;
-                        }
+                        bundle = embed->get_bundle(m_img_props.GetSize());
                     }
                 }
                 else  // XPM

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -75,7 +75,7 @@ bool AnimationGenerator::ConstructionCode(Code& code)
                 auto embed = ProjectImages.GetEmbeddedImage(parts[IndexImage]);
                 if (embed)
                 {
-                    name = "wxue_img::" + embed->array_name;
+                    name = "wxue_img::" + embed->imgs[0].array_name;
                 }
             }
 
@@ -104,7 +104,7 @@ bool AnimationGenerator::ConstructionCode(Code& code)
             {
                 if (const EmbeddedImage* embed = ProjectImages.GetEmbeddedImage(parts[IndexImage]); embed)
                 {
-                    code.Str("get_animation(").Str("$").Str(embed->array_name) += ")";
+                    code.Str("get_animation(").Str("$").Str(embed->imgs[0].array_name) += ")";
                     found_embedded = true;
                 }
             }

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -579,19 +579,19 @@ void BaseCodeGenerator::CollectImageHeaders(Node* node, std::set<std::string>& e
                             }
                             if (!is_found)
                             {
-                                if (embed->filename.file_exists())
+                                if (embed->imgs[0].filename.file_exists())
                                 {
-                                    auto file_time = embed->filename.last_write_time();
-                                    if (file_time != embed->file_time)
+                                    auto file_time = embed->imgs[0].filename.last_write_time();
+                                    if (file_time != embed->imgs[0].file_time)
                                     {
                                         ProjectImages.UpdateEmbeddedImage(embed);
-                                        embed->file_time = file_time;
+                                        embed->imgs[0].file_time = file_time;
                                     }
                                     m_embedded_images.emplace_back(embed);
                                 }
                                 else
                                 {
-                                    MSG_INFO(tt_string() << "Unable to get file time for " << embed->filename);
+                                    MSG_INFO(tt_string() << "Unable to get file time for " << embed->imgs[0].filename);
                                 }
                             }
                         }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -473,7 +473,7 @@ tt_string GenerateBitmapCode(const tt_string& description)
             auto embed = ProjectImages.GetEmbeddedImage(parts[IndexImage]);
             if (embed)
             {
-                name = "wxue_img::" + embed->array_name;
+                name = "wxue_img::" + embed->imgs[0].array_name;
             }
         }
 
@@ -592,9 +592,9 @@ bool GenerateBundleCode(const tt_string& description, tt_string& code)
             svg_size = GetSizeInfo(parts[IndexSize]);
         }
 
-        tt_string name = "wxue_img::" + embed->array_name;
-        code << "wxueBundleSVG(" << name << ", " << (embed->array_size & 0xFFFFFFFF) << ", ";
-        code << (embed->array_size >> 32) << ", wxSize(" << svg_size.x << ", " << svg_size.y << "))";
+        tt_string name = "wxue_img::" + embed->imgs[0].array_name;
+        code << "wxueBundleSVG(" << name << ", " << (embed->imgs[0].array_size & 0xFFFFFFFF) << ", ";
+        code << (embed->imgs[0].array_size >> 32) << ", wxSize(" << svg_size.x << ", " << svg_size.y << "))";
     }
     else
     {
@@ -624,7 +624,7 @@ bool GenerateBundleCode(const tt_string& description, tt_string& code)
                         return false;
                     }
 
-                    name = "wxue_img::" + embed->array_name;
+                    name = "wxue_img::" + embed->imgs[0].array_name;
                 }
 
                 if (Project.is_wxWidgets31())
@@ -651,12 +651,12 @@ bool GenerateBundleCode(const tt_string& description, tt_string& code)
                 if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed)
                 {
                     first_function = ProjectImages.GetBundleFuncName(embed);
-                    first_name = "wxue_img::" + embed->array_name;
+                    first_name = "wxue_img::" + embed->imgs[0].array_name;
                 }
                 if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[1]); embed)
                 {
                     second_function = ProjectImages.GetBundleFuncName(embed);
-                    second_name = "wxue_img::" + embed->array_name;
+                    second_name = "wxue_img::" + embed->imgs[0].array_name;
                 }
 
                 if (Project.is_wxWidgets31())
@@ -710,7 +710,7 @@ bool GenerateBundleCode(const tt_string& description, tt_string& code)
                     if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed)
                     {
                         function = ProjectImages.GetBundleFuncName(embed);
-                        name = "wxue_img::" + embed->array_name;
+                        name = "wxue_img::" + embed->imgs[0].array_name;
                     }
 
                     if (function.size())
@@ -734,7 +734,7 @@ bool GenerateBundleCode(const tt_string& description, tt_string& code)
                     if (auto embed = ProjectImages.GetEmbeddedImage(iter); embed)
                     {
                         function = ProjectImages.GetBundleFuncName(embed);
-                        name = "wxue_img::" + embed->array_name;
+                        name = "wxue_img::" + embed->imgs[0].array_name;
                     }
                     code << "\tbitmaps.push_back(";
                     if (function.size())
@@ -1202,9 +1202,9 @@ tt_string GenerateIconCode(const tt_string& description)
         }
         else
         {
-            tt_string name = "wxue_img::" + embed->array_name;
-            code << "SetIcon(wxueBundleSVG(" << name << ", " << (embed->array_size & 0xFFFFFFFF) << ", ";
-            code << (embed->array_size >> 32) << ", wxSize(" << svg_size.x << ", " << svg_size.y << "))";
+            tt_string name = "wxue_img::" + embed->imgs[0].array_name;
+            code << "SetIcon(wxueBundleSVG(" << name << ", " << (embed->imgs[0].array_size & 0xFFFFFFFF) << ", ";
+            code << (embed->imgs[0].array_size >> 32) << ", wxSize(" << svg_size.x << ", " << svg_size.y << "))";
         }
 
         code << ".GetIconFor(this));\n";
@@ -1226,7 +1226,7 @@ tt_string GenerateIconCode(const tt_string& description)
                     auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]);
                     if (embed)
                     {
-                        name = "wxue_img::" + embed->array_name;
+                        name = "wxue_img::" + embed->imgs[0].array_name;
                     }
                 }
 
@@ -1246,7 +1246,7 @@ tt_string GenerateIconCode(const tt_string& description)
                         auto embed = ProjectImages.GetEmbeddedImage(iter);
                         if (embed)
                         {
-                            name = "wxue_img::" + embed->array_name;
+                            name = "wxue_img::" + embed->imgs[0].array_name;
                         }
                     }
                     code << "\ticon.CopyFromBitmap(wxueImage(" << name << ", sizeof(" << name << ")));\n";
@@ -1499,7 +1499,7 @@ bool BitmapList(Code& code, const GenEnum::PropName prop)
                 auto embed = ProjectImages.GetEmbeddedImage(iter);
                 if (embed)
                 {
-                    name = "wxue_img::" + embed->array_name;
+                    name = "wxue_img::" + embed->imgs[0].array_name;
                 }
             }
             code.Eol().Str("bitmaps.push_back(wxueImage(") << name << ", sizeof(" << name << ")));";

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -905,7 +905,7 @@ void BaseCodeGenerator::GenerateCppClass(PANEL_PAGE panel_type)
         std::sort(m_embedded_images.begin(), m_embedded_images.end(),
                   [](const EmbeddedImage* a, const EmbeddedImage* b)
                   {
-                      return (a->array_name.compare(b->array_name) < 0);
+                      return (a->imgs[0].array_name.compare(b->imgs[0].array_name) < 0);
                   });
     }
 
@@ -1408,14 +1408,15 @@ void BaseCodeGenerator::GenerateCppHandlers()
     {
         for (auto& iter_img: m_embedded_images)
         {
-            if (iter_img->type != wxBITMAP_TYPE_BMP && iter_img->type != wxBITMAP_TYPE_SVG &&
-                m_type_generated.find(iter_img->type) == m_type_generated.end())
+            if (iter_img->imgs[0].type != wxBITMAP_TYPE_BMP && iter_img->imgs[0].type != wxBITMAP_TYPE_SVG &&
+                m_type_generated.find(iter_img->imgs[0].type) == m_type_generated.end())
             {
-                m_source->writeLine(tt_string("if (!wxImage::FindHandler(") << g_map_types[iter_img->type] << "))");
+                m_source->writeLine(tt_string("if (!wxImage::FindHandler(") << g_map_types[iter_img->imgs[0].type] << "))");
                 m_source->Indent();
-                m_source->writeLine(tt_string("\twxImage::AddHandler(new ") << g_map_handlers[iter_img->type] << ");");
+                m_source->writeLine(tt_string("\twxImage::AddHandler(new ")
+                                    << g_map_handlers[iter_img->imgs[0].type] << ");");
                 m_source->Unindent();
-                m_type_generated.insert(iter_img->type);
+                m_type_generated.insert(iter_img->imgs[0].type);
             }
         }
         m_source->writeLine();

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -220,8 +220,8 @@ void BaseCodeGenerator::GenerateImagesForm()
             tt_string code;
             code.reserve(Project.as_size_t(prop_cpp_line_length) + 16);
             // SVG images store the original size in the high 32 bits
-            size_t max_pos = (iter_array->array_size & 0xFFFFFFFF);
-            code << "const unsigned char " << iter_array->array_name << '[' << max_pos << "] {";
+            size_t max_pos = (iter_array->imgs[0].array_size & 0xFFFFFFFF);
+            code << "const unsigned char " << iter_array->imgs[0].array_name << '[' << max_pos << "] {";
             m_source->writeLine(code);
 
             size_t pos = 0;
@@ -231,7 +231,7 @@ void BaseCodeGenerator::GenerateImagesForm()
                 // -8 to account for 4 indent + max 3 chars for number + comma
                 for (; pos < max_pos && code.size() < Project.as_size_t(prop_cpp_line_length) - 8; ++pos)
                 {
-                    code << (to_int) iter_array->array_data[pos] << ',';
+                    code << (to_int) iter_array->imgs[0].array_data[pos] << ',';
                 }
                 if (pos >= max_pos && code.back() == ',')
                     code.pop_back();
@@ -254,8 +254,8 @@ void BaseCodeGenerator::GenerateImagesForm()
                 bundle && bundle->lst_filenames.size())
             {
                 auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]);
-                if (embed->type == wxBITMAP_TYPE_ICO || embed->type == wxBITMAP_TYPE_CUR ||
-                    embed->type == wxBITMAP_TYPE_GIF || embed->type == wxBITMAP_TYPE_ANI)
+                if (embed->imgs[0].type == wxBITMAP_TYPE_ICO || embed->imgs[0].type == wxBITMAP_TYPE_CUR ||
+                    embed->imgs[0].type == wxBITMAP_TYPE_GIF || embed->imgs[0].type == wxBITMAP_TYPE_ANI)
                 {
                     // Ignore types that can't be placed into a bundle. Technically, a .gif
                     // file could be added to a bundle, but use of .git instead of .png
@@ -268,15 +268,15 @@ void BaseCodeGenerator::GenerateImagesForm()
                 m_source->writeLine();
                 tt_string code("wxBitmapBundle bundle_");
 
-                if (embed->type == wxBITMAP_TYPE_SVG)
+                if (embed->imgs[0].type == wxBITMAP_TYPE_SVG)
                 {
-                    code << embed->array_name << "(int width, int height)";
+                    code << embed->imgs[0].array_name << "(int width, int height)";
                     m_source->writeLine(code);
                     m_source->writeLine("{");
                     m_source->Indent();
                     code = "return get_bundle_svg(";
-                    code << embed->array_name << ", " << (embed->array_size & 0xFFFFFFFF) << ", ";
-                    code << (embed->array_size >> (to_size_t) 32) << ", wxSize(width, height));";
+                    code << embed->imgs[0].array_name << ", " << (embed->imgs[0].array_size & 0xFFFFFFFF) << ", ";
+                    code << (embed->imgs[0].array_size >> (to_size_t) 32) << ", wxSize(width, height));";
                     m_source->writeLine(code);
                     m_source->Unindent();
                     m_source->writeLine("}");
@@ -284,14 +284,14 @@ void BaseCodeGenerator::GenerateImagesForm()
                 }
                 else
                 {
-                    code << embed->array_name << "()";
+                    code << embed->imgs[0].array_name << "()";
                     m_source->writeLine(code);
                     m_source->writeLine("{");
                     m_source->Indent();
                     if (bundle->lst_filenames.size() == 1)
                     {
                         code = "return wxBitmapBundle::FromBitmap(wxBitmap(get_image(";
-                        code << embed->array_name << ", " << embed->array_size << ")));";
+                        code << embed->imgs[0].array_name << ", " << embed->imgs[0].array_size << ")));";
                         m_source->writeLine(code);
                     }
                     else
@@ -306,8 +306,8 @@ void BaseCodeGenerator::GenerateImagesForm()
                             ASSERT_MSG(embed, tt_string("Unable to locate embedded image for ") << iter);
                             if (embed)
                             {
-                                code << "\t\tbitmaps.push_back(get_image(" << embed->array_name << ", sizeof("
-                                     << embed->array_name << ")));\n";
+                                code << "\t\tbitmaps.push_back(get_image(" << embed->imgs[0].array_name << ", sizeof("
+                                     << embed->imgs[0].array_name << ")));\n";
                             }
                         }
                         code += "return wxBitmapBundle::FromBitmaps(bitmaps);";
@@ -328,17 +328,17 @@ void BaseCodeGenerator::GenerateImagesForm()
         {
             // Unlike the wxBitmapBundle functions above, the wxImage functions work on a much wider variety of
             // images, including ICO, CUR, and GIT. The only types that don't work are .svg and .ani.
-            if (embed->type == wxBITMAP_TYPE_SVG || embed->type == wxBITMAP_TYPE_ANI)
+            if (embed->imgs[0].type == wxBITMAP_TYPE_SVG || embed->imgs[0].type == wxBITMAP_TYPE_ANI)
                 continue;
 
             m_source->writeLine();
             tt_string code("wxImage image_");
-            code << embed->array_name << "()";
+            code << embed->imgs[0].array_name << "()";
             m_source->writeLine(code);
             m_source->writeLine("{");
             m_source->Indent();
             code = "return get_image(";
-            code << embed->array_name << ", " << embed->array_size << ");";
+            code << embed->imgs[0].array_name << ", " << embed->imgs[0].array_size << ");";
             m_source->writeLine(code);
             m_source->Unindent();
             m_source->writeLine("}");
@@ -395,21 +395,21 @@ void BaseCodeGenerator::GenerateImagesForm()
                 bundle && bundle->lst_filenames.size())
             {
                 auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]);
-                if (embed->type == wxBITMAP_TYPE_ICO || embed->type == wxBITMAP_TYPE_CUR ||
-                    embed->type == wxBITMAP_TYPE_GIF || embed->type == wxBITMAP_TYPE_ANI)
+                if (embed->imgs[0].type == wxBITMAP_TYPE_ICO || embed->imgs[0].type == wxBITMAP_TYPE_CUR ||
+                    embed->imgs[0].type == wxBITMAP_TYPE_GIF || embed->imgs[0].type == wxBITMAP_TYPE_ANI)
                 {
                     // Don't generate bundle functions for image types that are probably being used for something else
                     continue;
                 }
 
                 tt_string code("wxBitmapBundle bundle_");
-                if (embed->type == wxBITMAP_TYPE_SVG)
+                if (embed->imgs[0].type == wxBITMAP_TYPE_SVG)
                 {
-                    code << embed->array_name << "(int width, int height);";
+                    code << embed->imgs[0].array_name << "(int width, int height);";
                 }
                 else
                 {
-                    code << embed->array_name << "();";
+                    code << embed->imgs[0].array_name << "();";
                     if (bundle->lst_filenames[0].size())
                     {
                         code << "  // " << bundle->lst_filenames[0].filename();
@@ -429,10 +429,10 @@ void BaseCodeGenerator::GenerateImagesForm()
         {
             // Unlike the wxBitmapBundle functions above, the wxImage functions work on a much wider variety of
             // images, including ICO, CUR, and GIT. The only types that don't work are .svg and .ani.
-            if (embed->type == wxBITMAP_TYPE_SVG || embed->type == wxBITMAP_TYPE_ANI)
+            if (embed->imgs[0].type == wxBITMAP_TYPE_SVG || embed->imgs[0].type == wxBITMAP_TYPE_ANI)
                 continue;
             tt_string code("wxImage image_");
-            code << embed->array_name << "();";
+            code << embed->imgs[0].array_name << "();";
             m_header->writeLine(code);
         }
 
@@ -445,10 +445,10 @@ void BaseCodeGenerator::GenerateImagesForm()
                     continue;
 
                 tt_string line("extern const unsigned char ");
-                line << iter_array->array_name << '[' << (iter_array->array_size & 0xFFFFFFFF) << "];";
-                if (iter_array->filename.size())
+                line << iter_array->imgs[0].array_name << '[' << (iter_array->imgs[0].array_size & 0xFFFFFFFF) << "];";
+                if (iter_array->imgs[0].filename.size())
                 {
-                    line << "  // " << iter_array->filename;
+                    line << "  // " << iter_array->imgs[0].filename;
                 }
                 m_header->writeLine(line);
             }

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -399,7 +399,7 @@ void BaseCodeGenerator::GeneratePythonClass(PANEL_PAGE panel_type)
                     code.clear();
                     images_file_imported = true;
                 }
-                if (iter->type == wxBITMAP_TYPE_SVG)
+                if (iter->imgs[0].type == wxBITMAP_TYPE_SVG)
                 {
                     m_source->writeLine("import zlib");
                     m_source->writeLine("import base64");
@@ -408,7 +408,7 @@ void BaseCodeGenerator::GeneratePythonClass(PANEL_PAGE panel_type)
             }
             else if (!svg_import_libs)
             {
-                if (iter->type == wxBITMAP_TYPE_SVG)
+                if (iter->imgs[0].type == wxBITMAP_TYPE_SVG)
                 {
                     m_source->writeLine("import zlib");
                     m_source->writeLine("import base64");
@@ -575,7 +575,7 @@ void BaseCodeGenerator::GeneratePythonClass(PANEL_PAGE panel_type)
     std::sort(m_embedded_images.begin(), m_embedded_images.end(),
               [](const EmbeddedImage* a, const EmbeddedImage* b)
               {
-                  return (a->array_name.compare(b->array_name) < 0);
+                  return (a->imgs[0].array_name.compare(b->imgs[0].array_name) < 0);
               });
 }
 
@@ -701,11 +701,11 @@ bool PythonBundleCode(Code& code, GenEnum::PropName prop)
             {
                 svg_name = embed->form->as_string(prop_python_file).filename();
                 svg_name.remove_extension();
-                svg_name << '.' << embed->array_name;
+                svg_name << '.' << embed->imgs[0].array_name;
             }
             else
             {
-                svg_name = embed->array_name;
+                svg_name = embed->imgs[0].array_name;
             }
             code.insert(0, tt_string("_svg_string_ = zlib.decompress(base64.b64decode(") << svg_name << "))\n");
             code += "wx.BitmapBundle.FromSVG(_svg_string_";
@@ -732,7 +732,7 @@ bool PythonBundleCode(Code& code, GenEnum::PropName prop)
             {
                 if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed)
                 {
-                    code.CheckLineLength(embed->array_name.size() + sizeof(".Bitmap)"));
+                    code.CheckLineLength(embed->imgs[0].array_name.size() + sizeof(".Bitmap)"));
                     AddPythonImageName(code, embed);
                     code += ".Bitmap)";
                     is_embed_success = true;
@@ -754,14 +754,14 @@ bool PythonBundleCode(Code& code, GenEnum::PropName prop)
             {
                 if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed)
                 {
-                    code.CheckLineLength(embed->array_name.size() + sizeof(".Bitmap"));
+                    code.CheckLineLength(embed->imgs[0].array_name.size() + sizeof(".Bitmap"));
                     AddPythonImageName(code, embed);
 
                     code += ".Bitmap";
 
                     if (auto embed2 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[1]); embed2)
                     {
-                        code.Comma().CheckLineLength(embed2->array_name.size() + sizeof(".Bitmap)"));
+                        code.Comma().CheckLineLength(embed2->imgs[0].array_name.size() + sizeof(".Bitmap)"));
                         AddPythonImageName(code, embed2);
                         code += ".Bitmap)";
                     }
@@ -792,7 +792,7 @@ bool PythonBundleCode(Code& code, GenEnum::PropName prop)
                 {
                     if (auto embed = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[idx]); embed)
                     {
-                        code.CheckLineLength(embed->array_name.size() + sizeof(".Bitmap"));
+                        code.CheckLineLength(embed->imgs[0].array_name.size() + sizeof(".Bitmap"));
                         AddPythonImageName(code, embed);
 
                         code += ".Bitmap";

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -484,7 +484,7 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
                     code.clear();
                     images_file_imported = true;
                 }
-                if (iter->type == wxBITMAP_TYPE_SVG)
+                if (iter->imgs[0].type == wxBITMAP_TYPE_SVG)
                 {
                     if (!zlib_requirement_written)
                     {
@@ -506,7 +506,7 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
             }
             else if (!svg_import_libs)
             {
-                if (iter->type == wxBITMAP_TYPE_SVG)
+                if (iter->imgs[0].type == wxBITMAP_TYPE_SVG)
                 {
                     if (!zlib_requirement_written)
                     {
@@ -802,11 +802,11 @@ bool RubyBundleCode(Code& code, GenEnum::PropName prop)
             {
                 svg_name = embed->form->as_string(prop_ruby_file).filename();
                 svg_name.remove_extension();
-                svg_name << ".$" << embed->array_name;
+                svg_name << ".$" << embed->imgs[0].array_name;
             }
             else
             {
-                svg_name = "$" + embed->array_name;
+                svg_name = "$" + embed->imgs[0].array_name;
             }
             code.insert(0, tt_string("_svg_string_ = Zlib::Inflate.inflate(Base64.decode64(") << svg_name << "))\n");
             code += "Wx::BitmapBundle.from_svg(_svg_string_";
@@ -844,18 +844,18 @@ bool RubyBundleCode(Code& code, GenEnum::PropName prop)
             }
             if (const EmbeddedImage* embed1 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[0]); embed1)
             {
-                code.Str("wxue_get_bundle(").Str("$").Str(embed1->array_name);
+                code.Str("wxue_get_bundle(").Str("$").Str(embed1->imgs[0].array_name);
                 if (bundle->lst_filenames.size() > 1)
                 {
                     if (EmbeddedImage* embed2 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[1]); embed2)
                     {
-                        code.Comma().Str("$").Str(embed2->array_name);
+                        code.Comma().Str("$").Str(embed2->imgs[0].array_name);
                     }
                     if (bundle->lst_filenames.size() > 2)
                     {
                         if (EmbeddedImage* embed3 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[2]); embed3)
                         {
-                            code.Comma().Str("$").Str(embed3->array_name);
+                            code.Comma().Str("$").Str(embed3->imgs[0].array_name);
                         }
                     }
                 }

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -39,11 +39,11 @@ void BaseCodeGenerator::WriteImagePreConstruction(Code& code)
             is_namespace_written = true;
             code.Str("namespace wxue_img").OpenBrace();
         }
-        code.Eol(eol_if_needed).Str("extern const unsigned char ").Str(iter_array->array_name);
-        code.Str("[").itoa(iter_array->array_size & 0xFFFFFFFF).Str("];");
-        if (iter_array->filename.size())
+        code.Eol(eol_if_needed).Str("extern const unsigned char ").Str(iter_array->imgs[0].array_name);
+        code.Str("[").itoa(iter_array->imgs[0].array_size & 0xFFFFFFFF).Str("];");
+        if (iter_array->imgs[0].filename.size())
         {
-            code.Str("  // ").Str(iter_array->filename);
+            code.Str("  // ").Str(iter_array->imgs[0].filename);
         }
     }
 
@@ -78,14 +78,14 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             }
 
             // SVG images store the original size in the high 32 bits
-            size_t max_pos = (iter_array->array_size & 0xFFFFFFFF);
+            size_t max_pos = (iter_array->imgs[0].array_size & 0xFFFFFFFF);
 
-            if (iter_array->filename.size())
+            if (iter_array->imgs[0].filename.size())
             {
-                code.Eol(eol_if_needed).Str("// ").Str(iter_array->filename);
+                code.Eol(eol_if_needed).Str("// ").Str(iter_array->imgs[0].filename);
             }
             code.Eol();
-            code.Str("const unsigned char ").Str(iter_array->array_name);
+            code.Str("const unsigned char ").Str(iter_array->imgs[0].array_name);
             code.Str("[").itoa(max_pos).Str("] {");
             m_source->writeLine(code);
             code.clear();
@@ -97,7 +97,7 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             {
                 for (; pos < max_pos && code.size() < cpp_line_length; ++pos)
                 {
-                    code.itoa(iter_array->array_data[pos]) += ",";
+                    code.itoa(iter_array->imgs[0].array_data[pos]) += ",";
                 }
                 if (pos >= max_pos && code.GetCode().back() == ',')
                 {
@@ -120,12 +120,12 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             {
                 continue;
             }
-            if (iter_array->filename.size())
+            if (iter_array->imgs[0].filename.size())
             {
-                code.Eol().Str("# ").Str(iter_array->filename);
+                code.Eol().Str("# ").Str(iter_array->imgs[0].filename);
             }
-            code.Eol().Str(iter_array->array_name);
-            if (iter_array->type == wxBITMAP_TYPE_SVG)
+            code.Eol().Str(iter_array->imgs[0].array_name);
+            if (iter_array->imgs[0].type == wxBITMAP_TYPE_SVG)
             {
                 code.Str(" = (");
             }
@@ -135,7 +135,8 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             }
             m_source->writeLine(code);
             code.clear();
-            auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF, GEN_LANG_PYTHON);
+            auto encoded = base64_encode(iter_array->imgs[0].array_data.get(), iter_array->imgs[0].array_size & 0xFFFFFFFF,
+                                         GEN_LANG_PYTHON);
             if (encoded.size())
             {
                 encoded.back() += ")";
@@ -148,12 +149,12 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             {
                 continue;
             }
-            if (iter_array->filename.size())
+            if (iter_array->imgs[0].filename.size())
             {
-                code.Eol().Str("# ").Str(iter_array->filename);
+                code.Eol().Str("# ").Str(iter_array->imgs[0].filename);
             }
-            code.Eol().Str("$").Str(iter_array->array_name);
-            if (iter_array->type == wxBITMAP_TYPE_SVG)
+            code.Eol().Str("$").Str(iter_array->imgs[0].array_name);
+            if (iter_array->imgs[0].type == wxBITMAP_TYPE_SVG)
             {
                 code.Str(" = (");
             }
@@ -163,7 +164,8 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             }
             m_source->writeLine(code);
             code.clear();
-            auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF, GEN_LANG_RUBY);
+            auto encoded = base64_encode(iter_array->imgs[0].array_data.get(), iter_array->imgs[0].array_size & 0xFFFFFFFF,
+                                         GEN_LANG_RUBY);
             if (encoded.size())
             {
                 // Remove the trailing '+' character
@@ -208,12 +210,13 @@ void BaseCodeGenerator::WriteImagePostHeader()
             m_header->Indent();
             is_namespace_written = true;
         }
-        if (iter_array->filename.size())
+        if (iter_array->imgs[0].filename.size())
         {
-            m_header->writeLine(tt_string("// ") << iter_array->filename);
+            m_header->writeLine(tt_string("// ") << iter_array->imgs[0].filename);
         }
         m_header->writeLine(tt_string("extern const unsigned char ")
-                            << iter_array->array_name << '[' << (iter_array->array_size & 0xFFFFFFFF) << "];");
+                            << iter_array->imgs[0].array_name << '[' << (iter_array->imgs[0].array_size & 0xFFFFFFFF)
+                            << "];");
     }
 
     if (is_namespace_written)
@@ -352,12 +355,12 @@ void BaseCodeGenerator::GeneratePythonImagesForm()
         if (iter_array->form != m_form_node)
             continue;
 
-        if (iter_array->filename.size())
+        if (iter_array->imgs[0].filename.size())
         {
-            code.Eol().Str("# ").Str(iter_array->filename);
+            code.Eol().Str("# ").Str(iter_array->imgs[0].filename);
         }
-        code.Eol().Str(iter_array->array_name);
-        if (iter_array->type == wxBITMAP_TYPE_SVG)
+        code.Eol().Str(iter_array->imgs[0].array_name);
+        if (iter_array->imgs[0].type == wxBITMAP_TYPE_SVG)
         {
             code.Str(" = (");
         }
@@ -368,7 +371,8 @@ void BaseCodeGenerator::GeneratePythonImagesForm()
 
         m_source->writeLine(code);
         code.clear();
-        auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF, GEN_LANG_PYTHON);
+        auto encoded = base64_encode(iter_array->imgs[0].array_data.get(), iter_array->imgs[0].array_size & 0xFFFFFFFF,
+                                     GEN_LANG_PYTHON);
         if (encoded.size())
         {
             encoded.back() += ")";
@@ -423,12 +427,12 @@ void BaseCodeGenerator::GenerateRubyImagesForm()
         if (iter_array->form != m_form_node)
             continue;
 
-        if (iter_array->filename.size())
+        if (iter_array->imgs[0].filename.size())
         {
-            code.Eol().Str("# ").Str(iter_array->filename);
+            code.Eol().Str("# ").Str(iter_array->imgs[0].filename);
         }
-        code.Eol().Str("$").Str(iter_array->array_name);
-        if (iter_array->type == wxBITMAP_TYPE_SVG)
+        code.Eol().Str("$").Str(iter_array->imgs[0].array_name);
+        if (iter_array->imgs[0].type == wxBITMAP_TYPE_SVG)
         {
             code.Str(" = (");
         }
@@ -438,7 +442,8 @@ void BaseCodeGenerator::GenerateRubyImagesForm()
         }
         m_source->writeLine(code);
         code.clear();
-        auto encoded = base64_encode(iter_array->array_data.get(), iter_array->array_size & 0xFFFFFFFF, GEN_LANG_RUBY);
+        auto encoded =
+            base64_encode(iter_array->imgs[0].array_data.get(), iter_array->imgs[0].array_size & 0xFFFFFFFF, GEN_LANG_RUBY);
         if (encoded.size())
         {
             // Remove the trailing '+' character
@@ -462,7 +467,7 @@ void AddPythonImageName(Code& code, const EmbeddedImage* embed)
 
         code.Str(import_name).Str(".");
     }
-    code.Str(embed->array_name);
+    code.Str(embed->imgs[0].array_name);
 }
 
 // ******************************* Bundle Code Generation *******************************
@@ -512,9 +517,9 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
 
     if (code.is_cpp())
     {
-        tt_string name = "wxue_img::" + embed->array_name;
-        code.Eol() << "\twxueBundleSVG(" << name << ", " << (embed->array_size & 0xFFFFFFFF) << ", ";
-        code.itoa(embed->array_size >> 32).Comma();
+        tt_string name = "wxue_img::" + embed->imgs[0].array_name;
+        code.Eol() << "\twxueBundleSVG(" << name << ", " << (embed->imgs[0].array_size & 0xFFFFFFFF) << ", ";
+        code.itoa(embed->imgs[0].array_size >> 32).Comma();
         if (get_bitmap)
         {
             code.FormFunction("FromDIP(").Add("wxSize(").itoa(svg_size.x).Comma().itoa(svg_size.y) += ")))";
@@ -534,11 +539,11 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
         {
             svg_name = embed->form->as_string(prop_python_file).filename();
             svg_name.remove_extension();
-            svg_name << '.' << embed->array_name;
+            svg_name << '.' << embed->imgs[0].array_name;
         }
         else
         {
-            svg_name = embed->array_name;
+            svg_name = embed->imgs[0].array_name;
         }
         code.insert(0, tt_string("_svg_string_ = zlib.decompress(base64.b64decode(") << svg_name << "))\n");
         code.Eol() += "\twx.BitmapBundle.FromSVG(_svg_string_";
@@ -546,7 +551,7 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
     else if (code.is_ruby())
     {
         tt_string svg_name;
-        svg_name = "$" + embed->array_name;
+        svg_name = "$" + embed->imgs[0].array_name;
         code.insert(0, tt_string("_svg_string_ = Zlib::Inflate.inflate(Base64.decode64(") << svg_name << "))\n");
         code += "Wx::BitmapBundle.from_svg(_svg_string_";
         code.Comma().Str("Wx::Size.new(").itoa(svg_size.x).Comma().itoa(svg_size.y) += "))";
@@ -637,18 +642,18 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
     if (code.is_ruby())
     {
         // Ruby has a single function that will create a bundle from 1 to 3 images
-        code.Str("wxue_get_bundle(").Str("$").Str(embed->array_name);
+        code.Str("wxue_get_bundle(").Str("$").Str(embed->imgs[0].array_name);
         if (bundle->lst_filenames.size() > 1)
         {
             if (EmbeddedImage* embed2 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[1]); embed2)
             {
-                code.Comma().Str("$").Str(embed2->array_name);
+                code.Comma().Str("$").Str(embed2->imgs[0].array_name);
             }
             if (bundle->lst_filenames.size() > 2)
             {
                 if (EmbeddedImage* embed3 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[2]); embed3)
                 {
-                    code.Comma().Str("$").Str(embed3->array_name);
+                    code.Comma().Str("$").Str(embed3->imgs[0].array_name);
                 }
             }
         }
@@ -684,7 +689,7 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
     {
         code.Eol().Tab() << "wxueImage(";
 
-        name = "wxue_img::" + embed->array_name;
+        name = "wxue_img::" + embed->imgs[0].array_name;
 
         code << name << ", sizeof(" << name << "))";
         code << ".Rescale(";
@@ -696,7 +701,7 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
         {
             code.Eol().Tab() << "wxueImage(";
 
-            name = "wxue_img::" + embed->array_name;
+            name = "wxue_img::" + embed->imgs[0].array_name;
 
             code << name << ", sizeof(" << name << "))";
         }
@@ -722,12 +727,12 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
         if (code.is_cpp())
         {
             code << "wxueImage(";
-            name = "wxue_img::" + embed->array_name;
+            name = "wxue_img::" + embed->imgs[0].array_name;
             code << name << ", sizeof(" << name << ")), wxueImage(";
 
             if (auto embed2 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[1]); embed2)
             {
-                name = "wxue_img::" + embed2->array_name;
+                name = "wxue_img::" + embed2->imgs[0].array_name;
                 name.remove_extension();
                 code << name << ", sizeof(" << name << ")))";
             }
@@ -738,12 +743,12 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
         }
         else if (code.is_python())
         {
-            code.CheckLineLength(embed->array_name.size() + sizeof(".Bitmap)"));
+            code.CheckLineLength(embed->imgs[0].array_name.size() + sizeof(".Bitmap)"));
             AddPythonImageName(code, embed);
             code += ".Bitmap";
             if (auto embed2 = ProjectImages.GetEmbeddedImage(bundle->lst_filenames[1]); embed2)
             {
-                code.Comma().CheckLineLength(embed2->array_name.size() + sizeof(".Bitmap)"));
+                code.Comma().CheckLineLength(embed2->imgs[0].array_name.size() + sizeof(".Bitmap)"));
                 AddPythonImageName(code, embed2);
                 code += ".Bitmap";
             }
@@ -778,7 +783,7 @@ static void GenerateEmbedBundle(Code& code, const tt_string_vector& parts, bool 
                     auto embed_img = ProjectImages.GetEmbeddedImage(iter);
                     if (embed_img)
                     {
-                        name_img = "wxue_img::" + embed_img->array_name;
+                        name_img = "wxue_img::" + embed_img->imgs[0].array_name;
                     }
                 }
                 code.Eol().Str("bitmaps.push_back(wxueImage(") << name_img << ", sizeof(" << name_img << ")));";

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -305,14 +305,6 @@ public:
             return wxNullBitmap;
     }
 
-    const ImageBundle* as_image_bundle(PropName name) const
-    {
-        if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())
-            return m_properties[result->second].as_image_bundle();
-        else
-            return nullptr;
-    }
-
     wxBitmap as_wxBitmap(PropName name) const
     {
         if (auto result = m_prop_indices.find(name); result != m_prop_indices.end())

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -342,7 +342,7 @@ wxBitmap NodeProperty::as_bitmap() const
 
 wxBitmapBundle NodeProperty::as_bitmap_bundle() const
 {
-    auto bundle = ProjectImages.GetBitmapBundle(m_value, m_node);
+    auto bundle = ProjectImages.GetBitmapBundle(m_value);
     if (!bundle.IsOk())
         return wxNullBitmap;
     else

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -349,15 +349,6 @@ wxBitmapBundle NodeProperty::as_bitmap_bundle() const
         return bundle;
 }
 
-const ImageBundle* NodeProperty::as_image_bundle() const
-{
-    auto bundle_ptr = ProjectImages.GetPropertyImageBundle(m_value);
-    if (!bundle_ptr || !bundle_ptr->bundle.IsOk())
-        return nullptr;
-    else
-        return bundle_ptr;
-}
-
 wxAnimation NodeProperty::as_animation() const
 {
     return ProjectImages.GetPropertyAnimation(m_value);

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -120,7 +120,6 @@ public:
     wxString as_wxString() const { return m_value.make_wxString(); }
 
     wxBitmapBundle as_bitmap_bundle() const;
-    const ImageBundle* as_image_bundle() const;
 
     const tt_string& as_string() const { return m_value; }
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1627,7 +1627,7 @@ void PropGridPanel::ModifyEmbeddedProperty(NodeProperty* node_prop, wxPGProperty
     {
         tt_string image_path(parts[IndexImage]);
         auto* embed = ProjectImages.GetEmbeddedImage(image_path);
-        if (embed && image_path == embed->filename)
+        if (embed && image_path == embed->imgs[0].filename)
         {
             // If the user is adding a node to a gen_Images node, then be sure that the embed
             // entry form is pointing to the gen_Images node.

--- a/src/previews.cpp
+++ b/src/previews.cpp
@@ -454,8 +454,8 @@ void MainFrame::PreviewCpp(Node* form_node)
                     wxWizard wizard;
                     if (form_node->hasValue(prop_bitmap))
                     {
-                        auto bundle = form_node->as_image_bundle(prop_bitmap);
-                        if (!wizard.Create(wxGetMainFrame(), wxID_ANY, form_node->as_string(prop_title), bundle->bundle,
+                        auto bundle = form_node->as_wxBitmapBundle(prop_bitmap);
+                        if (!wizard.Create(wxGetMainFrame(), wxID_ANY, form_node->as_string(prop_title), bundle,
                                            DlgPoint(this, form_node, prop_pos), GetStyleInt(form_node)))
                         {
                             wxMessageBox("Unable to create wizard", "C++ Preview");
@@ -511,8 +511,8 @@ void MainFrame::PreviewCpp(Node* form_node)
                         pages.emplace_back(wiz_page);
                         if (page->hasValue(prop_bitmap))
                         {
-                            auto bundle = page->as_image_bundle(prop_bitmap);
-                            wiz_page->Create(&wizard, nullptr, nullptr, bundle->bundle);
+                            auto bundle = page->as_wxBitmapBundle(prop_bitmap);
+                            wiz_page->Create(&wizard, nullptr, nullptr, bundle);
                         }
                         else
                             wiz_page->Create(&wizard);

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -1533,24 +1533,22 @@ tt_string ImageHandler::GetBundleFuncName(const tt_string& description)
 
                 if (parts[0] == form_image_parts[0] && parts[1].filename() == form_image_parts[1].filename())
                 {
-                    if (auto bundle = GetPropertyImageBundle(parts); bundle && bundle->lst_filenames.size())
+                    auto embed = GetEmbeddedImage(parts[IndexImage]);
+                    ASSERT(embed);  // should be impossible not to have an embed here
+                    if (embed->imgs[0].type == wxBITMAP_TYPE_SVG)
                     {
-                        auto embed = GetEmbeddedImage(bundle->lst_filenames[0]);
-                        if (embed->imgs[0].type == wxBITMAP_TYPE_SVG)
-                        {
-                            name << "wxue_img::bundle_" << embed->imgs[0].array_name << "(";
+                        name << "wxue_img::bundle_" << embed->imgs[0].array_name << "(";
 
-                            wxSize svg_size { -1, -1 };
-                            if (parts[IndexSize].size())
-                            {
-                                svg_size = GetSizeInfo(parts[IndexSize]);
-                            }
-                            name << svg_size.x << ", " << svg_size.y << ")";
-                        }
-                        else
+                        wxSize svg_size { -1, -1 };
+                        if (parts[IndexSize].size())
                         {
-                            name << "wxue_img::bundle_" << embed->imgs[0].array_name << "()";
+                            svg_size = GetSizeInfo(parts[IndexSize]);
                         }
+                        name << svg_size.x << ", " << svg_size.y << ")";
+                    }
+                    else
+                    {
+                        name << "wxue_img::bundle_" << embed->imgs[0].array_name << "()";
                     }
                     break;
                 }

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -53,18 +53,6 @@ namespace wxue_img
     extern const unsigned char pulsing_unknown_gif[377];
 }
 
-namespace lunasvg
-{
-    // returns ElementID::unknown if name is not found
-    extern ElementID elementid(const std::string& name);
-
-    // returns PropertyID::unknown if name is not found
-    extern PropertyID csspropertyid(const std::string& name);
-
-    // returns PropertyID::unknown if name is not found
-    extern PropertyID propertyid(const std::string& name);
-}  // namespace lunasvg
-
 bool CopyStreamData(wxInputStream* inputStream, wxOutputStream* outputStream, size_t size);
 
 // Convert a data array into a wxAnimation

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -195,6 +195,10 @@ wxBitmapBundle ImageHandler::GetBitmapBundle(const tt_string& description)
         return wxue_img::bundle_unknown_svg(32, 32);
 }
 
+// This gets called by PropertyGrid_Image::RefreshChildren() in pg_image.cpp when an XPM file
+// is encountered.
+//
+// Primary caller is ProcessBundleProperty() for retrieving all the images in a bundle.
 wxImage ImageHandler::GetPropertyBitmap(const tt_string_vector& parts, bool check_image)
 {
     if (parts.size() <= IndexImage || parts[IndexImage].empty())
@@ -303,6 +307,8 @@ EmbeddedImage* ImageHandler::GetEmbeddedImage(tt_string_view path)
     }
 }
 
+// This is called in BaseCodeGenerator::CollectImageHeaders (gen_base.cpp) when an animation file is found that
+// was not previously loaded.
 bool ImageHandler::AddEmbeddedImage(tt_string path, Node* form, bool is_animation)
 {
     if (!path.file_exists())
@@ -642,6 +648,7 @@ bool CopyStreamData(wxInputStream* inputStream, wxOutputStream* outputStream, si
     return true;
 }
 
+// This gets called whenever a project is loaded or imported.
 void ImageHandler::CollectBundles()
 {
     if (m_allow_ui)
@@ -704,6 +711,8 @@ void ImageHandler::CollectNodeBundles(Node* node, Node* form)
     }
 }
 
+// This will call AddSvgBundleImage(), AddXpmBundleImage() or AddEmbeddedBundleImage()
+// depending on the type of the image file.
 bool ImageHandler::AddNewEmbeddedBundle(const tt_string_vector& parts, tt_string path, Node* form)
 {
     ASSERT(parts.size() > 1)

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -889,33 +889,6 @@ bool ImageHandler::AddNewEmbeddedBundle(const tt_string_vector& parts, tt_string
         }
     }
 
-    if (img_bundle.lst_filenames.size() == 1)
-    {
-        if (embed = GetEmbeddedImage(img_bundle.lst_filenames[0]); embed)
-        {
-            wxMemoryInputStream stream(embed->imgs[0].array_data.get(), embed->imgs[0].array_size);
-            wxImage image;
-            image.LoadFile(stream);
-            // img_bundle.bundle = wxBitmapBundle::FromBitmap(image);
-        }
-    }
-    else
-    {
-        wxVector<wxBitmap> bitmaps;
-        for (auto& iter: img_bundle.lst_filenames)
-        {
-            if (embed = GetEmbeddedImage(iter); embed)
-            {
-                wxMemoryInputStream stream(embed->imgs[0].array_data.get(), embed->imgs[0].array_size);
-                wxImage image;
-                image.LoadFile(stream);
-                ASSERT(image.IsOk())
-                bitmaps.push_back(image);
-            }
-        }
-        // img_bundle.bundle = wxBitmapBundle::FromBitmaps(bitmaps);
-    }
-
     m_bundles[lookup_str] = std::move(img_bundle);
     return true;
 }

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -1494,16 +1494,6 @@ bool ImageHandler::AddXpmBundleImage(tt_string path, Node* form)
     return true;
 }
 
-wxBitmapBundle LoadSVG(EmbeddedImage* embed, tt_string_view size_description)
-{
-    size_t org_size = (embed->imgs[0].array_size >> 32);
-    auto str = std::make_unique<char[]>(org_size);
-    wxMemoryInputStream stream_in(embed->imgs[0].array_data.get(), embed->imgs[0].array_size & 0xFFFFFFFF);
-    wxZlibInputStream zlib_strm(stream_in);
-    zlib_strm.Read(str.get(), org_size);
-    return wxBitmapBundle::FromSVG(str.get(), GetSizeInfo(size_description));
-}
-
 // size parameter is only used for SVG files
 wxBitmapBundle EmbeddedImage::get_bundle(wxSize override_size)
 {

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -196,12 +196,12 @@ wxImage ImageHandler::GetImage(const tt_string& description)
         return GetInternalImage("unknown");
 }
 
-wxBitmapBundle ImageHandler::GetBitmapBundle(const tt_string& description, Node* node)
+wxBitmapBundle ImageHandler::GetBitmapBundle(const tt_string& description)
 {
     if (description.starts_with("Embed;") || description.starts_with("XPM;") || description.starts_with("Header;") ||
         description.starts_with("Art;") || description.starts_with("SVG;"))
     {
-        return GetPropertyBitmapBundle(description, node);
+        return GetPropertyBitmapBundle(description);
     }
     else
         return wxue_img::bundle_unknown_svg(32, 32);
@@ -1232,7 +1232,7 @@ void ImageHandler::UpdateBundle(const tt_string_vector& parts, Node* node)
     }
 }
 
-wxBitmapBundle ImageHandler::GetPropertyBitmapBundle(tt_string_view description, Node* node)
+wxBitmapBundle ImageHandler::GetPropertyBitmapBundle(tt_string_view description)
 {
     tt_string_vector parts(description, ';', tt::TRIM::both);
     if (parts.size() < 2)

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -39,6 +39,8 @@ struct EmbeddedImage
     std::vector<ImageInfo> imgs;  // InitializeEmbedStructure() will always create at least one entry
     wxSize size;                  // dimensions of the first image in the array
 
+    // Note that this will update any file within EmbeddedImage whose file_time has changed
+    // since the file was first loaded.
     wxBitmapBundle get_bundle();
 };
 
@@ -70,7 +72,7 @@ public:
 
     // Call this is the image file has been modified. This will update the array_data and
     // array_size for the image from the updated image file.
-    void UpdateEmbeddedImage(EmbeddedImage* embed);
+    static void UpdateEmbeddedImage(EmbeddedImage* embed, size_t index = 0);
 
     wxImage GetImage(const tt_string& description);
 

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -23,16 +23,21 @@ struct ImageBundle
     std::vector<tt_string> lst_filenames;
 };
 
-struct EmbeddedImage
+struct ImageInfo
 {
-    Node* form;  // the form node the image is declared in
-    tt_string array_name;
     tt_string filename;
+    tt_string array_name;
     size_t array_size;
     std::unique_ptr<unsigned char[]> array_data;
-    wxSize size;                                // dimensions of the first image in the array
     std::filesystem::file_time_type file_time;  // time the file was last modified
     wxBitmapType type;
+};
+
+struct EmbeddedImage
+{
+    Node* form;                   // the form node the image is declared in
+    std::vector<ImageInfo> imgs;  // InitializeEmbedStructure() will always create at least one entry
+    wxSize size;                  // dimensions of the first image in the array
 };
 
 wxBitmapBundle LoadSVG(EmbeddedImage* embed, tt_string_view size_description);
@@ -131,7 +136,7 @@ protected:
     void CollectNodeBundles(Node* node, Node* form);
 
     // Converts filename to a valid string name and sets EmbeddedImage::array_name
-    void InitializeArrayName(EmbeddedImage* embed, tt_string_view path);
+    void InitializeEmbedStructure(EmbeddedImage* embed, tt_string_view path, Node* form);
 
     bool AddNewEmbeddedImage(tt_string path, Node* form, std::unique_lock<std::mutex>& add_lock);
 

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -130,8 +130,8 @@ public:
     bool AddEmbeddedImage(tt_string path, Node* form, bool is_animation = false);
     EmbeddedImage* GetEmbeddedImage(tt_string_view path);
 
-    // This will collect bundles for the entire project -- it initializes
-    // std::map<std::string, ImageBundle> m_bundles for every image.
+    // This will collect bundles for the entire project -- it initializes m_bundles and
+    // m_map_embedded for every image.
     void CollectBundles();
 
     // Returns nullptr if the image is not found
@@ -145,11 +145,14 @@ protected:
     // Converts filename to a valid string name and sets EmbeddedImage::array_name
     void InitializeEmbedStructure(EmbeddedImage* embed, tt_string_view path, Node* form);
 
+    // This will update both m_bundles and m_map_embedded
     bool AddNewEmbeddedImage(tt_string path, Node* form);
 
     // Reads the image and stores it in m_map_embedded
     EmbeddedImage* AddEmbeddedBundleImage(tt_string path, Node* form, EmbeddedImage* embed = nullptr);
 
+    // This will call AddSvgBundleImage(), AddXpmBundleImage() or AddEmbeddedBundleImage()
+    // depending on the type of the image file.
     bool AddNewEmbeddedBundle(const tt_string_vector& parts, tt_string path, Node* form);
 
     inline bool AddNewEmbeddedBundle(const tt_string& description, tt_string path, Node* form)

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -41,7 +41,9 @@ struct EmbeddedImage
 
     // Note that this will update any file within EmbeddedImage whose file_time has changed
     // since the file was first loaded.
-    wxBitmapBundle get_bundle();
+    //
+    // size parameter is only used for SVG files
+    wxBitmapBundle get_bundle(wxSize size = { -1, -1});
 };
 
 wxBitmapBundle LoadSVG(EmbeddedImage* embed, tt_string_view size_description);
@@ -133,6 +135,9 @@ public:
     // This will collect bundles for the entire project -- it initializes
     // std::map<std::string, ImageBundle> m_bundles for every image.
     void CollectBundles();
+
+    // Returns nullptr if the image is not found
+    EmbeddedImage* FindEmbedded(std::string_view);
 
 protected:
     bool CheckNode(Node* node);

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -38,6 +38,8 @@ struct EmbeddedImage
     Node* form;                   // the form node the image is declared in
     std::vector<ImageInfo> imgs;  // InitializeEmbedStructure() will always create at least one entry
     wxSize size;                  // dimensions of the first image in the array
+
+    wxBitmapBundle get_bundle();
 };
 
 wxBitmapBundle LoadSVG(EmbeddedImage* embed, tt_string_view size_description);
@@ -141,7 +143,7 @@ protected:
     bool AddNewEmbeddedImage(tt_string path, Node* form, std::unique_lock<std::mutex>& add_lock);
 
     // Reads the image and stores it in m_map_embedded
-    bool AddEmbeddedBundleImage(tt_string path, Node* form);
+    EmbeddedImage* AddEmbeddedBundleImage(tt_string path, Node* form, EmbeddedImage* embed = nullptr);
 
     bool AddNewEmbeddedBundle(const tt_string_vector& parts, tt_string path, Node* form);
 

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -46,8 +46,6 @@ struct EmbeddedImage
     wxBitmapBundle get_bundle(wxSize size = { -1, -1 });
 };
 
-wxBitmapBundle LoadSVG(EmbeddedImage* embed, tt_string_view size_description);
-
 class ImageHandler
 {
 private:

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -160,8 +160,11 @@ protected:
         return AddNewEmbeddedBundle(parts, path, form);
     }
 
-    // Reads the image and stores it in m_map_embedded
+    // Reads the image, remove unused metadat, compresses it and stores it in m_map_embedded
     bool AddSvgBundleImage(tt_string path, Node* form);
+
+    // Read the image, compresses it and stores it in m_map_embedded
+    bool AddXpmBundleImage(tt_string path, Node* form);
 
 private:
     NodeSharedPtr m_project_node { nullptr };

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -76,7 +76,7 @@ public:
 
     wxImage GetImage(const tt_string& description);
 
-    wxBitmapBundle GetBitmapBundle(const tt_string& description, Node* node);
+    wxBitmapBundle GetBitmapBundle(const tt_string& description);
 
     // This takes the full bitmap property description and uses that to determine the image
     // to load. The image is cached for as long as the project is open.
@@ -90,7 +90,7 @@ public:
         return GetPropertyBitmap(parts, check_image);
     }
 
-    wxBitmapBundle GetPropertyBitmapBundle(tt_string_view description, Node* node);
+    wxBitmapBundle GetPropertyBitmapBundle(tt_string_view description);
 
     // ImageBundle contains the filenames of each image in the bundle, needed to generate the
     // code for the bundle.

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -142,7 +142,7 @@ protected:
     // Converts filename to a valid string name and sets EmbeddedImage::array_name
     void InitializeEmbedStructure(EmbeddedImage* embed, tt_string_view path, Node* form);
 
-    bool AddNewEmbeddedImage(tt_string path, Node* form, std::unique_lock<std::mutex>& add_lock);
+    bool AddNewEmbeddedImage(tt_string path, Node* form);
 
     // Reads the image and stores it in m_map_embedded
     EmbeddedImage* AddEmbeddedBundleImage(tt_string path, Node* form, EmbeddedImage* embed = nullptr);
@@ -160,9 +160,6 @@ protected:
 
 private:
     NodeSharedPtr m_project_node { nullptr };
-
-    std::mutex m_mutex_embed_add;
-    std::mutex m_mutex_embed_retrieve;
 
     std::map<std::string, wxImage> m_images;
 

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -17,9 +17,9 @@
 
 class wxAnimation;
 
+// This simply contains a list of the filenames that would be used to create a bundle.
 struct ImageBundle
 {
-    wxBitmapBundle bundle;
     std::vector<tt_string> lst_filenames;
 };
 
@@ -43,7 +43,7 @@ struct EmbeddedImage
     // since the file was first loaded.
     //
     // size parameter is only used for SVG files
-    wxBitmapBundle get_bundle(wxSize size = { -1, -1});
+    wxBitmapBundle get_bundle(wxSize size = { -1, -1 });
 };
 
 wxBitmapBundle LoadSVG(EmbeddedImage* embed, tt_string_view size_description);
@@ -166,10 +166,13 @@ protected:
 private:
     NodeSharedPtr m_project_node { nullptr };
 
-    std::map<std::string, wxImage> m_images;
-
     // std::string is the entire property for the image
     std::map<std::string, ImageBundle> m_bundles;
+
+    // This stores XPM images or any other non-embedded, non-art images
+    //
+    // std::string is parts[IndexImage].filename()
+    std::map<std::string, wxImage, std::less<>> m_images;
 
     // std::string is parts[IndexImage].filename()
     std::map<std::string, std::unique_ptr<EmbeddedImage>, std::less<>> m_map_embedded;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The PR changes the `EmbeddedImage` structure to store all of the different resolutions of an image (e.g., foo_1_x.png, foo_2x.png, etc.). It also adds a get_bundle() that creates a wxBitmapBundle when it is called, rather than storing it anywhere. For the Mockup panel, this is all that's needed.

Note that get_bundle() _will_ reload the image if it has changed, making the Mockup panel more accurate (the image will be reloaded as part of code generation if it has changed).

The `ImageBundle` structure no longer has a wxBitmapBundle field -- you need to call EmbeddedImage::get_bundle() to get the wxBitmapBundle.

AddEmbeddedBundleImage() still calls AddEmbeddedBundleImage() for every image in a bundle which makes it possible for code generation to use m_bundles (ImageBundle) for every image. However, m_map_embedded already contains all the filenames and data, so this duplicates that data. It would be better to use m_map_embedded directly and eliminate m_bundles. However, I'm leaving it in place for this PR as it only affects memory, and even then only for multiple Embed images (i.e., not for single bitmaps or SVGs).

One of the problems with XPM files is that they are _normally_ declared using a static variable, which means the data gets duplicated in every translation unit that `#includes` it. It also runs the risk of the variable name being used elsewhere in the module (rare, but it could happen). By contrast, if it used the wxUiEditor Embed mechanism, the variable name specified within the XPM file would be ignored, and the data would only be stored in one location. That's not going to be how people are used to seeing it, but of course neither is our entire embed method.

This PR does embed XPM files using the same compression algorithm as SVG files, however this is only used by EmbeddedImage::get_bundle(). Code generation still includes the XPM file directly.