### PR TITLE
Add ability to warn about unsupported language properties

### DIFF
--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -923,6 +923,32 @@ int BaseGenerator::GetRequiredVersion(Node* node)
     return minRequiredVer;
 }
 
+std::optional<tt_string> BaseGenerator::isLanguagePropSupported(Node* node, GenLang language, GenEnum::PropName prop)
+{
+    if (prop == prop_persist && node->as_bool(prop))
+    {
+        switch (language)
+        {
+            case GEN_LANG_LUA:
+                return "persist is not supported in Lua";
+            case GEN_LANG_PERL:
+                return "persist is not supported in Perl";
+            case GEN_LANG_PHP:
+                return "persist is not supported in PHP";
+            case GEN_LANG_PYTHON:
+                return "persist is not supported in Python";
+            case GEN_LANG_HASKELL:
+                return "persist is not supported in Haskell";
+            case GEN_LANG_XRC:
+                return "persist is not supported in XRC";
+            default:
+                return {};
+        }
+    }
+
+    return {};
+}
+
 PropDeclaration* DeclAddProp(NodeDeclaration* declaration, PropName prop_name, PropType type, std::string_view help,
                              std::string_view def_value)
 {

--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -200,6 +200,12 @@ public:
     // result.has_value() == true indicates that the generator cannot construct the object
     // using the current language and version. Use result.value() to get the error message.
     virtual std::optional<tt_string> isLanguageVersionSupported(GenLang /* language */) { return {}; }
+
+    // result.has_value() == true indicates that the property is not supported using the
+    // current language and version. Use result.value() to get the warning message. This will
+    // be called *after* the property is set, so the generator can query the property's
+    // current value.
+    virtual std::optional<tt_string> isLanguagePropSupported(Node*, GenLang, GenEnum::PropName);
 };
 
 PropDeclaration* DeclAddProp(NodeDeclaration* declaration, PropName prop_name, PropType type, std::string_view help = {},

--- a/src/generate/gen_radio_btn.cpp
+++ b/src/generate/gen_radio_btn.cpp
@@ -106,7 +106,7 @@ bool RadioButtonGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeP
     {
         if (m_info_warning)
         {
-            wxGetFrame().GetPropInfoBar()->Dismiss();
+            wxGetFrame().DismissInfoBar();
             m_info_warning = false;
         }
 
@@ -121,15 +121,15 @@ bool RadioButtonGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodeP
             if (pos > 0 && parent->getChild(pos - 1)->isGen(gen_wxRadioButton) &&
                 parent->getChild(pos - 1)->as_string(prop_style).contains("wxRB_GROUP"))
             {
-                auto info = wxGetFrame().GetPropInfoBar();
-                info->ShowMessage("The previous radio button is also set as the start of a group!", wxICON_INFORMATION);
+                wxGetFrame().ShowInfoBarMsg("The previous radio button is also set as the start of a group!",
+                                            wxICON_INFORMATION);
                 m_info_warning = true;
             }
             else if (pos + 1 < parent->getChildCount() && parent->getChild(pos + 1)->isGen(gen_wxRadioButton) &&
                      parent->getChild(pos + 1)->as_string(prop_style).contains("wxRB_GROUP"))
             {
-                auto info = wxGetFrame().GetPropInfoBar();
-                info->ShowMessage("The next radio button is also set as the start of a group!", wxICON_INFORMATION);
+                wxGetFrame().ShowInfoBarMsg("The next radio button is also set as the start of a group!",
+                                            wxICON_INFORMATION);
                 m_info_warning = true;
             }
         }

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -67,36 +67,24 @@ bool TextCtrlGenerator::OnPropertyChange(wxObject* widget, Node* node, NodePrope
     {
         if (prop->hasValue() && !node->as_string(prop_style).contains("wxTE_RICH2"))
         {
-            if (auto infobar = wxGetFrame().GetPropInfoBar(); infobar)
-            {
-                infobar->ShowMessage("When used on Windows, spell checking requires the style to contain wxTE_RICH2.",
-                                     wxICON_INFORMATION);
-            }
+            wxGetFrame().ShowInfoBarMsg("When used on Windows, spell checking requires the style to contain wxTE_RICH2.",
+                                        wxICON_INFORMATION);
         }
         else
         {
-            if (auto infobar = wxGetFrame().GetPropInfoBar(); infobar)
-            {
-                infobar->Dismiss();
-            }
+            wxGetFrame().DismissInfoBar();
         }
     }
     else if (prop->isProp(prop_style))
     {
         if (node->hasValue(prop_spellcheck) && !node->as_string(prop_style).contains("wxTE_RICH2"))
         {
-            if (auto infobar = wxGetFrame().GetPropInfoBar(); infobar)
-            {
-                infobar->ShowMessage("When used on Windows, spell checking requires the style to contain wxTE_RICH2.",
-                                     wxICON_INFORMATION);
-            }
+            wxGetFrame().ShowInfoBarMsg("When used on Windows, spell checking requires the style to contain wxTE_RICH2.",
+                                        wxICON_INFORMATION);
         }
         else
         {
-            if (auto infobar = wxGetFrame().GetPropInfoBar(); infobar)
-            {
-                infobar->Dismiss();
-            }
+            wxGetFrame().DismissInfoBar();
         }
     }
 #endif  // _WIN32

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -2270,3 +2270,18 @@ void MainFrame::OnReloadProject(wxCommandEvent& WXUNUSED(event))
         Project.LoadProject(Project.getProjectFile());
     }
 }
