### PR TITLE
Switch to user-customizable icon size for Navigation Panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - New Data List form allowing you to embed text, xml and binary files into your application.
 - Any generated .cmake file will also include a separate list of data files that can be used in the `add_custom_command` and `add_custom_target` commands of a CMakeLists.txt file.
 - Images list has a new auto_add property that will automatically add new images to the list when they are added to any control.
+- The size of the Icons in the tree control (Navigation Panel) can be set in the Preferences dialog. On Windows, these settings will be scaled to the current DPI setting.
 
 ### Changed
 

--- a/src/panels/nav_panel.h
+++ b/src/panels/nav_panel.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Navigation Panel
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -90,8 +90,6 @@ private:
 
     std::map<Node*, wxTreeItemId> m_node_tree_map;
     std::map<wxTreeItemId, Node*> m_tree_node_map;
-
-    wxImageList* m_iconList;
 
     std::map<GenName, int> m_iconIdx;
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -64,6 +64,8 @@ void Prefs::ReadConfig()
     m_python_line_length = config->Read("python_line_length", 90);
     m_ruby_line_length = config->Read("ruby_line_length", 80);
 
+    m_icon_size = config->Read("icon_size", 20);
+
     m_code_display_font = config->Read("code_display_font", "");
 
     config->SetPath("/");
@@ -115,6 +117,8 @@ void Prefs::WriteConfig()
     config->Write("cpp_line_length", m_cpp_line_length);
     config->Write("python_line_length", m_python_line_length);
     config->Write("ruby_line_length", m_ruby_line_length);
+
+    config->Write("icon_size", m_icon_size);
 
     if (m_dark_mode_pending & PENDING_DARK_MODE_ENABLE)
     {

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -72,6 +72,9 @@ public:
     int get_RubyLineLength() const { return m_ruby_line_length; }
     void set_RubyLineLength(int length) { m_ruby_line_length = length; }
 
+    int get_IconSize() const { return m_icon_size; }
+    void set_IconSize(int size) { m_icon_size = size; }
+
     // Use this string to construct a FontProperty() to get the values
     const tt_string& get_CodeDisplayFont() const { return m_code_display_font; }
 
@@ -213,6 +216,8 @@ private:
     int m_cpp_line_length { 110 };
     int m_python_line_length { 90 };
     int m_ruby_line_length { 80 };
+
+    int m_icon_size { 20 };
 
     bool m_sizers_all_borders { true };
     bool m_sizers_always_expand { true };

--- a/src/ui/preferences_dlg.cpp
+++ b/src/ui/preferences_dlg.cpp
@@ -78,10 +78,29 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     m_general_page_sizer->Add(box_sizer2, wxSizerFlags().Expand().Border(wxALL));
 
+    auto* box_sizer8 = new wxBoxSizer(wxHORIZONTAL);
+
+    auto* static_text4 = new wxStaticText(page_general, wxID_ANY, "&Icon Size:");
+    static_text4->SetToolTip("The size of the icons used in toolbars and tree controls");
+    box_sizer8->Add(static_text4, wxSizerFlags().Center().Border(wxALL));
+
+    m_choice_icon_size = new wxChoice(page_general, wxID_ANY);
+    m_choice_icon_size->Append("16");
+    m_choice_icon_size->Append("18");
+    m_choice_icon_size->Append("20");
+    m_choice_icon_size->Append("22");
+    m_choice_icon_size->Append("24");
+    m_choice_icon_size->Append("26");
+    m_choice_icon_size->Append("28");
+    m_choice_icon_size->Append("30");
+    m_choice_icon_size->Append("32");
+    box_sizer8->Add(m_choice_icon_size, wxSizerFlags().Border(wxALL));
+
+    m_general_page_sizer->Add(box_sizer8, wxSizerFlags().Border(wxALL));
+
     m_box_code_font = new wxBoxSizer(wxHORIZONTAL);
 
-    auto* staticText_2 = new wxStaticText(page_general, wxID_ANY, "Code Font:");
-    staticText_2->Wrap(200);
+    auto* staticText_2 = new wxStaticText(page_general, wxID_ANY, "&Code Font:");
     m_box_code_font->Add(staticText_2, wxSizerFlags().Center().Border(wxALL));
 
     m_btn_font = new wxButton(page_general, wxID_ANY, "Font");
@@ -405,6 +424,8 @@ void PreferencesDlg::OnInit(wxInitDialogEvent& event)
     m_python_line_length = std::to_string(UserPrefs.get_PythonLineLength());
     m_ruby_line_length = std::to_string(UserPrefs.get_RubyLineLength());
 
+    m_choice_icon_size->SetStringSelection(std::to_string(UserPrefs.get_IconSize()));
+
     FontProperty font_prop(UserPrefs.get_CodeDisplayFont().ToStdView());
     m_btn_font->SetLabel(font_prop.as_wxString());
     m_btn_font->SetFont(font_prop.GetFont());
@@ -628,11 +649,15 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
     fix_line_length();
     UserPrefs.set_RubyLineLength(line_length);
 
+    auto old_size = UserPrefs.get_IconSize();
+    UserPrefs.set_IconSize(tt::atoi(m_choice_icon_size->GetStringSelection().ToStdString()));
+    bool is_icon_size_changed = old_size != UserPrefs.get_IconSize();
+
     // UserPrefs.set_CodeDisplayFont(m_code_font_picker->GetSelectedFontInfo());
 
     UserPrefs.WriteConfig();
 
-    if (is_prop_grid_changed || is_dark_changed)
+    if (is_prop_grid_changed || is_dark_changed || is_icon_size_changed)
     {
         tt_string msg("You must close and reopen wxUiEditor for");
         if (is_prop_grid_changed)
@@ -643,8 +668,14 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
         }
         if (is_dark_changed)
             msg += " the Dark Mode";
+        if (is_icon_size_changed)
+        {
+            if (!msg.ends_with("for"))
+                msg += " and";
+            msg += " Icon Size";
+        }
 
-        msg += " settings to take effect.";
+        msg += " setting(s) to take effect.";
 
         wxMessageBox(msg);
     }

