### PR TITLE
Improve handling of unsupported components in specific code languages

### DIFF
--- a/src/generate/base_generator.h
+++ b/src/generate/base_generator.h
@@ -197,9 +197,9 @@ public:
     // Call this to retrieve any warning text when generating code for the specific language.
     virtual std::optional<tt_string> GetWarning(Node*, GenLang /* language */) { return {}; }
 
-    // result.has_value() == true indicates that the generator cannot construct the object
-    // using the current language and version. Use result.value() to get the error message.
-    virtual std::optional<tt_string> isLanguageVersionSupported(GenLang /* language */) { return {}; }
+    // result.first == false indicates that the generator cannot construct the object using
+    // the current language and version. result.second contains the error message.
+    virtual std::pair<bool, tt_string> isLanguageVersionSupported(GenLang /* language */) { return { true, {} }; }
 
     // result.has_value() == true indicates that the property is not supported using the
     // current language and version. Use result.value() to get the warning message. This will

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -164,6 +164,14 @@ void DataViewCtrl::RequiredHandlers(Node* /* node */, std::set<std::string>& han
     handlers.emplace("wxDataViewXmlHandler");
 }
 
+std::pair<bool, tt_string> DataViewCtrl::isLanguageVersionSupported(GenLang language)
+{
+    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+        return { true, {} };
+
+    return { false, tt_string() << "wxDataViewCtrl is not supported by " << ConvertFromGenLang(language) };
+}
+
 std::optional<tt_string> DataViewCtrl::GetWarning(Node* node, GenLang language)
 {
     switch (language)
@@ -295,6 +303,14 @@ void DataViewListCtrl::RequiredHandlers(Node* /* node */, std::set<std::string>&
     handlers.emplace("wxDataViewXmlHandler");
 }
 
+std::pair<bool, tt_string> DataViewListCtrl::isLanguageVersionSupported(GenLang language)
+{
+    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+        return { true, {} };
+
+    return { false, tt_string() << "wxDataViewListCtrl is not supported by " << ConvertFromGenLang(language) };
+}
+
 std::optional<tt_string> DataViewListCtrl::GetWarning(Node* node, GenLang language)
 {
     switch (language)
@@ -339,6 +355,14 @@ bool DataViewTreeCtrl::GetIncludes(Node* node, std::set<std::string>& set_src, s
 {
     InsertGeneratorInclude(node, "#include <wx/dataview.h>", set_src, set_hdr);
     return true;
+}
+
+std::pair<bool, tt_string> DataViewTreeCtrl::isLanguageVersionSupported(GenLang language)
+{
+    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+        return { true, {} };
+
+    return { false, tt_string() << "wxDataViewTreeCtrl is not supported by " << ConvertFromGenLang(language) };
 }
 
 std::optional<tt_string> DataViewTreeCtrl::GetWarning(Node* node, GenLang language)
@@ -417,6 +441,35 @@ bool DataViewColumn::ConstructionCode(Code& code)
     return true;
 }
 
+std::pair<bool, tt_string> DataViewColumn::isLanguageVersionSupported(GenLang language)
+{
+    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+    {
+        return { true, {} };
+    };
+
+    return { false, tt_string() << "DataViewColumn is not supported by " << ConvertFromGenLang(language) };
+}
+
+std::optional<tt_string> DataViewColumn::GetWarning(Node* node, GenLang language)
+{
+    switch (language)
+    {
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support DataViewColumn";
+                return msg;
+            }
+        default:
+            return {};
+    }
+}
+
 //////////////////////////////////////////  DataViewListColumn  //////////////////////////////////////////
 
 bool DataViewListColumn::ConstructionCode(Code& code)
@@ -437,4 +490,31 @@ bool DataViewListColumn::ConstructionCode(Code& code)
     }
 
     return true;
+}
+
+std::pair<bool, tt_string> DataViewListColumn::isLanguageVersionSupported(GenLang language)
+{
+    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+        return { true, {} };
+
+    return { false, tt_string() << "DataViewListColumn is not supported by " << ConvertFromGenLang(language) };
+}
+
+std::optional<tt_string> DataViewListColumn::GetWarning(Node* node, GenLang language)
+{
+    switch (language)
+    {
+        case GEN_LANG_RUBY:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << "wxRuby currently does not support DataViewListColumn";
+                return msg;
+            }
+        default:
+            return {};
+    }
 }

--- a/src/generate/dataview_widgets.h
+++ b/src/generate/dataview_widgets.h
@@ -23,6 +23,7 @@ public:
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
+    std::pair<bool, tt_string> isLanguageVersionSupported(GenLang language) override;
     std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };
 
@@ -40,6 +41,7 @@ public:
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
+    std::pair<bool, tt_string> isLanguageVersionSupported(GenLang language) override;
     std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };
 
@@ -56,6 +58,7 @@ public:
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
 
+    std::pair<bool, tt_string> isLanguageVersionSupported(GenLang language) override;
     std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };
 
@@ -63,10 +66,16 @@ class DataViewColumn : public BaseGenerator
 {
 public:
     bool ConstructionCode(Code&) override;
+
+    std::pair<bool, tt_string> isLanguageVersionSupported(GenLang language) override;
+    std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };
 
 class DataViewListColumn : public BaseGenerator
 {
 public:
     bool ConstructionCode(Code&) override;
+
+    std::pair<bool, tt_string> isLanguageVersionSupported(GenLang language) override;
+    std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };

--- a/src/generate/gen_construction.cpp
+++ b/src/generate/gen_construction.cpp
@@ -43,10 +43,10 @@ void BaseCodeGenerator::GenConstruction(Node* node)
         m_warnings.emplace(warning_msg.value());
     }
 
