### PR TITLE
Add ability to ask user to confirm widget creation when not supported by current language

### DIFF
--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Base widget generator class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -196,6 +196,8 @@ public:
 
     // Call this to retrieve any warning text when generating code for the specific language.
     virtual std::optional<tt_string> GetWarning(Node*, int /* language */) { return {}; }
+
+    virtual int SupportedLanguages() { return 0xFFF; }  // All languages supported
 };
 
 PropDeclaration* DeclAddProp(NodeDeclaration* declaration, PropName prop_name, PropType type, std::string_view help = {},

--- a/src/generate/gen_popup_win.cpp
+++ b/src/generate/gen_popup_win.cpp
@@ -299,3 +299,8 @@ bool PopupWinBaseGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
     InsertGeneratorInclude(node, "#include <wx/popupwin.h>", set_src, set_hdr);
     return true;
 }
+
+int PopupWinBaseGenerator::SupportedLanguages()
+{
+    return GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON | GEN_LANG_RUBY;
+}

--- a/src/generate/gen_popup_win.h
+++ b/src/generate/gen_popup_win.h
@@ -18,6 +18,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr,
                      int /* language */) override;
+    int SupportedLanguages() override;
 };
 
 class PopupWinGenerator : public PopupWinBaseGenerator

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -168,13 +168,11 @@ std::string GenerateXrcStr(Node* node_start, size_t xrc_flags)
     root.append_attribute("xmlns") = "http://www.wxwidgets.org/wxxrc";
     root.append_attribute("version") = "2.5.3.0";
 
-    NodeSharedPtr temp_form = nullptr;
     if (node_start->isGen(gen_MenuBar) || node_start->isGen(gen_RibbonBar) || node_start->isGen(gen_ToolBar))
     {
-        temp_form = NodeCreation.createNode(gen_PanelForm, nullptr);
-        if (temp_form)
+        if (auto temp_form = NodeCreation.createNode(gen_PanelForm, nullptr).first; temp_form)
         {
-            auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, temp_form.get());
+            auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, temp_form.get()).first;
             temp_form->adoptChild(sizer);
             auto node_copy = NodeCreation.makeCopy(node_start, sizer.get());
             sizer->adoptChild(node_copy);

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -67,7 +67,7 @@ bool DialogBlocks::Import(const tt_string& filename, bool write_doc)
             throw std::runtime_error("Invalid project file");
         }
 
-        m_project = NodeCreation.createNode(gen_Project, nullptr);
+        m_project = NodeCreation.createNode(gen_Project, nullptr).first;
         m_project->set_value(prop_code_preference, "C++");
 
         auto option = header.find_child_by_attribute("string", "name", "target_wx_version");
