### PR TITLE
Change ImportDLG initial Directory

### DIFF
--- a/src/wxui/import_base.cpp
+++ b/src/wxui/import_base.cpp
@@ -67,10 +67,10 @@ bool ImportBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     m_btnAddFile = new wxButton(m_import_staticbox->GetStaticBox(), wxID_ANY, "&Directory...");
     m_btnAddFile->SetToolTip("You can add multiple formbuilder projects to a single wxUiEdtior project.");
-    box_sizer6->Add(m_btnAddFile, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
+    box_sizer6->Add(m_btnAddFile, wxSizerFlags().Center().Border(wxALL));
 
-    m_static_cwd = new wxStaticText(m_import_staticbox->GetStaticBox(), wxID_ANY, "...", wxDefaultPosition, wxDefaultSize,
-        wxST_ELLIPSIZE_MIDDLE);
+    m_static_cwd = new wxStaticText(m_import_staticbox->GetStaticBox(), wxID_ANY, "Set directory to list project files",
+        wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_MIDDLE);
     box_sizer6->Add(m_static_cwd, wxSizerFlags(1).Center().Border(wxALL));
 
     m_import_staticbox->Add(box_sizer6, wxSizerFlags().Expand().Border(wxALL));

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -5440,11 +5440,10 @@
               var_name="m_btnAddFile"
               tooltip="You can add multiple formbuilder projects to a single wxUiEdtior project."
               alignment="wxALIGN_CENTER_VERTICAL"
-              borders="wxTOP|wxRIGHT|wxLEFT"
               wxEVT_BUTTON="OnDirectory" />
             <node
               class="wxStaticText"
-              label="..."
+              label="Set directory to list project files"
               style="wxST_ELLIPSIZE_MIDDLE"
               var_name="m_static_cwd"
               alignment="wxALIGN_CENTER_VERTICAL"


### PR DESCRIPTION
See PR for explanation

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the Import Project dialog. It now requires the user to choose a directory before it lists the available projects. This solves the hang caused when wxUiEditor was run on Ubuntu 22.04 (and probably other Linux distros as well). See #1477 for more details.

Note that Internal and Debug versions will set the directory and list current projects after at least one project file has been opened.