### PR TITLE
Support "none" as an empty event handler

### DIFF
--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -622,6 +622,64 @@ void EventHandlerDlg::OnChange(wxCommandEvent& WXUNUSED(event))
     FormatBindText();
 }
 
+void EventHandlerDlg::OnOK(wxCommandEvent& event)
+{
+    Update_m_value();
+    event.Skip();
+}
+
+void EventHandlerDlg::OnNone(wxCommandEvent& WXUNUSED(event))
+{
+    if (m_is_cpp_enabled && m_notebook->GetCurrentPage() == m_cpp_bookpage)
+        m_cpp_text_function->SetValue("none");
+    else if (m_is_python_enabled && m_notebook->GetCurrentPage() == m_python_bookpage)
+        m_py_text_function->SetValue("none");
+    else if (m_is_ruby_enabled && m_notebook->GetCurrentPage() == m_ruby_bookpage)
+        m_ruby_text_function->SetValue("none");
+
+    else if (m_is_fortran_enabled && m_notebook->GetCurrentPage() == m_fortran_bookpage)
+        m_fortran_text_function->SetValue("none");
+    else if (m_is_haskell_enabled && m_notebook->GetCurrentPage() == m_haskell_bookpage)
+        m_haskell_text_function->SetValue("none");
+    else if (m_is_lua_enabled && m_notebook->GetCurrentPage() == m_lua_bookpage)
+        m_lua_text_function->SetValue("none");
+    else if (m_is_perl_enabled && m_notebook->GetCurrentPage() == m_perl_bookpage)
+        m_perl_text_function->SetValue("none");
+    else if (m_is_rust_enabled && m_notebook->GetCurrentPage() == m_rust_bookpage)
+        m_rust_text_function->SetValue("none");
+}
+
+void EventHandlerDlg::OnDefault(wxCommandEvent& WXUNUSED(event))
+{
+    tt_string value;
+    if (auto default_name = s_EventNames.find(m_event->get_name()); default_name != s_EventNames.end())
+    {
+        value = default_name->second;
+    }
+    else
+    {
+        value = "OnEvent";
+    }
+
+    if (m_is_cpp_enabled && m_notebook->GetCurrentPage() == m_cpp_bookpage)
+        m_cpp_text_function->SetValue(value);
+    else if (m_is_python_enabled && m_notebook->GetCurrentPage() == m_python_bookpage)
+        m_py_text_function->SetValue(ConvertToSnakeCase(value.ToStdString()).make_wxString());
+    else if (m_is_ruby_enabled && m_notebook->GetCurrentPage() == m_ruby_bookpage)
+        m_ruby_text_function->SetValue(ConvertToSnakeCase(m_value.ToStdString()).make_wxString());
+
+    else if (m_is_fortran_enabled && m_notebook->GetCurrentPage() == m_fortran_bookpage)
+        m_fortran_text_function->SetValue(value);
+    else if (m_is_haskell_enabled && m_notebook->GetCurrentPage() == m_haskell_bookpage)
+        m_haskell_text_function->SetValue(value);
+    else if (m_is_lua_enabled && m_notebook->GetCurrentPage() == m_lua_bookpage)
+        m_lua_text_function->SetValue(value);
+    else if (m_is_perl_enabled && m_notebook->GetCurrentPage() == m_perl_bookpage)
+        m_perl_text_function->SetValue(value);
+    else if (m_is_rust_enabled && m_notebook->GetCurrentPage() == m_rust_bookpage)
+        m_rust_text_function->SetValue(value);
+}
+
 void EventHandlerDlg::FormatBindText()
 {
     auto page = m_notebook->GetSelection();
@@ -768,12 +826,6 @@ void EventHandlerDlg::CollectMemberVariables(Node* node, std::set<std::string>& 
     {
         CollectMemberVariables(child.get(), variables);
     }
-}
-
-void EventHandlerDlg::OnOK(wxCommandEvent& event)
-{
-    Update_m_value();
-    event.Skip();
 }
 
 // We could just call m_cpp_stc_lambda->GetTextRaw() however this method minimizes both the

--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -135,61 +135,78 @@ EventHandlerDlg::EventHandlerDlg(wxWindow* parent, NodeEvent* event) : EventHand
 
         // On Windows, this saves converting the UTF16 characters to ANSI.
         m_cpp_stc_lambda->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_u8_cpp_keywords);
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_COMMENT, UserPrefs.get_CppCommentColour());
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_COMMENTLINE, UserPrefs.get_CppCommentColour());
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_COMMENTDOC, UserPrefs.get_CppCommentColour());
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, UserPrefs.get_CppCommentColour());
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_NUMBER, UserPrefs.get_CppNumberColour());
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_STRING, UserPrefs.get_CppStringColour());
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_STRINGEOL, UserPrefs.get_CppStringColour());
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_WORD, UserPrefs.get_CppKeywordColour());
+        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_WORD2, UserPrefs.get_CppColour());
     }
     if (m_is_ruby_enabled)
     {
         m_ruby_stc_lambda->SetLexer(wxSTC_LEX_RUBY);
         m_ruby_stc_lambda->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_ruby_keywords);
 
-        m_ruby_stc_lambda->StyleSetForeground(wxSTC_RB_WORD, "#FF00FF");
-        m_ruby_stc_lambda->StyleSetForeground(wxSTC_RB_STRING, wxColour(0, 128, 0));
-        m_ruby_stc_lambda->StyleSetForeground(wxSTC_RB_COMMENTLINE, wxColour(0, 128, 0));
-        m_ruby_stc_lambda->StyleSetForeground(wxSTC_RB_NUMBER, *wxRED);
+        m_ruby_stc_lambda->StyleSetForeground(wxSTC_RB_COMMENTLINE, UserPrefs.get_RubyCommentColour());
+        m_ruby_stc_lambda->StyleSetForeground(wxSTC_RB_NUMBER, UserPrefs.get_RubyNumberColour());
+        m_ruby_stc_lambda->StyleSetForeground(wxSTC_RB_STRING, UserPrefs.get_RubyStringColour());
+        m_ruby_stc_lambda->StyleSetForeground(wxSTC_RB_WORD, UserPrefs.get_RubyColour());
     }
     if (m_is_fortran_enabled)
     {
-        m_fortran_stc_lambda->SetLexer(wxSTC_LEX_HASKELL);
+        m_fortran_stc_lambda->SetLexer(wxSTC_LEX_FORTRAN);
         m_fortran_stc_lambda->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_fortran_keywords);
 
-        m_fortran_stc_lambda->StyleSetForeground(wxSTC_HA_STRING, UserPrefs.get_FortranStringColour());
-        m_fortran_stc_lambda->StyleSetForeground(wxSTC_HA_COMMENTLINE, UserPrefs.get_FortranCommentColour());
-        m_fortran_stc_lambda->StyleSetForeground(wxSTC_HA_KEYWORD, UserPrefs.get_FortranKeywordColour());
+        m_fortran_stc_lambda->StyleSetForeground(wxSTC_F_COMMENT, UserPrefs.get_FortranCommentColour());
+        m_fortran_stc_lambda->StyleSetForeground(wxSTC_F_NUMBER, UserPrefs.get_FortranNumberColour());
+        m_fortran_stc_lambda->StyleSetForeground(wxSTC_F_STRING1, UserPrefs.get_FortranStringColour());
+        m_fortran_stc_lambda->StyleSetForeground(wxSTC_F_WORD, UserPrefs.get_FortranKeywordColour());
+        m_fortran_stc_lambda->StyleSetForeground(wxSTC_F_WORD2, UserPrefs.get_FortranColour());
     }
     if (m_is_haskell_enabled)
     {
         m_haskell_stc_lambda->SetLexer(wxSTC_LEX_HASKELL);
         m_haskell_stc_lambda->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_haskell_keywords);
 
