### PR TITLE
Change how filename properties are edited in the property grid panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 - Fixed generation of event handlers in C++ derived classes.
+- Fixed inability to hand-edit the location of a generated file
 
 ## [Released (1.2.1)]
 

--- a/src/customprops/tt_file_property.cpp
+++ b/src/customprops/tt_file_property.cpp
@@ -1,0 +1,227 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Version of wxFileProperty specific to wxUiEditor
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2024 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include <wx/filedlg.h>
+
+#include "node_prop.h"        // for wxNodeProperty
+#include "project_handler.h"  // ProjectHandler class
+
+#include "tt_file_property.h"
+
+wxPG_IMPLEMENT_PROPERTY_CLASS(ttFileProperty, wxEditorDialogProperty, TextCtrlAndButton);
+
+ttFileProperty::ttFileProperty(NodeProperty* prop) : wxEditorDialogProperty(prop->declName().make_wxString(), wxPG_LABEL)
+{
+    m_prop = prop;
+    SetValue(prop->value().make_wxString());
+}
+
+ttFileProperty::ttFileProperty(const wxString& label, const wxString& name, const wxString& value) :
+    wxEditorDialogProperty(label, name)
+{
+    ASSERT_MSG(false, "This constructor should not be called -- m_prop will not be set!");
+    SetValue(value);
+}
+
+bool ttFileProperty::DisplayEditorDialog(wxPropertyGrid* pg, wxVariant& value)
+{
+    tt_string root_path;
+    wxString wildcard;
+    wxString title;
+    auto* form = m_prop->getNode()->getForm();
+    auto* folder = form ? form->getFolder() : static_cast<Node*>(nullptr);  // this will usually be a nullptr
+
+    switch (m_prop->get_name())
+    {
+        case prop_base_file:
+            if (folder && folder->hasValue(prop_folder_base_directory))
+                root_path = folder->as_string(prop_folder_base_directory);
+            else if (Project.getProjectNode()->hasValue(prop_base_directory))
+                root_path = Project.getProjectNode()->as_string(prop_base_directory);
+            else
+                root_path = Project.getProjectPath();
+            title = "Base class filename";
+            wildcard = "C++ Files|*.cpp;*.cc;*.cxx";
+            break;
+
+        case prop_derived_file:
+
+            if (folder && folder->hasValue(prop_folder_derived_directory))
+                root_path = folder->as_string(prop_folder_derived_directory);
+            else if (Project.getProjectNode()->hasValue(prop_derived_directory))
+                root_path = Project.getProjectNode()->as_string(prop_derived_directory);
+            else
+                root_path = Project.getProjectPath();
+            title = "Derived class filename";
+            wildcard = "C++ Files|*.cpp;*.cc;*.cxx";
+            break;
+
+        case prop_xrc_file:
+        case prop_combined_xrc_file:
+        case prop_folder_combined_xrc_file:
+            if (folder && folder->hasValue(prop_folder_xrc_directory))
+                root_path = folder->as_string(prop_folder_xrc_directory);
+            else if (Project.getProjectNode()->hasValue(prop_xrc_directory))
+                root_path = Project.getProjectNode()->as_string(prop_xrc_directory);
+            else
+                root_path = Project.getProjectPath();
+            title = "XRC filename";
+            wildcard = "XRC Files|*.xrc";
+            break;
+
+        case prop_python_file:
+        case prop_python_combined_file:
+
+            if (folder && folder->hasValue(prop_folder_python_output_folder))
+                root_path = folder->as_string(prop_folder_python_output_folder);
+            else if (Project.getProjectNode()->hasValue(prop_python_output_folder))
+                root_path = Project.getProjectNode()->as_string(prop_python_output_folder);
+            else
+                root_path = Project.getProjectPath();
+            title = "Python filename";
+            wildcard = "Python Files|*.py";
+            break;
+
+        case prop_ruby_file:
+        case prop_ruby_combined_file:
+
+            if (folder && folder->hasValue(prop_folder_ruby_output_folder))
+                root_path = folder->as_string(prop_folder_ruby_output_folder);
+            else if (Project.getProjectNode()->hasValue(prop_ruby_output_folder))
+                root_path = Project.getProjectNode()->as_string(prop_ruby_output_folder);
+            else
+                root_path = Project.getProjectPath();
+            title = "Ruby filename";
+            wildcard = "Ruby Files|*.rb;*.rbw";
+            break;
+
+        case prop_cmake_file:
+        case prop_folder_cmake_file:
+            root_path = Project.getProjectPath();
+            title = "CMake filename";
+            wildcard = "CMake Files|*.cmake";
+            break;
+
+        // Currently this is for a wxFrame window
+        case prop_derived_header:
+            root_path = Project.getProjectPath();
+            title = "Derived Header";
+            wildcard = "Header Files|*.h;*.hh;*.hpp;*.hxx";
+            break;
+
+        case prop_output_file:
+            root_path = Project.getProjectPath();
+            title = "Data output filename";
+            wildcard = "C++ Files|*.cpp;*.cc;*.cxx";
+            break;
+
+        case prop_data_file:
+            if (m_prop->as_string().size())
+            {
+                root_path = m_prop->as_string();
+                root_path.remove_filename();
+            }
+            else
+            {
+                auto result = Project.GetOutputPath(m_prop->getNode()->getForm(), GEN_LANG_CPLUSPLUS);
+                root_path = result.first;
+                if (result.second)  // true if the the base filename was returned
+                    root_path.remove_filename();
+            }
+            if (m_prop->getNode()->isGen(gen_data_xml))
+            {
+                title = "XML file";
+                wildcard = "XML/XRC Files|*.xml;*.xrc";
+            }
+            else
+            {
+                title = "Data file";
+                wildcard = "Files|*.*";
+            }
+            break;
+
+        default:
+            FAIL_MSG(tt_string() << "Unknown property type: " << m_prop->declName().substr());
+            break;
+
+    }  // switch (m_prop->get_name())
+
+    tt_string full_path = root_path;
+    auto cur_path = value.GetString().utf8_string();
+    if (cur_path.starts_with("./"))
+    {
+        full_path = cur_path;
+    }
+    else
+    {
+        full_path.append_filename(cur_path);
+    }
+    full_path.make_absolute();
+    wxString filename = full_path.filename().make_wxString();
+    full_path.remove_filename();
+    wxFileDialog dlg(pg->GetPanel(), title, full_path.make_wxString(), filename, wildcard, wxFD_SAVE);
+    if (dlg.ShowModal() == wxID_OK)
+    {
+        full_path = dlg.GetPath().utf8_string();
+        // Note that no matter whether the filename is in one of the base or output directories, we
+        // always make it relative to the project path.
+        full_path.make_relative(Project.getProjectPath());
+        full_path.backslashestoforward();
+        if (!full_path.contains("/"))
+            full_path = "./" + full_path;
+        value = full_path.make_wxString();
+        return true;
+    }
+    return false;
+}
+
+wxString ttFileProperty::ValueToString(wxVariant& value, wxPGPropValFormatFlags WXUNUSED(flags)) const
+{
+    auto result = value.GetString();
+    return value.GetString();
+}
+
+bool ttFileProperty::StringToValue(wxVariant& variant, const wxString& text, wxPGPropValFormatFlags WXUNUSED(flags)) const
+{
+    if (auto filename = variant.GetString(); filename != text)
+    {
+        variant = text;
+        return true;
+    }
+
+    return false;
+}
+
+void ttFileProperty::OnSetValue() {}
+
+bool ttFileProperty::DoSetAttribute(const wxString& name, wxVariant& value)
+{
+    if (name == wxPG_FILE_INITIAL_PATH || name == wxPG_FILE_SHOW_RELATIVE_PATH)
+    {
+        return true;
+    }
+    return wxEditorDialogProperty::DoSetAttribute(name, value);
+}
+
+wxValidator* ttFileProperty::GetClassValidator()
+{
+    static wxValidator* pValidator = nullptr;
+    if (pValidator)
+        return pValidator;
+
+    pValidator = new wxTextValidator(wxFILTER_EXCLUDE_CHAR_LIST);
+
+    wxStaticCast(pValidator, wxTextValidator)->SetCharExcludes(wxString("?*|<>\""));
+
+    wxPGGlobalVars->m_arrValidators.push_back(pValidator);
+    return pValidator;
+}
+
+wxValidator* ttFileProperty::DoGetValidator() const
+{
+    return GetClassValidator();
+}

