### PR TITLE
Add additional support for missing sizers when importing

### DIFF
--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -1294,7 +1294,7 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
                 return CreateXrcNode(xml_obj, page.get(), sizeritem);
             }
         }
-        else if (parent && parent->isGen(gen_wxPanel))
+        else if (parent && (parent->isGen(gen_wxPanel) || parent->isGen(gen_PanelForm) || parent->isGen(gen_wxDialog)))
         {
             auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, parent);
             if (sizer)


### PR DESCRIPTION
There was already code that automatically adds a sizer to wxPanel for controls that don't have sizer parents. This commit extends that to include the form version of wxPanel as well as wxDialog.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR extends the special case when importing a project that does not have a sizer between a form and it's top level children. Previously, only the non-form version of wxPanel did this. It's now extended to the form version of wxPanel and wxDialog.

Note that while technically the sizer isn't needed, the Mockup panel as well as code generation fails without the expected sizer. So technically, this doesn't match the original intent, but it does allow the controls to be imported.

See issue #1478 for details of the problem.