### PR TITLE
Add Reload Project menu command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- File menu now has a Reload Project command to reload the current project file from disk.
+
 ### Changed
 
 - Generic option removed for wxAnimationCtrl. The generic version is automatically generated when a ANI animation file is specified. This will correctly display the file on wxGTK when generating C++ and wxPthon code. wxRuby3 does not support Wx::GenericAnimationCtrl in version 1.0, so only the regular version is generated.

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -740,6 +740,7 @@ void MainFrame::OnImportProject(wxCommandEvent&)
     Project.NewProject();
 }
 
+
 wxBitmapBundle wxueBundleSVG(const unsigned char* data, size_t size_data, size_t size_svg, wxSize def_size);
 
 #if defined(_DEBUG)
@@ -2213,5 +2214,15 @@ void MainFrame::OnDifferentProject(wxCommandEvent& WXUNUSED(event))
                 }
                 break;
         }
+    }
+}
+
+void MainFrame::OnReloadProject(wxCommandEvent& WXUNUSED(event))
+{
+    if (wxMessageBox(wxString() << "This will lose any changes you have made since the last save.\n\n"
+                         "Are you sure you want to reload the project?",
+                     "Reload Project", wxICON_WARNING | wxYES_NO) == wxYES)
+    {
+        Project.LoadProject(Project.getProjectFile());
     }
 }

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -740,7 +740,6 @@ void MainFrame::OnImportProject(wxCommandEvent&)
     Project.NewProject();
 }
 
-
 wxBitmapBundle wxueBundleSVG(const unsigned char* data, size_t size_data, size_t size_svg, wxSize def_size);
 
 #if defined(_DEBUG)
@@ -2220,7 +2219,7 @@ void MainFrame::OnDifferentProject(wxCommandEvent& WXUNUSED(event))
 void MainFrame::OnReloadProject(wxCommandEvent& WXUNUSED(event))
 {
     if (wxMessageBox(wxString() << "This will lose any changes you have made since the last save.\n\n"
-                         "Are you sure you want to reload the project?",
+                                   "Are you sure you want to reload the project?",
                      "Reload Project", wxICON_WARNING | wxYES_NO) == wxYES)
     {
         Project.LoadProject(Project.getProjectFile());

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -297,6 +297,7 @@ protected:
     void OnOpenRecentProject(wxCommandEvent& event);
     void OnPaste(wxCommandEvent& event) override;
     void OnPreferencesDlg(wxCommandEvent& event) override;
+    void OnReloadProject(wxCommandEvent& event) override;
     void OnSaveAsProject(wxCommandEvent& event) override;
     void OnToggleExpandLayout(wxCommandEvent&) override;
     void OnUpdateBrowseDocs(wxUpdateUIEvent& event) override;

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -178,6 +178,9 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     auto* menu_import = new wxMenuItem(m_menuFile, wxID_ANY, "&Import Project...");
     menu_import->SetBitmap(wxue_img::bundle_import_svg(16, 16));
     m_menuFile->Append(menu_import);
+    auto* menu_item3 = new wxMenuItem(m_menuFile, wxID_ANY, "Reload Project...",
+        "Reload current project from disk, losing any current changes", wxITEM_NORMAL);
+    m_menuFile->Append(menu_item3);
     m_menuFile->AppendSeparator();
     auto* menu_item = new wxMenuItem(m_menuFile, wxID_SAVE, "&Save\tCtrl+S", "Save current project", wxITEM_NORMAL);
     menu_item->SetBitmap(wxueBundleSVG(wxue_img::save_svg, 1064, 2928, wxSize(16, 16)));
@@ -414,6 +417,7 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
     Bind(wxEVT_MENU, &MainFrameBase::OnPaste, this, wxID_PASTE);
     Bind(wxEVT_MENU, &MainFrameBase::OnPreferencesDlg, this, id_PreferencesDlg);
     Bind(wxEVT_MENU, &MainFrameBase::OnPreviewXrc, this, id_PreviewForm);
+    Bind(wxEVT_MENU, &MainFrameBase::OnReloadProject, this, menu_item3->GetId());
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveAsProject, this, id_SaveProjectAs);
     Bind(wxEVT_MENU, &MainFrameBase::OnSaveProject, this, wxID_SAVE);
     Bind(wxEVT_MENU, &MainFrameBase::OnToggleExpandLayout, this, id_Expand);

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -114,6 +114,7 @@ protected:
     virtual void OnPaste(wxCommandEvent& event) { event.Skip(); }
     virtual void OnPreferencesDlg(wxCommandEvent& event) { event.Skip(); }
     virtual void OnPreviewXrc(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnReloadProject(wxCommandEvent& event) { event.Skip(); }
     virtual void OnSaveAsProject(wxCommandEvent& event) { event.Skip(); }
     virtual void OnSaveProject(wxCommandEvent& event) { event.Skip(); }
     virtual void OnToggleExpandLayout(wxCommandEvent& event) { event.Skip(); }

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -859,6 +859,12 @@
               var_name="menu_import"
               wxEVT_MENU="[](wxCommandEvent&amp;)@@{@@// Specifying false tells NewProject to import@@Project.NewProject(false);@@}" />
             <node
+              class="wxMenuItem"
+              help="Reload current project from disk, losing any current changes"
+              label="Reload Project..."
+              var_name="menu_item3"
+              wxEVT_MENU="OnReloadProject" />
+            <node
               class="separator" />
             <node
               class="wxMenuItem"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a Reload Project command to the File menu.

This is primarily valuable for testing, but could be useful for users as well. The command asks for confirmation to lose all unsaved changes, and if the user chooses Yes, it will reload the current project from disk.