### PR TITLE
Support data list in .cmake file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Added support for all four validators in wxRuby3 0.9.3 and up.
 - Non-derived C++ class headers now support protected: class methods in addition to the public: ones that were already supported.
 - New Data List form allowing you to embed text, xml and binary files into your application.
+- Any generated .cmake file will also include a separate list of data files that can be used in the `add_custom_command` and `add_custom_target` commands of a CMakeLists.txt file.
 - Images list has a new auto_add property that will automatically add new images to the list when they are added to any control.
 
 ### Changed

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -199,6 +199,32 @@ int WriteCMakeFile(Node* parent_node, std::vector<tt_string>& updated_files, std
     out.emplace_back();
     out.emplace_back(")");
 
+    if (auto* data_form = Project.getDataForm(); data_form && data_form->getChildCount())
+    {
+        out.emplace_back();
+        out.emplace_back();
+        var_name = Project.as_string(prop_cmake_varname);
+        var_name += "_data";
+        out.at(out.size() - 1) << "set (" << var_name;
+        out.emplace_back();
+
+        for (auto& iter: data_form->getChildNodePtrs())
+        {
+            tt_string base_file = iter->as_string(prop_data_file);
+            if (base_file.size())
+            {
+                base_file.make_relative(cur_dir);
+                base_file.backslashestoforward();
+
+                out.emplace_back();
+                out.at(out.size() - 1) << "    ${CMAKE_CURRENT_LIST_DIR}/" << base_file;
+            }
+        }
+
+        out.emplace_back();
+        out.emplace_back(")");
+    }
+
     // flag == 2 if a temporary file is being written
     if (flag == 2)
     {

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -616,6 +616,22 @@ Node* ProjectHandler::getImagesForm()
     return m_ImagesForm;
 }
 
+Node* ProjectHandler::getDataForm()
+{
+    if (!m_DataForm)
+    {
+        if (m_project_node->getChildCount() > 0 && m_project_node->getChild(0)->isGen(gen_Data))
+        {
+            m_DataForm = m_project_node->getChild(0);
+        }
+        else if (m_project_node->getChildCount() > 1 && m_project_node->getChild(1)->isGen(gen_Data))
+        {
+            m_DataForm = m_project_node->getChild(1);
+        }
+    }
+    return m_DataForm;
+}
+
 int ProjectHandler::get_WidgetsMinorVersion()
 {
     tt_string_view version = m_project_node->as_string(prop_wxWidgets_version);

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -177,6 +177,10 @@ public:
     // either return that Node* or nullptr if no ImagesList class is found.
     Node* getImagesForm();
 
+    // This will assume any Data class will be the first or second child of the project, and
+    // will either return that Node* or nullptr if no Data class is found.
+    Node* getDataForm();
+
     // Sets project property value only if the property exists, returns false if it doesn't
     // exist.
     template <typename T>
@@ -201,6 +205,7 @@ private:
     Node* m_form_BundleBitmaps { nullptr };
     Node* m_form_Animation { nullptr };
     Node* m_ImagesForm { nullptr };
+    Node* m_DataForm { nullptr };
 
     tt_string m_projectFile;
     tt_string m_projectPath;


### PR DESCRIPTION
See PR description for more details

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the list of data files in any `gen_Data` node to an additional macro in any generated .cmake file. It takes the variable name the dev specified for the main source file list, appends `_data` and generates the list from that.

Sample usage:

```CMake
# Custom command to generate UI code
add_custom_command(
    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/wxue_data.cc
    COMMAND wxUiEditor --gen_cpp ../src/ui/MyProject.wxui
    COMMAND type ..\\src\\ui\\MyProject.log
    DEPENDS ${wxue_generated_code_data}
    COMMENT "Generating UI code..."
)

# Add a custom target to ensure the command is run before the main target
add_custom_target(GenerateUiCode DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/wxue_data.cc)

add_executable(MyProgram
    ${srcfile_list}
    ${wxue_generated_code}
)

add_dependencies(MyProgram GenerateUiCode)
```

The above will result in wxUiEditor being called to regenerate wxue_data.cc if any of the data files have changed since the last time the code was generated.