-    if (auto supported_msg = generator->isLanguageVersionSupported(m_language); supported_msg)
+    if (auto supported = generator->isLanguageVersionSupported(m_language); !supported.first)
     {
         Code gen_code(node, m_language);
-        gen_code.AddComment(supported_msg.value(), true);
+        gen_code.AddComment(supported.second, true);
         m_source->writeLine(gen_code);
         return;
     }

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -15,6 +15,7 @@
 
 #include "../customprops/eventhandler_dlg.h"  // EventHandlerDlg static functions
 #include "base_generator.h"                   // BaseGenerator -- Base Generator class
+#include "base_generator.h"                   // BaseGenerator -- Base widget generator class
 #include "code.h"                             // Code -- Helper class for generating code
 #include "file_codewriter.h"                  // FileCodeWriter -- Classs to write code to disk
 #include "lambdas.h"                          // Functions for formatting and storage of lamda events
@@ -40,6 +41,10 @@ constexpr auto prop_sheet_events =
 
 void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& class_name)
 {
+    if (auto generator = event->getNode()->getGenerator();
+        !generator || !generator->isLanguageVersionSupported(code.get_language()).first)
+        return;  // Current language does not support this node
+
     Code handler(event->getNode(), code.m_language);
     tt_string event_code;
     if (code.m_language == GEN_LANG_CPLUSPLUS)

--- a/src/generate/gen_popup_win.cpp
+++ b/src/generate/gen_popup_win.cpp
@@ -300,12 +300,13 @@ bool PopupWinBaseGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
     return true;
 }
 
-std::optional<tt_string> PopupWinBaseGenerator::isLanguageVersionSupported(GenLang language)
+std::pair<bool, tt_string> PopupWinBaseGenerator::isLanguageVersionSupported(GenLang language)
 {
     if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON | GEN_LANG_RUBY)))
-        return {};
+        return { true, {} };
     // TODO: [Randalphwa - 10-01-2024] At some point, other languages may have versions that support these,
     // in which case call Project.getLangVersion()
 
-    return tt_string() << "wxPopupWindow and wxPopupTransientWindow are not supported by " << ConvertFromGenLang(language);
+    return { false, tt_string() << "wxPopupWindow and wxPopupTransientWindow are not supported by "
+                                << ConvertFromGenLang(language) };
 }

--- a/src/generate/gen_popup_win.h
+++ b/src/generate/gen_popup_win.h
@@ -18,7 +18,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr,
                      GenLang /* language */) override;
-    std::optional<tt_string> isLanguageVersionSupported(GenLang language) override;
+    std::pair<bool, tt_string> isLanguageVersionSupported(GenLang language) override;
 };
 
 class PopupWinGenerator : public PopupWinBaseGenerator

--- a/src/generate/gen_tree_list.cpp
+++ b/src/generate/gen_tree_list.cpp
@@ -36,7 +36,8 @@ void TreeListCtrlGenerator::AfterCreation(wxObject* wxobject, wxWindow* /* wxpar
 
 bool TreeListCtrlGenerator::ConstructionCode(Code& code)
 {
-    ASSERT_MSG(!isLanguageVersionSupported(code.get_language()), isLanguageVersionSupported(code.get_language()).value());
+    ASSERT_MSG(isLanguageVersionSupported(code.get_language()).first,
+               isLanguageVersionSupported(code.get_language()).second);
     code.AddAuto().NodeName().CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.PosSizeFlags(code::allow_scaling, true, "wxTL_DEFAULT_STYLE");
 
@@ -79,12 +80,12 @@ std::optional<tt_string> TreeListCtrlGenerator::GetWarning(Node* node, GenLang l
     }
 }
 
-std::optional<tt_string> TreeListCtrlGenerator::isLanguageVersionSupported(GenLang language)
+std::pair<bool, tt_string> TreeListCtrlGenerator::isLanguageVersionSupported(GenLang language)
 {
     if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
-        return {};
+        return { true, {} };
 
-    return tt_string() << "wxTreeListCtrl is not supported by " << ConvertFromGenLang(language);
+    return { false, tt_string() << "wxTreeListCtrl is not supported by " << ConvertFromGenLang(language) };
 }
 
 //////////////////////////////////////////  TreeListCtrlColumnGenerator  //////////////////////////////////////////

--- a/src/generate/gen_tree_list.h
+++ b/src/generate/gen_tree_list.h
@@ -22,7 +22,7 @@ public:
 
     void GenEvent(Code& code, NodeEvent* event, const std::string& class_name) override;
 
-    std::optional<tt_string> isLanguageVersionSupported(GenLang language) override;
+    std::pair<bool, tt_string> isLanguageVersionSupported(GenLang language) override;
     std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };
 

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -226,9 +226,9 @@ std::pair<NodeSharedPtr, int> NodeCreator::createNode(GenName name, Node* parent
         if (auto gen = node->getGenerator(); gen)
         {
             auto result = gen->isLanguageVersionSupported(Project.getCodePreference());
-            if (result.has_value())
+            if (!result.first)
             {
-                if (wxMessageBox(result.value() + ". Create anyway?", "Unsupported widget", wxYES_NO | wxICON_QUESTION) ==
+                if (wxMessageBox(result.second + ". Create anyway?", "Unsupported widget", wxYES_NO | wxICON_QUESTION) ==
                     wxNO)
                 {
                     // Because node only has a sigle reference, it will be deleted when it goes out


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors BaseGenerator::isLanguageVersionSupported() to make it more readable.

DataViewCtrl, DataViewListCtrl, DataViewTreeCtrl, DataViewColumn, and DataViewListColumn are all marked as unsupported in wxRuby.

Events are no longer generated for languages that don't support the component generating the event (e.g., wxRuby not supporting DataView components).
