### PR TITLE
Prevent crash if not file specified

### DIFF
--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -1277,12 +1277,20 @@ void ImageHandler::GetPropertyAnimation(const tt_string& description, wxAnimatio
 
     if (parts.size() <= IndexImage || parts[IndexImage].empty())
     {
-        // return GetAnimFromHdr(wxue_img::pulsing_unknown_gif, sizeof(wxue_img::pulsing_unknown_gif));
+        wxMemoryInputStream stream(wxue_img::pulsing_unknown_gif, sizeof(wxue_img::pulsing_unknown_gif));
+        p_animation->Load(stream);
+        return;
     }
 
     tt_string path = parts[IndexImage];
     if (!path.file_exists())
     {
+        if (path == Project.as_string(prop_art_directory))
+        {
+            wxMemoryInputStream stream(wxue_img::pulsing_unknown_gif, sizeof(wxue_img::pulsing_unknown_gif));
+            p_animation->Load(stream);
+            return;
+        }
         path = Project.as_string(prop_art_directory);
         path.append_filename(parts[IndexImage]);
     }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a crash when `GetPropertyAnimation()` is called on an animation control that doesn't have a filename specified. The crash occurred after the refactoring work in #1476.