### PR TITLE
Fix unrelated validator/var_name changes when changing a widget's type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Starting with version 1.2.1, wxUiEditor uses LunaSVG instead of NanoSVG to displ
 - Fixed code generation for variant, font, and background color in **wxPropertySheetDialog**
 - Add `no` as a Center option to prevent any wxWizard centering so that it will honor the `pos` property.
 - Fixed `variant` property code generation in wxWizard.
+- Changing a sizer or widget type no longer changes validator names
 
 ## [Released (1.1.0)]
 

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -332,6 +332,8 @@ ChangeSizerType::ChangeSizerType(Node* node, GenEnum::GenName new_gen_sizer)
     ASSERT(m_node);
     if (m_node)
     {
+        auto new_name = m_old_node->getUniqueName(m_node->as_string(prop_var_name), prop_var_name);
+        m_node->set_value(prop_var_name, new_name);
         if (m_new_gen_sizer == gen_wxFlexGridSizer &&
             (m_old_node->isGen(gen_wxBoxSizer) || m_old_node->isGen(gen_VerticalBoxSizer)))
         {
@@ -359,10 +361,6 @@ void ChangeSizerType::Change()
     m_parent->removeChild(m_old_node);
     m_old_node->setParent(NodeSharedPtr());
     m_parent->adoptChild(m_node);
-    if (auto parent_form = m_parent->getForm(); parent_form)
-    {
-        parent_form->fixDuplicateNodeNames();
-    }
     m_parent->changeChildPosition(m_node, pos);
 
     wxGetFrame().FireDeletedEvent(m_old_node.get());

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -477,7 +477,10 @@ ChangeNodeType::ChangeNodeType(Node* node, GenEnum::GenName new_node)
     ASSERT(m_node);
     if (m_node)
     {
+        // If the node type has changed, then we use the new type's default name.
+        auto new_name = m_old_node->getUniqueName(m_node->as_string(prop_var_name), prop_var_name);
         CopyCommonProperties(m_old_node.get(), m_node.get());
+        m_node->set_value(prop_var_name, new_name);
         if (m_new_gen_node == gen_wxCheckBox || m_new_gen_node == gen_wxRadioBox)
         {
             m_node->set_value(prop_checked, m_old_node->as_bool(prop_checked));
@@ -496,10 +499,6 @@ void ChangeNodeType::Change()
     m_parent->removeChild(m_old_node);
     m_old_node->setParent(NodeSharedPtr());
     m_parent->adoptChild(m_node);
-    if (auto parent_form = m_parent->getForm(); parent_form)
-    {
-        parent_form->fixDuplicateNodeNames();
-    }
     m_parent->changeChildPosition(m_node, pos);
 
     wxGetFrame().FireDeletedEvent(m_old_node.get());


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes unrelated name changes when a widget's type is changed. Now the only thing that changes is the widget's `var_name` property.