### PR TITLE
Prevent wxTreeListCtrl from generating code in unsupported languages (e.g., wxRuby3)

### DIFF
--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -43,6 +43,14 @@ void BaseCodeGenerator::GenConstruction(Node* node)
         m_warnings.emplace(warning_msg.value());
     }
 
+    if (auto supported_msg = generator->isLanguageVersionSupported(m_language); supported_msg)
+    {
+        Code gen_code(node, m_language);
+        gen_code.AddComment(supported_msg.value(), true);
+        m_source->writeLine(gen_code);
+        return;
+    }
+
     bool need_closing_brace = false;
     Code gen_code(node, m_language);
 

--- a/src/generate/gen_tree_list.h
+++ b/src/generate/gen_tree_list.h
@@ -20,6 +20,9 @@ public:
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr,
                      GenLang /* language */) override;
 
+    void GenEvent(Code& code, NodeEvent* event, const std::string& class_name) override;
+
+    std::optional<tt_string> isLanguageVersionSupported(GenLang language) override;
     std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR prevents wxTreeListCtrl from generating code for any language other than C++ and Python.

This should be used as a template for any other generator that has limited language support. It requires overriding the following BaseGenerator methods:

- GenEvent()
- isLanguageVersionSupported()
- GetWarning()

Closes #1529