--- a/src/customprops/tt_file_property.h
+++ b/src/customprops/tt_file_property.h
@@ -1,0 +1,40 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Version of wxFileProperty specific to wxUiEditor
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2024 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <wx/propgrid/propgrid.h>  // for wxEditorDialogProperty
+
+class NodeProperty;
+
+class ttFileProperty : public wxEditorDialogProperty
+{
+    WX_PG_DECLARE_PROPERTY_CLASS(ttFileProperty)
+
+public:
+    ttFileProperty(NodeProperty* prop);
+    ttFileProperty(const wxString& label = wxPG_LABEL, const wxString& name = wxPG_LABEL,
+                   const wxString& value = wxString());
+
+    ~ttFileProperty() = default;
+
+    void OnSetValue() override;
+    wxString ValueToString(wxVariant& value, wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
+    bool StringToValue(wxVariant& variant, const wxString& text,
+                       wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
+
+    bool DoSetAttribute(const wxString& name, wxVariant& value) override;
+
+    static wxValidator* GetClassValidator();
+    virtual wxValidator* DoGetValidator() const override;
+
+protected:
+    bool DisplayEditorDialog(wxPropertyGrid* pg, wxVariant& value) override;
+
+private:
+    NodeProperty* m_prop;
+};

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -50,6 +50,8 @@ set (file_list
     customprops/font_prop_dlg.cpp       # Dialog for editing Font Property
     customprops/img_props.cpp           # Handles property grid image properties
 
+    customprops/tt_file_property.cpp    # Version of wxFileProperty specific to wxUiEditor
+
     customprops/pg_image.cpp            # Custom property grid class for images
     customprops/pg_animation.cpp        # Custom property grid class for animations
     customprops/pg_point.cpp            # Custom wxPGProperty for wxPoint


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR replace most of the instances of `wxFileProperty` with a new custom equivalent (`ttFileProperty`). The new version does a much better job of displaying a relative path, as well as supporting editing the text edit field directly, and using the correct directory when requesting a File dialog.

While I was at it I also refactored the `CreatePGProperty` function in propgrid_panel.cpp to use switch statements instead of multiple if-else statements. This doesn't directly change any functionality -- it's just to make the code easier to read.

Closes #1462