--- a/src/ui/preferences_dlg.h
+++ b/src/ui/preferences_dlg.h
@@ -64,6 +64,7 @@ protected:
     wxCheckBox* m_check_right_propgrid;
     wxCheckBox* m_check_svg_bitmaps;
     wxChoice* m_choice_cpp_version;
+    wxChoice* m_choice_icon_size;
     wxChoice* m_choice_python_version;
     wxChoice* m_choice_ruby_version;
     wxColourPickerCtrl* m_colour_cpp;

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -6964,7 +6964,8 @@
               class="wxBoxSizer"
               class_access="protected:"
               orientation="wxVERTICAL"
-              var_name="m_general_page_sizer">
+              var_name="m_general_page_sizer"
+              flags="wxEXPAND">
               <node
                 class="wxBoxSizer"
                 class_access="protected:"
@@ -7029,15 +7030,29 @@
               </node>
               <node
                 class="wxBoxSizer"
+                var_name="box_sizer8">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Icon Size:"
+                  var_name="static_text4"
+                  tooltip="The size of the icons used in toolbars and tree controls"
+                  alignment="wxALIGN_CENTER_VERTICAL" />
+                <node
+                  class="wxChoice"
+                  contents="&quot;16&quot; &quot;18&quot; &quot;20&quot; &quot;22&quot; &quot;24&quot; &quot;26&quot; &quot;28&quot; &quot;30&quot; &quot;32&quot;"
+                  var_name="m_choice_icon_size" />
+              </node>
+              <node
+                class="wxBoxSizer"
                 class_access="protected:"
                 var_name="m_box_code_font"
                 flags="wxEXPAND">
                 <node
                   class="wxStaticText"
                   class_access="none"
-                  label="Code Font:"
+                  label="&amp;Code Font:"
                   var_name="staticText_2"
-                  wrap="200"
                   alignment="wxALIGN_CENTER_VERTICAL" />
                 <node
                   class="wxButton"

--- a/src/wxui/wxui_code.cmake
+++ b/src/wxui/wxui_code.cmake
@@ -68,3 +68,21 @@ set (wxue_generated_code
     ${CMAKE_CURRENT_LIST_DIR}/ribbonpanel_base.cpp
 
 )
+
+set (wxue_generated_code_data
+
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/forms.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/widgets.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/containers.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/bars.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/project.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/sizers.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/text_ctrls.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/buttons.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/boxes.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/data_ctrls.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/mdi.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/pickers.xml
+    ${CMAKE_CURRENT_LIST_DIR}/../xml/interfaces.xml
+
+)


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds an Icon Size preference setting in the Preferences Dialog which is used to set the icon size of the icons in the tree control (Navigation Panel). On Windows, the specified size will first be adjusted for the current display scaling factor before being applied to the icons.

This combines the replacement of all PNG images with SVG images, now integrated into the toolbars, menus and with this the tree control. As such, this finally closes #1192.