### PR TITLE
Switch to C sources for plutovg library

### DIFF
--- a/wxWidgets/CMakeLists.txt
+++ b/wxWidgets/CMakeLists.txt
@@ -189,8 +189,10 @@ target_include_directories(wxWidgets33 PRIVATE
     src/stc/scintilla/src
 
     3rdparty/lunasvg/include
-    3rdparty/lunasvg/source/plutovg
-    #  3rdparty/lunasvg/3rdparty/plutovg
+
+    # if using C++ plutovg sources, uncomment source/plutovg and comment 3rdparty/plutovg
+    # 3rdparty/lunasvg/source/plutovg
+    3rdparty/lunasvg/3rdparty/plutovg
 )
 
 target_include_directories(wxCLib PRIVATE
@@ -201,7 +203,9 @@ target_include_directories(wxCLib PRIVATE
     src/zlib
     3rdparty/pcre/src/wx
     src/expat/expat/lib
-    # 3rdparty/lunasvg/3rdparty/plutovg
+
+    # Comment the following line if using C++ plutovg sources
+    3rdparty/lunasvg/3rdparty/plutovg
 )
 
 if (BUILD_SHARED_LIBS)

--- a/wxWidgets/wxCLib.cmake
+++ b/wxWidgets/wxCLib.cmake
@@ -161,15 +161,15 @@ set (wxCLib_sources
 
     # plutovg used by lunasvg
     # Note that there is a non-official version of these as C++ code
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg-blend.c
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg-dash.c
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg-ft-math.c
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg-ft-raster.c
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg-ft-stroker.c
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg-geometry.c
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg-paint.c
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg-rle.c
-    # 3rdparty/lunasvg/3rdparty/plutovg/plutovg.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg-blend.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg-dash.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg-ft-math.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg-ft-raster.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg-ft-stroker.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg-geometry.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg-paint.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg-rle.c
+    3rdparty/lunasvg/3rdparty/plutovg/plutovg.c
 
     # wxBase
     src/common/extended.c

--- a/wxWidgets/wxWidgets.cmake
+++ b/wxWidgets/wxWidgets.cmake
@@ -644,15 +644,15 @@ set (common_sources
     # Using C++ also works but is not how the official build of lunasvg is done
     # If this is enabled, then the plutovg sources in wxCLib.cmake must be
     # disabled
-    3rdparty/lunasvg/source/plutovg/plutovg-blend.cpp
-    3rdparty/lunasvg/source/plutovg/plutovg-dash.cpp
-    3rdparty/lunasvg/source/plutovg/plutovg-ft-math.cpp
-    3rdparty/lunasvg/source/plutovg/plutovg-ft-raster.cpp
-    3rdparty/lunasvg/source/plutovg/plutovg-ft-stroker.cpp
-    3rdparty/lunasvg/source/plutovg/plutovg-geometry.cpp
-    3rdparty/lunasvg/source/plutovg/plutovg-paint.cpp
-    3rdparty/lunasvg/source/plutovg/plutovg-rle.cpp
-    3rdparty/lunasvg/source/plutovg/plutovg.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg-blend.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg-dash.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg-ft-math.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg-ft-raster.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg-ft-stroker.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg-geometry.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg-paint.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg-rle.cpp
+    # 3rdparty/lunasvg/source/plutovg/plutovg.cpp
 )
 
 set (msw_sources


### PR DESCRIPTION
See PR for description of why

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the wxWidgets portion of the build to use the C sources for plutovg (sub module for LunaSVG) instead of the C++ sources. This is done to match the way the LunaSVG sources will be integrated into the official wxWidgets 3.3 sources.

While I prefer the C++ sources, the PR with these sources submitted to the LunaSVG project was rejected. The reasoning is that while changes to the underlying plutovg library are rare (in fact, they may never change again), using C++ sources would complicate updating LunaSVG should plutovg ever change.

I can't justify the C++ sources when submitting the LunaSVG PR to wxWidgets, so it makes sense to use the C sources here as well.

Note to future self -- we may _have_ to use the C++ sources if we ever provide the option to the user to display SVG using NanoSVG instead of LunaSVG.