### PR TITLE
Fix problems with importing wxSmith properties,  and <font> property in xrc/wxSmith

### DIFF
--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -622,40 +622,6 @@ bool WxGlade::HandleNormalProperty(const pugi::xml_node& xml_obj, Node* node, No
         node->set_value(prop_id, id);
         return true;
     }
-    else if (wxue_prop == prop_font)
-    {
-        FontProperty font_info;
-        if (auto size_child = xml_obj.child("size"); size_child)
-        {
-            font_info.PointSize(size_child.text().as_double());
-        }
-        if (auto family_child = xml_obj.child("family"); family_child && family_child.text().as_view() != "default")
-        {
-            FontFamilyPairs family_pair;
-            font_info.Family(family_pair.GetValue(family_child.text().as_view()));
-        }
-        if (auto style_child = xml_obj.child("style"); style_child && style_child.text().as_view() != "normal")
-        {
-            FontStylePairs style_pair;
-            font_info.Style(style_pair.GetValue(style_child.text().as_view()));
-        }
-        if (auto weight_child = xml_obj.child("weight"); weight_child && weight_child.text().as_view() != "normal")
-        {
-            FontWeightPairs weight_pair;
-            font_info.Weight(weight_pair.GetValue(weight_child.text().as_view()));
-        }
-        if (auto underline_child = xml_obj.child("underline"); underline_child)
-        {
-            font_info.Underlined(underline_child.text().as_bool());
-        }
-        if (auto face_child = xml_obj.child("face"); face_child)
-        {
-            font_info.FaceName(face_child.text().as_cstr().make_wxString());
-        }
-
-        node->set_value(prop_font, font_info.as_string());
-        return true;
-    }
 
     return false;
 }

--- a/src/import/import_wxsmith.h
+++ b/src/import/import_wxsmith.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Import a wxSmith file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -20,4 +20,6 @@ public:
 
     // wxSmith only supports C++ code generation
     int GetLanguage() const override { return GEN_LANG_CPLUSPLUS; }
+
+    bool HandleUnknownProperty(const pugi::xml_node& /* xml_obj */, Node* /* node */, Node* /* parent */) override;
 };

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -717,6 +717,11 @@ void ImportXML::ProcessProperties(const pugi::xml_node& xml_obj, Node* node, Nod
             node->set_value(prop_extra_accels, accel_list);
             continue;
         }
+        else if (wxue_prop == prop_font)
+        {
+            ProcessFont(iter, node);
+            continue;
+        }
 
         // Now process names that are identical.
 
@@ -1538,4 +1543,38 @@ tt_string_view ImportXML::GetCorrectEventName(tt_string_view name)
     {
         return name;
     }
+}
+
+void ImportXML::ProcessFont(const pugi::xml_node& xml_obj, Node* node)
+{
+    FontProperty font_info;
+    if (auto size_child = xml_obj.child("size"); size_child)
+    {
+        font_info.PointSize(size_child.text().as_double());
+    }
+    if (auto family_child = xml_obj.child("family"); family_child && family_child.text().as_view() != "default")
+    {
+        FontFamilyPairs family_pair;
+        font_info.Family(family_pair.GetValue(family_child.text().as_view()));
+    }
+    if (auto style_child = xml_obj.child("style"); style_child && style_child.text().as_view() != "normal")
+    {
+        FontStylePairs style_pair;
+        font_info.Style(style_pair.GetValue(style_child.text().as_view()));
+    }
+    if (auto weight_child = xml_obj.child("weight"); weight_child && weight_child.text().as_view() != "normal")
+    {
+        FontWeightPairs weight_pair;
+        font_info.Weight(weight_pair.GetValue(weight_child.text().as_view()));
+    }
+    if (auto underline_child = xml_obj.child("underline"); underline_child)
+    {
+        font_info.Underlined(underline_child.text().as_bool());
+    }
+    if (auto face_child = xml_obj.child("face"); face_child)
+    {
+        font_info.FaceName(face_child.text().as_cstr().make_wxString());
+    }
+
+    node->set_value(prop_font, font_info.as_string());
 }

--- a/src/import/import_xml.h
+++ b/src/import/import_xml.h
@@ -56,6 +56,7 @@ public:
     void HandleSizerItemProperty(const pugi::xml_node& xml_prop, Node* node, Node* parent = nullptr);
 
 protected:
+    void ProcessFont(const pugi::xml_node& xml_obj, Node* node);
     void ProcessUnknownProperty(const pugi::xml_node& xml_obj, Node* node, Node* parent);
     std::optional<pugi::xml_document> LoadDocFile(const tt_string& file);
     GenEnum::GenName ConvertToGenName(const tt_string& object_name, Node* parent);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR completes fixing the problems reported in #1478 by adding a new HandleUnknownProperty() override function specifically for wxSmith.

The second part of the PR is fixing font importing from xrc and related projects. Previously, this was only in wxGlade, but the function there also works on XRC and wxSmith imports, so it was moved to a common place.