### PR TITLE
Change Font button to wxCommandLinkButton

### DIFF
--- a/src/ui/preferences_dlg.cpp
+++ b/src/ui/preferences_dlg.cpp
@@ -7,6 +7,7 @@
 
 // clang-format off
 
+#include <wx/button.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
 #include <wx/stattext.h>
@@ -80,7 +81,7 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     auto* box_sizer8 = new wxBoxSizer(wxHORIZONTAL);
 
-    auto* static_text4 = new wxStaticText(page_general, wxID_ANY, "&Icon Size:");
+    auto* static_text4 = new wxStaticText(page_general, wxID_ANY, "Tree &Icon Size:");
     static_text4->SetToolTip("The size of the icons used in toolbars and tree controls");
     box_sizer8->Add(static_text4, wxSizerFlags().Center().Border(wxALL));
 
@@ -100,13 +101,11 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     m_box_code_font = new wxBoxSizer(wxHORIZONTAL);
 
-    auto* staticText_2 = new wxStaticText(page_general, wxID_ANY, "&Code Font:");
-    m_box_code_font->Add(staticText_2, wxSizerFlags().Center().Border(wxALL));
+    m_btn_font = new wxCommandLinkButton(page_general, wxID_ANY, "Font", "Font for code panels");
+    m_box_code_font->Add(m_btn_font, wxSizerFlags().Border(wxLEFT|wxRIGHT|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
 
-    m_btn_font = new wxButton(page_general, wxID_ANY, "Font");
-    m_box_code_font->Add(m_btn_font, wxSizerFlags().Border(wxALL));
-
-    m_general_page_sizer->Add(m_box_code_font, wxSizerFlags().Expand().Border(wxALL));
+    m_general_page_sizer->Add(m_box_code_font,
+    wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT|wxBOTTOM, wxSizerFlags::GetDefaultBorder()));
     page_general->SetSizerAndFit(m_general_page_sizer);
 
     auto* page_cpp = new wxPanel(notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
@@ -427,14 +426,14 @@ void PreferencesDlg::OnInit(wxInitDialogEvent& event)
     m_choice_icon_size->SetStringSelection(std::to_string(UserPrefs.get_IconSize()));
 
     FontProperty font_prop(UserPrefs.get_CodeDisplayFont().ToStdView());
-    m_btn_font->SetLabel(font_prop.as_wxString());
-    m_btn_font->SetFont(font_prop.GetFont());
+    m_btn_font->SetMainLabel(font_prop.as_wxString());
 
 #if defined(__WXMSW__)
     m_box_dark_settings->ShowItems(true);
     m_general_page_sizer->Layout();
-    Fit();
 #endif
+
+    Fit();
 
     // This will transfer data from the validator variables to the controls
     event.Skip();
@@ -442,12 +441,11 @@ void PreferencesDlg::OnInit(wxInitDialogEvent& event)
 
 void PreferencesDlg::OnFontButton(wxCommandEvent& WXUNUSED(event))
 {
-    FontPropDlg dlg(this, m_btn_font->GetLabel());
+    FontPropDlg dlg(this, m_btn_font->GetMainLabel());
     if (dlg.ShowModal() == wxID_OK)
     {
         FontProperty font_prop(dlg.GetFontDescription());
-        m_btn_font->SetLabel(dlg.GetResults());
-        m_btn_font->SetFont(font_prop.GetFont());
+        m_btn_font->SetMainLabel(dlg.GetResults());
         Fit();
     }
 }
@@ -617,9 +615,9 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
         }
     }
 
-    if (UserPrefs.get_CodeDisplayFont() != m_btn_font->GetLabel().utf8_string())
+    if (UserPrefs.get_CodeDisplayFont() != m_btn_font->GetMainLabel().utf8_string())
     {
-        FontProperty font_prop(tt_string_view(m_btn_font->GetLabel().utf8_string()));
+        FontProperty font_prop(tt_string_view(m_btn_font->GetMainLabel().utf8_string()));
         auto font = font_prop.GetFont();
         UserPrefs.set_CodeDisplayFont(font_prop.as_string());
         wxGetFrame().GetCppPanel()->SetCodeFont(font);

--- a/src/ui/preferences_dlg.h
+++ b/src/ui/preferences_dlg.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
-#include <wx/button.h>
 #include <wx/checkbox.h>
 #include <wx/choice.h>
 #include <wx/clrpicker.h>
 #include <wx/colour.h>
+#include <wx/commandlinkbutton.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
@@ -55,7 +55,6 @@ protected:
     wxBoxSizer* m_box_code_font;
     wxBoxSizer* m_box_dark_settings;
     wxBoxSizer* m_general_page_sizer;
-    wxButton* m_btn_font;
     wxCheckBox* m_check_cpp_snake_case;
     wxCheckBox* m_check_dark_mode;
     wxCheckBox* m_check_fullpath;
@@ -84,6 +83,7 @@ protected:
     wxColourPickerCtrl* m_colour_xrc_attribute;
     wxColourPickerCtrl* m_colour_xrc_string;
     wxColourPickerCtrl* m_colour_xrc_tag;
+    wxCommandLinkButton* m_btn_font;
 };
 
 // ************* End of generated code ***********

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -7034,7 +7034,7 @@
                 <node
                   class="wxStaticText"
                   class_access="none"
-                  label="&amp;Icon Size:"
+                  label="Tree &amp;Icon Size:"
                   var_name="static_text4"
                   tooltip="The size of the icons used in toolbars and tree controls"
                   alignment="wxALIGN_CENTER_VERTICAL" />
@@ -7047,17 +7047,14 @@
                 class="wxBoxSizer"
                 class_access="protected:"
                 var_name="m_box_code_font"
+                borders="wxBOTTOM|wxRIGHT|wxLEFT"
                 flags="wxEXPAND">
                 <node
-                  class="wxStaticText"
-                  class_access="none"
-                  label="&amp;Code Font:"
-                  var_name="staticText_2"
-                  alignment="wxALIGN_CENTER_VERTICAL" />
-                <node
-                  class="wxButton"
-                  label="Font"
+                  class="wxCommandLinkButton"
+                  main_label="Font"
+                  note="Font for code panels"
                   var_name="m_btn_font"
+                  borders="wxBOTTOM|wxRIGHT|wxLEFT"
                   wxEVT_BUTTON="OnFontButton" />
               </node>
             </node>


### PR DESCRIPTION
This avoids the button be truncated on Unix, as well as providing a better description of what the button is for without taking up more space in the dialog.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR switches the Font button in Preferences to a `wxCommandLinkButton`. This fixes the truncated button on Linux, makes the button still readable in case a non-ASCII font is chosen, and provides a longer description without taking up more UI space.