### PR TITLE
Support explanatory comments preference

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -16,6 +16,7 @@
 #include "mainapp.h"          // App class
 #include "mainframe.h"        // MainFrame class
 #include "node.h"             // Node class
+#include "preferences.h"      // Prefs -- Set/Get wxUiEditor preferences
 #include "project_handler.h"  // ProjectHandler class
 #include "utils.h"            // Miscellaneous utilities
 
@@ -2267,29 +2268,6 @@ void Code::GenFontColourSettings()
     }
 }
 
-Code& Code::AddComment(tt_string_view text)
-{
-    if (empty() || !tt::is_whitespace(back()))
-    {
-        *this << ' ';
-    }
-
-    if (is_cpp())
-    {
-        *this << "// " << text;
-    }
-    else if (is_python() || is_ruby())
-    {
-        *this << "# " << text;
-    }
-    else
-    {
-        // Default for any new languages
-        *this << "# " << text;
-    }
-    return *this;
-}
-
 Code& Code::ColourCode(GenEnum::PropName prop_name)
 {
     if (!hasValue(prop_name))
@@ -2347,4 +2325,29 @@ bool Code::is_ScalingEnabled(GenEnum::PropName prop_name, int enable_dpi_scaling
         return false;
 
     return true;
+}
+
+Code& Code::AddComment(std::string_view comment, bool force)
+{
+    if (!UserPrefs.is_AddComments() && !force)
+        return *this;
+    Eol(eol_if_needed);
+    switch (m_language)
+    {
+        case GEN_LANG_CPLUSPLUS:
+            *this << "// " << comment;
+            break;
+        case GEN_LANG_PYTHON:
+        case GEN_LANG_RUBY:
+            *this << "# " << comment;
+            break;
+        default:
+            *this << "# " << comment;
+            break;
+    }
+
+    if (back() != '\n')
+        *this << '\n';  // Ensure that the comment is on its own line
+
+    return *this;
 }

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -227,6 +227,12 @@ public:
     // Equibalent to Add(node->as_constant(prop_name, "...")
     Code& AddConstant(GenEnum::PropName prop_name, tt_string_view short_name);
 
+    // If UserPrefs.is_AddComments() is true, then add the comment on it's own line.
+    // Set force to true to always add the comment.
+    // The comment will be prefixed with "// " for C++ and "# " for Python and Ruby.
+    // The comment will be followed by a newline.
+    Code& AddComment(std::string_view comment, bool force = false);
+
     // Adds "true" for all languages except Python, which adds "True"
     Code& True() { return Str(is_python() ? "True" : "true"); }
 
@@ -381,9 +387,6 @@ public:
         *this += is_cpp() ? "wxEmptyString" : "\"\"";
         return *this;
     }
-
-    // Will prefix text with "// " for C++ or "# " for Python
-    Code& AddComment(tt_string_view text);
 
     // Will either generate wxSize(...) or FromDIP(wxSize(...))
     Code& WxSize(GenEnum::PropName prop_name = GenEnum::PropName::prop_size, int enable_dpi_scaling = conditional_scaling);

--- a/src/generate/gen_dialog.cpp
+++ b/src/generate/gen_dialog.cpp
@@ -137,7 +137,7 @@ bool DialogFormGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.AddComment("Unknown language");
+        code.AddComment("Unknown language", true);
     }
     code.ResetIndent();
     code.ResetBraces();  // In C++, caller must close the final brace after all construction

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -238,7 +238,7 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
             code.Add("self.");
         if (!event->getNode()->hasValue(prop_id))
         {
-            code.AddComment("**WARNING** -- tool id not specified, event handler may never be called\n");
+            code.AddComment("**WARNING** -- tool id not specified, event handler may never be called.", true);
             if (code.is_cpp() || code.is_python())
             {
                 code << "Bind(" << handler.GetCode() << comma;

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -95,7 +95,7 @@ bool FrameFormGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.AddComment("Unknown language");
+        code.AddComment("Unknown language", true);
     }
 
     code.ResetIndent();

--- a/src/generate/gen_menuitem.cpp
+++ b/src/generate/gen_menuitem.cpp
@@ -235,8 +235,7 @@ bool MenuItemGenerator::SettingsCode(Code& code)
 
     if (code.hasValue(prop_unchecked_bitmap))
     {
-        code.Eol();
-        code.AddComment("Set the unchecked bitmap").Eol();
+        code.AddComment("Set the unchecked bitmap");
         if (code.is_cpp())
         {
             auto& description = node->as_string(prop_unchecked_bitmap);

--- a/src/generate/gen_panel_form.cpp
+++ b/src/generate/gen_panel_form.cpp
@@ -98,7 +98,7 @@ bool PanelFormGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.AddComment("Unknown language");
+        code.AddComment("Unknown language", true);
     }
 
     code.ResetIndent();

--- a/src/generate/gen_popup_trans_win.cpp
+++ b/src/generate/gen_popup_trans_win.cpp
@@ -50,7 +50,7 @@ bool PopupWinGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.AddComment("Unknown language");
+        code.AddComment("Unknown language", true);
     }
     return true;
 }

