### PR TITLE
Fix invalid line break in wxPthon code generation

### DIFF
--- a/src/generate/gen_std_dlgbtn_sizer.cpp
+++ b/src/generate/gen_std_dlgbtn_sizer.cpp
@@ -265,9 +265,13 @@ void StdDialogButtonSizerGenerator::GenPythonConstruction(Code& code)
     // CreateSeparatedSizer, the dialog will not display correctly and will shortly exit. To
     // work around this, we create the line ourselves (except on MAC).
 
-    code += "if \"wxMac\" not in wx.PlatformInfo:";
-    code.Eol().Tab().NodeName().Add("_line = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))");
-    code.Eol().Tab().ParentName().Function("Add(").NodeName() += "_line, wx.SizerFlags().Expand().Border(wx.ALL))";
+    code.Str("if \"wxMac\" not in wx.PlatformInfo:");
+    // Because we are combining the node name with "_line", we need to do it *before* we add the
+    // wx.StaticLine portion, or Str() will break the line after NodeName().
+    code.Eol().Tab().NodeName().Str("_line = \\");
+    code.Eol().Tab().Tab().Str("wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))");
+    code.Eol().Tab().ParentName().Function("Add(").NodeName().Str("_line, ");
+    code.Str("wx.SizerFlags().Expand().Border(wx.ALL))");
 
     code.Eol().Eol().NodeName().Add(" = wx.StdDialogButtonSizer()");
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The `GenPythonConstruction()` for `StdDialogButtonSizerGenerator` needs to combine the standard button node name with "_line". However, because NodeName() is a separate function, the call to add the rest of the line inserted an EOL first because the line would otherwise be too long.

Fixes #1518