-        m_haskell_stc_lambda->StyleSetForeground(wxSTC_HA_STRING, UserPrefs.get_PythonStringColour());
-        m_haskell_stc_lambda->StyleSetForeground(wxSTC_HA_COMMENTLINE, UserPrefs.get_PythonCommentColour());
-        m_haskell_stc_lambda->StyleSetForeground(wxSTC_HA_KEYWORD, UserPrefs.get_PythonKeywordColour());
+        m_haskell_stc_lambda->StyleSetForeground(wxSTC_HA_COMMENTLINE, UserPrefs.get_HaskellCommentColour());
+        m_haskell_stc_lambda->StyleSetForeground(wxSTC_HA_NUMBER, UserPrefs.get_HaskellNumberColour());
+        m_haskell_stc_lambda->StyleSetForeground(wxSTC_HA_STRING, UserPrefs.get_HaskellStringColour());
+        m_haskell_stc_lambda->StyleSetForeground(wxSTC_HA_KEYWORD, UserPrefs.get_HaskellKeywordColour());
     }
     if (m_is_lua_enabled)
     {
         m_lua_stc_lambda->SetLexer(wxSTC_LEX_LUA);
         m_lua_stc_lambda->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_lua_keywords);
 
-        m_lua_stc_lambda->StyleSetForeground(wxSTC_LUA_STRING, UserPrefs.get_PythonStringColour());
-        m_lua_stc_lambda->StyleSetForeground(wxSTC_LUA_COMMENT, UserPrefs.get_PythonCommentColour());
-        m_lua_stc_lambda->StyleSetForeground(wxSTC_LUA_WORD, UserPrefs.get_PythonKeywordColour());
+        m_lua_stc_lambda->StyleSetForeground(wxSTC_LUA_COMMENT, UserPrefs.get_LuaCommentColour());
+        m_lua_stc_lambda->StyleSetForeground(wxSTC_LUA_NUMBER, UserPrefs.get_LuaNumberColour());
+        m_lua_stc_lambda->StyleSetForeground(wxSTC_LUA_STRING, UserPrefs.get_LuaStringColour());
+        m_lua_stc_lambda->StyleSetForeground(wxSTC_LUA_WORD, UserPrefs.get_LuaKeywordColour());
+        m_lua_stc_lambda->StyleSetForeground(wxSTC_LUA_WORD2, UserPrefs.get_LuaColour());
     }
     if (m_is_perl_enabled)
     {
         m_perl_stc_lambda->SetLexer(wxSTC_LEX_PERL);
         m_perl_stc_lambda->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_perl_keywords);
 
-        m_perl_stc_lambda->StyleSetForeground(wxSTC_PL_STRING, UserPrefs.get_PythonStringColour());
-        m_perl_stc_lambda->StyleSetForeground(wxSTC_PL_COMMENTLINE, UserPrefs.get_PythonCommentColour());
-        m_perl_stc_lambda->StyleSetForeground(wxSTC_PL_WORD, UserPrefs.get_PythonKeywordColour());
+        m_perl_stc_lambda->StyleSetForeground(wxSTC_PL_COMMENTLINE, UserPrefs.get_PerlCommentColour());
+        m_perl_stc_lambda->StyleSetForeground(wxSTC_PL_NUMBER, UserPrefs.get_PerlNumberColour());
+        m_perl_stc_lambda->StyleSetForeground(wxSTC_PL_STRING, UserPrefs.get_PerlStringColour());
+        m_perl_stc_lambda->StyleSetForeground(wxSTC_PL_WORD, UserPrefs.get_PerlKeywordColour());
     }
     if (m_is_rust_enabled)
     {
-        m_rust_stc_lambda->SetLexer(wxSTC_LEX_PHPSCRIPT);
+        m_rust_stc_lambda->SetLexer(wxSTC_LEX_RUST);
         m_rust_stc_lambda->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_rust_keywords);
 
-        m_rust_stc_lambda->StyleSetForeground(wxSTC_HPHP_HSTRING, UserPrefs.get_PythonStringColour());
-        m_rust_stc_lambda->StyleSetForeground(wxSTC_HPHP_COMMENT, UserPrefs.get_PythonCommentColour());
-        m_rust_stc_lambda->StyleSetForeground(wxSTC_HPHP_WORD, UserPrefs.get_PythonKeywordColour());
+        m_rust_stc_lambda->StyleSetForeground(wxSTC_RUST_COMMENTLINE, UserPrefs.get_RustCommentColour());
+        m_rust_stc_lambda->StyleSetForeground(wxSTC_RUST_NUMBER, UserPrefs.get_RustNumberColour());
+        m_rust_stc_lambda->StyleSetForeground(wxSTC_RUST_STRING, UserPrefs.get_RustStringColour());
+        m_rust_stc_lambda->StyleSetForeground(wxSTC_RUST_WORD, UserPrefs.get_RustKeywordColour());
+        m_rust_stc_lambda->StyleSetForeground(wxSTC_RUST_WORD2, UserPrefs.get_RustColour());
     }
 
     auto form = event->getNode()->getForm();
@@ -208,7 +225,6 @@ EventHandlerDlg::EventHandlerDlg(wxWindow* parent, NodeEvent* event) : EventHand
             if (keywords.size() && keywords.back() == ' ')
                 keywords.pop_back();
             m_cpp_stc_lambda->SetKeyWords(1, keywords);
-            m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_WORD2, wxColour("#E91AFF"));
         }
 
         // Python lambdas are an anonymous function expressed as a single statement.
@@ -266,19 +282,6 @@ EventHandlerDlg::EventHandlerDlg(wxWindow* parent, NodeEvent* event) : EventHand
             m_rust_stc_lambda->SetLexer(wxSTC_LEX_PHPSCRIPT);
             m_rust_stc_lambda->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_rust_keywords);
         }
-    }
-    if (m_is_cpp_enabled)
-    {
-        m_cpp_stc_lambda->StyleSetBold(wxSTC_C_WORD, true);
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_WORD, *wxBLUE);
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_STRING, wxColour(0, 128, 0));
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_STRINGEOL, wxColour(0, 128, 0));
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_PREPROCESSOR, wxColour(49, 106, 197));
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_COMMENT, wxColour(0, 128, 0));
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_COMMENTLINE, wxColour(0, 128, 0));
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_COMMENTDOC, wxColour(0, 128, 0));
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_COMMENTLINEDOC, wxColour(0, 128, 0));
-        m_cpp_stc_lambda->StyleSetForeground(wxSTC_C_NUMBER, *wxRED);
     }
 
     if (m_code_preference == GEN_LANG_CPLUSPLUS)

--- a/src/customprops/eventhandler_dlg.h
+++ b/src/customprops/eventhandler_dlg.h
@@ -111,6 +111,8 @@ protected:
     void OnUsePythonLambda(wxCommandEvent& event) override;
     void OnUseRubyFunction(wxCommandEvent& event) override;
     void OnUseRubyLambda(wxCommandEvent& WXUNUSED(event)) override;
+    void OnDefault(wxCommandEvent& event) override;
+    void OnNone(wxCommandEvent& event) override;
 
     wxString m_value;
 

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -86,7 +86,7 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
         event_code.clear();
     }
 
-    if (event_code.empty())
+    if (event_code.empty() || event_code == "none")
         return;
 
     // This is what we normally use if an ID is needed. However, a C++ lambda needs to put the

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -173,11 +173,11 @@ CodeDisplay::CodeDisplay(wxWindow* parent, GenLang panel_type) : CodeDisplayBase
         {
             m_scintilla->StyleSetForeground(wxSTC_P_STRINGEOL, wxColour(0, 128, 0));
         }
-        m_scintilla->StyleSetForeground(wxSTC_P_WORD2, UserPrefs.get_PythonColour());
-        m_scintilla->StyleSetForeground(wxSTC_P_WORD, UserPrefs.get_PythonKeywordColour());
+        m_scintilla->StyleSetForeground(wxSTC_P_COMMENTLINE, UserPrefs.get_PythonCommentColour());
         m_scintilla->StyleSetForeground(wxSTC_P_NUMBER, UserPrefs.get_PythonNumberColour());
         m_scintilla->StyleSetForeground(wxSTC_P_STRING, UserPrefs.get_PythonStringColour());
