### PR TITLE
Additional changes to support high dpi

### DIFF
--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -60,6 +60,7 @@ CustomPointProperty::CustomPointProperty(const wxString& label, NodeProperty* pr
     if (type != CustomPointProperty::type_SVG)
     {
         AddPrivateChild(new wxBoolProperty("support high dpi", wxPG_LABEL, m_dpi_scaling));
+        AddPrivateChild(new CustomBoolProperty("high dpi support", wxPG_LABEL, m_dpi_scaling));
         Item(2)->SetHelpString("When checked, values will be scaled on high DPI displays.");
     }
 #endif

--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -54,7 +54,8 @@ CustomPointProperty::CustomPointProperty(const wxString& label, NodeProperty* pr
     if (type != CustomPointProperty::type_SVG)
     {
         AddPrivateChild(new CustomBoolProperty("high dpi support", wxPG_LABEL, m_dpi_scaling));
-        Item(2)->SetHelpString("When checked, values will be scaled on high DPI displays.");
+        Item(2)->SetHelpString("When checked, values will be scaled on high DPI displays. Requires wxWidgets 3.2 or later, "
+                               "ignored on wxWidgets 3.1.");
     }
 }
 
@@ -90,11 +91,9 @@ wxVariant CustomPointProperty::ChildChanged(wxVariant& /* thisValue */, int chil
             point.y = childValue.GetLong();
             break;
 
-#if NO_SCALING_OPTION
         case 2:
             dpi_scaling = childValue.GetBool();
             break;
-#endif
     }
 
     value.clear();

--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -22,7 +22,8 @@ CustomPointProperty::CustomPointProperty(const wxString& label, NodeProperty* pr
 {
     m_prop_type = type;
 
-    if (type == CustomPointProperty::type_SVG && prop->hasValue() && prop->as_string().contains("["))
+    if ((type == CustomPointProperty::type_SVG || type == CustomPointProperty::type_ART) && prop->hasValue() &&
+        prop->as_string().contains("["))
     {
         tt_string value(prop->as_string().substr(prop->as_string().find('[') + 1));
         if (value.back() == ']')
@@ -51,7 +52,8 @@ CustomPointProperty::CustomPointProperty(const wxString& label, NodeProperty* pr
 
     // Starting with wxUiEditor 1.2.9.0, scaling information should never be stored in the property
     // itself as all scaling is done automatically.
-    if (type != CustomPointProperty::type_SVG)
+    if (type != CustomPointProperty::type_SVG && type != CustomPointProperty::type_ART &&
+        type != CustomPointProperty::type_BITMAP)
     {
         AddPrivateChild(new CustomBoolProperty("high dpi support", wxPG_LABEL, m_dpi_scaling));
         Item(2)->SetHelpString("When checked, values will be scaled on high DPI displays. Requires wxWidgets 3.2 or later, "
@@ -67,7 +69,7 @@ void CustomPointProperty::RefreshChildren()
         InitValues(value.utf8_string());
         Item(0)->SetValue(m_point.x);
         Item(1)->SetValue(m_point.y);
-        if (m_prop_type != type_SVG)
+        if (m_prop_type != type_SVG && m_prop_type != type_ART && m_prop_type != type_BITMAP)
             Item(2)->SetValue(m_dpi_scaling);
     }
 }
@@ -98,7 +100,7 @@ wxVariant CustomPointProperty::ChildChanged(wxVariant& /* thisValue */, int chil
 
     value.clear();
     value << point.x << ',' << point.y;
-    if (!dpi_scaling)
+    if (!dpi_scaling && m_prop_type != type_SVG && m_prop_type != type_ART && m_prop_type != type_BITMAP)
         value << 'n';
 
     return value;
@@ -153,7 +155,7 @@ tt_string CustomPointProperty::CombineValues()
 {
     tt_string value;
     value << m_point.x << ',' << m_point.y;
-    if (!m_dpi_scaling)
+    if (!m_dpi_scaling && m_prop_type != type_SVG && m_prop_type != type_ART && m_prop_type != type_BITMAP)
         value << 'n';
     return value;
 }

--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -31,6 +31,22 @@ CustomPointProperty::CustomPointProperty(const wxString& label, NodeProperty* pr
         m_value = value;
         InitValues(value);
     }
+    else if (type == CustomPointProperty::type_BITMAP && prop->hasValue())
+    {
+        tt_view_vector parts;
+        parts.SetString(prop->as_string(), ';');
+        if (parts.size() > IndexImage)
+        {
+            auto embed = ProjectImages.GetEmbeddedImage(parts[IndexImage]);
+            if (embed)
+            {
+                m_org_size.x = embed->size.x;
+                m_org_size.y = embed->size.y;
+            }
+        }
+        m_value = prop->as_wxString();
+        InitValues(prop->as_string());
+    }
     else
     {
         m_value = prop->as_wxString();
@@ -121,7 +137,14 @@ void CustomPointProperty::InitValues(tt_string_view value)
         else
             parts.SetString(value, ',');
 
-        if (parts.size() < 2 || m_prop_type == type_BITMAP)
+        if (m_prop_type == type_BITMAP)
+        {
+            m_point.x = m_org_size.x;
+            m_point.y = m_org_size.y;
+            return;
+        }
+
+        if (parts.size() < 2)
         {
             m_point.x = -1;
             m_point.y = -1;

--- a/src/customprops/pg_point.h
+++ b/src/customprops/pg_point.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <wx/propgrid/property.h>
+#include <wx/propgrid/props.h>
 
 class NodeProperty;
 
@@ -39,4 +40,16 @@ private:
     wxPoint m_point { wxDefaultPosition };
     bool m_dpi_scaling { true };
     DataType m_prop_type;
+};
+
+// Custom version that uses "No " instead of "Not " as the prefix if the value is false
+class CustomBoolProperty : public wxBoolProperty
+{
+public:
+    CustomBoolProperty(const wxString& label = wxPG_LABEL, const wxString& name = wxPG_LABEL, bool value = false) :
+        wxBoolProperty(label, name, value)
+    {
+    }
+
+    wxString ValueToString(wxVariant& value, wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
 };

--- a/src/customprops/pg_point.h
+++ b/src/customprops/pg_point.h
@@ -38,6 +38,7 @@ public:
 
 private:
     wxPoint m_point { wxDefaultPosition };
+    wxSize m_org_size { wxDefaultSize };  // original size of an embedded image
     bool m_dpi_scaling { true };
     DataType m_prop_type;
 };

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1508,7 +1508,7 @@ Code& Code::Style(const char* prefix, tt_string_view force_style)
     return *this;
 }
 
-Code& Code::PosSizeFlags(int enable_dpi_scaling, bool uses_def_validator, tt_string_view def_style)
+Code& Code::PosSizeFlags(ScalingType enable_dpi_scaling, bool uses_def_validator, tt_string_view def_style)
 {
     auto pos_scaling = is_ScalingEnabled(prop_pos, enable_dpi_scaling);
     auto size_scaling = is_ScalingEnabled(prop_size, enable_dpi_scaling);

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1228,6 +1228,7 @@ Code& Code::WxSize(GenEnum::PropName prop_name, int enable_dpi_scaling)
 {
     auto cur_pos = size();
     auto size = m_node->as_wxSize(prop_name);
+    auto size_scaling = is_ScalingEnabled(prop_size, enable_dpi_scaling);
 
     if (is_ruby())
     {
@@ -1238,7 +1239,7 @@ Code& Code::WxSize(GenEnum::PropName prop_name, int enable_dpi_scaling)
             return *this;
         }
 
-        if (enable_dpi_scaling == force_scaling || (enable_dpi_scaling == conditional_scaling && !m_node->isForm()))
+        if (size_scaling)
         {
             CheckLineLength(sizeof(", from_DIP(Wx::Size.new(999, 999))"));
         }
@@ -1247,11 +1248,16 @@ Code& Code::WxSize(GenEnum::PropName prop_name, int enable_dpi_scaling)
             CheckLineLength(sizeof("Wx::Size.new(999, 999)"));
         }
 
-        if (enable_dpi_scaling == force_scaling || (enable_dpi_scaling == conditional_scaling && !m_node->isForm()))
+        if (size_scaling)
+        {
             FormFunction("FromDIP(");
-        Class("Wx::Size.new(").itoa(size.x).Comma().itoa(size.y) << ')';
-        if (enable_dpi_scaling == force_scaling || (enable_dpi_scaling == conditional_scaling && !m_node->isForm()))
+            Class("Wx::Size.new(").itoa(size.x).Comma().itoa(size.y) << ')';
             *this += ')';
+        }
+        else
+        {
+            Class("Wx::Size.new(").itoa(size.x).Comma().itoa(size.y) << ')';
+        }
 
         if (m_auto_break && this->size() > m_break_at)
         {
@@ -1270,7 +1276,7 @@ Code& Code::WxSize(GenEnum::PropName prop_name, int enable_dpi_scaling)
         return *this;
     }
 
-    if (enable_dpi_scaling == force_scaling || (enable_dpi_scaling == conditional_scaling && !m_node->isForm()))
+    if (size_scaling)
     {
         if (is_cpp())
         {
@@ -1313,6 +1319,8 @@ Code& Code::Pos(GenEnum::PropName prop_name, int enable_dpi_scaling)
 {
     auto cur_pos = size();
     auto point = m_node->as_wxPoint(prop_name);
+    auto pos_scaling = is_ScalingEnabled(prop_pos, enable_dpi_scaling);
+
     if (m_node->as_string(prop_name).contains("d", tt::CASE::either))
     {
         FAIL_MSG("Pos() should not be used with a string that contains 'd'");
@@ -1328,7 +1336,7 @@ Code& Code::Pos(GenEnum::PropName prop_name, int enable_dpi_scaling)
             return *this;
         }
 
-        if (enable_dpi_scaling == force_scaling || (enable_dpi_scaling == conditional_scaling && !m_node->isForm()))
+        if (pos_scaling)
         {
             CheckLineLength(sizeof(", from_DIP(Wx::Point.new(999, 999))"));
             FormFunction("FromDIP(");
@@ -1358,7 +1366,7 @@ Code& Code::Pos(GenEnum::PropName prop_name, int enable_dpi_scaling)
         return *this;
     }
 
-    if (enable_dpi_scaling == force_scaling || (enable_dpi_scaling == conditional_scaling && !m_node->isForm()))
+    if (pos_scaling)
     {
         if (is_cpp())
         {
@@ -1502,11 +1510,14 @@ Code& Code::Style(const char* prefix, tt_string_view force_style)
 
 Code& Code::PosSizeFlags(int enable_dpi_scaling, bool uses_def_validator, tt_string_view def_style)
 {
+    auto pos_scaling = is_ScalingEnabled(prop_pos, enable_dpi_scaling);
+    auto size_scaling = is_ScalingEnabled(prop_size, enable_dpi_scaling);
+
     if (m_node->hasValue(prop_window_name))
     {
         // Window name is always the last parameter, so if it is specified, everything has to be generated.
         Comma();
-        Pos(prop_pos, enable_dpi_scaling).Comma().WxSize(prop_size, enable_dpi_scaling).Comma();
+        Pos(prop_pos, pos_scaling).Comma().WxSize(prop_size, size_scaling).Comma();
         Style();
         if (uses_def_validator)
             Comma().Add("wxDefaultValidator");
@@ -1537,7 +1548,7 @@ Code& Code::PosSizeFlags(int enable_dpi_scaling, bool uses_def_validator, tt_str
     if (style_needed)
     {
         Comma();
-        Pos(prop_pos, enable_dpi_scaling).Comma().WxSize(prop_size, enable_dpi_scaling).Comma().Style();
+        Pos(prop_pos, pos_scaling).Comma().WxSize(prop_size, size_scaling).Comma().Style();
         if (def_style.size() && ends_with(def_style))
         {
             erase(size() - def_style.size());
@@ -1548,12 +1559,12 @@ Code& Code::PosSizeFlags(int enable_dpi_scaling, bool uses_def_validator, tt_str
     else if (m_node->as_wxSize(prop_size) != wxDefaultSize)
     {
         Comma();
-        Pos(prop_pos, enable_dpi_scaling).Comma().WxSize(prop_size, enable_dpi_scaling);
+        Pos(prop_pos, pos_scaling).Comma().WxSize(prop_size, size_scaling);
     }
     else if (m_node->as_wxPoint(prop_pos) != wxDefaultPosition)
     {
         Comma();
-        Pos(prop_pos, enable_dpi_scaling);
+        Pos(prop_pos, pos_scaling);
     }
     EndFunction();
     return *this;

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -2323,3 +2323,16 @@ Code& Code::Bundle(GenEnum::PropName prop_name)
 
     return *this;
 }
+
+bool Code::is_ScalingEnabled(GenEnum::PropName prop_name, int enable_dpi_scaling) const
+{
+    if (enable_dpi_scaling == code::no_dpi_scaling ||
+        tt::contains(m_node->as_string(prop_name), 'n', tt::CASE::either) == true)
+        return false;
+    else if (m_language == GEN_LANG_CPLUSPLUS && Project.is_wxWidgets31())
+        return false;
+    if (enable_dpi_scaling == code::conditional_scaling && m_node->isForm())
+        return false;
+
+    return true;
+}

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -32,8 +32,9 @@ namespace code
     enum
     {
         no_scaling = 0,
-        conditional_scaling = 1,  // only if non-form and prop != prop_size
-        force_scaling = 2
+        allowed = 1,
+        conditional_scaling,
+        force_scaling
     };
 
     enum
@@ -446,6 +447,11 @@ public:
     void ResetBraces() { m_within_braces = false; }
 
     bool is_WithinBraces() const { return m_within_braces; }
+
+    // Returns false if enable_dpi_scaling is set to no_dpi_scaling, or property contains a
+    // 'n', or language is C++ and wxWidgets 3.1 is being used, or enable_dpi_scaling is set
+    // to conditional_scaling and the node is a form.
+    bool is_ScalingEnabled(GenEnum::PropName prop_name, int enable_dpi_scaling = code::allowed) const;
 
 protected:
     void InsertLineBreak(size_t cur_pos);

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -37,7 +37,6 @@ namespace code
         force_scaling
     };
 
-
     enum
     {
         // Will add eol if empty.

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -29,13 +29,14 @@ namespace code
         window_name_needed = 1 << 3
     };
 
-    enum
+    enum ScalingType
     {
         no_scaling = 0,
-        allowed = 1,
+        allow_scaling = 1,
         conditional_scaling,
         force_scaling
     };
+
 
     enum
     {
@@ -395,7 +396,7 @@ public:
     // starting with a comma, e.g. -- ", wxPoint(x, y), wxSize(x, y), styles, name);"
     //
     // If the only style specified is def_style, then it will not be added.
-    Code& PosSizeFlags(int enable_dpi_scaling = conditional_scaling, bool uses_def_validator = false,
+    Code& PosSizeFlags(ScalingType enable_dpi_scaling = conditional_scaling, bool uses_def_validator = false,
                        tt_string_view def_style = tt_empty_cstr);
 
     // Call this when you need to force a specific style such as "wxCHK_3STATE"
@@ -451,7 +452,7 @@ public:
     // Returns false if enable_dpi_scaling is set to no_dpi_scaling, or property contains a
     // 'n', or language is C++ and wxWidgets 3.1 is being used, or enable_dpi_scaling is set
     // to conditional_scaling and the node is a form.
-    bool is_ScalingEnabled(GenEnum::PropName prop_name, int enable_dpi_scaling = code::allowed) const;
+    bool is_ScalingEnabled(GenEnum::PropName prop_name, int enable_dpi_scaling = code::allow_scaling) const;
 
 protected:
     void InsertLineBreak(size_t cur_pos);

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -125,7 +125,7 @@ void DataViewCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent */, N
 bool DataViewCtrl::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }
@@ -256,7 +256,7 @@ void DataViewListCtrl::AfterCreation(wxObject* wxobject, wxWindow* /* wxparent *
 bool DataViewListCtrl::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }
@@ -329,7 +329,7 @@ wxObject* DataViewTreeCtrl::CreateMockup(Node* node, wxObject* parent)
 bool DataViewTreeCtrl::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -80,7 +80,7 @@ bool AnimationGenerator::ConstructionCode(Code& code)
             {
                 code.Str("Wx::Animation.new");
             }
-            code.PosSizeFlags(false);
+            code.PosSizeFlags();
         }
     }
     else
@@ -89,7 +89,7 @@ bool AnimationGenerator::ConstructionCode(Code& code)
         code.AddAuto().NodeName().CreateClass(code.node()->hasValue(prop_animation) &&
                                               code.node()->as_string(prop_animation).contains(".ani", tt::CASE::either));
         code.ValidParentName().Comma().as_string(prop_id).Comma().Add("wxNullAnimation").CheckLineLength();
-        code.PosSizeFlags(false);
+        code.PosSizeFlags();
     }
 
     if (code.hasValue(prop_inactive_bitmap))

--- a/src/generate/gen_aui_notebook.cpp
+++ b/src/generate/gen_aui_notebook.cpp
@@ -89,7 +89,7 @@ void AuiNotebookGenerator::OnPageChanged(wxNotebookEvent& event)
 bool AuiNotebookGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags();
     BookCtorAddImagelist(code);
 
     if (code.IsEqualTo(prop_art_provider, "wxAuiGenericTabArt"))

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -399,7 +399,7 @@ bool AuiToolBarGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(false, "wxAUI_TB_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, false, "wxAUI_TB_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_banner_window.cpp
+++ b/src/generate/gen_banner_window.cpp
@@ -65,7 +65,7 @@ bool BannerWindowGenerator::ConstructionCode(Code& code)
         code.Str("# unknown language") << "wxBannerWindow";
     }
 
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_bitmap_combo.cpp
+++ b/src/generate/gen_bitmap_combo.cpp
@@ -89,7 +89,7 @@ bool BitmapComboBoxGenerator::ConstructionCode(Code& code)
         if (code.WhatParamsNeeded() != nothing_needed)
         {
             code.Comma().Add("wxEmptyString");
-            code.PosSizeFlags(true);
+            code.PosSizeFlags(code::allow_scaling, true);
         }
         else
         {

--- a/src/generate/gen_book_page.cpp
+++ b/src/generate/gen_book_page.cpp
@@ -249,7 +249,7 @@ bool BookPageGenerator::ConstructionCode(Code& code)
             code.ValidParentName();
         }
         code.Comma().as_string(prop_id);
-        code.PosSizeFlags(false);
+        code.PosSizeFlags();
         if (node->getParent()->isGen(gen_wxPropertySheetDialog))
         {
             // Break out the close parenthesis so that the Ruby code can remove the () entirely.

--- a/src/generate/gen_button.cpp
+++ b/src/generate/gen_button.cpp
@@ -157,7 +157,7 @@ bool ButtonGenerator::ConstructionCode(Code& code)
         code.Add("wxEmptyString");
     }
 
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_checkbox.cpp
+++ b/src/generate/gen_checkbox.cpp
@@ -51,7 +51,7 @@ bool CheckBoxGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_choice.cpp
+++ b/src/generate/gen_choice.cpp
@@ -83,7 +83,7 @@ bool ChoiceGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.PosSizeFlags(true);
+        code.PosSizeFlags(code::allow_scaling, true);
     }
 
     return true;

--- a/src/generate/gen_choicebook.cpp
+++ b/src/generate/gen_choicebook.cpp
@@ -36,7 +36,7 @@ void ChoicebookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 bool ChoicebookGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false, "wxCHB_DEFAULT");
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(code::allow_scaling, false, "wxCHB_DEFAULT");
 
     return true;
 }

--- a/src/generate/gen_clr_picker.cpp
+++ b/src/generate/gen_clr_picker.cpp
@@ -38,7 +38,7 @@ bool ColourPickerGenerator::ConstructionCode(Code& code)
         else
             code.Add("wxBLACK");
     }
-    code.PosSizeFlags(true, "wxCLRP_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, true, "wxCLRP_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_cmd_link_btn.cpp
+++ b/src/generate/gen_cmd_link_btn.cpp
@@ -64,7 +64,7 @@ bool CommandLinkBtnGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_main_label);
-    code.Comma().QuotedString(prop_note).PosSizeFlags(true);
+    code.Comma().QuotedString(prop_note).PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_collapsible.cpp
+++ b/src/generate/gen_collapsible.cpp
@@ -58,7 +58,7 @@ bool CollapsiblePaneGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
-    code.PosSizeFlags(true, "wxCP_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, true, "wxCP_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_combobox.cpp
+++ b/src/generate/gen_combobox.cpp
@@ -75,7 +75,7 @@ bool ComboBoxGenerator::ConstructionCode(Code& code)
         if (code.WhatParamsNeeded() != nothing_needed)
         {
             code.Comma().Add("wxEmptyString");
-            code.PosSizeFlags(true);
+            code.PosSizeFlags(code::allow_scaling, true);
         }
         else
         {

--- a/src/generate/gen_ctx_help_btn.cpp
+++ b/src/generate/gen_ctx_help_btn.cpp
@@ -31,7 +31,7 @@ bool CtxHelpButtonGenerator::ConstructionCode(Code& code)
     // TODO: [Randalphwa - 12-18-2023] Usually you only need the parent.
     code.ValidParentName().Comma().as_string(prop_id);
 
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_date_picker.cpp
+++ b/src/generate/gen_date_picker.cpp
@@ -41,7 +41,7 @@ bool DatePickerCtrlGenerator::ConstructionCode(Code& code)
         code.Add("wxDefaultDateTime");
     }
 
-    code.PosSizeFlags(true, "wxDP_DEFAULT|wxDP_SHOWCENTURY");
+    code.PosSizeFlags(code::allow_scaling, true, "wxDP_DEFAULT|wxDP_SHOWCENTURY");
 
     return true;
 }

--- a/src/generate/gen_dir_ctrl.cpp
+++ b/src/generate/gen_dir_ctrl.cpp
@@ -40,7 +40,7 @@ bool GenericDirCtrlGenerator::ConstructionCode(Code& code)
 
     if (!code.hasValue(prop_filter) && code.IntValue(prop_defaultfilter) == 0 && !code.hasValue(prop_window_name))
     {
-        code.PosSizeFlags(false, "wxDIRCTRL_DEFAULT_STYLE");
+        code.PosSizeFlags(code::allow_scaling, false, "wxDIRCTRL_DEFAULT_STYLE");
     }
     else
     {

--- a/src/generate/gen_dir_picker.cpp
+++ b/src/generate/gen_dir_picker.cpp
@@ -62,7 +62,7 @@ bool DirPickerGenerator::ConstructionCode(Code& code)
             code.Add("wxDirSelectorPromptStr");
     }
 
-    code.PosSizeFlags(false, "wxDIRP_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, false, "wxDIRP_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_file_picker.cpp
+++ b/src/generate/gen_file_picker.cpp
@@ -79,7 +79,7 @@ bool FilePickerGenerator::ConstructionCode(Code& code)
         code.AddType("wxFileSelectorDefaultWildcardStr");
     }
 
-    code.PosSizeFlags(true, "wxFLP_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, true, "wxFLP_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_font_picker.cpp
+++ b/src/generate/gen_font_picker.cpp
@@ -71,7 +71,7 @@ bool FontPickerGenerator::ConstructionCode(Code& code)
             code.Add("wxNullFont");
     }
 
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -175,11 +175,13 @@ bool FrameFormGenerator::SettingsCode(Code& code)
         return false;
     }
 
-    if (code.is_cpp() && (code.is_ScalingEnabled(prop_pos, code::allow_scaling) || code.is_ScalingEnabled(prop_size, code::allow_scaling)))
+    if (code.is_cpp() &&
+        (code.is_ScalingEnabled(prop_pos, code::allow_scaling) || code.is_ScalingEnabled(prop_size, code::allow_scaling)))
     {
         code.Eol().Str("// Don't call FromDIP() until the window has been created");
         code.Eol().Str("if (pos != wxDefaultPosition || size != wxDefaultSize)");
-        code.Eol().Tab().Str("SetSize(FromDIP(pos).x, FromDIP(pos).y, FromDIP(size).x, FromDIP(size).y, wxSIZE_USE_EXISTING);");
+        code.Eol().Tab().Str(
+            "SetSize(FromDIP(pos).x, FromDIP(pos).y, FromDIP(size).x, FromDIP(size).y, wxSIZE_USE_EXISTING);");
     }
 
     Node* frame = code.node();

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -149,8 +149,14 @@ bool FrameFormGenerator::SettingsCode(Code& code)
             else
                 code += ' ';
         }
+        code += "parent, id, title, ";
 
-        code += "parent, id, title, wxWindow::FromDIP(pos), wxWindow::FromDIP(size), style, name))";
+        if (code.is_ScalingEnabled(prop_pos, code::allow_scaling) || code.is_ScalingEnabled(prop_size, code::allow_scaling))
+            code += "wxDefaultPosition, wxDefaultSize";
+        else
+            code += "pos, size";
+
+        code += ", style, name))";
         code.Eol().Tab().Str("return false;");
     }
     else if (code.is_python())
@@ -167,6 +173,13 @@ bool FrameFormGenerator::SettingsCode(Code& code)
     else
     {
         return false;
+    }
+
+    if (code.is_cpp() && (code.is_ScalingEnabled(prop_pos, code::allow_scaling) || code.is_ScalingEnabled(prop_size, code::allow_scaling)))
+    {
+        code.Eol().Str("// Don't call FromDIP() until the window has been created");
+        code.Eol().Str("if (pos != wxDefaultPosition || size != wxDefaultSize)");
+        code.Eol().Tab().Str("SetSize(FromDIP(pos).x, FromDIP(pos).y, FromDIP(size).x, FromDIP(size).y, wxSIZE_USE_EXISTING);");
     }
 
     Node* frame = code.node();

--- a/src/generate/gen_gauge.cpp
+++ b/src/generate/gen_gauge.cpp
@@ -42,7 +42,7 @@ bool GaugeGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().as_string(prop_range);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_grid.cpp
+++ b/src/generate/gen_grid.cpp
@@ -159,7 +159,7 @@ wxObject* GridGenerator::CreateMockup(Node* node, wxObject* parent)
 bool GridGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(false, "wxWANTS_CHARS");
+    code.PosSizeFlags(code::allow_scaling, false, "wxWANTS_CHARS");
 
     return true;
 }

--- a/src/generate/gen_html_window.cpp
+++ b/src/generate/gen_html_window.cpp
@@ -58,7 +58,7 @@ wxObject* HtmlWindowGenerator::CreateMockup(Node* node, wxObject* parent)
 bool HtmlWindowGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(false, "wxHW_SCROLLBAR_AUTO");
+    code.PosSizeFlags(code::allow_scaling, false, "wxHW_SCROLLBAR_AUTO");
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's
     // not needed.

--- a/src/generate/gen_hyperlink.cpp
+++ b/src/generate/gen_hyperlink.cpp
@@ -67,7 +67,7 @@ bool HyperlinkGenerator::ConstructionCode(Code& code)
 
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
     code.Comma().QuotedString(prop_url);
-    code.PosSizeFlags(false, "wxHL_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, false, "wxHL_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_listbook.cpp
+++ b/src/generate/gen_listbook.cpp
@@ -42,7 +42,7 @@ void ListbookGenerator::OnPageChanged(wxListbookEvent& event)
 bool ListbookGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false, "wxBK_DEFAULT");
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(code::allow_scaling, false, "wxBK_DEFAULT");
     BookCtorAddImagelist(code);
 
     return true;

--- a/src/generate/gen_listview.cpp
+++ b/src/generate/gen_listview.cpp
@@ -57,7 +57,7 @@ bool ListViewGenerator::ConstructionCode(Code& code)
     // Note that the default style is not specified, so that it will always be generated. That makes the generated code
     // easier to understand since you know exactly which type of list view is being created instead of having to know what
     // the default is.
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_notebook.cpp
+++ b/src/generate/gen_notebook.cpp
@@ -41,7 +41,7 @@ void NotebookGenerator::OnPageChanged(wxNotebookEvent& event)
 bool NotebookGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags();
     BookCtorAddImagelist(code);
 
     return true;

--- a/src/generate/gen_prop_grid.cpp
+++ b/src/generate/gen_prop_grid.cpp
@@ -39,7 +39,7 @@ void PropertyGridGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
 bool PropertyGridGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(false, "wxPG_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, false, "wxPG_DEFAULT_STYLE");
 
     if (code.hasValue(prop_extra_style))
         code.Eol().NodeName().Function("SetExtraStyle(").Add(prop_extra_style).EndFunction();

--- a/src/generate/gen_prop_grid_mgr.cpp
+++ b/src/generate/gen_prop_grid_mgr.cpp
@@ -87,7 +87,7 @@ void PropertyGridManagerGenerator::AfterCreation(wxObject* wxobject, wxWindow* /
 bool PropertyGridManagerGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(false, "wxPGMAN_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, false, "wxPGMAN_DEFAULT_STYLE");
 
     if (code.hasValue(prop_extra_style))
         code.Eol().NodeName().Function("SetExtraStyle(").Add(prop_extra_style).EndFunction();

--- a/src/generate/gen_radio_btn.cpp
+++ b/src/generate/gen_radio_btn.cpp
@@ -50,7 +50,7 @@ bool RadioButtonGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_label);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_ribbon_bar.cpp
+++ b/src/generate/gen_ribbon_bar.cpp
@@ -238,7 +238,7 @@ bool RibbonBarGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName();
     code.CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(false, "wxRIBBON_BAR_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, false, "wxRIBBON_BAR_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_rich_text.cpp
+++ b/src/generate/gen_rich_text.cpp
@@ -32,7 +32,7 @@ bool RichTextCtrlGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_value);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_search_ctrl.cpp
+++ b/src/generate/gen_search_ctrl.cpp
@@ -47,7 +47,7 @@ bool SearchCtrlGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().QuotedString(prop_value);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_simplebook.cpp
+++ b/src/generate/gen_simplebook.cpp
@@ -45,7 +45,7 @@ void SimplebookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 bool SimplebookGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags();
 
     return true;
 }

--- a/src/generate/gen_slider.cpp
+++ b/src/generate/gen_slider.cpp
@@ -60,7 +60,7 @@ bool SliderGenerator::ConstructionCode(Code& code)
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma();
     code.as_string(prop_position).Comma().as_string(prop_minValue).Comma().as_string(prop_maxValue);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_spin_btn.cpp
+++ b/src/generate/gen_spin_btn.cpp
@@ -36,7 +36,7 @@ wxObject* SpinButtonGenerator::CreateMockup(Node* node, wxObject* parent)
 bool SpinButtonGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(false, "wxSP_VERTICAL");
+    code.PosSizeFlags(code::allow_scaling, false, "wxSP_VERTICAL");
 
     // If the last parameter is wxID_ANY, then remove it. This is the default value, so it's
     // not needed.

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -109,7 +109,7 @@ bool TextCtrlGenerator::ConstructionCode(Code& code)
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).Comma().CheckLineLength();
     code.QuotedString(prop_value);
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_time_picker.cpp
+++ b/src/generate/gen_time_picker.cpp
@@ -37,7 +37,7 @@ bool TimePickerCtrlGenerator::ConstructionCode(Code& code)
     {
         code.Add("wxDefaultDateTime");
     }
-    code.PosSizeFlags(true, "wxTP_DEFAULT");
+    code.PosSizeFlags(code::allow_scaling, true, "wxTP_DEFAULT");
 
     return true;
 }

--- a/src/generate/gen_toggle_btn.cpp
+++ b/src/generate/gen_toggle_btn.cpp
@@ -105,7 +105,7 @@ bool ToggleButtonGenerator::ConstructionCode(Code& code)
         code.Add("wxEmptyString");
     }
 
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }
@@ -234,7 +234,7 @@ bool BitmapToggleButtonGenerator::ConstructionCode(Code& code)
 
     code.Add("wxNullBitmap");
 
-    code.PosSizeFlags(true);
+    code.PosSizeFlags(code::allow_scaling, true);
 
     return true;
 }

--- a/src/generate/gen_toolbook.cpp
+++ b/src/generate/gen_toolbook.cpp
@@ -56,7 +56,7 @@ void ToolbookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 bool ToolbookGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags();
 
     BookCtorAddImagelist(code);
 

--- a/src/generate/gen_tree_ctrl.cpp
+++ b/src/generate/gen_tree_ctrl.cpp
@@ -28,7 +28,7 @@ wxObject* TreeCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 bool TreeCtrlGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(true, "wxTR_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, true, "wxTR_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_tree_list.cpp
+++ b/src/generate/gen_tree_list.cpp
@@ -37,7 +37,7 @@ void TreeListCtrlGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
 bool TreeListCtrlGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
-    code.PosSizeFlags(true, "wxTL_DEFAULT_STYLE");
+    code.PosSizeFlags(code::allow_scaling, true, "wxTL_DEFAULT_STYLE");
 
     return true;
 }

--- a/src/generate/gen_treebook.cpp
+++ b/src/generate/gen_treebook.cpp
@@ -40,7 +40,7 @@ void TreebookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 bool TreebookGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName().CreateClass();
-    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags(false);
+    code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags();
     BookCtorAddImagelist(code);
 
     return true;

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -600,12 +600,12 @@ static void GenerateARTBundle(Code& code, const tt_string_vector& parts, bool ge
     // Note that current documentation states that the client is required, but the header file says otherwise
     if (art_client.size())
         code.Comma().Add(art_client);
-    auto bmp = wxArtProvider::GetBitmap(art_id.make_wxString(), wxART_MAKE_CLIENT_ID_FROM_STR(art_client.make_wxString()));
-    if (bmp.IsOk())
+    if (parts.size() > IndexSize)
     {
         code.Comma();
         code.CheckLineLength(sizeof("wxSize(999, 999)))"));
-        code << "wxSize(" << bmp.GetSize().GetWidth() << ", " << bmp.GetSize().GetHeight() << ")";
+        auto size = GetSizeInfo(parts[IndexSize]);
+        code << "wxSize(" << size.x << ", " << size.y << ")";
     }
     code << ')';
 }

--- a/src/internal/msgframe_base.cpp
+++ b/src/internal/msgframe_base.cpp
@@ -22,8 +22,11 @@ bool MsgFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& title
     const wxPoint& pos, const wxSize& size, long style, const wxString &name)
 {
 
-    if (!wxFrame::Create(parent, id, title, pos, size, style, name))
+    if (!wxFrame::Create(parent, id, title, wxDefaultPosition, wxDefaultSize, style, name))
         return false;
+    // Don't call FromDIP() until the window has been created
+    if (pos != wxDefaultPosition || size != wxDefaultSize)
+        SetSize(FromDIP(pos).x, FromDIP(pos).y, FromDIP(size).x, FromDIP(size).y, wxSIZE_USE_EXISTING);
 
     auto* menubar = new wxMenuBar();
 
@@ -84,7 +87,7 @@ bool MsgFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& title
 
     m_textCtrl = new wxTextCtrl(m_page_log, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
         wxTE_MULTILINE|wxTE_READONLY|wxTE_RICH|wxHSCROLL);
-    m_textCtrl->SetMinSize(wxSize(350, 300));
+    m_textCtrl->SetMinSize(FromDIP(wxSize(350, 300)));
     log_sizer->Add(m_textCtrl, wxSizerFlags(1).Expand().Border(wxALL, 0));
     m_page_log->SetSizerAndFit(log_sizer);
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -13,10 +13,11 @@
 #include <wx/gdicmn.h>   // Common GDI classes, types and declarations
 #include <wx/mstream.h>  // Memory stream classes
 
-#include "mainframe.h"     // MainFrame -- Main window frame
-#include "node.h"          // Node class
-#include "node_creator.h"  // NodeCreator class
-#include "utils.h"         // Utility functions that work with properties
+#include "mainframe.h"        // MainFrame -- Main window frame
+#include "node.h"             // Node class
+#include "node_creator.h"     // NodeCreator class
+#include "project_handler.h"  // ProjectHandler class
+#include "utils.h"            // Utility functions that work with properties
 
 tt_string DoubleToStr(double val)
 {
@@ -253,11 +254,15 @@ tt_string ConvertEscapeSlashes(tt_string_view str)
 
 wxPoint DlgPoint(Node* node, GenEnum::PropName prop)
 {
+    if (!isScalingEnabled(node, prop))
+        return node->as_wxPoint(prop);
     return wxGetMainFrame()->getWindow()->FromDIP(node->as_wxPoint(prop));
 }
 
 wxSize DlgSize(Node* node, GenEnum::PropName prop)
 {
+    if (!isScalingEnabled(node, prop))
+        return node->as_wxSize(prop);
     return wxGetMainFrame()->getWindow()->FromDIP(node->as_wxSize(prop));
 }
 
@@ -528,4 +533,14 @@ std::optional<tt_string> FileNameToVarName(tt_string_view filename, size_t max_l
     }
 
     return var_name;
+}
+
+bool isScalingEnabled(Node* node, GenEnum::PropName prop_name, int m_language)
+{
+    if (tt::contains(node->as_string(prop_name), 'n', tt::CASE::either) == true)
+        return false;
+    else if (m_language == GEN_LANG_CPLUSPLUS && Project.is_wxWidgets31())
+        return false;
+    else
+        return true;
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Miscellaneous utility functions
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -41,7 +41,7 @@ wxPoint DlgPoint(Node* node, GenEnum::PropName prop);
 // This will *always* call wxGetMainFrame()->getWindow()->FromDIP()
 wxSize DlgSize(Node* node, GenEnum::PropName prop);
 
-// Given a width (wxPoint::x) this will convert it using FromDIP()
+// Given a width this will convert it using wxGetMainFrame()->getWindow()->FromDIP()
 int DlgPoint(int width);
 
 // Convert a filename to a valid variable name. This will handle filnames with leading
@@ -74,3 +74,7 @@ tt_string ConvertToSnakeCase(tt_string_view str);
 
 // Converts string to snake_case, then converts to upper case
 tt_string ConvertToUpperSnakeCase(tt_string_view str);
+
+// Returns false if property contains a 'n', or language is C++ and wxWidgets 3.1 is being
+// used.
+bool isScalingEnabled(Node* node, GenEnum::PropName prop_name, int m_language = GEN_LANG_NONE);

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -57,11 +57,11 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
         wxImage::AddHandler(new wxPNGHandler);
 
     if (!wxFrame::Create(parent, id, title, wxDefaultPosition, wxDefaultSize, style, name))
-    // if (!wxFrame::Create(parent, id, title, pos, size, style, name))
         return false;
+    // Don't call FromDIP() until the window has been created
     if (pos != wxDefaultPosition || size != wxDefaultSize)
         SetSize(FromDIP(pos).x, FromDIP(pos).y, FromDIP(size).x, FromDIP(size).y, wxSIZE_USE_EXISTING);
-    SetMinSize(wxSize(800, 800));
+    SetMinSize(FromDIP(wxSize(800, 800)));
 
     m_mainframe_sizer = new wxBoxSizer(wxVERTICAL);
 

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <wxUiEditorData
-  data_version="19">
+  data_version="21">
   <node
     class="Project"
     art_directory="../art_src"
@@ -796,8 +796,8 @@
               class="wxPanel"
               class_access="protected:"
               var_name="m_nav_panel"
-              derived_class="NavigationPanel"
-              derived_header="../panels/nav_panel.h"
+              subclass="NavigationPanel"
+              subclass_header="../panels/nav_panel.h"
               window_style="0"
               flags="wxEXPAND" />
             <node
@@ -2437,8 +2437,8 @@
                 focus="1"
                 type="wxLB_MULTIPLE"
                 var_name="m_lb_folders"
-                maximum_size="-1,-1d"
-                minimum_size="-1,80d"
+                maximum_size="-1,-1"
+                minimum_size="-1,200"
                 flags="wxEXPAND"
                 wxEVT_LISTBOX="OnSelectFolders" />
               <node
@@ -2476,7 +2476,7 @@
                 style="wxLB_SORT"
                 type="wxLB_MULTIPLE"
                 var_name="m_lb_forms"
-                minimum_size="-1,80d"
+                minimum_size="-1,200"
                 flags="wxEXPAND"
                 wxEVT_LISTBOX="OnSelectForms" />
               <node
@@ -2542,7 +2542,7 @@
                     class="wxComboBox"
                     style="wxCB_DROPDOWN|wxCB_SORT|wxTE_PROCESS_ENTER"
                     var_name="m_combo_prefixes"
-                    minimum_size="-1,-1d"
+                    minimum_size="-1,-1"
                     flags="wxEXPAND"
                     wxEVT_COMBOBOX_CLOSEUP="OnUpdate"
                     wxEVT_TEXT_ENTER="OnUpdate" />
@@ -2574,7 +2574,7 @@
                     class="wxComboBox"
                     style="wxCB_DROPDOWN|wxCB_SORT|wxTE_PROCESS_ENTER"
                     var_name="m_combo_suffixes"
-                    minimum_size="-1,-1d"
+                    minimum_size="-1,-1"
                     flags="wxEXPAND"
                     wxEVT_COMBOBOX_CLOSEUP="OnUpdate"
                     wxEVT_TEXT_ENTER="OnUpdate" />
@@ -2740,7 +2740,7 @@
                 header="../custom_ctrls/colour_rect_ctrl.h"
                 namespace="wxue_ctrl"
                 var_name="m_colour_rect"
-                maximum_size="32,32d" />
+                maximum_size="64,80" />
               <node
                 class="wxStaticText"
                 label="Sample Text"
@@ -2782,9 +2782,9 @@
             <node
               class="wxColourPickerCtrl"
               style="wxCLRP_USE_TEXTCTRL|wxCLRP_SHOW_LABEL"
-              derived_class="kwColourPickerCtrl"
-              derived_header="../custom_ctrls/kw_color_picker.h"
               disabled="1"
+              subclass="kwColourPickerCtrl"
+              subclass_header="../custom_ctrls/kw_color_picker.h"
               window_style="wxWANTS_CHARS"
               wxEVT_COLOURPICKER_CHANGED="OnColourChanged" />
           </node>
@@ -2936,7 +2936,7 @@
                       wrap_indent_mode="indent"
                       wrap_mode="word"
                       wrap_visual_flag="end"
-                      minimum_size="200,-1d"
+                      minimum_size="400,-1"
                       border_size="10"
                       flags="wxEXPAND"
                       proportion="1" />
@@ -3049,7 +3049,7 @@
                         wrap_indent_mode="indent"
                         wrap_mode="word"
                         wrap_visual_flag="end"
-                        minimum_size="200,-1d"
+                        minimum_size="400,-1"
                         border_size="10"
                         flags="wxEXPAND"
                         proportion="1" />
@@ -3074,7 +3074,7 @@
         class_name="EditHtmlDialogBase"
         persist="1"
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
-        size="500,400d"
+        size="1000,1000"
         base_file="edit_html_dialog_base"
         derived_class_name="EditHtmlDialog"
         wxEVT_INIT_DIALOG="OnInit">
@@ -3336,7 +3336,7 @@
                   selection_string="default"
                   style="wxCB_READONLY|wxCB_SORT"
                   var_name="m_comboFacenames"
-                  minimum_size="-1,-1d"
+                  minimum_size="-1,-1"
                   tooltip="Leave Facename set to default to create a font that isn't dependent on a user's installed fonts."
                   flags="wxEXPAND"
                   wxEVT_COMBOBOX="OnFacename" />
@@ -3541,7 +3541,7 @@
                 style="wxCB_READONLY|wxCB_SORT"
                 var_name="m_comboPrefixes"
                 disabled="1"
-                minimum_size="75,-1d"
+                minimum_size="150,-1"
                 tooltip="The prefix list is edited in the Project's id_prefixes property."
                 column="1"
                 proportion="1"
@@ -3562,7 +3562,7 @@
                 style="wxCB_READONLY|wxCB_SORT"
                 var_name="m_comboSuffix"
                 disabled="1"
-                minimum_size="75,-1d"
+                minimum_size="150,-1"
                 tooltip="The suffix list is edited in the Project's id_suffixes property."
                 column="3"
                 proportion="1"
@@ -3713,7 +3713,7 @@
             <node
               class="wxListBox"
               focus="1"
-              minimum_size="100,80d"
+              minimum_size="200,200"
               wxEVT_LISTBOX="OnItemSelected" />
             <node
               class="wxBoxSizer"
@@ -3769,7 +3769,7 @@
         persist="1"
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Add System Header(s)"
-        minimum_size="400,-1d"
+        minimum_size="800,-1"
         base_file="..\customprops\sys_header_dlg.cpp"
         local_src_includes="node.h;node_prop.h;project_handler.h"
         system_src_includes="wx/filedlg.h"
@@ -3797,14 +3797,14 @@
               flags="wxEXPAND">
               <node
                 class="wxBoxSizer"
-                minimum_size="-1,-1d">
+                minimum_size="-1,-1">
                 <node
                   class="wxTextCtrl"
                   style="wxTE_MULTILINE|wxTE_READONLY|wxTE_NO_VSCROLL"
                   value="Start by selecting or adding a root directory. This should either be a directory in your $INCLUDE environment, or one that is passed to the compiler using -I. Header files will then be displayed automatically relative to this directory. Check the ones you want to add."
                   var_name="m_text_ctrl"
                   background_colour="#F0F0F0"
-                  minimum_size="200,-1d"
+                  minimum_size="400,-1"
                   window_style="wxBORDER_NONE"
                   flags="wxEXPAND"
                   proportion="1" />
@@ -3854,7 +3854,7 @@
               type="wxLB_MULTIPLE"
               var_name="m_check_list_files"
               validator_variable="m_file_indexes"
-              minimum_size="-1,90d"
+              minimum_size="-1,225"
               flags="wxEXPAND"
               proportion="1" />
           </node>
@@ -4138,7 +4138,7 @@
                   var_name="app_classname"
                   get_function="get_app_class"
                   validator_variable="m_app_class"
-                  minimum_size="100,-1d"
+                  minimum_size="200,-1"
                   tooltip="Change this to something unique to your project."
                   proportion="1"
                   wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />
@@ -4239,7 +4239,7 @@
                   var_name="doc_classname"
                   get_function="get_doc_class"
                   validator_variable="m_doc_class"
-                  minimum_size="100,-1d"
+                  minimum_size="200,-1"
                   tooltip="Change this to something unique to your project."
                   proportion="1"
                   wxEVT_TEXT="[this](wxCommandEvent&amp;)@@{VerifyClassName();@@}" />
@@ -5110,7 +5110,7 @@
           class="wxListBox"
           class_access="public:"
           var_name="m_lb_files"
-          minimum_size="150,100d"
+          minimum_size="300,250"
           flags="wxEXPAND"
           proportion="1" />
         <node
@@ -5122,7 +5122,7 @@
           class="wxListBox"
           class_access="public:"
           var_name="m_lb_info"
-          minimum_size="100,40d"
+          minimum_size="200,100"
           flags="wxEXPAND" />
         <node
           class="wxStdDialogButtonSizer"
@@ -5163,7 +5163,7 @@
             message="Combined XRC File"
             style="wxFLP_USE_TEXTCTRL|wxFLP_SAVE"
             wildcard="*.xrc"
-            minimum_size="120,-1d"
+            minimum_size="240,-1"
             flags="wxEXPAND"
             proportion="1"
             wxEVT_FILEPICKER_CHANGED="OnCombinedFilenameChanged" />
@@ -5184,7 +5184,7 @@
             var_name="staticText" />
           <node
             class="wxListBox"
-            minimum_size="-1,50d"
+            minimum_size="-1,125"
             flags="wxEXPAND"
             proportion="1" />
         </node>
@@ -5872,7 +5872,7 @@
           class_access="protected:"
           style="wxLI_VERTICAL"
           var_name="m_static_line"
-          size="-1,100d"
+          size="-1,250"
           column="1"
           proportion="1"
           rowspan="3" />
@@ -6414,7 +6414,7 @@
         persist="1"
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Test XRC"
-        minimum_size="600,500d"
+        minimum_size="1200,1250"
         base_file="..\internal\xrcpreview"
         derived_class_name="XrcPreview"
         derived_file="xrcpreview"
@@ -6517,7 +6517,7 @@
                 var_name="box_sizer3">
                 <node
                   class="wxSearchCtrl"
-                  minimum_size="100,-1d"
+                  minimum_size="200,-1"
                   borders="wxBOTTOM|wxRIGHT|wxLEFT"
                   wxEVT_SEARCHCTRL_SEARCH_BTN="OnSearch" />
               </node>
@@ -6551,7 +6551,7 @@
         persist="1"
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Node Search"
-        minimum_size="-1,-1d"
+        minimum_size="-1,-1"
         base_file="..\internal\node_search_dlg"
         local_src_includes="../panels/nav_panel.h;mainframe.h;node.h;project_handler.h;unused_gen_dlg.h"
         header_preamble="class Node;"
@@ -6568,12 +6568,12 @@
           class="wxBoxSizer"
           orientation="wxVERTICAL"
           var_name="dlg_sizer"
-          minimum_size="-1,-1d"
+          minimum_size="-1,-1"
           flags="wxEXPAND">
           <node
             class="wxBoxSizer"
             var_name="box_sizer_3"
-            minimum_size="250,-1d"
+            minimum_size="500,-1"
             flags="wxEXPAND">
             <node
               class="wxRadioButton"
@@ -6630,7 +6630,7 @@
           <node
             class="wxBoxSizer"
             var_name="box_sizer_4"
-            minimum_size="250,-1d"
+            minimum_size="500,-1"
             borders="wxBOTTOM|wxRIGHT|wxLEFT"
             flags="wxEXPAND"
             proportion="1">
@@ -6648,7 +6648,7 @@
                 borders="wxTOP|wxRIGHT|wxLEFT" />
               <node
                 class="wxListBox"
-                minimum_size="120,100d"
+                minimum_size="240,250"
                 flags="wxEXPAND"
                 proportion="1"
                 wxEVT_LISTBOX="OnSelectLocated" />
@@ -6669,7 +6669,7 @@
                 class="wxListBox"
                 style="wxLB_SORT"
                 var_name="m_listbox_forms"
-                minimum_size="-1,100d"
+                minimum_size="-1,250"
                 flags="wxEXPAND"
                 proportion="1" />
             </node>
@@ -6925,7 +6925,7 @@
             wrap="200" />
           <node
             class="wxListBox"
-            minimum_size="120,100d"
+            minimum_size="240,250"
             flags="wxEXPAND" />
           <node
             class="wxButton"
@@ -7027,7 +7027,7 @@
           var_name="dlg_sizer">
           <node
             class="wxListBox"
-            minimum_size="100,70d"
+            minimum_size="200,175"
             flags="wxEXPAND" />
           <node
             class="wxStdDialogButtonSizer"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds the ability to turn off high dpi support in the in the Property Grid panel for individual positions and sizes.

This also changes code generation for wxFrame so that high dpi support will work even if the wxFrame is for the main window (which means `wxWindow::FromDPI()` will not work correctly). If position or size are specified with high dpi support, then default parameters are passed to the `wxFrame::Create()` function followed by a call to `SetSize()` using `FromDPI()` from the newly created `wxFrame`.

The `CustomPointProperty` dialog is further updated to _not_ show the high dpi support checkbox if the property is Art, Bitmap, or SVG image. For Bitmap, it will now show the original image size if the image is embedded, but will not allow the user to change the size. The user can change the size for Art and SVG images.

Code generation for `wxToolbar` tools using ART files no longer adds the size unless the user modified it from the default ART size.

All of the wxUiEditor source files have now been regenerated to help verify the high dpi support changes.

This is a continuation of the scaling work being done for ##603.