### PR TITLE
Fix event code generation in C++ derived class and Ruby inherit class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 ### Changed
 ### Fixed
+- Fixed generation of event handlers in C++ derived classes.
 
 ## [Released (1.2.1)]
 

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -530,7 +530,7 @@ void BaseCodeGenerator::CollectEventHandlers(Node* node, std::vector<NodeEvent*>
                 if (node->getParent()->isGen(gen_wxContextMenuEvent))
                     m_ctx_menu_events.push_back(&iter.second);
                 else
-                    m_events.push_back(&iter.second);
+                    events.push_back(&iter.second);
             }
         }
     }

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -9,14 +9,16 @@
 
     There are several situations we need to deal with here:
 
-    This could be a non-derived class (prop_use_derived_class is false) in which case the header file is empty, and we don't
-   use the derived class name or derived filename even if specified.
+    This could be a non-derived class (prop_use_derived_class is false) in which case the
+    header file is empty, and we don't use the derived class name or derived filename
+    even if specified.
 
-    This could be a derived class, but either the class name or the filename is empty. In that case, we can't write to disk,
-   but we can mockup a temporary class name if needed as well as a temporary filename.
+    This could be a derived class, but either the class name or the filename is empty. In
+    that case, we can't write to disk, but we can mockup a temporary class name if needed
+    as well as a temporary filename.
 
-    If we are trying to write to disk, we have to return result::exists if a non-derived class, result::ignored if filename
-   or classname is empty.
+    If we are trying to write to disk, we have to return result::exists if a non-derived
+    class, result::ignored if filename or classname is empty.
 
 */
 
@@ -378,22 +380,8 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
                     }
                 }
 
-                wxString prototype;
-
-                // If this is a button that closes a dialog, and the dialog is marked as persist, then event.Skip() must be
-                // called.
-                if (event->getEventInfo()->get_name().is_sameas("wxEVT_INIT_DIALOG") ||
-                    (close_type_button && m_form_node->as_bool(prop_persist)))
-                {
-                    // OnInitDialog needs to call event.Skip() in order to initialize validators and update the UI
-                    prototype.Format("%s(%s& event)", event_code.c_str(), event->getEventInfo()->get_event_class().c_str());
-                }
-                else
-                {
-                    prototype.Format("%s(%s& WXUNUSED(event))", event_code.c_str(),
-                                     event->getEventInfo()->get_event_class().c_str());
-                }
-                m_header->writeLine(tt_string("void ") << prototype.ToStdString() << " override;");
+                m_header->writeLine(tt_string("void ") << event_code << '(' << event->getEventInfo()->get_event_class()
+                                                       << "& event) override;");
 
                 if (panel_type != HDR_PANEL)
                 {
@@ -414,7 +402,8 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
                             continue;
                     }
                     m_source->writeLine();
-                    m_source->writeLine(tt_string() << "void " << derived_name << "::" << prototype.ToStdString());
+                    m_source->writeLine(tt_string() << "void " << derived_name << "::" << event_code << '('
+                                                    << event->getEventInfo()->get_event_class() << "& WXUNUSED(event))");
                     m_source->writeLine("{");
                     m_source->Indent();
                     auto name = event->getEventInfo()->get_name();

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -925,20 +925,9 @@ void BaseCodeGenerator::GenRubyEventHandlers(EventVector& events)
         m_source->writeLine(ruby_begin_cmt_block, indent::none);
         m_source->writeLine(undefined_handlers);
         m_source->writeLine(ruby_end_cmt_block, indent::none);
-    }
 
-    if (found_user_handlers)
-    {
-        m_header->writeLine("# Unimplemented Event handler functions");
-    }
-    else
-    {
         m_header->writeLine("# Event handler functions");
+        m_header->writeLine(undefined_handlers);
     }
-    m_header->writeLine(code);
-
-    if (!inherited_class)
-    {
-        m_header->Unindent();
-    }
+    m_header->Unindent();
 }

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -582,7 +582,7 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
     tt_string inherit_name = m_form_node->as_string(prop_ruby_inherit_name);
     if (inherit_name.empty())
     {
-        inherit_name += " < " + m_form_node->as_string(prop_class_name);
+        inherit_name += "Sample < " + m_form_node->as_string(prop_class_name);
     }
     if (inherit_name.size())
     {
@@ -680,6 +680,8 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
         m_source->ResetIndent();
         m_source->writeLine("\tend", indent::none);
     }
+    m_header->ResetIndent();
+    m_header->writeLine("end", indent::none);
 
     thrd_need_img_func.join();
 

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -368,7 +368,6 @@ private:
     DocViewPanel* m_docviewPanel { nullptr };
 
     BasePanel* m_cppPanel { nullptr };
-    BasePanel* m_derivedPanel { nullptr };
 
     // Language panels
     BasePanel* m_pythonPanel { nullptr };

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -462,4 +462,9 @@ void BasePanel::SetCodeFont(const wxFont& font)
 {
     m_cppPanel->SetCodeFont(font);
     m_hPanel->SetCodeFont(font);
+    if (m_panel_type == GEN_LANG_CPLUSPLUS)
+    {
+        m_derived_src_panel->SetCodeFont(font);
+        m_derived_hdr_panel->SetCodeFont(font);
+    }
 }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes code generation of event handlers in a derived class. For the header file, it generates `override` declarations, and in the source file, empty handlers with a `// TODO: Implement handler` comment. It used to do this, and I'm not sure when it got broken.

This also fixes the font in the two derived panels when the dev sets font preferences for all the display panels. Previously you had to exit and rerun wxUiEditor for the font change to show up.

This adds generation of event handlers to the `inherit` tab in the Ruby panel, along with adding a `Sample` class name since we don't currently provide the user with a way to set the inherited class name.

Closes #1458 -- but see #1459 for Ruby inherit code generation that is still needed.