-        m_scintilla->StyleSetForeground(wxSTC_P_COMMENTLINE, UserPrefs.get_PythonCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_P_WORD, UserPrefs.get_PythonColour());
+        m_scintilla->StyleSetForeground(wxSTC_P_WORD2, UserPrefs.get_PythonKeywordColour());
     }
     else if (panel_type == GEN_LANG_RUBY)
     {
@@ -252,43 +252,17 @@ CodeDisplay::CodeDisplay(wxWindow* parent, GenLang panel_type) : CodeDisplayBase
             }
         }
 
-        m_scintilla->StyleSetForeground(wxSTC_HA_STRING, UserPrefs.get_PythonStringColour());
-        m_scintilla->StyleSetForeground(wxSTC_HA_COMMENTLINE, UserPrefs.get_PythonCommentColour());
-        m_scintilla->StyleSetForeground(wxSTC_HA_KEYWORD, UserPrefs.get_PythonKeywordColour());
+        m_scintilla->StyleSetForeground(wxSTC_F_COMMENT, UserPrefs.get_FortranCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_F_NUMBER, UserPrefs.get_FortranNumberColour());
+        m_scintilla->StyleSetForeground(wxSTC_F_STRING1, UserPrefs.get_FortranStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_F_WORD, UserPrefs.get_FortranColour());
+        m_scintilla->StyleSetForeground(wxSTC_F_WORD2, UserPrefs.get_FortranKeywordColour());
     }
-    else if (panel_type == GEN_LANG_PERL)
+    else if (panel_type == GEN_LANG_HASKELL)
     {
-        m_scintilla->SetLexer(wxSTC_LEX_PERL);
+        m_scintilla->SetLexer(wxSTC_LEX_HASKELL);
         // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
-        m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_perl_keywords);
-
-        tt_string wxPerl_keywords;
-        for (auto iter: lst_widgets_keywords)
-        {
-            if (wxPerl_keywords.size())
-                wxPerl_keywords << ' ' << (iter + 2);
-            else
-                wxPerl_keywords = (iter + 2);
-        }
-
-        for (auto iter: NodeCreation.getNodeDeclarationArray())
-        {
-            if (!iter)
-            {
-                // This will happen if there is an enumerated value but no generator for it
-                continue;
-            }
-
-            if (!iter->declName().starts_with("wx"))
-                continue;
-            else if (iter->declName().is_sameas("wxContextMenuEvent") || iter->declName() == "wxTreeCtrlBase" ||
-                     iter->declName().starts_with("wxRuby") || iter->declName().starts_with("wxPython"))
-                continue;
-            wxPerl_keywords << ' ' << iter->declName().subview(2);
-        }
-
-        // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
-        m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) wxPerl_keywords.c_str());
+        m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_haskell_keywords);
 
         if (UserPrefs.is_DarkMode())
         {
@@ -301,9 +275,10 @@ CodeDisplay::CodeDisplay(wxWindow* parent, GenLang panel_type) : CodeDisplayBase
             }
         }
 
-        m_scintilla->StyleSetForeground(wxSTC_PL_STRING, UserPrefs.get_PythonStringColour());
-        m_scintilla->StyleSetForeground(wxSTC_PL_COMMENTLINE, UserPrefs.get_PythonCommentColour());
-        m_scintilla->StyleSetForeground(wxSTC_PL_WORD, UserPrefs.get_PythonKeywordColour());
+        m_scintilla->StyleSetForeground(wxSTC_HA_COMMENTLINE, UserPrefs.get_HaskellCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_HA_NUMBER, UserPrefs.get_HaskellNumberColour());
+        m_scintilla->StyleSetForeground(wxSTC_HA_STRING, UserPrefs.get_HaskellStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_HA_KEYWORD, UserPrefs.get_HaskellColour());
     }
     else if (panel_type == GEN_LANG_LUA)
     {
@@ -350,9 +325,61 @@ CodeDisplay::CodeDisplay(wxWindow* parent, GenLang panel_type) : CodeDisplayBase
             }
         }
 
-        m_scintilla->StyleSetForeground(wxSTC_LUA_STRING, UserPrefs.get_PythonStringColour());
-        m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENT, UserPrefs.get_PythonCommentColour());
-        m_scintilla->StyleSetForeground(wxSTC_LUA_WORD, UserPrefs.get_PythonKeywordColour());
+        m_scintilla->StyleSetForeground(wxSTC_LUA_COMMENT, UserPrefs.get_LuaCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_LUA_NUMBER, UserPrefs.get_LuaNumberColour());
+        m_scintilla->StyleSetForeground(wxSTC_LUA_STRING, UserPrefs.get_LuaStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_LUA_WORD, UserPrefs.get_LuaColour());
+        m_scintilla->StyleSetForeground(wxSTC_LUA_WORD2, UserPrefs.get_LuaKeywordColour());
+    }
+    else if (panel_type == GEN_LANG_PERL)
+    {
+        m_scintilla->SetLexer(wxSTC_LEX_PERL);
+        // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
+        m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_perl_keywords);
+
+        tt_string wxPerl_keywords;
+        for (auto iter: lst_widgets_keywords)
+        {
+            if (wxPerl_keywords.size())
+                wxPerl_keywords << ' ' << (iter + 2);
+            else
+                wxPerl_keywords = (iter + 2);
+        }
+
+        for (auto iter: NodeCreation.getNodeDeclarationArray())
+        {
+            if (!iter)
+            {
+                // This will happen if there is an enumerated value but no generator for it
+                continue;
+            }
+
+            if (!iter->declName().starts_with("wx"))
+                continue;
+            else if (iter->declName().is_sameas("wxContextMenuEvent") || iter->declName() == "wxTreeCtrlBase" ||
+                     iter->declName().starts_with("wxRuby") || iter->declName().starts_with("wxPython"))
+                continue;
+            wxPerl_keywords << ' ' << iter->declName().subview(2);
+        }
+
+        // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
+        m_scintilla->SendMsg(SCI_SETKEYWORDS, 1, (wxIntPtr) wxPerl_keywords.c_str());
+
+        if (UserPrefs.is_DarkMode())
+        {
+            auto fg = UserPrefs.GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            auto bg = UserPrefs.GetColour(wxSYS_COLOUR_WINDOW);
+            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
+            {
+                m_scintilla->StyleSetForeground(idx, fg);
+                m_scintilla->StyleSetBackground(idx, bg);
+            }
+        }
+
+        m_scintilla->StyleSetForeground(wxSTC_PL_COMMENTLINE, UserPrefs.get_PerlCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_PL_NUMBER, UserPrefs.get_PerlNumberColour());
+        m_scintilla->StyleSetForeground(wxSTC_PL_STRING, UserPrefs.get_PerlStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_PL_WORD, UserPrefs.get_PerlColour());
     }
     else if (panel_type == GEN_LANG_RUST)
     {
@@ -371,30 +398,11 @@ CodeDisplay::CodeDisplay(wxWindow* parent, GenLang panel_type) : CodeDisplayBase
             }
         }
 
