### PR TITLE
Enable asserts in release build when testing menu is enabled

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -13,6 +13,9 @@ on:
       - .github
   workflow_dispatch:
 
+env:
+  BUILD_TYPE: Release
+
 jobs:
   clangFormat:
     runs-on: ubuntu-latest

--- a/src/assertion_dlg.cpp
+++ b/src/assertion_dlg.cpp
@@ -10,6 +10,9 @@
 
 #include <wx/msgdlg.h>
 
+#include "mainapp.h"    // App -- Main application class
+#include "mainframe.h"  // MainFrame -- Main window frame
+
 static std::mutex g_mutexAssert;
 
 bool AssertionDlg(const char* filename, const char* function, int line, const char* cond, const std::string& msg)
@@ -41,6 +44,23 @@ bool AssertionDlg(const char* filename, const char* function, int line, const ch
     else if (answer == wxID_CANCEL)
     {
         std::quick_exit(2);
+    }
+    else
+    {
+        if (auto frame = wxGetApp().getMainFrame(); frame && frame->IsShown())
+        {
+            if (wxGetApp().isTestingMenuEnabled())
+            {
+                tt_string log_msg = str.ToStdString();
+                if (auto pos = log_msg.find("\n\nPress Yes"); tt::is_found(pos))
+                {
+                    log_msg.erase(pos, std::string::npos);
+                }
+                log_msg.Replace("\n\n", "\n", true);
+                log_msg += "\n";
+                MSG_WARNING(log_msg);
+            }
+        }
     }
 
     return false;

--- a/src/assertion_dlg.cpp
+++ b/src/assertion_dlg.cpp
@@ -45,3 +45,54 @@ bool AssertionDlg(const char* filename, const char* function, int line, const ch
 
     return false;
 }
+
+// wxSetAssertHandler(ttAssertionHandler) will change wxASSERT dialogs to this one.
+void ttAssertionHandler(const wxString& filename, int line, const wxString& function, const wxString& cond,
+                        const wxString& msg)
+{
+    // This is in case additional message processing results in an assert while this one is already being displayed.
+    std::unique_lock<std::mutex> classLock(g_mutexAssert);
+
+    wxString str;
+
+    if (cond.size())
+        str << "Expression: " << cond << "\n\n";
+    if (msg.size())
+        str << "Comment: " << msg << "\n\n";
+
+    str << "File: " << filename << "\n";
+    str << "Function: " << function << "\n";
+    str << "Line: " << line << "\n\n";
+    str << "Press Yes to call wxTrap, No to continue, Cancel to exit program.";
+
+    wxMessageDialog dlg(nullptr, str, "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
+    dlg.SetYesNoCancelLabels("wxTrap", "Continue", "Exit program");
+
+    auto answer = dlg.ShowModal();
+
+    if (answer == wxID_YES)
+    {
+        wxTrap();
+    }
+    else if (answer == wxID_CANCEL)
+    {
+        std::quick_exit(2);
+    }
+    else
+    {
+        if (auto frame = wxGetApp().getMainFrame(); frame && frame->IsShown())
+        {
+            if (wxGetApp().isTestingMenuEnabled())
+            {
+                tt_string log_msg = str.ToStdString();
+                if (auto pos = log_msg.find("\n\nPress Yes"); tt::is_found(pos))
+                {
+                    log_msg.erase(pos, std::string::npos);
+                }
+                log_msg.Replace("\n\n", "\n", true);
+                log_msg += "\n";
+                MSG_WARNING(log_msg);
+            }
+        }
+    }
+}

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -425,7 +425,6 @@ inline MainFrame& wxGetFrame()
 // Returns a pointer to the mainframe window
 inline MainFrame* wxGetMainFrame()
 {
-    ASSERT_MSG(wxGetApp().getMainFrame(), "MainFrame hasn't been created yet.");
     return wxGetApp().getMainFrame();
 }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR enables wxWidgets ASSERTS in a release build if the testing menu is enabled. It also replaces the dialog normally displayed by wxASSERT with our own dialog that matches the one displayed when our own ASSERT is called. In both cases, the assert now gets sent to the MsgLogging window so that if Continue is chosen, the assert will be tracked so that it can be optionally written to a log file.