--- a/src/generate/gen_propsheet_dlg.cpp
+++ b/src/generate/gen_propsheet_dlg.cpp
@@ -205,7 +205,7 @@ bool PropSheetDlgGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.AddComment("Unknown language");
+        code.AddComment("Unknown language", true);
     }
     code.ResetIndent();
     code.ResetBraces();  // In C++, caller must close the final brace after all construction

--- a/src/generate/gen_styled_text.cpp
+++ b/src/generate/gen_styled_text.cpp
@@ -606,8 +606,8 @@ bool StyledTextGenerator::SettingsCode(Code& code)
     {
         if (code.isPropValue(prop_stc_left_margin_width, 5))
         {
-            code.Eol(eol_if_needed).AddComment("Sets text margin scaled appropriately for the current DPI on Windows,");
-            code.Eol().AddComment("5 on wxGTK or wxOSX");
+            code.AddComment("Sets text margin scaled appropriately for the current DPI on Windows,");
+            code.AddComment("5 on wxGTK or wxOSX");
             code.Eol()
                 .NodeName()
                 .Function("SetMarginLeft(")
@@ -629,9 +629,8 @@ bool StyledTextGenerator::SettingsCode(Code& code)
     {
         if (!code.isPropValue(prop_stc_left_margin_width, 5) && code.isPropValue(prop_stc_right_margin_width, 5))
         {
-            code.Eol(eol_if_needed);
             code.AddComment("Sets text margin scaled appropriately for the current DPI on Windows");
-            code.Eol().AddComment("5 on wxGTK or wxOSX");
+            code.AddComment("5 on wxGTK or wxOSX");
         }
         code.Eol(eol_if_needed).NodeName().Function("SetMarginRight(");
         if (code.isPropValue(prop_stc_right_margin_width, 5))
@@ -770,8 +769,8 @@ bool StyledTextGenerator::SettingsCode(Code& code)
         else  // circle tree or box tree
         {
             code.OpenBrace();
-            code.Eol().AddComment("The outline colour of the circle and box tree symbols is reversed by default.");
-            code.Eol().AddComment("The code below ensures that the symbol is visible.");
+            code.AddComment("The outline colour of the circle and box tree symbols is reversed by default.");
+            code.AddComment("The code below ensures that the symbol is visible.");
             code.Eol().Str(code.is_cpp() ? "auto clr_foreground" : "_clr_foreground_") += " = ";
             code.NodeName().Function("StyleGetForeground(").Add("wxSTC_STYLE_DEFAULT").EndFunction();
             code.Eol().Str(code.is_cpp() ? "clr_background" : "_clr_background_");

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -90,7 +90,7 @@ bool WizardFormGenerator::ConstructionCode(Code& code)
     }
     else
     {
-        code.AddComment("Unknown language");
+        code.AddComment("Unknown language", true);
     }
 
     return true;

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -26,6 +26,7 @@ void Prefs::ReadConfig()
     m_sizers_always_expand = config->ReadBool("always_expand", true);
     m_var_prefix = config->ReadBool("var_prefix", true);
     m_fullpath_title = config->ReadBool("fullpath_title", false);
+    m_add_comments = config->ReadBool("add_comments", false);
     m_svg_images = config->ReadBool("svg_images", false);
 
     m_enable_wakatime = config->ReadBool("enable_wakatime", true);
@@ -80,6 +81,7 @@ void Prefs::WriteConfig()
     config->Write("always_expand", m_sizers_always_expand);
     config->Write("var_prefix", m_var_prefix);
     config->Write("fullpath_title", m_fullpath_title);
+    config->Write("add_comments", m_add_comments);
     config->Write("svg_images", m_svg_images);
 
     config->Write("enable_wakatime", m_enable_wakatime);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -51,6 +51,9 @@ public:
     bool is_FullPathTitle() const { return m_fullpath_title; }
     void set_FullPathTitle(bool value) { m_fullpath_title = value; }
 
+    bool is_AddComments() const { return m_add_comments; }
+    void set_AddComments(bool value) { m_add_comments = value; }
+
     bool is_SvgImages() const { return m_svg_images; }
     void set_SvgImages(bool value) { m_svg_images = value; }
 
@@ -234,6 +237,7 @@ private:
     bool m_is_load_last_project { false };
     bool m_is_right_propgrid { false };
     bool m_is_cpp_snake_case { true };
+    bool m_add_comments { false };
 };
 
 extern Prefs& UserPrefs;

--- a/src/ui/preferences_dlg.cpp
+++ b/src/ui/preferences_dlg.cpp
@@ -58,6 +58,7 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     box_sizer3->Add(m_check_load_last, wxSizerFlags(1).Border(wxALL));
 
     m_check_fullpath = new wxCheckBox(page_general, wxID_ANY, "Full project path in title bar");
+    m_check_fullpath->SetValue(true);
     box_sizer3->Add(m_check_fullpath, wxSizerFlags(1).Border(wxALL));
 
     auto* checkBox_wakatime = new wxCheckBox(page_general, wxID_ANY, "Enable WakaTime");
@@ -74,6 +75,11 @@ bool PreferencesDlg::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     m_check_svg_bitmaps = new wxCheckBox(page_general, wxID_ANY, "Default SVG bitmaps");
     m_check_svg_bitmaps->SetToolTip("If checked, new bitmaps will default to SVG files");
     box_sizer4->Add(m_check_svg_bitmaps, wxSizerFlags().Border(wxALL));
+
+    m_check_prefer_comments = new wxCheckBox(page_general, wxID_ANY, "Generate explanatory comments");
+    m_check_prefer_comments->SetValue(true);
+    m_check_prefer_comments->SetToolTip("When checked, explanatory comments will sometimes be added to the generated code.");
+    box_sizer4->Add(m_check_prefer_comments, wxSizerFlags().Border(wxALL));
 
     box_sizer2->Add(box_sizer4, wxSizerFlags().Border(wxALL));
 
@@ -386,6 +392,7 @@ void PreferencesDlg::OnInit(wxInitDialogEvent& event)
     m_check_dark_mode->SetValue(UserPrefs.is_DarkMode());
     m_check_high_contrast->SetValue(UserPrefs.is_HighContrast());
     m_check_fullpath->SetValue(UserPrefs.is_FullPathTitle());
+    m_check_prefer_comments->SetValue(UserPrefs.is_AddComments());
     m_check_svg_bitmaps->SetValue(UserPrefs.is_SvgImages());
 
     m_check_cpp_snake_case->SetValue(UserPrefs.is_CppSnakeCase());
@@ -494,6 +501,7 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
         (m_check_dark_mode->GetValue() ? Prefs::PENDING_DARK_MODE_ON : Prefs::PENDING_DARK_MODE_OFF));
     UserPrefs.set_HighContrast(m_check_high_contrast->GetValue());
     UserPrefs.set_FullPathTitle(m_check_fullpath->GetValue());
+    UserPrefs.set_AddComments(m_check_prefer_comments->GetValue());
     UserPrefs.set_SvgImages(m_check_svg_bitmaps->GetValue());
 
     UserPrefs.set_CppSnakeCase(m_check_cpp_snake_case->GetValue());

--- a/src/ui/preferences_dlg.h
+++ b/src/ui/preferences_dlg.h
@@ -60,6 +60,7 @@ protected:
     wxCheckBox* m_check_fullpath;
     wxCheckBox* m_check_high_contrast;
     wxCheckBox* m_check_load_last;
+    wxCheckBox* m_check_prefer_comments;
     wxCheckBox* m_check_right_propgrid;
     wxCheckBox* m_check_svg_bitmaps;
     wxChoice* m_choice_cpp_version;

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -7103,6 +7103,7 @@
                     proportion="1" />
                   <node
                     class="wxCheckBox"
+                    checked="1"
                     label="Full project path in title bar"
                     var_name="m_check_fullpath"
                     proportion="1" />
@@ -7124,6 +7125,12 @@
                     label="Default SVG bitmaps"
                     var_name="m_check_svg_bitmaps"
                     tooltip="If checked, new bitmaps will default to SVG files" />
+                  <node
+                    class="wxCheckBox"
+                    checked="1"
+                    label="Generate explanatory comments"
+                    var_name="m_check_prefer_comments"
+                    tooltip="When checked, explanatory comments will sometimes be added to the generated code." />
                 </node>
               </node>
               <node


### PR DESCRIPTION
Unless forced, only generate comments if the user requests comments.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `Generate explanatory comments` checkbox to the Preferences dialog. This allows the user to control whether or not explanatory comments will be generated to explain various parts of the generated code. The default value is `true`.