### PR TITLE
Ribbon

### DIFF
--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -922,6 +922,20 @@ EmbeddedImage* ImageHandler::AddEmbeddedBundleImage(tt_string path, Node* form, 
                     InitializeEmbedStructure(embed, path, form);
                     embed->size = image.GetSize();
                 }
+                else if (idx != 0)
+                {
+                    embed->imgs[idx].filename = path;
+                    embed->imgs[idx].file_time = embed->imgs[idx].filename.last_write_time();
+                    if (auto result = FileNameToVarName(path.filename()); result)
+                    {
+                        embed->imgs[idx].array_name = result.value();
+                    }
+                    else
+                    {
+                        embed->imgs[idx].array_name = embed->imgs[0].array_name;
+                        embed->imgs[idx].array_name << "_" << idx;
+                    }
+                }
 
                 // If possible, convert the file to a PNG -- even if the original file is a PNG, since we might end up
                 // with better compression.

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -507,14 +507,14 @@ void ImageHandler::UpdateEmbeddedImage(EmbeddedImage* embed, size_t index)
         wxMemoryOutputStream memory_stream;
         wxZlibOutputStream save_strem(memory_stream, wxZ_BEST_COMPRESSION);
 
-        size_t org_size = (stream.GetLength() & 0xFFFFFFFF);
+        uint64_t org_size = (stream.GetLength() & 0xFFFFFFFF);
 
         if (!CopyStreamData(&stream, &save_strem, stream.GetLength()))
         {
             return;
         }
         save_strem.Close();
-        auto compressed_size = memory_stream.TellO();
+        auto compressed_size = static_cast<uint64_t>(memory_stream.TellO());
 
         auto read_stream = memory_stream.GetOutputStreamBuffer();
         embed->imgs[0].array_size = (compressed_size | (org_size << 32));
@@ -1372,7 +1372,7 @@ bool ImageHandler::AddSvgBundleImage(tt_string path, Node* form)
     auto* embed = m_map_embedded[path.filename().as_str()].get();
     InitializeEmbedStructure(embed, path, form);
 
-    size_t org_size = (stream.GetLength() & 0xFFFFFFFF);
+    uint64_t org_size = (stream.GetLength() & 0xFFFFFFFF);
 
     if (!CopyStreamData(&stream, &save_strem, stream.GetLength()))
     {
@@ -1380,7 +1380,7 @@ bool ImageHandler::AddSvgBundleImage(tt_string path, Node* form)
         return false;
     }
     save_strem.Close();
-    auto compressed_size = memory_stream.TellO();
+    auto compressed_size = static_cast<uint64_t>(memory_stream.TellO());
 
     auto read_stream = memory_stream.GetOutputStreamBuffer();
     embed->imgs[0].type = wxBITMAP_TYPE_SVG;
@@ -1444,7 +1444,7 @@ bool ImageHandler::AddXpmBundleImage(tt_string path, Node* form)
     {
         return false;
     }
-    size_t org_size = (stream.GetLength() & 0xFFFFFFFF);
+    uint64_t org_size = (stream.GetLength() & 0xFFFFFFFF);
 
     wxImage image;
     if (!image.LoadFile(stream, wxBITMAP_TYPE_XPM))
@@ -1488,7 +1488,7 @@ wxBitmapBundle EmbeddedImage::get_bundle(wxSize override_size)
         {
             ImageHandler::UpdateEmbeddedImage(this, 0);
         }
-        size_t org_size = (imgs[0].array_size >> 32);
+        uint64_t org_size = (imgs[0].array_size >> 32);
         auto str = std::make_unique<char[]>(org_size);
         wxMemoryInputStream stream_in(imgs[0].array_data.get(), imgs[0].array_size & 0xFFFFFFFF);
         wxZlibInputStream zlib_strm(stream_in);
@@ -1502,7 +1502,7 @@ wxBitmapBundle EmbeddedImage::get_bundle(wxSize override_size)
         {
             ImageHandler::UpdateEmbeddedImage(this, 0);
         }
-        size_t org_size = (imgs[0].array_size >> 32);
+        uint64_t org_size = (imgs[0].array_size >> 32);
         auto str = std::make_unique<char[]>(org_size);
         wxMemoryInputStream stream_in(imgs[0].array_data.get(), imgs[0].array_size & 0xFFFFFFFF);
         wxZlibInputStream zlib_strm(stream_in);

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -27,7 +27,7 @@ struct ImageInfo
 {
     tt_string filename;
     tt_string array_name;
-    size_t array_size;
+    uint64_t array_size;
     std::unique_ptr<unsigned char[]> array_data;
     std::filesystem::file_time_type file_time;  // time the file was last modified
     wxBitmapType type;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a but where the additional filenames specified for a `EmbeddedImage` structure were not being initialized. This caused `EmbeddedImage::get_bundle()` to generate warnings because while there was data for the additional files, there were no names or file timestamps.