### PR TITLE
Try to find an appropriate parent when adding a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - All coordinates using dialog units will automatically be converted to physical pixels. For C++ using wxWidgets 3.2 or higher along with wxPython and wxRuby, FromDIP() will be called to scale the UI as needed on high DPI displays.
+- In most cases, you no longer need to select a sizer or container before adding a widget. wxUiEditor will now attempt to find an appropriate parent for what you want to add starting from your current selection.
 - Generic option removed for wxAnimationCtrl. The generic version is automatically generated when a ANI animation file is specified. This will correctly display the file on wxGTK when generating C++ and wxPthon code. wxRuby3 does not support Wx::GenericAnimationCtrl in version 1.0, so only the regular version is generated.
 - derived_class property in the wxWindows category has been changed to subclass to better reflect that the generated class derives from your specified class. The derived_class_name in the various language categories remain unchanged to indicate you derive your class from the generated class.
 - wxRuby3 generated code now supports persistence property (`Wx.persistent_register_and_restore`)

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -617,7 +617,7 @@ wxSizerFlags Node::getSizerFlags() const
     return flags;
 }
 
-std::pair<NodeSharedPtr, int> Node::createChildNode(GenName name, bool verify_language_support)
+std::pair<NodeSharedPtr, int> Node::createChildNode(GenName name, bool verify_language_support, int pos)
 {
     auto& frame = wxGetFrame();
 
@@ -698,7 +698,7 @@ std::pair<NodeSharedPtr, int> Node::createChildNode(GenName name, bool verify_la
 
         tt_string undo_str;
         undo_str << "insert " << map_GenNames[name];
-        frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str));
+        frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, pos));
     }
 
     // A "ribbonButton" component is used for both wxRibbonButtonBar and wxRibbonToolBar. If creating the node failed,
@@ -712,7 +712,7 @@ std::pair<NodeSharedPtr, int> Node::createChildNode(GenName name, bool verify_la
         }
         new_node = result.first;
         tt_string undo_str = "insert ribbon tool";
-        frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), this, undo_str));
+        frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), this, undo_str, pos));
     }
     else
     {
@@ -757,10 +757,10 @@ std::pair<NodeSharedPtr, int> Node::createChildNode(GenName name, bool verify_la
                     }
                 }
 
-                auto pos = parent->findInsertionPos(this);
+                auto insert_pos = parent->findInsertionPos(this);
                 tt_string undo_str;
                 undo_str << "insert " << map_GenNames[name];
-                frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, pos));
+                frame.PushUndoAction(std::make_shared<InsertNodeAction>(new_node.get(), parent, undo_str, insert_pos));
             }
         }
         else

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -409,7 +409,7 @@ public:
     //
     // If verify_language_support is true, then the node will only be created if the
     // preferred language supports it (unless the user agrees to create it anyway)
-    std::pair<NodeSharedPtr, int> createChildNode(GenName name, bool verify_language_support = false);
+    std::pair<NodeSharedPtr, int> createChildNode(GenName name, bool verify_language_support = false, int pos = -1);
 
     // Gets the current selected node and uses that to call createChildNode().
     Node* createNode(GenName name);
@@ -417,7 +417,7 @@ public:
     // This is the preferred way to create a new node when requested by the user (tool, menu,
     // or dialog). Besides creating the node, some nodes will get special processing to
     // automatically create additional child nodes.
-    bool createToolNode(GenName name);
+    bool createToolNode(GenName name, int pos = -1);
 
     // This will modify the property and fire a EVT_NodePropChange event if the property
     // actually changed

--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -56,8 +56,8 @@ public:
     // preferred language supports it (unless the user agrees to create it anyway)
     std::pair<NodeSharedPtr, int> createNode(GenName name, Node* parent, bool verify_language_support = false);
 
-    // Only creates the node if the parent allows it as a child. Returns the node and an
-    // error code.
+    // Only creates the node if the parent allows it as a child. Returns the node and a
+    // Node:: error code (see enum in node.h).
     //
     // If verify_language_support is true, then the node will only be created if the
     // preferred language supports it (unless the user agrees to create it anyway)
@@ -96,7 +96,14 @@ public:
 
     bool isOldHostType(tt_string_view old_type) const { return m_setOldHostTypes.contains(old_type); }
 
-    size_t countChildrenWithSameType(Node* parent, GenType type);
+    // Returns valid parent if there is one, which may be different from the parent passed to
+    // the function.
+    //
+    // Returns nullptr if no parent can be found that allows this child type (which might
+    // mean that parent already has the maximum number of children allowed).
+    Node* isValidCreateParent(GenName name, Node* parent) const;
+
+    size_t countChildrenWithSameType(Node* parent, GenType type) const;
 
 protected:
     // This must

--- a/src/nodes/tool_creator.cpp
+++ b/src/nodes/tool_creator.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Functions for creating new nodes from Ribbon Panel
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -112,10 +112,11 @@ static void SetUniqueRibbonToolID(Node* node)
     node->set_value(prop_id, new_name);
 }
 
-bool Node::createToolNode(GenName name)
+bool Node::createToolNode(GenName name, int pos)
 {
     if (isGen(gen_Project))
     {
+        // If needed, change the names to the Form version version the normal child version
         if (name == gen_wxMenuBar)
         {
             name = gen_MenuBar;
@@ -243,7 +244,17 @@ bool Node::createToolNode(GenName name)
         name = gen_ribbonTool;
     }
 
-    auto result = createChildNode(name, true);
+    if (auto valid_parent = NodeCreation.isValidCreateParent(name, this); valid_parent && valid_parent != this)
+    {
+        if (valid_parent && valid_parent == getParent() && !valid_parent->isGen(gen_wxGridBagSizer))
+        {
+            auto new_pos = valid_parent->getChildPosition(this) + 1;
+            return valid_parent->createToolNode(name, static_cast<int>(new_pos));
+        }
+        return valid_parent->createToolNode(name, pos);
+    }
+
+    auto result = createChildNode(name, true, pos);
     if (result.second == Node::unsupported_language)
     {
         return true;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how a new node gets created. Instead of failing to insert a node if the currently selected item can't be a parent, it will walk up the parent hierarchy to see if it can find an appropriate parent.

Besides no longer requiring you to change your selection before adding sequential items, if the item you are adding and the item selected have the same parent, then the new item will be added directly after the selected item. This is different than selecting the parent, where the item is always added to the end of the parent's children.