@@ -166,7 +166,7 @@ bool DialogBlocks::CreateFolderNode(pugi::xml_node& form_xml, const NodeSharedPt
         if (auto folder_name = form_xml.find_child_by_attribute("string", "name", "title"); folder_name)
         {
             auto gen_folder_type = parent->isGen(gen_folder) ? gen_sub_folder : gen_folder;
-            if (auto new_parent = NodeCreation.createNode(gen_folder_type, parent.get()); new_parent)
+            if (auto new_parent = NodeCreation.createNode(gen_folder_type, parent.get()).first; new_parent)
             {
                 new_parent->set_value(prop_label, ExtractQuotedString(folder_name));
                 parent->adoptChild(new_parent);
@@ -237,7 +237,7 @@ bool DialogBlocks::CreateFormNode(pugi::xml_node& form_xml, const NodeSharedPtr&
             }
         }
 
-        auto form = NodeCreation.createNode(getGenName, parent.get());
+        auto form = NodeCreation.createNode(getGenName, parent.get()).first;
         if (!form)
         {
             if (parent->isGen(gen_Project) || parent->isGen(gen_folder) || parent->isGen(gen_sub_folder))
@@ -272,7 +272,7 @@ bool DialogBlocks::CreateFormNode(pugi::xml_node& form_xml, const NodeSharedPtr&
                         getGenName = gen_PopupMenu;
                         break;
                 }
-                if (form = NodeCreation.createNode(getGenName, parent.get()); !form)
+                if (form = NodeCreation.createNode(getGenName, parent.get()).first; !form)
                 {
                     auto msg = GatherErrorDetails(form_xml, getGenName);
                     FAIL_MSG(tt_string() << "Unable to create " << type_name << "\n" << msg)
@@ -414,7 +414,7 @@ void DialogBlocks::createChildNode(pugi::xml_node& child_xml, Node* parent)
     }
 
     bool allow_adoption = true;  // set to false if node has already been adopted, e.g. a genPageCtrl was inserted
-    auto node = NodeCreation.createNode(getGenName, parent);
+    auto node = NodeCreation.createNode(getGenName, parent).first;
     if (!node)
     {
         if (parent->isGen(gen_wxStdDialogButtonSizer) && getGenName == gen_wxButton)
@@ -442,7 +442,7 @@ void DialogBlocks::createChildNode(pugi::xml_node& child_xml, Node* parent)
 
         if (parent->isSizer() && parent->getParent()->isForm())
         {
-            node = NodeCreation.createNode(getGenName, parent->getParent());
+            node = NodeCreation.createNode(getGenName, parent->getParent()).first;
             if (node)
             {
                 parent = parent->getParent();
@@ -454,7 +454,7 @@ void DialogBlocks::createChildNode(pugi::xml_node& child_xml, Node* parent)
         {
             if (auto form = parent->getForm(); form)
             {
-                node = NodeCreation.createNode(getGenName, form);
+                node = NodeCreation.createNode(getGenName, form).first;
                 if (node)
                 {
                     parent = form;
@@ -463,9 +463,9 @@ void DialogBlocks::createChildNode(pugi::xml_node& child_xml, Node* parent)
         }
         else if (tt::contains(map_GenTypes[parent->getGenType()], "book"))
         {
-            if (auto page_ctrl = NodeCreation.createNode(gen_PageCtrl, parent); page_ctrl)
+            if (auto page_ctrl = NodeCreation.createNode(gen_PageCtrl, parent).first; page_ctrl)
             {
-                if (node = NodeCreation.createNode(getGenName, page_ctrl.get()); node)
+                if (node = NodeCreation.createNode(getGenName, page_ctrl.get()).first; node)
                 {
                     page_ctrl->adoptChild(node);
                     parent->adoptChild(page_ctrl);
@@ -542,7 +542,7 @@ void DialogBlocks::createChildNode(pugi::xml_node& child_xml, Node* parent)
 
 void DialogBlocks::CreateCustomNode(pugi::xml_node& child_xml, Node* parent)
 {
-    auto node = NodeCreation.createNode(gen_CustomControl, parent);
+    auto node = NodeCreation.createNode(gen_CustomControl, parent).first;
     if (!node)
     {
         auto msg = GatherErrorDetails(child_xml, gen_CustomControl);

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -62,7 +62,7 @@ bool FormBuilder::Import(const tt_string& filename, bool write_doc)
             throw std::runtime_error("Invalid project file");
         }
 
-        m_project = NodeCreation.createNode(gen_Project, nullptr);
+        m_project = NodeCreation.createNode(gen_Project, nullptr).first;
 
         createProjectNode(object, m_project.get());
 
@@ -243,12 +243,12 @@ NodeSharedPtr FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, 
         getGenName = gen_auitool;
     }
 
-    auto newobject = NodeCreation.createNode(getGenName, parent);
+    auto newobject = NodeCreation.createNode(getGenName, parent).first;
     if (!newobject && parent && tt::contains(map_GenTypes[parent->getGenType()], "book"))
     {
-        if (auto page_ctrl = NodeCreation.createNode(gen_PageCtrl, parent); page_ctrl)
+        if (auto page_ctrl = NodeCreation.createNode(gen_PageCtrl, parent).first; page_ctrl)
         {
-            if (newobject = NodeCreation.createNode(getGenName, page_ctrl.get()); newobject)
+            if (newobject = NodeCreation.createNode(getGenName, page_ctrl.get()).first; newobject)
             {
                 page_ctrl->adoptChild(newobject);
                 parent->adoptChild(page_ctrl);

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -93,7 +93,7 @@ bool WxCrafter::Import(const tt_string& filename, bool write_doc)
         return false;
     }
 
-    m_project = NodeCreation.createNode(gen_Project, nullptr);
+    m_project = NodeCreation.createNode(gen_Project, nullptr).first;
 
     try
     {
@@ -188,7 +188,7 @@ void WxCrafter::ProcessForm(const Value& form)
         return;
     }
 
-    auto new_node = NodeCreation.createNode(getGenName, m_project.get());
+    auto new_node = NodeCreation.createNode(getGenName, m_project.get()).first;
     m_project->adoptChild(new_node);
 
     if (!m_generate_ids)
@@ -332,7 +332,7 @@ void WxCrafter::ProcessChild(Node* parent, const Value& object)
         getGenName = gen_auitool;
     }
 
-    auto new_node = NodeCreation.createNode(getGenName, parent);
+    auto new_node = NodeCreation.createNode(getGenName, parent).first;
     if (!new_node)
     {
         m_errors.emplace(tt_string() << map_GenNames.at(getGenName) << " cannot be a child of " << parent->declName());
@@ -382,7 +382,7 @@ void WxCrafter::ProcessChild(Node* parent, const Value& object)
         {
             // We always supply one page even if it's empty so that wxPropertyGridManager::Clear() will work correctly
             getGenName = gen_propGridPage;
-            auto child_node = NodeCreation.createNode(getGenName, new_node.get());
+            auto child_node = NodeCreation.createNode(getGenName, new_node.get()).first;
             if (!child_node)
             {
                 m_errors.emplace(tt_string()

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -56,7 +56,7 @@ bool WxGlade::Import(const tt_string& filename, bool write_doc)
 
     try
     {
-        m_project = NodeCreation.createNode(gen_Project, nullptr);
+        m_project = NodeCreation.createNode(gen_Project, nullptr).first;
         if (auto src_ext = root.attribute("source_extension").as_view(); src_ext.size())
         {
             if (src_ext == ".cpp" || src_ext == ".cc" || src_ext == ".cxx")
@@ -223,7 +223,7 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
         }
     }
 
-    auto new_node = NodeCreation.createNode(getGenName, parent);
+    auto new_node = NodeCreation.createNode(getGenName, parent).first;
     if (new_node && object_not_generator)
     {
         new_node->set_value(prop_class_name, object_name);
@@ -262,7 +262,7 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
         {
             if (getGenName == gen_wxPanel)
             {
-                new_node = NodeCreation.createNode(gen_BookPage, parent);
+                new_node = NodeCreation.createNode(gen_BookPage, parent).first;
                 if (new_node)
                 {
                     if (!xml_obj.attribute("name").empty())
@@ -278,7 +278,7 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
             }
             else
             {
-                if (auto page = NodeCreation.createNode(gen_PageCtrl, parent); page)
+                if (auto page = NodeCreation.createNode(gen_PageCtrl, parent).first; page)
                 {
                     parent->adoptChild(page);
                     if (!xml_obj.attribute("name").empty())
@@ -290,7 +290,7 @@ NodeSharedPtr WxGlade::CreateGladeNode(pugi::xml_node& xml_obj, Node* parent, No
                         }
                     }
 
-                    new_node = NodeCreation.createNode(getGenName, page.get());
+                    new_node = NodeCreation.createNode(getGenName, page.get()).first;
                     if (new_node)
                         continue;
                 }
@@ -635,7 +635,7 @@ void WxGlade::CreateMenus(pugi::xml_node& xml_obj, Node* parent)
 
     for (auto& menu: menus.children("menu"))
     {
-        auto menu_node = NodeCreation.createNode(gen_wxMenu, parent);
+        auto menu_node = NodeCreation.createNode(gen_wxMenu, parent).first;
         parent->adoptChild(menu_node);
         for (auto& iter: menu.attributes())
         {
@@ -654,7 +654,8 @@ void WxGlade::CreateMenus(pugi::xml_node& xml_obj, Node* parent)
             auto id = item.child("id");
 
             auto new_item =
-                NodeCreation.createNode(id.text().as_view() == "---" ? gen_separator : gen_wxMenuItem, menu_node.get());
+                NodeCreation.createNode(id.text().as_view() == "---" ? gen_separator : gen_wxMenuItem, menu_node.get())
+                    .first;
             menu_node->adoptChild(new_item);
 
             for (auto& iter: item.children())
@@ -713,7 +714,7 @@ void WxGlade::CreateToolbar(pugi::xml_node& xml_obj, Node* parent)
     {
         auto id = tool.child("id");
 
-        auto new_tool = NodeCreation.createNode(id.text().as_view() == "---" ? gen_separator : gen_wxMenuItem, parent);
+        auto new_tool = NodeCreation.createNode(id.text().as_view() == "---" ? gen_separator : gen_wxMenuItem, parent).first;
         parent->adoptChild(new_tool);
         for (auto& iter: tool.children())
         {

--- a/src/import/import_wxsmith.cpp
+++ b/src/import/import_wxsmith.cpp
@@ -36,7 +36,7 @@ bool WxSmith::Import(const tt_string& filename, bool write_doc)
 
     try
     {
-        m_project = NodeCreation.createNode(gen_Project, nullptr);
+        m_project = NodeCreation.createNode(gen_Project, nullptr).first;
         for (auto& iter: root.children())
         {
             CreateXrcNode(iter, m_project.get());

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -1300,7 +1300,7 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
         getGenName = gen_ToolBar;
     }
 
-    auto new_node = NodeCreation.createNode(getGenName, parent);
+    auto new_node = NodeCreation.createNode(getGenName, parent).first;
     if (new_node && is_generic_version)
     {
         new_node->set_value(prop_use_generic, true);
@@ -1309,7 +1309,7 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
     {
         if (sizeritem && sizeritem->isGen(gen_oldbookpage))
         {
-            if (auto page = NodeCreation.createNode(gen_PageCtrl, parent); page)
+            if (auto page = NodeCreation.createNode(gen_PageCtrl, parent).first; page)
             {
                 if (sizeritem->hasValue(prop_label))
                 {
@@ -1321,10 +1321,10 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
         }
         else if (parent && (parent->isGen(gen_wxPanel) || parent->isGen(gen_PanelForm) || parent->isGen(gen_wxDialog)))
         {
-            auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, parent);
+            auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, parent).first;
             if (sizer)
             {
-                new_node = NodeCreation.createNode(getGenName, sizer.get());
+                new_node = NodeCreation.createNode(getGenName, sizer.get()).first;
                 if (new_node)
                 {
                     parent->adoptChild(sizer);
@@ -1337,7 +1337,7 @@ NodeSharedPtr ImportXML::CreateXrcNode(pugi::xml_node& xml_obj, Node* parent, No
         // visually distinguish it as a parent.
         else if (parent && getGenName == gen_wxMenu && (parent->isGen(gen_wxMenu) || parent->isGen(gen_submenu)))
         {
-            new_node = NodeCreation.createNode(gen_submenu, parent);
+            new_node = NodeCreation.createNode(gen_submenu, parent).first;
             if (new_node)
             {
                 continue;

--- a/src/newdialogs/new_dialog.cpp
+++ b/src/newdialogs/new_dialog.cpp
@@ -160,7 +160,7 @@ void NewDialog::OnInit(wxInitDialogEvent& event)
 
 void NewDialog::createNode()
 {
-    auto form_node = NodeCreation.createNode(gen_wxDialog, nullptr);
+    auto form_node = NodeCreation.createNode(gen_wxDialog, nullptr).first;
     ASSERT(form_node);
 
     if (m_title.size())
@@ -168,29 +168,29 @@ void NewDialog::createNode()
         form_node->set_value(prop_title, m_title.utf8_string());
     }
 
-    auto parent_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, form_node.get());
+    auto parent_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, form_node.get()).first;
     ASSERT(parent_sizer);
     parent_sizer->set_value(prop_var_name, "dlg_sizer");
     form_node->adoptChild(parent_sizer);
 
     if (m_has_tabs)
     {
-        auto notebook = NodeCreation.createNode(gen_wxNotebook, parent_sizer.get());
+        auto notebook = NodeCreation.createNode(gen_wxNotebook, parent_sizer.get()).first;
         ASSERT(notebook);
         parent_sizer->adoptChild(notebook);
 
         for (int count = 0; count < m_num_tabs; ++count)
         {
-            auto book_page = NodeCreation.createNode(gen_BookPage, notebook.get());
+            auto book_page = NodeCreation.createNode(gen_BookPage, notebook.get()).first;
             notebook->adoptChild(book_page);
 
             tt_string label("Tab ");
             label << count + 1;
             book_page->set_value(prop_label, label);
-            auto page_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, book_page.get());
+            auto page_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, book_page.get()).first;
             page_sizer->set_value(prop_var_name, tt_string() << "page_sizer_" << count + 1);
             book_page->adoptChild(page_sizer);
-            auto static_text = NodeCreation.createNode(gen_wxStaticText, page_sizer.get());
+            auto static_text = NodeCreation.createNode(gen_wxStaticText, page_sizer.get()).first;
             page_sizer->adoptChild(static_text);
             static_text->set_value(prop_label, "TODO: replace this control with something more useful...");
             static_text->set_value(prop_wrap, "200");
@@ -199,7 +199,7 @@ void NewDialog::createNode()
 
     if (m_has_std_btns)
     {
-        auto std_btn = NodeCreation.createNode(gen_wxStdDialogButtonSizer, parent_sizer.get());
+        auto std_btn = NodeCreation.createNode(gen_wxStdDialogButtonSizer, parent_sizer.get()).first;
         parent_sizer->adoptChild(std_btn);
 
         std_btn->set_value(prop_OK, "1");

--- a/src/newdialogs/new_frame.cpp
+++ b/src/newdialogs/new_frame.cpp
@@ -157,26 +157,26 @@ void NewFrame::OnCheckMainFrame(wxCommandEvent& WXUNUSED(event))
 
 void NewFrame::createNode()
 {
-    auto form_node = NodeCreation.createNode(gen_wxFrame, nullptr);
+    auto form_node = NodeCreation.createNode(gen_wxFrame, nullptr).first;
     ASSERT(form_node);
 
     if (m_has_mainframe)
     {
         if (m_has_toolbar)
         {
-            auto bar = NodeCreation.createNode(gen_wxToolBar, form_node.get());
+            auto bar = NodeCreation.createNode(gen_wxToolBar, form_node.get()).first;
             ASSERT(bar);
             form_node->adoptChild(bar);
         }
         if (m_has_menu)
         {
-            auto bar = NodeCreation.createNode(gen_wxMenuBar, form_node.get());
+            auto bar = NodeCreation.createNode(gen_wxMenuBar, form_node.get()).first;
             ASSERT(bar);
             form_node->adoptChild(bar);
         }
         if (m_has_statusbar)
         {
-            auto bar = NodeCreation.createNode(gen_wxStatusBar, form_node.get());
+            auto bar = NodeCreation.createNode(gen_wxStatusBar, form_node.get()).first;
             ASSERT(bar);
             form_node->adoptChild(bar);
         }

--- a/src/newdialogs/new_mdi.cpp
+++ b/src/newdialogs/new_mdi.cpp
@@ -271,9 +271,9 @@ void NewMdiForm::OnOK(wxCommandEvent& WXUNUSED(event))
 
 void NewMdiForm::createNode()
 {
-    auto folder = NodeCreation.createNode(gen_folder, nullptr);
+    auto folder = NodeCreation.createNode(gen_folder, nullptr).first;
     folder->set_value(prop_label, get_folder_name());
-    auto form_node = NodeCreation.createNode(gen_DocViewApp, folder.get());
+    auto form_node = NodeCreation.createNode(gen_DocViewApp, folder.get()).first;
     ASSERT(form_node);
     folder->adoptChild(form_node);
 
@@ -284,7 +284,7 @@ void NewMdiForm::createNode()
     }
     if (m_view_type == "Text Control")
     {
-        auto doc_node = NodeCreation.createNode(gen_DocumentTextCtrl, folder.get());
+        auto doc_node = NodeCreation.createNode(gen_DocumentTextCtrl, folder.get()).first;
         ASSERT(doc_node);
         folder->adoptChild(doc_node);
         doc_node->set_value(prop_mdi_class_name, form_node->as_string(prop_class_name));
@@ -309,15 +309,15 @@ void NewMdiForm::createNode()
             doc_node->set_value(prop_template_doc_name, get_doc_class());
         }
 
-        auto frame_menu = NodeCreation.createNode(gen_MdiFrameMenuBar, doc_node.get());
+        auto frame_menu = NodeCreation.createNode(gen_MdiFrameMenuBar, doc_node.get()).first;
         ASSERT(frame_menu);
 
-        auto file_menu = NodeCreation.createNode(gen_wxMenu, frame_menu.get());
+        auto file_menu = NodeCreation.createNode(gen_wxMenu, frame_menu.get()).first;
         ASSERT(file_menu);
         file_menu->set_value(prop_stock_id, "wxID_FILE");
         file_menu->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_FILE")));
 
-        auto menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        auto menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_NEW");
         menu_item->set_value(prop_id, "wxID_NEW");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_NEW")));
@@ -325,7 +325,7 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_NEW|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_OPEN");
         menu_item->set_value(prop_id, "wxID_OPEN");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_OPEN")));
@@ -333,10 +333,10 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_FILE_OPEN|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_separator, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_separator, file_menu.get()).first;
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_EXIT");
         menu_item->set_value(prop_id, "wxID_EXIT");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_EXIT")));
@@ -344,12 +344,12 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_QUIT|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        auto help_menu = NodeCreation.createNode(gen_wxMenu, frame_menu.get());
+        auto help_menu = NodeCreation.createNode(gen_wxMenu, frame_menu.get()).first;
         ASSERT(help_menu);
         help_menu->set_value(prop_stock_id, "wxID_HELP");
         help_menu->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_HELP")));
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_ABOUT");
         menu_item->set_value(prop_id, "wxID_ABOUT");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_ABOUT")));
@@ -360,14 +360,14 @@ void NewMdiForm::createNode()
         frame_menu->adoptChild(help_menu);
 
         doc_node->adoptChild(frame_menu);
-        auto doc_menu = NodeCreation.createNode(gen_MdiDocMenuBar, doc_node.get());
+        auto doc_menu = NodeCreation.createNode(gen_MdiDocMenuBar, doc_node.get()).first;
         ASSERT(doc_menu);
-        file_menu = NodeCreation.createNode(gen_wxMenu, doc_menu.get());
+        file_menu = NodeCreation.createNode(gen_wxMenu, doc_menu.get()).first;
         ASSERT(file_menu);
         file_menu->set_value(prop_stock_id, "wxID_FILE");
         file_menu->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_FILE")));
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_NEW");
         menu_item->set_value(prop_id, "wxID_NEW");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_NEW")));
@@ -375,7 +375,7 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_NEW|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_OPEN");
         menu_item->set_value(prop_id, "wxID_OPEN");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_OPEN")));
@@ -383,7 +383,7 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_FILE_OPEN|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_SAVE");
         menu_item->set_value(prop_id, "wxID_SAVE");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_SAVE")));
@@ -391,7 +391,7 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_FILE_SAVE|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_SAVEAS");
         menu_item->set_value(prop_id, "wxID_SAVEAS");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_SAVEAS")));
@@ -399,10 +399,10 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_FILE_SAVE_AS|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_separator, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_separator, file_menu.get()).first;
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_PRINT");
         menu_item->set_value(prop_id, "wxID_PRINT");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_PRINT")));
@@ -410,10 +410,10 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_PRINT|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_separator, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_separator, file_menu.get()).first;
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_CLOSE");
         menu_item->set_value(prop_id, "wxID_CLOSE");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_CLOSE")));
@@ -421,7 +421,7 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_CLOSE|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_EXIT");
         menu_item->set_value(prop_id, "wxID_EXIT");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_EXIT")));
@@ -429,12 +429,12 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_QUIT|wxART_MENU");
         file_menu->adoptChild(menu_item);
 
-        auto edit_menu = NodeCreation.createNode(gen_wxMenu, doc_menu.get());
+        auto edit_menu = NodeCreation.createNode(gen_wxMenu, doc_menu.get()).first;
         ASSERT(edit_menu);
         edit_menu->set_value(prop_stock_id, "wxID_EDIT");
         edit_menu->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_EDIT")));
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_CUT");
         menu_item->set_value(prop_id, "wxID_CUT");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_CUT")));
@@ -442,7 +442,7 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_CUT|wxART_MENU");
         edit_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_COPY");
         menu_item->set_value(prop_id, "wxID_COPY");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_COPY")));
@@ -450,7 +450,7 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_COPY|wxART_MENU");
         edit_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_PASTE");
         menu_item->set_value(prop_id, "wxID_PASTE");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_PASTE")));
@@ -458,10 +458,10 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxID_PASTE|wxART_MENU");
         edit_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_separator, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_separator, file_menu.get()).first;
         edit_menu->adoptChild(menu_item);
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_SELECTALL");
         menu_item->set_value(prop_id, "wxID_SELECTALL");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_SELECTALL")));
@@ -469,12 +469,12 @@ void NewMdiForm::createNode()
         menu_item->set_value(prop_bitmap, "Art;wxART_PASTE|wxART_MENU");
         edit_menu->adoptChild(menu_item);
 
-        help_menu = NodeCreation.createNode(gen_wxMenu, doc_menu.get());
+        help_menu = NodeCreation.createNode(gen_wxMenu, doc_menu.get()).first;
         ASSERT(help_menu);
         help_menu->set_value(prop_label, "wxID_HELP");
         help_menu->set_value(prop_stock_id, "wxID_HELP");
 
-        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get());
+        menu_item = NodeCreation.createNode(gen_wxMenuItem, file_menu.get()).first;
         menu_item->set_value(prop_stock_id, "wxID_ABOUT");
         menu_item->set_value(prop_id, "wxID_ABOUT");
         menu_item->set_value(prop_label, wxGetStockLabel(NodeCreation.getConstantAsInt("wxID_ABOUT")));
@@ -486,7 +486,7 @@ void NewMdiForm::createNode()
         doc_menu->adoptChild(help_menu);
 
         doc_node->adoptChild(doc_menu);
-        auto view = NodeCreation.createNode(gen_ViewTextCtrl, folder.get());
+        auto view = NodeCreation.createNode(gen_ViewTextCtrl, folder.get()).first;
         ASSERT(view);
         view->set_value(prop_mdi_doc_name, doc_node->as_string(prop_class_name));
         folder->adoptChild(view);

--- a/src/newdialogs/new_panel.cpp
+++ b/src/newdialogs/new_panel.cpp
@@ -154,12 +154,12 @@ void NewPanel::createNode()
     NodeSharedPtr new_node;
     if (m_is_form)
     {
-        new_node = NodeCreation.createNode(gen_PanelForm, Project.getProjectNode());
+        new_node = NodeCreation.createNode(gen_PanelForm, Project.getProjectNode()).first;
         ASSERT(new_node);
     }
     else
     {
-        new_node = NodeCreation.createNode(gen_wxPanel, wxGetFrame().getSelectedNode());
+        new_node = NodeCreation.createNode(gen_wxPanel, wxGetFrame().getSelectedNode()).first;
         if (!new_node)
         {
             wxMessageBox("You need to have a sizer selected before you can create a wxPanel.", "Create wxPanel");
@@ -171,27 +171,27 @@ void NewPanel::createNode()
 
     if (m_sizer_type == "FlexGrid")
     {
-        sizer = NodeCreation.createNode(gen_wxFlexGridSizer, new_node.get());
+        sizer = NodeCreation.createNode(gen_wxFlexGridSizer, new_node.get()).first;
     }
     else if (m_sizer_type == "Grid")
     {
-        sizer = NodeCreation.createNode(gen_wxGridSizer, new_node.get());
+        sizer = NodeCreation.createNode(gen_wxGridSizer, new_node.get()).first;
     }
     else if (m_sizer_type == "GridBag")
     {
-        sizer = NodeCreation.createNode(gen_wxGridBagSizer, new_node.get());
+        sizer = NodeCreation.createNode(gen_wxGridBagSizer, new_node.get()).first;
     }
     else if (m_sizer_type == "StaticBox")
     {
-        sizer = NodeCreation.createNode(gen_wxStaticBoxSizer, new_node.get());
+        sizer = NodeCreation.createNode(gen_wxStaticBoxSizer, new_node.get()).first;
     }
     else if (m_sizer_type == "Wrap")
     {
-        sizer = NodeCreation.createNode(gen_wxWrapSizer, new_node.get());
+        sizer = NodeCreation.createNode(gen_wxWrapSizer, new_node.get()).first;
     }
     else
     {
-        sizer = NodeCreation.createNode(gen_VerticalBoxSizer, new_node.get());
+        sizer = NodeCreation.createNode(gen_VerticalBoxSizer, new_node.get()).first;
     }
 
     new_node->adoptChild(sizer);

--- a/src/newdialogs/new_propsheet.cpp
+++ b/src/newdialogs/new_propsheet.cpp
@@ -144,7 +144,7 @@ void NewPropSheet::OnInit(wxInitDialogEvent& event)
 
 void NewPropSheet::createNode()
 {
-    auto form_node = NodeCreation.createNode(gen_wxPropertySheetDialog, nullptr);
+    auto form_node = NodeCreation.createNode(gen_wxPropertySheetDialog, nullptr).first;
     ASSERT(form_node);
 
     if (m_title.size())
@@ -154,16 +154,16 @@ void NewPropSheet::createNode()
 
     for (int count = 0; count < m_num_tabs; ++count)
     {
-        auto book_page = NodeCreation.createNode(gen_BookPage, form_node.get());
+        auto book_page = NodeCreation.createNode(gen_BookPage, form_node.get()).first;
         form_node->adoptChild(book_page);
 
         tt_string label("Page ");
         label << count + 1;
         book_page->set_value(prop_label, label);
-        auto page_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, book_page.get());
+        auto page_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, book_page.get()).first;
         page_sizer->set_value(prop_var_name, tt_string() << "page_sizer_" << count + 1);
         book_page->adoptChild(page_sizer);
-        auto static_text = NodeCreation.createNode(gen_wxStaticText, page_sizer.get());
+        auto static_text = NodeCreation.createNode(gen_wxStaticText, page_sizer.get()).first;
         page_sizer->adoptChild(static_text);
         static_text->set_value(prop_label, "TODO: replace this control with something more useful...");
         static_text->set_value(prop_wrap, "200");

--- a/src/newdialogs/new_ribbon.cpp
+++ b/src/newdialogs/new_ribbon.cpp
@@ -151,12 +151,12 @@ void NewRibbon::createNode()
     NodeSharedPtr bar_node;
     if (m_is_form)
     {
-        bar_node = NodeCreation.createNode(gen_RibbonBar, Project.getProjectNode());
+        bar_node = NodeCreation.createNode(gen_RibbonBar, Project.getProjectNode()).first;
         ASSERT(bar_node);
     }
     else
     {
-        bar_node = NodeCreation.createNode(gen_wxRibbonBar, wxGetFrame().getSelectedNode());
+        bar_node = NodeCreation.createNode(gen_wxRibbonBar, wxGetFrame().getSelectedNode()).first;
         if (!bar_node)
         {
             wxMessageBox("You need to have a sizer selected before you can create a wxRibbonBar.", "Create wxRibbonBar");
@@ -166,36 +166,36 @@ void NewRibbon::createNode()
 
     for (int count = 0; count < m_num_pages; ++count)
     {
-        auto ribbon_page = NodeCreation.createNode(gen_wxRibbonPage, bar_node.get());
+        auto ribbon_page = NodeCreation.createNode(gen_wxRibbonPage, bar_node.get()).first;
         bar_node->adoptChild(ribbon_page);
         tt_string label("Page ");
         label << count + 1;
         ribbon_page->set_value(prop_label, label);
 
-        auto ribbon_panel = NodeCreation.createNode(gen_wxRibbonPanel, ribbon_page.get());
+        auto ribbon_panel = NodeCreation.createNode(gen_wxRibbonPanel, ribbon_page.get()).first;
         ribbon_page->adoptChild(ribbon_panel);
         label << ", panel 1";
         ribbon_panel->set_value(prop_label, label);
 
         if (m_panel_type == "Tool")
         {
-            auto tool_bar = NodeCreation.createNode(gen_wxRibbonToolBar, ribbon_panel.get());
+            auto tool_bar = NodeCreation.createNode(gen_wxRibbonToolBar, ribbon_panel.get()).first;
             ribbon_panel->adoptChild(tool_bar);
-            auto tool = NodeCreation.createNode(gen_ribbonTool, tool_bar.get());
+            auto tool = NodeCreation.createNode(gen_ribbonTool, tool_bar.get()).first;
             tool_bar->adoptChild(tool);
         }
         else if (m_panel_type == "Button")
         {
-            auto button_bar = NodeCreation.createNode(gen_wxRibbonButtonBar, ribbon_panel.get());
+            auto button_bar = NodeCreation.createNode(gen_wxRibbonButtonBar, ribbon_panel.get()).first;
             ribbon_panel->adoptChild(button_bar);
-            auto button = NodeCreation.createNode(gen_ribbonButton, button_bar.get());
+            auto button = NodeCreation.createNode(gen_ribbonButton, button_bar.get()).first;
             button_bar->adoptChild(button);
         }
         else if (m_panel_type == "Gallery")
         {
-            auto gallery_bar = NodeCreation.createNode(gen_wxRibbonGallery, ribbon_panel.get());
+            auto gallery_bar = NodeCreation.createNode(gen_wxRibbonGallery, ribbon_panel.get()).first;
             ribbon_panel->adoptChild(gallery_bar);
-            auto item = NodeCreation.createNode(gen_ribbonGalleryItem, gallery_bar.get());
+            auto item = NodeCreation.createNode(gen_ribbonGalleryItem, gallery_bar.get()).first;
             gallery_bar->adoptChild(item);
         }
     }

--- a/src/newdialogs/new_wizard.cpp
+++ b/src/newdialogs/new_wizard.cpp
@@ -144,7 +144,7 @@ void NewWizard::OnInit(wxInitDialogEvent& event)
 
 void NewWizard::createNode()
 {
-    auto new_node = NodeCreation.createNode(gen_wxWizard, nullptr);
+    auto new_node = NodeCreation.createNode(gen_wxWizard, nullptr).first;
     ASSERT(new_node);
 
     if (m_title.size())
@@ -154,12 +154,12 @@ void NewWizard::createNode()
 
     for (int count = 0; count < m_num_pages; ++count)
     {
-        if (auto page = NodeCreation.createNode(gen_wxWizardPageSimple, new_node.get()); page)
+        if (auto page = NodeCreation.createNode(gen_wxWizardPageSimple, new_node.get()).first; page)
         {
             page->set_value(prop_var_name, tt_string("wizard_page_") << count + 1);
-            auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, page.get());
+            auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, page.get()).first;
 
-            auto static_text = NodeCreation.createNode(gen_wxStaticText, sizer.get());
+            auto static_text = NodeCreation.createNode(gen_wxStaticText, sizer.get()).first;
             static_text->set_value(prop_class_access, "none");
             static_text->set_value(prop_var_name, tt_string("static_text_") << count + 1);
             sizer->adoptChild(static_text);

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -37,6 +37,22 @@ using namespace GenEnum;
 class Node : public std::enable_shared_from_this<Node>
 {
 public:
+    // node creation error codes
+    enum
+    {
+        valid_node = 0,
+        unsupported_language = -1,
+        unknown_gen_name = -2,
+        parent_not_wxFrame = -3,
+        invalid_tool_grandparent = -4,
+        invalid_page_grandparent = -5,
+        invalid_child_count = -6,
+        gridbag_insert_error = -7,
+        invalid_child = -8,  // Requiested child is not allowed for the parent
+
+        unknown_error = -99,
+    };
+
     Node(NodeDeclaration* declaration);
 
     // Use get_name() if you want the enum value.
@@ -381,8 +397,11 @@ public:
     void createDoc(pugi::xml_document& doc);
 
     // This creates an orphaned node -- it is the caller's responsibility to hook it up with
-    // a parent.
-    Node* createChildNode(GenName name);
+    // a parent. Returns the node and an error code.
+    //
+    // If verify_language_support is true, then the node will only be created if the
+    // preferred language supports it (unless the user agrees to create it anyway)
+    std::pair<NodeSharedPtr, int> createChildNode(GenName name, bool verify_language_support = false);
 
     // Gets the current selected node and uses that to call createChildNode().
     Node* createNode(GenName name);

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Node class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Class used to create nodes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <set>
 #include <unordered_set>
+#include <utility>  // for std::pair
 
 #include "hash_map.h"  // Find std::string_view key in std::unordered_map
 
@@ -48,11 +49,19 @@ public:
 public:
     void Initialize();
 
-    // Only creates the node if the parent allows it as a child
-    NodeSharedPtr createNode(GenName name, Node* parent);
+    // Only creates the node if the parent allows it as a child. Returns the node and an
+    // error code.
+    //
+    // If verify_language_support is true, then the node will only be created if the
+    // preferred language supports it (unless the user agrees to create it anyway)
+    std::pair<NodeSharedPtr, int> createNode(GenName name, Node* parent, bool verify_language_support = false);
 
-    // Only creates the node if the parent allows it as a child
-    NodeSharedPtr createNode(tt_string_view name, Node* parent);
+    // Only creates the node if the parent allows it as a child. Returns the node and an
+    // error code.
+    //
+    // If verify_language_support is true, then the node will only be created if the
+    // preferred language supports it (unless the user agrees to create it anyway)
+    std::pair<NodeSharedPtr, int> createNode(tt_string_view name, Node* parent, bool verify_language_support = false);
 
     NodeSharedPtr createNodeFromXml(pugi::xml_node& node, Node* parent = nullptr, bool check_for_duplicates = false,
                                     bool allow_ui = true);

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -1156,7 +1156,7 @@ void NavPopupMenu::CreateSizerParent(Node* node, tt_string_view widget)
     // Avoid the temptation to set new_parent to the raw pointer so that .get() doesn't have to be called below. Doing so
     // will result in the reference count being decremented before we are done hooking it up, and you end up crashing.
 
-    auto new_parent = NodeCreation.createNode(widget, parent);
+    auto new_parent = NodeCreation.createNode(widget, parent).first;
     if (new_parent)
     {
         wxGetFrame().Freeze();

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1682,7 +1682,7 @@ void PropGridPanel::ModifyEmbeddedProperty(NodeProperty* node_prop, wxPGProperty
 
             auto group = std::make_shared<GroupUndoActions>("Update bitmap property", node);
 
-            auto new_embedded = NodeCreation.createNode(gen_embedded_image, image_list_node);
+            auto new_embedded = NodeCreation.createNode(gen_embedded_image, image_list_node).first;
             new_embedded->set_value(prop_bitmap, value);
             auto insert_action = std::make_shared<InsertNodeAction>(new_embedded.get(), image_list_node, tt_empty_cstr, pos);
             insert_action->AllowSelectEvent(false);

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -256,7 +256,7 @@ NodeSharedPtr NodeCreator::createNodeFromXml(pugi::xml_node& xml_obj, Node* pare
     if (class_name == "wxListCtrl")
         class_name = "wxListView";
 
-    auto new_node = createNode(class_name, parent);
+    auto new_node = createNode(class_name, parent).first;
     if (!new_node)
     {
         FAIL_MSG(tt_string() << "Invalid project file: could not create " << class_name);

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -370,6 +370,8 @@ int ProjectHandler::getCodePreference(Node* node) const
         return GEN_LANG_PYTHON;
     else if (value == "Ruby")
         return GEN_LANG_RUBY;
+    else if (value == "Perl")
+        return GEN_LANG_PERL;
     else if (value == "XRC")
         return GEN_LANG_XRC;
     else

--- a/src/winres/import_winres.cpp
+++ b/src/winres/import_winres.cpp
@@ -104,7 +104,7 @@ bool WinResource::ImportRc(const tt_string& rc_file, std::vector<tt_string>& for
 
     if (!isNested)
     {
-        m_project = NodeCreation.createNode(gen_Project, nullptr);
+        m_project = NodeCreation.createNode(gen_Project, nullptr).first;
         m_codepage = 1252;
     }
 

--- a/src/winres/winres_layout.cpp
+++ b/src/winres/winres_layout.cpp
@@ -14,7 +14,7 @@ void resForm::CreateDialogLayout()
 {
     if (!m_ctrls.size())
     {
-        m_dlg_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_form_node.get());
+        m_dlg_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_form_node.get()).first;
         m_dlg_sizer->set_value(prop_var_name, "dlg_sizer");
         m_form_node->adoptChild(m_dlg_sizer);
 
@@ -29,7 +29,7 @@ void resForm::CreateDialogLayout()
 
     // dlg_sizer is the top level sizer for the entire dialog
 
-    m_dlg_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_form_node.get());
+    m_dlg_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_form_node.get()).first;
     ASSERT(m_dlg_sizer);
     m_dlg_sizer->set_value(prop_var_name, "dlg_sizer");
     m_form_node->adoptChild(m_dlg_sizer);
@@ -65,14 +65,14 @@ void resForm::CreateDialogLayout()
                 if (m_ctrls[idx_child].getNode()->as_string(prop_alignment).contains("wxALIGN_RIGHT") ||
                     m_ctrls[idx_child].getNode()->as_string(prop_alignment).contains("wxALIGN_CENTER_HORIZONTAL"))
                 {
-                    auto vertical_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_dlg_sizer.get());
+                    auto vertical_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_dlg_sizer.get()).first;
                     vertical_sizer->set_value(prop_flags, "wxEXPAND");
                     m_dlg_sizer->adoptChild(vertical_sizer);
                     adoptChild(vertical_sizer, m_ctrls[idx_child]);
                 }
                 else
                 {
-                    auto sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get());
+                    auto sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get()).first;
                     m_dlg_sizer->adoptChild(sizer);
                     adoptChild(sizer, m_ctrls[idx_child]);
                 }
@@ -131,10 +131,10 @@ void resForm::CreateDialogLayout()
                         is_within_vertical(m_ctrls, idx_child + 2, idx_child))
                     // clang-format on
                     {
-                        auto horizontal_sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get());
+                        auto horizontal_sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get()).first;
                         m_dlg_sizer->adoptChild(horizontal_sizer);
                         adoptChild(horizontal_sizer, m_ctrls[idx_child]);
-                        auto vertical_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_dlg_sizer.get());
+                        auto vertical_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_dlg_sizer.get()).first;
                         horizontal_sizer->adoptChild(vertical_sizer);
                         auto listbox_child = idx_child;
                         NextChild(idx_child);
@@ -152,7 +152,7 @@ void resForm::CreateDialogLayout()
                                 m_ctrls[idx_child + 1].isGen(gen_wxButton) && !m_ctrls[idx_child + 1].isAdded() &&
                                 is_same_top(m_ctrls, idx_child, idx_child + 1))
                             {
-                                auto box_sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get());
+                                auto box_sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get()).first;
                                 vertical_sizer->adoptChild(box_sizer);
                                 adoptChild(box_sizer, m_ctrls[idx_child]);
                                 adoptChild(box_sizer, m_ctrls[idx_child + 1]);
@@ -170,7 +170,7 @@ void resForm::CreateDialogLayout()
 
             // If there is more than one child with the same top position, then create a horizontal box sizer
             // and add all children with the same top position.
-            auto sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get());
+            auto sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get()).first;
             m_dlg_sizer->adoptChild(sizer);
 
             if (m_ctrls[idx_child].getNode()->isGen(gen_wxStaticBoxSizer))
@@ -246,7 +246,7 @@ void resForm::CreateDialogLayout()
 
                 if (a_left_siblings.size() || a_right_siblings.size())
                 {
-                    auto sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get());
+                    auto sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get()).first;
                     if (a_left_siblings.size() && !a_left_siblings[0].get().isAdded())
                         AddSiblings(sizer.get(), a_left_siblings, &m_ctrls[idx_child]);
                     adoptChild(sizer, m_ctrls[idx_child]);
@@ -262,7 +262,7 @@ void resForm::CreateDialogLayout()
                 continue;
             }
 
-            auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_dlg_sizer.get());
+            auto sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_dlg_sizer.get()).first;
             m_dlg_sizer->adoptChild(sizer);
             adoptChild(sizer, m_ctrls[idx_child]);
             auto first_child = idx_child++;
@@ -339,9 +339,9 @@ void resForm::AddSiblings(Node* parent_sizer, std::vector<std::reference_wrapper
             // There's only one item which is positioned below the top of the sibling. We create a vertical box sizer and add
             // a spacer before the control to provide approximately the same amount of vertical space above the control.
 
-            auto vert_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, parent_sizer);
+            auto vert_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, parent_sizer).first;
             parent_sizer->adoptChild(vert_sizer);
-            auto spacer = NodeCreation.createNode(gen_spacer, vert_sizer.get());
+            auto spacer = NodeCreation.createNode(gen_spacer, vert_sizer.get()).first;
             spacer->set_value(prop_height, actrls[0].get().du_top() - pSibling->du_top());
             vert_sizer->adoptChild(spacer);
             adoptChild(vert_sizer.get(), &actrls[0].get());
@@ -349,7 +349,7 @@ void resForm::AddSiblings(Node* parent_sizer, std::vector<std::reference_wrapper
     }
     else
     {
-        auto vert_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, parent_sizer);
+        auto vert_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, parent_sizer).first;
         parent_sizer->adoptChild(vert_sizer);
 
         for (size_t idx_child = 0; idx_child < actrls.size(); ++idx_child)
@@ -364,7 +364,7 @@ void resForm::AddSiblings(Node* parent_sizer, std::vector<std::reference_wrapper
             {
                 // If there is more than one child with the same top position, then create a horizontal box sizer
                 // and add all children with the same top position.
-                auto horz_sizer = NodeCreation.createNode(gen_wxBoxSizer, vert_sizer.get());
+                auto horz_sizer = NodeCreation.createNode(gen_wxBoxSizer, vert_sizer.get()).first;
                 vert_sizer->adoptChild(horz_sizer);
                 horz_sizer->set_value(prop_orientation, "wxHORIZONTAL");
 
@@ -427,7 +427,7 @@ void resForm::AddSiblings(Node* parent_sizer, std::vector<std::reference_wrapper
 
                     if (a_left_siblings.size() || a_right_siblings.size())
                     {
-                        auto horz_sizer = NodeCreation.createNode(gen_wxBoxSizer, vert_sizer.get());
+                        auto horz_sizer = NodeCreation.createNode(gen_wxBoxSizer, vert_sizer.get()).first;
                         if (a_left_siblings.size())
                             AddSiblings(horz_sizer.get(), a_left_siblings, &actrls[idx_child].get());
                         adoptChild(horz_sizer, actrls[first_child]);
@@ -481,7 +481,7 @@ void resForm::AddStaticBoxChildren(const resCtrl& box, size_t idx_group_box)
         else if (result == 0)
         {
             // Single row with all control tops the same, so use a horizontal box sizer
-            auto sizer = NodeCreation.createNode(gen_wxBoxSizer, box.getNode());
+            auto sizer = NodeCreation.createNode(gen_wxBoxSizer, box.getNode()).first;
             sizer->set_value(prop_orientation, "wxHORIZONTAL");
             static_box.getNode()->adoptChild(sizer);
 
@@ -501,7 +501,7 @@ void resForm::AddStaticBoxChildren(const resCtrl& box, size_t idx_group_box)
             // work, but it would add a lot of complexity to figure that out, and visually it would look the same.
 
             auto total_columns = result;  // This is just for readability
-            auto grid_sizer = NodeCreation.createNode(gen_wxFlexGridSizer, box.getNode());
+            auto grid_sizer = NodeCreation.createNode(gen_wxFlexGridSizer, box.getNode()).first;
             grid_sizer->set_value(prop_cols, tt::itoa(total_columns));
             static_box.getNode()->adoptChild(grid_sizer);
 
@@ -541,7 +541,7 @@ void resForm::AddStaticBoxChildren(const resCtrl& box, size_t idx_group_box)
                         is_within_vertical(group_ctrls, idx_group_child + 2, idx_group_child))
                     // clang-format on
                     {
-                        auto vertical_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_dlg_sizer.get());
+                        auto vertical_sizer = NodeCreation.createNode(gen_VerticalBoxSizer, m_dlg_sizer.get()).first;
                         grid_sizer->adoptChild(vertical_sizer);
                         auto listbox_child = idx_group_child;
                         ++idx_group_child;
@@ -561,7 +561,7 @@ void resForm::AddStaticBoxChildren(const resCtrl& box, size_t idx_group_box)
                                 !group_ctrls[idx_group_child + 1].get().isAdded() &&
                                 is_same_top(group_ctrls, idx_group_child, idx_group_child + 1))
                             {
-                                auto box_sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get());
+                                auto box_sizer = NodeCreation.createNode(gen_wxBoxSizer, m_dlg_sizer.get()).first;
                                 vertical_sizer->adoptChild(box_sizer);
                                 adoptChild(box_sizer, group_ctrls[idx_group_child]);
                                 adoptChild(box_sizer, group_ctrls[idx_group_child + 1]);
@@ -604,7 +604,7 @@ void resForm::AddStaticBoxChildren(const resCtrl& box, size_t idx_group_box)
                     // out the total number of columns.
                     while (cur_column < total_columns)
                     {
-                        auto spacer = NodeCreation.createNode(gen_spacer, grid_sizer.get());
+                        auto spacer = NodeCreation.createNode(gen_spacer, grid_sizer.get()).first;
                         grid_sizer->adoptChild(spacer);
                         ++cur_column;
                     }
@@ -870,7 +870,7 @@ void resForm::CreateStdButton()
 {
     if (!m_stdButtonSizer)
     {
-        m_stdButtonSizer = NodeCreation.createNode(gen_wxStdDialogButtonSizer, m_dlg_sizer.get());
+        m_stdButtonSizer = NodeCreation.createNode(gen_wxStdDialogButtonSizer, m_dlg_sizer.get()).first;
         m_stdButtonSizer->set_value(prop_OK, "0");
         m_stdButtonSizer->set_value(prop_Cancel, "0");
         m_stdButtonSizer->set_value(prop_flags, "wxEXPAND");
@@ -879,7 +879,7 @@ void resForm::CreateStdButton()
 
 size_t resForm::AddTwoColumnPairs(size_t idx_start)
 {
-    auto grid_sizer = NodeCreation.createNode(gen_wxFlexGridSizer, m_dlg_sizer.get());
+    auto grid_sizer = NodeCreation.createNode(gen_wxFlexGridSizer, m_dlg_sizer.get()).first;
     grid_sizer->set_value(prop_cols, 2);
     m_dlg_sizer->adoptChild(grid_sizer);
 
@@ -921,7 +921,7 @@ size_t resForm::AddTwoColumnPairs(size_t idx_start)
 
 size_t resForm::AddTwoColumnStaticText(size_t idx_start)
 {
-    auto grid_sizer = NodeCreation.createNode(gen_wxFlexGridSizer, m_dlg_sizer.get());
+    auto grid_sizer = NodeCreation.createNode(gen_wxFlexGridSizer, m_dlg_sizer.get()).first;
     grid_sizer->set_value(prop_cols, 2);
     m_dlg_sizer->adoptChild(grid_sizer);
 
@@ -1006,7 +1006,7 @@ void resForm::CheckForFlexGrid(Node* parent)
                 continue;
 
             // If we get here, then the two box sizers can be converted into a single flex grid sizer
-            auto grid_sizer = NodeCreation.createNode(gen_wxFlexGridSizer, m_dlg_sizer.get());
+            auto grid_sizer = NodeCreation.createNode(gen_wxFlexGridSizer, m_dlg_sizer.get()).first;
             grid_sizer->set_value(prop_cols, tt_string() << first_sizer->getChildCount());
             for (box_child = 0; box_child < first_sizer->getChildCount(); ++box_child)
             {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes `NodeCreator::createNode` and `Node::createChildNode` so that they take a `verify_language_support` parameter and return a `std::pair<NodeSharedPtr, int>` containing the node and an error code. In addition, generators can now override a new `SupportedLanguages()` method which allows each generator to specify which languages the generator supports. Combining the two changes makes it possible to notify the user that a requested widget is not supported in the project's `code_preference` setting. The user then has the option of creating the node anyway, or cancelling creation of the widget.

See #1509