### PR TITLE
Use correct wxPython library for wxTreeListCtrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Add missing events to wxPropertyGrid and wxPropertyGridManager
 - wxPython now correctly loads embedded animation files for wx.adv.AnimationCtrl
 - XRC generation now includes variant property settings for forms
+- wxPython now places wxTreeListCtrol in the dataview library
 
 ## [Released (1.2.1)]
 

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -50,6 +50,9 @@ static const view_map s_short_python_map
     { "wxGRID_", "wx.grid."},
 
     { "wxEVT_DATAVIEW_", "wx.dataview."},
+    { "wxEVT_TREELIST_", "wx.dataview." },
+    { "wxTL_", "wx.dataview." },
+
     { "wxEVT_DATE_", "wx.adv."},
     { "wxEVT_GRID_", "wx.grid." },
     { "wxEVT_RIBBON", "wx.ribbon." },
@@ -91,6 +94,7 @@ const view_map g_map_python_prefix
     { "wxDataViewCtrl",         "wx.dataview."},
     { "wxDataViewListCtrl",     "wx.dataview."},
     { "wxDataViewTreeCtrl",     "wx.dataview."},
+    { "wxTreeListCtrl",         "wx.dataview."},
     { "wxGrid",                 "wx.grid."},
     { "wxPropertyGridManager",  "wx.propgrid."},
     { "wxPropertyGrid",         "wx.propgrid."},


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This places the wxPython generation of `wxTreeListCtrl` and it's events in the `dataview` library. See issue #1516 for details.