-        m_scintilla->StyleSetForeground(wxSTC_HPHP_HSTRING, UserPrefs.get_PythonStringColour());
-        m_scintilla->StyleSetForeground(wxSTC_HPHP_COMMENT, UserPrefs.get_PythonCommentColour());
-        m_scintilla->StyleSetForeground(wxSTC_HPHP_WORD, UserPrefs.get_PythonKeywordColour());
-    }
-    else if (panel_type == GEN_LANG_HASKELL)
-    {
-        m_scintilla->SetLexer(wxSTC_LEX_HASKELL);
-        // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
-        m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_haskell_keywords);
-
-        if (UserPrefs.is_DarkMode())
-        {
-            auto fg = UserPrefs.GetColour(wxSYS_COLOUR_WINDOWTEXT);
-            auto bg = UserPrefs.GetColour(wxSYS_COLOUR_WINDOW);
-            for (int idx = 0; idx <= wxSTC_STYLE_LASTPREDEFINED; idx++)
-            {
-                m_scintilla->StyleSetForeground(idx, fg);
-                m_scintilla->StyleSetBackground(idx, bg);
-            }
-        }
-
-        m_scintilla->StyleSetForeground(wxSTC_HA_STRING, UserPrefs.get_PythonStringColour());
-        m_scintilla->StyleSetForeground(wxSTC_HA_COMMENTLINE, UserPrefs.get_PythonCommentColour());
-        m_scintilla->StyleSetForeground(wxSTC_HA_KEYWORD, UserPrefs.get_PythonKeywordColour());
+        m_scintilla->StyleSetForeground(wxSTC_RUST_COMMENTLINE, UserPrefs.get_RustCommentColour());
+        m_scintilla->StyleSetForeground(wxSTC_RUST_NUMBER, UserPrefs.get_RustNumberColour());
+        m_scintilla->StyleSetForeground(wxSTC_RUST_STRING, UserPrefs.get_RustStringColour());
+        m_scintilla->StyleSetForeground(wxSTC_RUST_WORD, UserPrefs.get_RustColour());
+        m_scintilla->StyleSetForeground(wxSTC_RUST_WORD2, UserPrefs.get_RustKeywordColour());
     }
 
     else  // C++

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -106,12 +106,12 @@ public:
     const tt_string& get_RubyVersion() const { return m_ruby_version; }
     void set_RubyVersion(const tt_string& version) { m_ruby_version = version; }
 
-    const wxColour& get_CppColour() const { return m_colour_cpp; }
+    const wxColour& get_CppColour() const { return m_colour_cpp; }  // wxWidgets keywords
     void set_CppColour(const wxColour& colour) { m_colour_cpp = colour; }
+    const wxColour& get_CppKeywordColour() const { return m_colour_cpp_keyword; }  // C++ keywords
+    void set_CppKeywordColour(const wxColour& colour) { m_colour_cpp_keyword = colour; }
     const wxColour& get_CppCommentColour() const { return m_colour_cpp_comment; }
     void set_CppCommentColour(const wxColour& colour) { m_colour_cpp_comment = colour; }
-    const wxColour& get_CppKeywordColour() const { return m_colour_cpp_keyword; }
-    void set_CppKeywordColour(const wxColour& colour) { m_colour_cpp_keyword = colour; }
     const wxColour& get_CppNumberColour() const { return m_colour_cpp_number; }
     void set_CppNumberColour(const wxColour& colour) { m_colour_cpp_number = colour; }
     const wxColour& get_CppStringColour() const { return m_colour_cpp_string; }

--- a/src/ui/preferences_dlg.cpp
+++ b/src/ui/preferences_dlg.cpp
@@ -795,7 +795,7 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
         if (UserPrefs.get_CppColour() != m_colour_cpp->GetColour())
         {
             UserPrefs.set_CppColour(m_colour_cpp->GetColour());
-            panel->SetColor(wxSTC_C_WORD2, m_colour_cpp->GetColour());
+            panel->SetColor(wxSTC_C_WORD, m_colour_cpp->GetColour());
         }
 
         if (UserPrefs.get_CppCommentColour() != m_colour_cpp_comment->GetColour())
@@ -807,7 +807,7 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
         if (UserPrefs.get_CppKeywordColour() != m_colour_cpp_keyword->GetColour())
         {
             UserPrefs.set_CppKeywordColour(m_colour_cpp_keyword->GetColour());
-            panel->SetColor(wxSTC_C_WORD, m_colour_cpp_keyword->GetColour());
+            panel->SetColor(wxSTC_C_WORD2, m_colour_cpp_keyword->GetColour());
         }
 
         if (UserPrefs.get_CppNumberColour() != m_colour_cpp_number->GetColour())
@@ -828,19 +828,19 @@ void PreferencesDlg::OnOK(wxCommandEvent& WXUNUSED(event))
         if (UserPrefs.get_PythonColour() != m_colour_python->GetColour())
         {
             UserPrefs.set_PythonColour(m_colour_python->GetColour());
-            panel->SetColor(wxSTC_P_WORD2, m_colour_python->GetColour());
+            panel->SetColor(wxSTC_P_WORD, m_colour_python->GetColour());
+        }
+
+        if (UserPrefs.get_PythonKeywordColour() != m_colour_python_keyword->GetColour())
+        {
+            UserPrefs.set_PythonKeywordColour(m_colour_python_keyword->GetColour());
+            panel->SetColor(wxSTC_P_WORD2, m_colour_python_keyword->GetColour());
         }
 
         if (UserPrefs.get_PythonCommentColour() != m_colour_python_comment->GetColour())
         {
             UserPrefs.set_PythonCommentColour(m_colour_python_comment->GetColour());
             panel->SetColor(wxSTC_P_COMMENTLINE, m_colour_python_comment->GetColour());
-        }
-
-        if (UserPrefs.get_PythonKeywordColour() != m_colour_python_keyword->GetColour())
-        {
-            UserPrefs.set_PythonKeywordColour(m_colour_python_keyword->GetColour());
-            panel->SetColor(wxSTC_P_WORD, m_colour_python_keyword->GetColour());
         }
 
         if (UserPrefs.get_PythonNumberColour() != m_colour_python_number->GetColour())

--- a/src/wxui/eventhandler_dlg_base.cpp
+++ b/src/wxui/eventhandler_dlg_base.cpp
@@ -8,11 +8,8 @@
 // clang-format off
 
 #include <wx/button.h>
-#include <wx/colour.h>
-#include <wx/panel.h>
 #include <wx/persist.h>
 #include <wx/persist/toplevel.h>
-#include <wx/settings.h>
 
 #include "ui_images.h"
 
@@ -47,24 +44,34 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     }
     box_sizer->Add(m_notebook, wxSizerFlags().Expand().Border(wxALL));
 
-    auto* cpp_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(cpp_page, "C++", false, 0);
-    cpp_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    m_cpp_bookpage = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(m_cpp_bookpage, "C++", false, 0);
+    m_cpp_bookpage->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     auto* page_sizer = new wxBoxSizer(wxVERTICAL);
 
