### PR TITLE
Improve horizontal movement in navigation pane

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -2067,7 +2067,8 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
             return false;
 
         case MoveDirection::Right:
-            if (node->isGen(gen_folder) || node->isGen(gen_data_folder) || node->isGen(gen_Images) || node->isGen(gen_Data))
+            if (node->isGen(gen_folder) || node->isGen(gen_sub_folder) || node->isGen(gen_data_folder) ||
+                node->isGen(gen_Images) || node->isGen(gen_Data))
             {
                 return false;
             }

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -2025,131 +2025,130 @@ bool MainFrame::MoveNode(Node* node, MoveDirection where, bool check_only)
     }
 
     if (parent->isGen(gen_wxGridBagSizer))
+    {
         return GridBag::MoveNode(node, where, check_only);
-
-    if (where == MoveDirection::Left)
-    {
-        if (node->isGen(gen_folder) || node->isGen(gen_data_folder))
-            return false;
-        else if (node->isGen(gen_sub_folder) && parent->isGen(gen_folder))
-            return false;  // You can't have Project as the parent of a sub_folder
-
-        if (parent->isGen(gen_folder) || parent->isGen(gen_sub_folder))
-        {
-            if (!check_only)
-            {
-                wxWindowUpdateLocker freeze(this);
-                PushUndoAction(std::make_shared<ChangeParentAction>(node, parent->getParent()));
-            }
-            return true;
-        }
-
-        auto grandparent = parent->getParent();
-        while (grandparent && !grandparent->isSizer())
-        {
-            grandparent = grandparent->getParent();
-        }
-
-        if (check_only)
-            return (grandparent ? true : false);
-
-        if (grandparent)
-        {
-            wxWindowUpdateLocker freeze(this);
-            PushUndoAction(std::make_shared<ChangeParentAction>(node, grandparent));
-            return true;
-        }
-        wxMessageBox("There is no sizer to the left of this item that it can be moved into.", "Move item");
     }
-    else if (where == MoveDirection::Right)
+
+    switch (where)
     {
-        if (node->isGen(gen_folder) || node->isGen(gen_data_folder))
-            return false;
+        case MoveDirection::Left:
+            if (node->isGen(gen_folder) || node->isGen(gen_data_folder))
+                return false;
+            else if (node->isGen(gen_sub_folder) && parent->isGen(gen_folder))
+                return false;  // You can't have Project as the parent of a sub_folder
 
-        auto pos = parent->getChildPosition(node) - 1;
-        if (pos < parent->getChildCount())
-        {
-            if (node->isForm() && pos >= 0)
+            if (parent->isGen(gen_folder) || parent->isGen(gen_sub_folder))
             {
-                auto* new_parent = parent->getChild(pos);
-                if (new_parent->isForm())
+                if (!check_only)
                 {
-                    if (!check_only)
-                        wxMessageBox("You cannot move a form to the right of another form.", "Move item");
-                    return false;
+                    wxWindowUpdateLocker freeze(this);
+                    PushUndoAction(std::make_shared<ChangeParentAction>(node, parent->getParent()));
                 }
-                else if (new_parent->isGen(gen_folder) || new_parent->isGen(gen_sub_folder))
-                {
-                    if (!check_only)
-                    {
-                        wxWindowUpdateLocker freeze(this);
-                        PushUndoAction(std::make_shared<ChangeParentAction>(node, new_parent));
-                    }
-                    return true;
-                }
-            }
-            else if (node->isGen(gen_sub_folder) && pos >= 0)
-            {
-                auto* new_parent = parent->getChild(pos);
-                while (new_parent->isForm())
-                {
-                    if (pos == 0)
-                    {
-                        if (!check_only)
-                            wxMessageBox("You cannot move a folder to the right of a form.", "Move item");
-                        return false;
-                    }
-                }
-                if (new_parent->isGen(gen_folder) || new_parent->isGen(gen_sub_folder))
-                {
-                    if (!check_only)
-                    {
-                        wxWindowUpdateLocker freeze(this);
-                        PushUndoAction(std::make_shared<ChangeParentAction>(node, new_parent));
-                    }
-                    return true;
-                }
-            }
-            parent = FindChildSizerItem(parent->getChild(pos), true);
-
-            if (check_only)
-                return (parent ? true : false);
-
-            if (parent)
-            {
-                wxWindowUpdateLocker freeze(this);
-                PushUndoAction(std::make_shared<ChangeParentAction>(node, parent));
                 return true;
             }
-        }
-        if (!check_only)
-            wxMessageBox("There is nothing above this item that it can be moved into.", "Move item");
-    }
-    else if (where == MoveDirection::Up)
-    {
-        auto pos = parent->getChildPosition(node);
-        if (check_only)
-            return (pos > 0);
-        if (pos > 0)
-        {
-            wxWindowUpdateLocker freeze(this);
-            PushUndoAction(std::make_shared<ChangePositionAction>(node, pos - 1));
-            return true;
-        }
-        wxMessageBox("This component cannot be moved up any further.", "Move item");
-    }
-    else if (where == MoveDirection::Down)
-    {
-        auto pos = parent->getChildPosition(node) + 1;
-        if (check_only)
-            return (pos < parent->getChildCount());
-        if (pos < parent->getChildCount())
-        {
-            wxWindowUpdateLocker freeze(this);
-            PushUndoAction(std::make_shared<ChangePositionAction>(node, pos));
-            return true;
-        }
-        wxMessageBox(tt_string() << node->declName() << " cannot be moved down any lower.", "Move item");
+
+            if (auto grandparent = parent->getParent(); grandparent)
+            {
+                auto valid_parent = NodeCreation.isValidCreateParent(node->getGenName(), grandparent);
+                if (check_only)
+                    return (valid_parent ? true : false);
+                if (valid_parent)
+                {
+                    wxWindowUpdateLocker freeze(this);
+                    PushUndoAction(std::make_shared<ChangeParentAction>(node, grandparent));
+                    return true;
+                }
+                ASSERT_MSG(check_only, tt_string() << "MoveDirection::Left called even though check would have failed.");
+            }
+            return false;
+
+        case MoveDirection::Right:
+            if (node->isGen(gen_folder) || node->isGen(gen_data_folder) || node->isGen(gen_Images) || node->isGen(gen_Data))
+            {
+                return false;
+            }
+
+            if (auto pos = parent->getChildPosition(node) - 1; pos < parent->getChildCount())
+            {
+                if (node->isForm() && pos >= 0)
+                {
+                    auto* new_parent = parent->getChild(pos);
+                    if (new_parent->isForm())
+                    {
+                        ASSERT_MSG(check_only, tt_string()
+                                                   << "MoveDirection::Right called even though check would have failed.");
+                        return false;
+                    }
+                    else if (new_parent->isGen(gen_folder) || new_parent->isGen(gen_sub_folder))
+                    {
+                        if (!check_only)
+                        {
+                            wxWindowUpdateLocker freeze(this);
+                            PushUndoAction(std::make_shared<ChangeParentAction>(node, new_parent));
+                        }
+                        return true;
+                    }
+                }
+                else if (node->isGen(gen_sub_folder) && pos >= 0)
+                {
+                    auto* new_parent = parent->getChild(pos);
+                    while (new_parent->isForm())
+                    {
+                        if (pos == 0)
+                        {
+                            ASSERT_MSG(check_only,
+                                       tt_string() << "MoveDirection::Right called even though check would have failed.");
+                            return false;
+                        }
+                    }
+                    if (new_parent->isGen(gen_folder) || new_parent->isGen(gen_sub_folder))
+                    {
+                        if (!check_only)
+                        {
+                            wxWindowUpdateLocker freeze(this);
+                            PushUndoAction(std::make_shared<ChangeParentAction>(node, new_parent));
+                        }
+                        return true;
+                    }
+                }
+
+                auto possible_parent = parent->getChild(pos);
+                if (auto valid_parent = NodeCreation.isValidCreateParent(node->getGenName(), possible_parent, false);
+                    valid_parent)
+                {
+                    if (!check_only)
+                    {
+                        wxWindowUpdateLocker freeze(this);
+                        PushUndoAction(std::make_shared<ChangeParentAction>(node, valid_parent));
+                    }
+                    return true;
+                }
+            }
+            return false;
+
+        case MoveDirection::Up:
+            if (auto pos = parent->getChildPosition(node); pos > 0)
+            {
+                if (!check_only)
+                {
+                    wxWindowUpdateLocker freeze(this);
+                    PushUndoAction(std::make_shared<ChangePositionAction>(node, pos - 1));
+                }
+                return true;
+            }
+            return false;
+
+        case MoveDirection::Down:
+            if (auto pos = parent->getChildPosition(node) + 1; pos < parent->getChildCount())
+            {
+                if (!check_only)
+                {
+                    wxWindowUpdateLocker freeze(this);
+                    PushUndoAction(std::make_shared<ChangePositionAction>(node, pos));
+                }
+                return true;
+            }
+            return false;
     }
 
     return false;
@@ -2186,26 +2185,6 @@ void MainFrame::ChangeEventHandler(NodeEvent* event, const tt_string& value)
         PushUndoAction(std::make_shared<ModifyEventAction>(event, value));
         UpdateWakaTime();
     }
