### PR TITLE
Let wxString convert case rather than std::to...()

### DIFF
--- a/src/tt/tt_string.cpp
+++ b/src/tt/tt_string.cpp
@@ -412,21 +412,17 @@ size_t tt_string::get_hash() const noexcept
 
 tt_string& tt_string::MakeLower()
 {
-    auto utf8locale = std::locale("en_US.utf8");
-    for (auto iter = begin(); iter != end(); ++iter)
-    {
-        *iter = std::tolower(*iter, utf8locale);
-    }
+    wxString str = wxString::FromUTF8(data());
+    str.MakeLower();
+    *this = str.utf8_string();
     return *this;
 }
 
 tt_string& tt_string::MakeUpper()
 {
-    auto utf8locale = std::locale("en_US.utf8");
-    for (auto iter = begin(); iter != end(); ++iter)
-    {
-        *iter = std::toupper(*iter, utf8locale);
-    }
+    wxString str = wxString::FromUTF8(data());
+    str.MakeUpper();
+    *this = str.utf8_string();
     return *this;
 }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Now that wxString is build as UTF8, it makes more sense to let wxWidgets handle case-conversion. This should resolve problems with non-english locales that occurred with the previous code.

For more info, see #1519