### PR TITLE
Change widget type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - The ability to generate only a C++ header file without a source file has been removed.
 - Books now display images on pages by default. If you don't want the images, you can uncheck the `display_images` property.
 - Before generating code, any images that you used are checked to see if they have been modified since you created them, and if so, the new file is loaded before generating the code.
+- When using the context menu to change a widgets from one type to another, all identical events will have their handler names preserved, and if the var_name is used for class access, that will be preserved as well.
 
 ### Fixed
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -153,8 +153,10 @@ void Node::copyEventsFrom(Node* from)
     {
         if (iter.second.get_value().size())
         {
-            auto event = getEvent(iter.second.get_name());
-            event->set_value(iter.second.get_value());
+            if (auto* event = getEvent(iter.second.get_name()); event)
+            {
+                event->set_value(iter.second.get_value());
+            }
         }
     }
 }

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -456,6 +456,9 @@ static void CopyCommonProperties(Node* old_node, Node* new_node)
             }
         }
     }
+
+    // Copy all identical events that have handlers
+    new_node->copyEventsFrom(old_node);
 }
 
 ChangeNodeType::ChangeNodeType(Node* node, GenEnum::GenName new_node)

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -440,6 +440,22 @@ static void CopyCommonProperties(Node* old_node, Node* new_node)
     {
         new_node->set_value(prop_var_name, old_node->as_string(prop_var_name));
     }
+
+    if (old_node->isGen(gen_wxComboBox) && new_node->isGen(gen_wxChoice))
+    {
+        auto map_old_events = old_node->getMapEvents();
+        if (auto event = map_old_events.find("wxEVT_COMBOBOX"); event != map_old_events.end())
+        {
+            if (event->second.get_value().size())
+            {
+                auto* new_event = new_node->getEvent("wxEVT_CHOICE");
+                if (new_event)
+                {
+                    new_event->set_value(event->second.get_value());
+                }
+            }
+        }
+    }
 }
 
 ChangeNodeType::ChangeNodeType(Node* node, GenEnum::GenName new_node)

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -435,6 +435,11 @@ static void CopyCommonProperties(Node* old_node, Node* new_node)
             new_node->set_value(prop, old_node->as_string(prop));
         }
     }
+
+    if (old_node->hasProp(prop_var_name) && old_node->as_string(prop_class_access) != "none")
+    {
+        new_node->set_value(prop_var_name, old_node->as_string(prop_var_name));
+    }
 }
 
 ChangeNodeType::ChangeNodeType(Node* node, GenEnum::GenName new_node)


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR expands what gets copied when the context menu from the Navigation Panel is used to change one type of a widget to another. The new behavior will copy the var_name if the node has class access and all identical events will have any declared handlers copied.

A special case is made when converting a wxComboBox to a wxChoice -- in this case any handler declared for wxEVT_COMBOBOX will be copied as a handler for wxEVT_CHOICE.

These changes are related to #1447 -- this should make it easier to switch read-only wxComboBoxes to wxChoice without having to change any of the underlying code.