-}
-
-Node* MainFrame::FindChildSizerItem(Node* node, bool include_splitter)
-{
-    if (include_splitter && node->isGen(gen_wxSplitterWindow) && node->getChildCount() < 2)
-        return node;
-    else if (node->getNodeDeclaration()->isSubclassOf(gen_sizer_dimension))
-        return node;
-    else
-    {
-        for (const auto& child: node->getChildNodePtrs())
-        {
-            if (auto result = FindChildSizerItem(child, include_splitter); result)
-            {
-                return result;
-            }
-        }
-    }
-
-    return nullptr;
 }
 
 void MainFrame::UpdateWakaTime(bool FileSavedEvent)

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -186,14 +186,6 @@ public:
     // that aligns with the PropertyGrid panel.
     void setStatusField(const tt_string text, int position = -1);
 
-    // Search for a sizer to move the node into.
-    // Set include_splitter to treat a splitter window like a sizer.
-    Node* FindChildSizerItem(Node* node, bool include_splitter = false);
-    Node* FindChildSizerItem(const NodeSharedPtr& node, bool include_splitter = false)
-    {
-        return FindChildSizerItem(node.get(), include_splitter);
-    }
-
     const wxSize& GetMenuDpiSize() { return m_dpi_menu_size; }
     const wxSize& GetRibbonDpiSize() { return m_dpi_ribbon_size; }
     const wxSize& GetToolbarDpiSize() { return m_dpi_toolbar_size; }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -775,7 +775,7 @@ std::pair<NodeSharedPtr, int> Node::createChildNode(GenName name, bool verify_la
         bool is_name_changed = false;
         if (Project.getCodePreference(this) == GEN_LANG_CPLUSPLUS)
         {
-            if (UserPrefs.is_CppSnakeCase())
+            if (new_node->hasProp(prop_var_name) && UserPrefs.is_CppSnakeCase())
             {
                 auto member_name = ConvertToSnakeCase(new_node->as_string(prop_var_name));
                 new_node->set_value(prop_var_name, member_name);

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -241,7 +241,7 @@ std::pair<NodeSharedPtr, int> NodeCreator::createNode(GenName name, Node* parent
     return { node, 0 };
 }
 
-Node* NodeCreator::isValidCreateParent(GenName name, Node* parent) const
+Node* NodeCreator::isValidCreateParent(GenName name, Node* parent, bool use_recursion) const
 {
     ASSERT(name != gen_unknown);
     if (name == gen_unknown)
@@ -336,7 +336,7 @@ Node* NodeCreator::isValidCreateParent(GenName name, Node* parent) const
             }
         }
     }
-    else
+    else if (use_recursion)
     {
         if (auto grandfather = parent->getParent(); grandfather)
         {

--- a/src/nodes/node_creator.h
+++ b/src/nodes/node_creator.h
@@ -101,7 +101,7 @@ public:
     //
     // Returns nullptr if no parent can be found that allows this child type (which might
     // mean that parent already has the maximum number of children allowed).
-    Node* isValidCreateParent(GenName name, Node* parent) const;
+    Node* isValidCreateParent(GenName name, Node* parent, bool use_recursion = true) const;
 
     size_t countChildrenWithSameType(Node* parent, GenType type) const;
 

--- a/src/undo_cmds.h
+++ b/src/undo_cmds.h
@@ -159,8 +159,8 @@ private:
 class ChangeParentAction : public UndoAction
 {
 public:
-    ChangeParentAction(Node* node, Node* parent);
-    ChangeParentAction(const NodeSharedPtr node, const NodeSharedPtr parent);
+    ChangeParentAction(Node* node, Node* parent, int pos = -1);
+    ChangeParentAction(const NodeSharedPtr node, const NodeSharedPtr parent, int pos = -1);
 
     void Change() override;
     void Revert() override;
@@ -172,7 +172,7 @@ public:
     size_t GetMemorySize() override { return sizeof(*this); }
 
 protected:
-    void Init(const NodeSharedPtr node, const NodeSharedPtr parent);
+    void Init(const NodeSharedPtr node, const NodeSharedPtr parent, int pos);
 
 private:
     NodeSharedPtr m_change_parent;
@@ -181,6 +181,7 @@ private:
     size_t m_revert_position;
     int m_revert_row;
     int m_revert_col;
+    int m_pos;
 };
 
 // Specify node and new sizer gen_ name.


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors the Move left and right functionality, with the result that horizontal moving is no longer restricted to sizer parents.

Closes #1538

## Details

The refactoring updates `isValidCreateParent()`, adding a `use_recursion` flag to prevent walking up the parent heirarchy. Move left and Move right now use this function rather than `FindChildSizerItem()` to look for a parent to move the selected item under.