### PR TITLE
Fix Daily Release build

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -18,19 +18,17 @@ jobs:
     - run: mkdir ${{github.workspace}}/build
 
     - name: Configure CMake
-      # run: cmake -G "Visual Studio 17 2022" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-      run: cmake -G "Visual Studio 17 2022" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      run: cmake -G "Visual Studio 17 2022" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build wxUiEditor
-      # run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target wxUiEditor
-      run: cmake --build ${{github.workspace}}/build --config RelWithDebInfo --target wxUiEditor
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target wxUiEditor
 
     - name: Create Windows Artifact
       uses: actions/upload-artifact@v4
       with:
         name: WindowsExecutable
         path: |
-          build/bin/RelWithDebInfo/wxUiEditor.exe
+          build/bin/Release/wxUiEditor.exe
 
 
   buildUnix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,12 +259,10 @@ else()
 endif()
 
 if (MSVC)
-    # /GL -- combined with the Linker flag /LTCG to perform whole program optimization in Release build
     # /FC -- Full path to source code file in diagnostics
-    target_compile_options(wxUiEditor PRIVATE "$<$<CONFIG:Release>:/GL>" "/FC" "/W4" "/Zc:__cplusplus" "/utf-8")
-    target_compile_options(check_build PRIVATE "$<$<CONFIG:Release>:/GL>" "/FC" "/W4" "/Zc:__cplusplus" "/utf-8")
+    target_compile_options(wxUiEditor PRIVATE "/FC" "/W4" "/Zc:__cplusplus" "/utf-8")
+    target_compile_options(check_build PRIVATE "/FC" "/W4" "/Zc:__cplusplus" "/utf-8")
 
-    target_link_options(wxUiEditor PRIVATE "$<$<CONFIG:Release>:/LTCG>")
     target_link_options(wxUiEditor PRIVATE "$<$<CONFIG:Debug>:/OPT:REF>")
 
     # Assume the manifest is in the resource file


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes global optimization from MSVC builds to prevent a hang or crash in wxUiEditor. Fixes #1483.

I have little or no control over specific versions of MSVC (only the major versions), and apparently the one currently being used by github actions has a bug in global optimization that in the case of wxUiEditor causes it to either hang or crash. Removing the global optimization seems to resolve the problem.