-    m_cpp_radio_use_function = new wxRadioButton(cpp_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+    m_cpp_radio_use_function = new wxRadioButton(m_cpp_bookpage, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
         wxRB_SINGLE);
-    m_cpp_function_box = new wxStaticBoxSizer(new wxStaticBox(cpp_page, wxID_ANY, m_cpp_radio_use_function), wxVERTICAL);
+    m_cpp_function_box = new wxStaticBoxSizer(new wxStaticBox(m_cpp_bookpage, wxID_ANY, m_cpp_radio_use_function), wxVERTICAL);
+
+    auto* box_sizer7 = new wxBoxSizer(wxHORIZONTAL);
 
     m_cpp_text_function = new wxTextCtrl(m_cpp_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_cpp_function_box->Add(m_cpp_text_function, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer7->Add(m_cpp_text_function, wxSizerFlags(1).Expand().Border(wxALL));
+
+    auto* btn = new wxButton(m_cpp_function_box->GetStaticBox(), wxID_ANY, "Default");
+    box_sizer7->Add(btn, wxSizerFlags().Border(wxALL));
+
+    auto* btn2 = new wxButton(m_cpp_function_box->GetStaticBox(), wxID_ANY, "None");
+    box_sizer7->Add(btn2, wxSizerFlags().Border(wxALL));
+
+    m_cpp_function_box->Add(box_sizer7, wxSizerFlags().Expand().Border(wxALL));
 
     page_sizer->Add(m_cpp_function_box, wxSizerFlags().Expand().Border(wxALL));
 
-    m_cpp_radio_use_lambda = new wxRadioButton(cpp_page, wxID_ANY, "Use lambda", wxDefaultPosition, wxDefaultSize,
+    m_cpp_radio_use_lambda = new wxRadioButton(m_cpp_bookpage, wxID_ANY, "Use lambda", wxDefaultPosition, wxDefaultSize,
         wxRB_SINGLE);
-    m_cpp_lambda_box = new wxStaticBoxSizer(new wxStaticBox(cpp_page, wxID_ANY, m_cpp_radio_use_lambda), wxVERTICAL);
+    m_cpp_lambda_box = new wxStaticBoxSizer(new wxStaticBox(m_cpp_bookpage, wxID_ANY, m_cpp_radio_use_lambda), wxVERTICAL);
 
     auto* box_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
 
@@ -106,25 +113,37 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_cpp_lambda_box->Add(m_cpp_stc_lambda, wxSizerFlags(1).Expand().DoubleBorder(wxALL));
 
     page_sizer->Add(m_cpp_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
-    cpp_page->SetSizerAndFit(page_sizer);
+    m_cpp_bookpage->SetSizerAndFit(page_sizer);
 
-    auto* python_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(python_page, "Python", false, 1);
-    python_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    m_python_bookpage = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(m_python_bookpage, "Python", false, 1);
+    m_python_bookpage->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     auto* page_sizer_2 = new wxBoxSizer(wxVERTICAL);
 
-    m_py_radio_use_function = new wxRadioButton(python_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+    m_py_radio_use_function = new wxRadioButton(m_python_bookpage, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
         wxRB_SINGLE);
-    m_py_function_box = new wxStaticBoxSizer(new wxStaticBox(python_page, wxID_ANY, m_py_radio_use_function), wxVERTICAL);
+    m_py_function_box = new wxStaticBoxSizer(new wxStaticBox(m_python_bookpage, wxID_ANY, m_py_radio_use_function),
+        wxVERTICAL);
+
+    auto* box_sizer8 = new wxBoxSizer(wxHORIZONTAL);
 
     m_py_text_function = new wxTextCtrl(m_py_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_py_function_box->Add(m_py_text_function, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer8->Add(m_py_text_function, wxSizerFlags(1).Expand().Border(wxALL));
+
+    auto* btn3 = new wxButton(m_py_function_box->GetStaticBox(), wxID_ANY, "Default");
+    box_sizer8->Add(btn3, wxSizerFlags().Border(wxALL));
+
+    auto* btn4 = new wxButton(m_py_function_box->GetStaticBox(), wxID_ANY, "None");
+    box_sizer8->Add(btn4, wxSizerFlags().Border(wxALL));
+
+    m_py_function_box->Add(box_sizer8, wxSizerFlags().Expand().Border(wxALL));
 
     page_sizer_2->Add(m_py_function_box, wxSizerFlags().Expand().Border(wxALL));
 
-    m_py_radio_use_lambda = new wxRadioButton(python_page, wxID_ANY, "Lambda", wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
-    m_py_lambda_box = new wxStaticBoxSizer(new wxStaticBox(python_page, wxID_ANY, m_py_radio_use_lambda), wxVERTICAL);
+    m_py_radio_use_lambda = new wxRadioButton(m_python_bookpage, wxID_ANY, "Lambda", wxDefaultPosition, wxDefaultSize,
+        wxRB_SINGLE);
+    m_py_lambda_box = new wxStaticBoxSizer(new wxStaticBox(m_python_bookpage, wxID_ANY, m_py_radio_use_lambda), wxVERTICAL);
 
     auto* staticText_2 = new wxStaticText(m_py_lambda_box->GetStaticBox(), wxID_ANY, "Function:");
     m_py_lambda_box->Add(staticText_2, wxSizerFlags().Border(wxALL));
@@ -133,20 +152,31 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_py_lambda_box->Add(m_py_text_lambda, wxSizerFlags().Expand().Border(wxALL));
 
     page_sizer_2->Add(m_py_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
-    python_page->SetSizerAndFit(page_sizer_2);
+    m_python_bookpage->SetSizerAndFit(page_sizer_2);
 
-    auto* ruby_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(ruby_page, "Ruby", false, 2);
-    ruby_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    m_ruby_bookpage = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(m_ruby_bookpage, "Ruby", false, 2);
+    m_ruby_bookpage->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     auto* page_sizer_3 = new wxBoxSizer(wxVERTICAL);
 
-    m_ruby_radio_use_function = new wxRadioButton(ruby_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+    m_ruby_radio_use_function = new wxRadioButton(m_ruby_bookpage, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
         wxRB_SINGLE);
-    m_ruby_function_box = new wxStaticBoxSizer(new wxStaticBox(ruby_page, wxID_ANY, m_ruby_radio_use_function), wxVERTICAL);
+    m_ruby_function_box = new wxStaticBoxSizer(new wxStaticBox(m_ruby_bookpage, wxID_ANY, m_ruby_radio_use_function),
+        wxVERTICAL);
+
+    auto* box_sizer14 = new wxBoxSizer(wxHORIZONTAL);
 
     m_ruby_text_function = new wxTextCtrl(m_ruby_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_ruby_function_box->Add(m_ruby_text_function, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer14->Add(m_ruby_text_function, wxSizerFlags(1).Expand().Border(wxALL));
+
+    auto* btn15 = new wxButton(m_ruby_function_box->GetStaticBox(), wxID_ANY, "Default");
+    box_sizer14->Add(btn15, wxSizerFlags().Border(wxALL));
+
+    auto* btn16 = new wxButton(m_ruby_function_box->GetStaticBox(), wxID_ANY, "None");
+    box_sizer14->Add(btn16, wxSizerFlags().Border(wxALL));
+
+    m_ruby_function_box->Add(box_sizer14, wxSizerFlags().Expand().Border(wxALL));
 
     m_ruby_radio_use_lambda = new wxRadioButton(m_ruby_function_box->GetStaticBox(), wxID_ANY, "Use lambda",
         wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
@@ -188,21 +218,31 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_ruby_function_box->Add(m_ruby_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
 
     page_sizer_3->Add(m_ruby_function_box, wxSizerFlags().Expand().Border(wxALL));
-    ruby_page->SetSizerAndFit(page_sizer_3);
+    m_ruby_bookpage->SetSizerAndFit(page_sizer_3);
 
-    auto* fortran_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(fortran_page, "Fortran", false, 3);
-    fortran_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    m_fortran_bookpage = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(m_fortran_bookpage, "Fortran", false, 3);
+    m_fortran_bookpage->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     auto* page_sizer6 = new wxBoxSizer(wxVERTICAL);
 
-    m_fortran_radio_use_function = new wxRadioButton(fortran_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
-        wxRB_SINGLE);
-    m_fortran_function_box = new wxStaticBoxSizer(new wxStaticBox(fortran_page, wxID_ANY, m_fortran_radio_use_function),
-        wxVERTICAL);
+    m_fortran_radio_use_function = new wxRadioButton(m_fortran_bookpage, wxID_ANY, "Use function", wxDefaultPosition,
+        wxDefaultSize, wxRB_SINGLE);
+    m_fortran_function_box = new wxStaticBoxSizer(new wxStaticBox(m_fortran_bookpage, wxID_ANY, m_fortran_radio_use_function
+        ), wxVERTICAL);
+
+    auto* box_sizer9 = new wxBoxSizer(wxHORIZONTAL);
 
     m_fortran_text_function = new wxTextCtrl(m_fortran_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_fortran_function_box->Add(m_fortran_text_function, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer9->Add(m_fortran_text_function, wxSizerFlags(1).Expand().Border(wxALL));
+
+    auto* btn5 = new wxButton(m_fortran_function_box->GetStaticBox(), wxID_ANY, "Default");
+    box_sizer9->Add(btn5, wxSizerFlags().Border(wxALL));
+
+    auto* btn6 = new wxButton(m_fortran_function_box->GetStaticBox(), wxID_ANY, "None");
+    box_sizer9->Add(btn6, wxSizerFlags().Border(wxALL));
+
+    m_fortran_function_box->Add(box_sizer9, wxSizerFlags().Expand().Border(wxALL));
 
     m_fortran_radio_use_lambda = new wxRadioButton(m_fortran_function_box->GetStaticBox(), wxID_ANY, "Use lambda",
         wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
@@ -244,21 +284,31 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_fortran_function_box->Add(m_fortran_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
 
     page_sizer6->Add(m_fortran_function_box, wxSizerFlags().Expand().Border(wxALL));
-    fortran_page->SetSizerAndFit(page_sizer6);
+    m_fortran_bookpage->SetSizerAndFit(page_sizer6);
 
-    auto* haskell_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(haskell_page, "Haskell", false, 4);
-    haskell_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    m_haskell_bookpage = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(m_haskell_bookpage, "Haskell", false, 4);
+    m_haskell_bookpage->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     auto* page_sizer2 = new wxBoxSizer(wxVERTICAL);
 
-    m_haskell_radio_use_function = new wxRadioButton(haskell_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
-        wxRB_SINGLE);
-    m_haskell_function_box = new wxStaticBoxSizer(new wxStaticBox(haskell_page, wxID_ANY, m_haskell_radio_use_function),
-        wxVERTICAL);
+    m_haskell_radio_use_function = new wxRadioButton(m_haskell_bookpage, wxID_ANY, "Use function", wxDefaultPosition,
+        wxDefaultSize, wxRB_SINGLE);
+    m_haskell_function_box = new wxStaticBoxSizer(new wxStaticBox(m_haskell_bookpage, wxID_ANY, m_haskell_radio_use_function
+        ), wxVERTICAL);
+
+    auto* box_sizer10 = new wxBoxSizer(wxHORIZONTAL);
 
     m_haskell_text_function = new wxTextCtrl(m_haskell_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_haskell_function_box->Add(m_haskell_text_function, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer10->Add(m_haskell_text_function, wxSizerFlags(1).Expand().Border(wxALL));
+
+    auto* btn7 = new wxButton(m_haskell_function_box->GetStaticBox(), wxID_ANY, "Default");
+    box_sizer10->Add(btn7, wxSizerFlags().Border(wxALL));
+
+    auto* btn8 = new wxButton(m_haskell_function_box->GetStaticBox(), wxID_ANY, "None");
+    box_sizer10->Add(btn8, wxSizerFlags().Border(wxALL));
+
+    m_haskell_function_box->Add(box_sizer10, wxSizerFlags().Expand().Border(wxALL));
 
     m_haskell_radio_use_lambda = new wxRadioButton(m_haskell_function_box->GetStaticBox(), wxID_ANY, "Use lambda",
         wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
@@ -300,20 +350,30 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_haskell_function_box->Add(m_ruby_lambda_box2, wxSizerFlags(1).Expand().Border(wxALL));
 
     page_sizer2->Add(m_haskell_function_box, wxSizerFlags().Expand().Border(wxALL));
-    haskell_page->SetSizerAndFit(page_sizer2);
+    m_haskell_bookpage->SetSizerAndFit(page_sizer2);
 
-    auto* lua_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(lua_page, "Lua", false, 5);
-    lua_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    m_lua_bookpage = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(m_lua_bookpage, "Lua", false, 5);
+    m_lua_bookpage->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     auto* page_sizer3 = new wxBoxSizer(wxVERTICAL);
 
-    m_lua_radio_use_function = new wxRadioButton(lua_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+    m_lua_radio_use_function = new wxRadioButton(m_lua_bookpage, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
         wxRB_SINGLE);
-    m_lua_function_box = new wxStaticBoxSizer(new wxStaticBox(lua_page, wxID_ANY, m_lua_radio_use_function), wxVERTICAL);
+    m_lua_function_box = new wxStaticBoxSizer(new wxStaticBox(m_lua_bookpage, wxID_ANY, m_lua_radio_use_function), wxVERTICAL);
+
+    auto* box_sizer11 = new wxBoxSizer(wxHORIZONTAL);
 
     m_lua_text_function = new wxTextCtrl(m_lua_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_lua_function_box->Add(m_lua_text_function, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer11->Add(m_lua_text_function, wxSizerFlags(1).Expand().Border(wxALL));
+
+    auto* btn9 = new wxButton(m_lua_function_box->GetStaticBox(), wxID_ANY, "Default");
+    box_sizer11->Add(btn9, wxSizerFlags().Border(wxALL));
+
+    auto* btn10 = new wxButton(m_lua_function_box->GetStaticBox(), wxID_ANY, "None");
+    box_sizer11->Add(btn10, wxSizerFlags().Border(wxALL));
+
+    m_lua_function_box->Add(box_sizer11, wxSizerFlags().Expand().Border(wxALL));
 
     m_lua_radio_use_anon_func = new wxRadioButton(m_lua_function_box->GetStaticBox(), wxID_ANY, "Anonymous function",
         wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
@@ -355,20 +415,31 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_lua_function_box->Add(m_lua_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
 
     page_sizer3->Add(m_lua_function_box, wxSizerFlags().Expand().Border(wxALL));
-    lua_page->SetSizerAndFit(page_sizer3);
+    m_lua_bookpage->SetSizerAndFit(page_sizer3);
 
-    auto* perl_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(perl_page, "Perl", false, 6);
-    perl_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    m_perl_bookpage = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(m_perl_bookpage, "Perl", false, 6);
+    m_perl_bookpage->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     auto* page_sizer4 = new wxBoxSizer(wxVERTICAL);
 
-    m_perl_radio_use_function = new wxRadioButton(perl_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+    m_perl_radio_use_function = new wxRadioButton(m_perl_bookpage, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
         wxRB_SINGLE);
-    m_perl_function_box = new wxStaticBoxSizer(new wxStaticBox(perl_page, wxID_ANY, m_perl_radio_use_function), wxVERTICAL);
+    m_perl_function_box = new wxStaticBoxSizer(new wxStaticBox(m_perl_bookpage, wxID_ANY, m_perl_radio_use_function),
+        wxVERTICAL);
+
+    auto* box_sizer12 = new wxBoxSizer(wxHORIZONTAL);
 
     m_perl_text_function = new wxTextCtrl(m_perl_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_perl_function_box->Add(m_perl_text_function, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer12->Add(m_perl_text_function, wxSizerFlags(1).Expand().Border(wxALL));
+
+    auto* btn11 = new wxButton(m_perl_function_box->GetStaticBox(), wxID_ANY, "Default");
+    box_sizer12->Add(btn11, wxSizerFlags().Border(wxALL));
+
+    auto* btn12 = new wxButton(m_perl_function_box->GetStaticBox(), wxID_ANY, "None");
+    box_sizer12->Add(btn12, wxSizerFlags().Border(wxALL));
+
+    m_perl_function_box->Add(box_sizer12, wxSizerFlags().Expand().Border(wxALL));
 
     m_perl_radio_use_anon_func = new wxRadioButton(m_perl_function_box->GetStaticBox(), wxID_ANY, "Anonymous function",
         wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
@@ -410,20 +481,31 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_perl_function_box->Add(m_perl_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
 
     page_sizer4->Add(m_perl_function_box, wxSizerFlags().Expand().Border(wxALL));
-    perl_page->SetSizerAndFit(page_sizer4);
+    m_perl_bookpage->SetSizerAndFit(page_sizer4);
 
-    auto* rust_page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    m_notebook->AddPage(rust_page, "Rust", false, 7);
-    rust_page->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    m_rust_bookpage = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_notebook->AddPage(m_rust_bookpage, "Rust", false, 7);
+    m_rust_bookpage->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 
     auto* page_sizer5 = new wxBoxSizer(wxVERTICAL);
 
-    m_php_radio_use_function = new wxRadioButton(rust_page, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
+    m_php_radio_use_function = new wxRadioButton(m_rust_bookpage, wxID_ANY, "Use function", wxDefaultPosition, wxDefaultSize,
         wxRB_SINGLE);
-    m_php_function_box = new wxStaticBoxSizer(new wxStaticBox(rust_page, wxID_ANY, m_php_radio_use_function), wxVERTICAL);
+    m_php_function_box = new wxStaticBoxSizer(new wxStaticBox(m_rust_bookpage, wxID_ANY, m_php_radio_use_function),
+        wxVERTICAL);
+
+    auto* box_sizer13 = new wxBoxSizer(wxHORIZONTAL);
 
     m_rust_text_function = new wxTextCtrl(m_php_function_box->GetStaticBox(), wxID_ANY, wxEmptyString);
-    m_php_function_box->Add(m_rust_text_function, wxSizerFlags().Expand().Border(wxALL));
+    box_sizer13->Add(m_rust_text_function, wxSizerFlags(1).Expand().Border(wxALL));
+
+    auto* btn13 = new wxButton(m_php_function_box->GetStaticBox(), wxID_ANY, "Default");
+    box_sizer13->Add(btn13, wxSizerFlags().Border(wxALL));
+
+    auto* btn14 = new wxButton(m_php_function_box->GetStaticBox(), wxID_ANY, "None");
+    box_sizer13->Add(btn14, wxSizerFlags().Border(wxALL));
+
+    m_php_function_box->Add(box_sizer13, wxSizerFlags().Expand().Border(wxALL));
 
     m_php_radio_use_anon_func = new wxRadioButton(m_php_function_box->GetStaticBox(), wxID_ANY, "Anonymous function",
         wxDefaultPosition, wxDefaultSize, wxRB_SINGLE);
@@ -465,7 +547,7 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
     m_php_function_box->Add(m_php_lambda_box, wxSizerFlags(1).Expand().Border(wxALL));
 
     page_sizer5->Add(m_php_function_box, wxSizerFlags().Expand().Border(wxALL));
-    rust_page->SetSizerAndFit(page_sizer5);
+    m_rust_bookpage->SetSizerAndFit(page_sizer5);
 
     parent_sizer->Add(box_sizer, wxSizerFlags(1).Expand().Border(wxALL));
 
@@ -498,6 +580,22 @@ bool EventHandlerDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString
 
     // Event handlers
     Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnOK, this, wxID_OK);
+    btn->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnDefault, this);
+    btn11->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnDefault, this);
+    btn13->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnDefault, this);
+    btn15->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnDefault, this);
+    btn3->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnDefault, this);
+    btn5->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnDefault, this);
+    btn7->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnDefault, this);
+    btn9->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnDefault, this);
+    btn10->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnNone, this);
+    btn12->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnNone, this);
+    btn14->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnNone, this);
+    btn16->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnNone, this);
+    btn2->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnNone, this);
+    btn4->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnNone, this);
+    btn6->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnNone, this);
+    btn8->Bind(wxEVT_BUTTON, &EventHandlerDlgBase::OnNone, this);
     m_check_capture_this->Bind(wxEVT_CHECKBOX, &EventHandlerDlgBase::OnChange, this);
     m_check_include_event->Bind(wxEVT_CHECKBOX, &EventHandlerDlgBase::OnChange, this);
     Bind(wxEVT_INIT_DIALOG, &EventHandlerDlgBase::OnInit, this);

--- a/src/wxui/eventhandler_dlg_base.h
+++ b/src/wxui/eventhandler_dlg_base.h
@@ -10,11 +10,14 @@
 #pragma once
 
 #include <wx/checkbox.h>
+#include <wx/colour.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
 #include <wx/notebook.h>
+#include <wx/panel.h>
 #include <wx/radiobut.h>
+#include <wx/settings.h>
 #include <wx/sizer.h>
 #include <wx/statbox.h>
 #include <wx/stattext.h>
@@ -40,7 +43,9 @@ protected:
     // Virtual event handlers -- override them in your derived class
 
     virtual void OnChange(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnDefault(wxCommandEvent& event) { event.Skip(); }
     virtual void OnInit(wxInitDialogEvent& event) { event.Skip(); }
+    virtual void OnNone(wxCommandEvent& event) { event.Skip(); }
     virtual void OnOK(wxCommandEvent& event) { event.Skip(); }
     virtual void OnPageChanged(wxBookCtrlEvent& event) { event.Skip(); }
     virtual void OnUseCppFunction(wxCommandEvent& event) { event.Skip(); }
@@ -60,6 +65,14 @@ protected:
     wxCheckBox* m_check_capture_this;
     wxCheckBox* m_check_include_event;
     wxNotebook* m_notebook;
+    wxPanel* m_cpp_bookpage;
+    wxPanel* m_fortran_bookpage;
+    wxPanel* m_haskell_bookpage;
+    wxPanel* m_lua_bookpage;
+    wxPanel* m_perl_bookpage;
+    wxPanel* m_python_bookpage;
+    wxPanel* m_ruby_bookpage;
+    wxPanel* m_rust_bookpage;
     wxRadioButton* m_cpp_radio_use_function;
     wxStaticBoxSizer* m_cpp_function_box;
     wxRadioButton* m_cpp_radio_use_lambda;

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -4,6 +4,7 @@
   <node
     class="Project"
     art_directory="../art_src"
+    generate_languages="C++"
     cpp_line_length="125"
     generate_cmake="1">
     <node
@@ -3964,8 +3965,9 @@
               <node
                 class="BookPage"
                 bitmap="SVG;cpp_logo.svg;[24,24]"
+                class_access="protected:"
                 label="C++"
-                var_name="cpp_page"
+                var_name="m_cpp_bookpage"
                 background_colour="wxSYS_COLOUR_BTNFACE"
                 window_style="wxTAB_TRAVERSAL">
                 <node
@@ -3982,10 +3984,28 @@
                     flags="wxEXPAND"
                     wxEVT_RADIOBUTTON="OnUseCppFunction">
                     <node
-                      class="wxTextCtrl"
-                      var_name="m_cpp_text_function"
-                      flags="wxEXPAND"
-                      wxEVT_TEXT="OnChange" />
+                      class="wxBoxSizer"
+                      var_name="box_sizer7"
+                      flags="wxEXPAND">
+                      <node
+                        class="wxTextCtrl"
+                        var_name="m_cpp_text_function"
+                        flags="wxEXPAND"
+                        proportion="1"
+                        wxEVT_TEXT="OnChange" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="Default"
+                        var_name="btn"
+                        wxEVT_BUTTON="OnDefault" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="None"
+                        var_name="btn2"
+                        wxEVT_BUTTON="OnNone" />
+                    </node>
                   </node>
                   <node
                     class="StaticRadioBtnBoxSizer"
@@ -4040,8 +4060,9 @@
               <node
                 class="BookPage"
                 bitmap="SVG;python-logo-only.svg;[24,24]"
+                class_access="protected:"
                 label="Python"
-                var_name="python_page"
+                var_name="m_python_bookpage"
                 background_colour="wxSYS_COLOUR_BTNFACE"
                 window_style="wxTAB_TRAVERSAL">
                 <node
@@ -4058,10 +4079,28 @@
                     flags="wxEXPAND"
                     wxEVT_RADIOBUTTON="OnUsePythonFunction">
                     <node
-                      class="wxTextCtrl"
-                      var_name="m_py_text_function"
-                      flags="wxEXPAND"
-                      wxEVT_TEXT="OnChange" />
+                      class="wxBoxSizer"
+                      var_name="box_sizer8"
+                      flags="wxEXPAND">
+                      <node
+                        class="wxTextCtrl"
+                        var_name="m_py_text_function"
+                        flags="wxEXPAND"
+                        proportion="1"
+                        wxEVT_TEXT="OnChange" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="Default"
+                        var_name="btn3"
+                        wxEVT_BUTTON="OnDefault" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="None"
+                        var_name="btn4"
+                        wxEVT_BUTTON="OnNone" />
+                    </node>
                   </node>
                   <node
                     class="StaticRadioBtnBoxSizer"
@@ -4089,8 +4128,9 @@
               <node
                 class="BookPage"
                 bitmap="SVG;ruby_logo.svg;[24,24]"
+                class_access="protected:"
                 label="Ruby"
-                var_name="ruby_page"
+                var_name="m_ruby_bookpage"
                 background_colour="wxSYS_COLOUR_BTNFACE"
                 window_style="wxTAB_TRAVERSAL">
                 <node
@@ -4107,10 +4147,28 @@
                     flags="wxEXPAND"
                     wxEVT_RADIOBUTTON="OnUseRubyFunction">
                     <node
-                      class="wxTextCtrl"
-                      var_name="m_ruby_text_function"
-                      flags="wxEXPAND"
-                      wxEVT_TEXT="OnChange" />
+                      class="wxBoxSizer"
+                      var_name="box_sizer14"
+                      flags="wxEXPAND">
+                      <node
+                        class="wxTextCtrl"
+                        var_name="m_ruby_text_function"
+                        flags="wxEXPAND"
+                        proportion="1"
+                        wxEVT_TEXT="OnChange" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="Default"
+                        var_name="btn15"
+                        wxEVT_BUTTON="OnDefault" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="None"
+                        var_name="btn16"
+                        wxEVT_BUTTON="OnNone" />
+                    </node>
                     <node
                       class="StaticRadioBtnBoxSizer"
                       checked="0"
@@ -4154,8 +4212,9 @@
               <node
                 class="BookPage"
                 bitmap="SVG;fortran_logo.svg;[24,24]"
+                class_access="protected:"
                 label="Fortran"
-                var_name="fortran_page"
+                var_name="m_fortran_bookpage"
                 background_colour="wxSYS_COLOUR_BTNFACE"
                 window_style="wxTAB_TRAVERSAL">
                 <node
@@ -4172,10 +4231,28 @@
                     flags="wxEXPAND"
                     wxEVT_RADIOBUTTON="OnUseFortranFunction">
                     <node
-                      class="wxTextCtrl"
-                      var_name="m_fortran_text_function"
-                      flags="wxEXPAND"
-                      wxEVT_TEXT="OnChange" />
+                      class="wxBoxSizer"
+                      var_name="box_sizer9"
+                      flags="wxEXPAND">
+                      <node
+                        class="wxTextCtrl"
+                        var_name="m_fortran_text_function"
+                        flags="wxEXPAND"
+                        proportion="1"
+                        wxEVT_TEXT="OnChange" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="Default"
+                        var_name="btn5"
+                        wxEVT_BUTTON="OnDefault" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="None"
+                        var_name="btn6"
+                        wxEVT_BUTTON="OnNone" />
+                    </node>
                     <node
                       class="StaticRadioBtnBoxSizer"
                       checked="0"
@@ -4219,8 +4296,9 @@
               <node
                 class="BookPage"
                 bitmap="SVG;haskell-logo.svg;[24,24]"
+                class_access="protected:"
                 label="Haskell"
-                var_name="haskell_page"
+                var_name="m_haskell_bookpage"
                 background_colour="wxSYS_COLOUR_BTNFACE"
                 window_style="wxTAB_TRAVERSAL">
                 <node
@@ -4237,10 +4315,28 @@
                     flags="wxEXPAND"
                     wxEVT_RADIOBUTTON="OnUseHaskellFunction">
                     <node
-                      class="wxTextCtrl"
-                      var_name="m_haskell_text_function"
-                      flags="wxEXPAND"
-                      wxEVT_TEXT="OnChange" />
+                      class="wxBoxSizer"
+                      var_name="box_sizer10"
+                      flags="wxEXPAND">
+                      <node
+                        class="wxTextCtrl"
+                        var_name="m_haskell_text_function"
+                        flags="wxEXPAND"
+                        proportion="1"
+                        wxEVT_TEXT="OnChange" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="Default"
+                        var_name="btn7"
+                        wxEVT_BUTTON="OnDefault" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="None"
+                        var_name="btn8"
+                        wxEVT_BUTTON="OnNone" />
+                    </node>
                     <node
                       class="StaticRadioBtnBoxSizer"
                       checked="0"
@@ -4284,8 +4380,9 @@
               <node
                 class="BookPage"
                 bitmap="SVG;lua-logo.svg;[24,24]"
+                class_access="protected:"
                 label="Lua"
-                var_name="lua_page"
+                var_name="m_lua_bookpage"
                 background_colour="wxSYS_COLOUR_BTNFACE"
                 window_style="wxTAB_TRAVERSAL">
                 <node
@@ -4302,10 +4399,28 @@
                     flags="wxEXPAND"
                     wxEVT_RADIOBUTTON="OnUseRubyFunction">
                     <node
-                      class="wxTextCtrl"
-                      var_name="m_lua_text_function"
-                      flags="wxEXPAND"
-                      wxEVT_TEXT="OnChange" />
+                      class="wxBoxSizer"
+                      var_name="box_sizer11"
+                      flags="wxEXPAND">
+                      <node
+                        class="wxTextCtrl"
+                        var_name="m_lua_text_function"
+                        flags="wxEXPAND"
+                        proportion="1"
+                        wxEVT_TEXT="OnChange" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="Default"
+                        var_name="btn9"
+                        wxEVT_BUTTON="OnDefault" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="None"
+                        var_name="btn10"
+                        wxEVT_BUTTON="OnNone" />
+                    </node>
                     <node
                       class="StaticRadioBtnBoxSizer"
                       checked="0"
@@ -4349,8 +4464,9 @@
               <node
                 class="BookPage"
                 bitmap="SVG;perl-logo.svg;[24,24]"
+                class_access="protected:"
                 label="Perl"
-                var_name="perl_page"
+                var_name="m_perl_bookpage"
                 background_colour="wxSYS_COLOUR_BTNFACE"
                 window_style="wxTAB_TRAVERSAL">
                 <node
@@ -4367,10 +4483,28 @@
                     flags="wxEXPAND"
                     wxEVT_RADIOBUTTON="OnUseRubyFunction">
                     <node
-                      class="wxTextCtrl"
-                      var_name="m_perl_text_function"
-                      flags="wxEXPAND"
-                      wxEVT_TEXT="OnChange" />
+                      class="wxBoxSizer"
+                      var_name="box_sizer12"
+                      flags="wxEXPAND">
+                      <node
+                        class="wxTextCtrl"
+                        var_name="m_perl_text_function"
+                        flags="wxEXPAND"
+                        proportion="1"
+                        wxEVT_TEXT="OnChange" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="Default"
+                        var_name="btn11"
+                        wxEVT_BUTTON="OnDefault" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="None"
+                        var_name="btn12"
+                        wxEVT_BUTTON="OnNone" />
+                    </node>
                     <node
                       class="StaticRadioBtnBoxSizer"
                       checked="0"
@@ -4414,8 +4548,9 @@
               <node
                 class="BookPage"
                 bitmap="SVG;rust_logo.svg;[24,24]"
+                class_access="protected:"
                 label="Rust"
-                var_name="rust_page"
+                var_name="m_rust_bookpage"
                 background_colour="wxSYS_COLOUR_BTNFACE"
                 window_style="wxTAB_TRAVERSAL">
                 <node
@@ -4432,10 +4567,28 @@
                     flags="wxEXPAND"
                     wxEVT_RADIOBUTTON="OnUseRubyFunction">
                     <node
-                      class="wxTextCtrl"
-                      var_name="m_rust_text_function"
-                      flags="wxEXPAND"
-                      wxEVT_TEXT="OnChange" />
+                      class="wxBoxSizer"
+                      var_name="box_sizer13"
+                      flags="wxEXPAND">
+                      <node
+                        class="wxTextCtrl"
+                        var_name="m_rust_text_function"
+                        flags="wxEXPAND"
+                        proportion="1"
+                        wxEVT_TEXT="OnChange" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="Default"
+                        var_name="btn13"
+                        wxEVT_BUTTON="OnDefault" />
+                      <node
+                        class="wxButton"
+                        class_access="none"
+                        label="None"
+                        var_name="btn14"
+                        wxEVT_BUTTON="OnNone" />
+                    </node>
                     <node
                       class="StaticRadioBtnBoxSizer"
                       checked="0"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds "none" as an optional value for an event handler, indicating that there is no event handler. In the event handler dialog, all the functions have a button called "None" that will enter "none" as the event handler.

Closes #1528
