### PR TITLE
Fix variable name prefix fix-up for different programming languages

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1085,26 +1085,16 @@ Code& Code::NodeName(Node* node)
 {
     if (!node)
         node = m_node;
-    auto& node_name = node->getNodeName();
+    auto node_name = node->getNodeName(get_language());
     if (is_python() && !node->isForm() && !node->isLocal())
     {
         *this += "self.";
     }
-    if (is_ruby() && !node->isForm() && !node->isLocal())
+    if (is_ruby() && !node->isForm() && !node->isLocal() && node_name[0] != '@')
     {
         *this += "@";
     }
-
-    // We don't create these, preferring to add them like the above, however the user can
-    // create them. For Ruby and Python, they will get duplicated since they already got added
-    // above, and for C++ the @ is invalid, and the _ not recommended.
-    if (node_name[0] == '@' || node_name[0] == '_')
-        *this += node_name.subview(1);
-    // m_ prefix should only be used for C++ code, so remove it if this isn't C++ code
-    else if (!is_cpp() && node_name.is_sameprefix("m_"))
-        *this += node_name.subview(2);
-    else
-        *this += node_name;
+    *this += node_name;
     return *this;
 }
 

--- a/src/generate/gen_box_sizer.cpp
+++ b/src/generate/gen_box_sizer.cpp
@@ -73,7 +73,7 @@ bool BoxSizerGenerator::AfterChildrenCode(Code& code)
         }
         else
         {
-            if (GetParentName(code.node()) != "this")
+            if (GetParentName(code.node(), code.get_language()) != "this")
             {
                 code.ValidParentName().Function("SetSizerAndFit(");
             }

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -121,7 +121,7 @@ static constexpr GenType s_GenParentTypes[] = {
 
 // clang-format on
 
-tt_string GetParentName(Node* node)
+tt_string GetParentName(Node* node, GenLang language)
 {
     auto parent = node->getParent();
     while (parent)
@@ -130,7 +130,7 @@ tt_string GetParentName(Node* node)
         {
             if (parent->isStaticBoxSizer())
             {
-                return (tt_string() << parent->getNodeName() << "->GetStaticBox()");
+                return (tt_string() << parent->getNodeName(language) << "->GetStaticBox()");
             }
         }
         if (parent->isForm())
@@ -142,7 +142,7 @@ tt_string GetParentName(Node* node)
         {
             if (parent->isType(iter))
             {
-                tt_string name = parent->getNodeName();
+                tt_string name = parent->getNodeName(language);
                 if (parent->isGen(gen_wxCollapsiblePane))
                 {
                     name << "->GetPane()";

--- a/src/generate/gen_common.h
+++ b/src/generate/gen_common.h
@@ -45,7 +45,7 @@ void InsertGeneratorInclude(Node* node, const std::string& include, std::set<std
 
 // This is *NOT* the same as getNodeName() -- this will handle wxStaticBox and
 // wxCollapsiblePane parents as well as "normal" parents
-tt_string GetParentName(Node* node);
+tt_string GetParentName(Node* node, GenLang language);
 
 // Used for controls that need to call SetBitmap(bitmap). Returns true if wxVector generated.
 //

--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -194,7 +194,7 @@ void BaseCodeGenerator::GenConstruction(Node* node)
             }
             else
             {
-                if (GetParentName(node) != "this")
+                if (GetParentName(node, m_language) != "this")
                     gen_code.ParentName();
                 else if (gen_code.is_python())
                     gen_code.Str("self");

--- a/src/generate/gen_ctx_menu.cpp
+++ b/src/generate/gen_ctx_menu.cpp
@@ -114,7 +114,8 @@ bool CtxMenuGenerator::AfterChildrenCode(Code& code)
         if (auto generator = iter->getNode()->getNodeDeclaration()->getGenerator(); generator)
         {
             Code event_code(iter->getNode(), code.m_language);
-            if (generator->GenEvent(event_code, iter, code.node()->getParentName()); event_code.size())
+            if (generator->GenEvent(event_code, iter, code.node()->getParentName(code.get_language()).as_str());
+                event_code.size())
             {
                 event_code.GetCode().Replace("\t", "\t\t", true);
                 code.Eol(eol_if_needed).Str("ctx_menu.") += event_code.GetCode();

--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -98,7 +98,7 @@ bool CustomControl::ConstructionCode(Code& code)
     tt_string parameters(code.view(prop_parameters));
     if (parameters.starts_with('('))
         parameters.erase(0, 1);
-    parameters.Replace("${parent}", code.node()->getParentName(), tt::REPLACE::all);
+    parameters.Replace("${parent}", code.node()->getParentName(code.get_language()), tt::REPLACE::all);
     if (code.is_cpp())
     {
         parameters.Replace("self", "this", tt::REPLACE::all);

--- a/src/generate/gen_flexgrid_sizer.cpp
+++ b/src/generate/gen_flexgrid_sizer.cpp
@@ -171,7 +171,7 @@ bool FlexGridSizerGenerator::AfterChildrenCode(Code& code)
         }
         else
         {
-            if (GetParentName(code.node()) != "this")
+            if (GetParentName(code.node(), code.get_language()) != "this")
             {
                 code.ValidParentName().Function("SetSizerAndFit(");
             }

--- a/src/generate/gen_grid_sizer.cpp
+++ b/src/generate/gen_grid_sizer.cpp
@@ -74,7 +74,7 @@ bool GridSizerGenerator::AfterChildrenCode(Code& code)
         }
         else
         {
-            if (GetParentName(code.node()) != "this")
+            if (GetParentName(code.node(), code.get_language()) != "this")
             {
                 code.ValidParentName().Function("SetSizerAndFit(");
             }

--- a/src/generate/gen_gridbag_sizer.cpp
+++ b/src/generate/gen_gridbag_sizer.cpp
@@ -234,7 +234,7 @@ bool GridBagSizerGenerator::AfterChildrenCode(Code& code)
         }
         else
         {
-            if (GetParentName(code.node()) != "this")
+            if (GetParentName(code.node(), code.get_language()) != "this")
             {
                 code.ValidParentName().Function("SetSizerAndFit(");
             }

--- a/src/generate/gen_menu.cpp
+++ b/src/generate/gen_menu.cpp
@@ -59,13 +59,13 @@ bool MenuGenerator::AfterChildrenCode(Code& code)
         if (parent_type == type_form || parent_type == type_frame_form || parent_type == type_panel_form ||
             parent_type == type_wizard)
         {
-            code << "Bind(wxEVT_RIGHT_DOWN, &" << node->getParentName() << "::" << node->getParentName()
-                 << "OnContextMenu, this);";
+            code << "Bind(wxEVT_RIGHT_DOWN, &" << node->getParentName(code.get_language())
+                 << "::" << node->getParentName(code.get_language()) << "OnContextMenu, this);";
         }
         else
         {
             code.ValidParentName().Function("Bind(wxEVT_RIGHT_DOWN, &")
-                << node->getFormName() << "::" << node->getParentName() << "OnContextMenu, this);";
+                << node->getFormName() << "::" << node->getParentName(code.get_language()) << "OnContextMenu, this);";
         }
     }
     code.Eol(eol_if_needed);

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -218,7 +218,7 @@ bool StaticCheckboxBoxSizerGenerator::AfterChildrenCode(Code& code)
         }
         else
         {
-            if (GetParentName(code.node()) != "this")
+            if (GetParentName(code.node(), code.get_language()) != "this")
             {
                 code.ParentName().Add(".");
                 code.Function("SetSizerAndFit(");

--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -66,6 +66,13 @@ bool StaticBoxSizerGenerator::ConstructionCode(Code& code)
             }
             parent = parent->getParent();
         }
+        if (parent)
+        {
+            if (code.is_python() && !parent->isLocal())
+                parent_name = "self." + parent_name;
+            else if (code.is_ruby() && !parent->isLocal())
+                parent_name = "@" + parent_name;
+        }
     }
     code.AddAuto().NodeName().CreateClass().Add(prop_orientation).Comma().Str(parent_name);
 

--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -49,13 +49,13 @@ bool StaticBoxSizerGenerator::ConstructionCode(Code& code)
         {
             if (parent->isContainer())
             {
-                parent_name = parent->getNodeName();
+                parent_name = parent->getNodeName(code.get_language());
                 break;
             }
             else if (parent->isGen(gen_wxStaticBoxSizer) || parent->isGen(gen_StaticCheckboxBoxSizer) ||
                      parent->isGen(gen_StaticRadioBtnBoxSizer))
             {
-                parent_name = parent->getNodeName();
+                parent_name = parent->getNodeName(code.get_language());
                 if (code.is_cpp())
                     parent_name << "->GetStaticBox()";
                 else if (code.is_python())

--- a/src/generate/gen_staticbox_sizer.cpp
+++ b/src/generate/gen_staticbox_sizer.cpp
@@ -118,7 +118,7 @@ bool StaticBoxSizerGenerator::AfterChildrenCode(Code& code)
         }
         else
         {
-            if (GetParentName(code.node()) != "this")
+            if (GetParentName(code.node(), code.get_language()) != "this")
             {
                 code.ValidParentName().Function("SetSizerAndFit(");
             }

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -207,7 +207,7 @@ bool StaticRadioBtnBoxSizerGenerator::AfterChildrenCode(Code& code)
         }
         else
         {
-            if (GetParentName(code.node()) != "this")
+            if (GetParentName(code.node(), code.get_language()) != "this")
             {
                 code.ValidParentName().Function("SetSizerAndFit(");
             }

--- a/src/generate/gen_wrap_sizer.cpp
+++ b/src/generate/gen_wrap_sizer.cpp
@@ -71,7 +71,7 @@ bool WrapSizerGenerator::AfterChildrenCode(Code& code)
         }
         else
         {
-            if (GetParentName(code.node()) != "this")
+            if (GetParentName(code.node(), code.get_language()) != "this")
             {
                 code.ValidParentName().Function("SetSizerAndFit(");
             }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -499,10 +499,46 @@ const tt_string& Node::getNodeName() const
         return tt_empty_cstr;
 }
 
+tt_string_view Node::getNodeName(GenLang lang) const
+{
+    tt_string_view name = getNodeName();
+    if (lang == GEN_LANG_CPLUSPLUS)
+    {
+        // Valid for Ruby, but not for C++
+        if (name[0] == '@')
+            name.remove_prefix(1);
+        // Used for local Python variables, but non-standard for C++ where '_' is typically used for
+        // member variables
+        else if (name[0] == '_' && isLocal())
+            name.remove_prefix(1);
+        return name;
+    }
+
+    if (name[0] == '@' && lang != GEN_LANG_RUBY)
+    {
+        name.remove_prefix(1);
+        return name;
+    }
+
+    // GEN_LANG_CPLUSPLUS is handled above
+    ASSERT(lang != GEN_LANG_CPLUSPLUS);
+    if (name.starts_with("m_"))
+        name.remove_prefix(2);
+    return name;
+}
+
 const tt_string& Node::getParentName() const
 {
     if (m_parent)
         return m_parent->getNodeName();
+
+    return tt_empty_cstr;
+}
+
+tt_string_view Node::getParentName(GenLang lang) const
+{
+    if (m_parent)
+        return m_parent->getNodeName(lang);
 
     return tt_empty_cstr;
 }

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -165,8 +165,16 @@ public:
     // Returns the value of the property "var_name" or "class_name"
     const tt_string& getNodeName() const;
 
+    // May remove prefix based on the language -- e.g., @foo become foo unless the language
+    // is GEN_LANG_RUBY
+    tt_string_view getNodeName(GenLang lang) const;
+
     // Returns the value of the parent property "var_name" or "class_name"
     const tt_string& getParentName() const;
+
+    // May remove prefix based on the language -- e.g., @foo become foo unless the language
+    // is GEN_LANG_RUBY
+    tt_string_view getParentName(GenLang lang) const;
 
     // Returns this if the node is a form, else walks up node tree to find the parent form.
     Node* getForm() noexcept;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Programming languages sometimes have different conventions for a variable's name prefix. C++ often uses `m_` for class members, whereas Ruby typically uses `@`. If a project is being used to generate more than one language, then the prefix may need to be removed depending on the language currently being generated.

This PR adds a variation of `Node::getNodeName(...)` which takes a language parameter. For non-Ruby languages, this will remove a leading `@`. For non-C++ languages, this will remove a leading `m_`. For C++, if the node name does not have class access, this will remove a leading `_`.

Verified with update to TestFormPanel in wxUiTesting repository (modified from the project file in #1521).

Closes #1521