### PR TITLE
Change Import CWD on Unix/Mac

### DIFF
--- a/src/ui/import_dlg.cpp
+++ b/src/ui/import_dlg.cpp
@@ -38,9 +38,16 @@ void ImportDlg::OnInitDialog(wxInitDialogEvent& WXUNUSED(event))
     m_stdBtn->GetAffirmativeButton()->Disable();
     m_radio_wxFormBuilder->SetFocus();
 
+#if !defined(__WINDOWS__)
+    // Setup will typically set the cwd to /home/.../Desktop -- there won't be any projects here, so change it to the
+    // standard Unix home directory.
+    wxFileName::SetCwd(wxGetHomeDir());
+    m_static_cwd->SetLabel(wxFileName::GetCwd());
+#else
     tt_string cwd;
     cwd.assignCwd();
     m_static_cwd->SetLabel(cwd.make_wxString());
+#endif
 
     auto config = wxConfig::Get();
     config->SetPath("/preferences");


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes `ImportDlg` so that on non-Windows platforms, the default directory is set to `wxGetHomeDir()`. This is the most likely location for projects to exist, and will hopefully fix the hang reported in #1477 (I can't confirm until a package build is created and installed).