+
+void MainFrame::ShowInfoBarMsg(const tt_string& msg, int icon)
+{
+    m_info_bar->ShowMessage(msg, icon);
+    m_info_bar_dismissed = false;
+}
+
+void MainFrame::DismissInfoBar()
+{
+    if (!m_info_bar_dismissed)
+    {
+        m_info_bar->Dismiss();
+        m_info_bar_dismissed = true;
+    }
+}

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -237,6 +237,11 @@ public:
 
     wxInfoBar* GetPropInfoBar() { return m_info_bar; }
 
+    // Shows info bar message above code display panels
+    // icon is one of wxICON_INFORMATION, wxICON_WARNING, wxICON_ERROR, or wxICON_QUESTION
+    void ShowInfoBarMsg(const tt_string& msg, int icon = wxICON_WARNING);
+    void DismissInfoBar();
+
     wxFileHistory* GetAppendImportHistory() { return &m_ImportHistory; }
 
     void ProjectLoaded();
@@ -406,6 +411,7 @@ private:
     wxSize m_dpi_toolbar_size;
 
     wxInfoBar* m_info_bar { nullptr };
+    bool m_info_bar_dismissed { true };
 
     ueStatusBar* m_statBar { nullptr };
 

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -263,7 +263,7 @@ void NavigationPanel::OnSelChanged(wxTreeEvent& event)
             m_pMainFrame->getPropPanel()->Create();
 
         // TODO: [Randalphwa - 09-30-2024] Once all generators support isLanguageVersionSupported(),
-        // this could should be changed to call the generator to determine if the control is
+        // this should be changed to call the generator to determine if the control is
         // supported by the current language.
 
         if (Project.getCodePreference() == GEN_LANG_PYTHON)
@@ -271,9 +271,7 @@ void NavigationPanel::OnSelChanged(wxTreeEvent& event)
             if (std::find(unsupported_gen_python.begin(), unsupported_gen_python.end(), iter->second->getGenName()) !=
                 unsupported_gen_python.end())
             {
-                auto info = wxGetFrame().GetPropInfoBar();
-                info->Dismiss();
-                info->ShowMessage("This control is not supported by wxPython.", wxICON_INFORMATION);
+                wxGetFrame().ShowInfoBarMsg("This control is not supported by wxPython.", wxICON_INFORMATION);
             }
         }
         else if (Project.getCodePreference() == GEN_LANG_RUBY)
@@ -281,9 +279,7 @@ void NavigationPanel::OnSelChanged(wxTreeEvent& event)
             if (std::find(unsupported_gen_ruby.begin(), unsupported_gen_ruby.end(), iter->second->getGenName()) !=
                 unsupported_gen_ruby.end())
             {
-                auto info = wxGetFrame().GetPropInfoBar();
-                info->Dismiss();
-                info->ShowMessage("This control is not supported by wxRuby.", wxICON_INFORMATION);
+                wxGetFrame().ShowInfoBarMsg("This control is not supported by wxRuby.", wxICON_INFORMATION);
             }
         }
         else if (Project.as_string(prop_code_preference) == "XRC")
@@ -291,9 +287,7 @@ void NavigationPanel::OnSelChanged(wxTreeEvent& event)
             if (std::find(unsupported_gen_XRC.begin(), unsupported_gen_XRC.end(), iter->second->getGenName()) !=
                 unsupported_gen_XRC.end())
             {
-                auto info = wxGetFrame().GetPropInfoBar();
-                info->Dismiss();
-                info->ShowMessage("This control is not supported by XRC.", wxICON_INFORMATION);
+                wxGetFrame().ShowInfoBarMsg("This control is not supported by XRC.", wxICON_INFORMATION);
             }
         }
 

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -1358,6 +1358,23 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
     }
 
     ChangeEnableState(prop);
+
+    if (auto gen = prop->getNode()->getGenerator(); gen)
+    {
+        auto result = gen->isLanguagePropSupported(prop->getNode(), Project.getCodePreference(), prop->get_name());
+        if (result.has_value())
+        {
+            wxGetFrame().ShowInfoBarMsg(result.value());
+        }
+        else
+        {
+            wxGetFrame().DismissInfoBar();
+        }
+    }
+    else
+    {
+        wxGetFrame().DismissInfoBar();
+    }
 }
 
 void PropGridPanel::ChangeEnableState(NodeProperty* changed_prop)


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR is related to issue #1509 by adding the ability for generators to warn the user if the current code preference language does not support the property being modified from it's default value. The proof of concept is the `persist` property which is only available for C++ and wxRuby3. It is implemented in `BaseGenerator`, but can be implemented in individual generators as well.