### PR TITLE
Bug fixes for Ruby code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - XRC generation now includes variant property settings for forms
 - wxPython now places wxTreeListCtrl in the dataview library
 - Fixed code generation for Python and Ruby wxStdDialogButtonSizer events
+- Ruby code generation no longer writes the class `end` line before the final generated comment block
 
 ## [Released (1.2.1)]
 

--- a/src/generate/file_codewriter.cpp
+++ b/src/generate/file_codewriter.cpp
@@ -110,9 +110,22 @@ int FileCodeWriter::WriteFile(GenLang language, int flags)
     {
         m_buffer += end_lua_haskell_block;
     }
-    else if (language == GEN_LANG_PYTHON || language == GEN_LANG_RUBY || language == GEN_LANG_PERL)
+    else if (language == GEN_LANG_PYTHON || language == GEN_LANG_PERL)
     {
         m_buffer += end_python_perl_ruby_block;
+    }
+    else if (language == GEN_LANG_RUBY)
+    {
+        m_buffer += end_python_perl_ruby_block;
+
+        // If the file has never been written before, then add "end" line that is required to close
+        // the class definition. This is written outside of the comment block, so presumably any
+        // user edits will be made above this line or they will remove it and replace it with their
+        // own "end" line.
+        if (!file_exists)
+        {
+            m_buffer += "\nend";
+        }
     }
 
     size_t additional_content = (to_size_t) -1;

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -25,8 +25,8 @@ using namespace code;
 
 extern const char* python_perl_ruby_end_cmt_line;  // "# ************* End of generated code"
 extern const char* python_triple_quote;            // "\"\"\"";
-extern const char* ruby_begin_cmt_block;           // "# begin";
-extern const char* ruby_end_cmt_block;             // "# end";
+extern const char* ruby_begin_cmt_block;           // "=begin";
+extern const char* ruby_end_cmt_block;             // "=end";
 
 /////////////////////////////////////////// Default generator event code ///////////////////////////////////////////
 
@@ -951,7 +951,7 @@ void BaseCodeGenerator::GenRubyEventHandlers(EventVector& events)
             undefined_handlers.Tab().Str("event.skip");
         }
         undefined_handlers.Eol().Unindent();
-        undefined_handlers.Str("end").Eol().Eol();
+        undefined_handlers.Str("end").Eol();
     }
 
     if (undefined_handlers.size())
@@ -959,6 +959,7 @@ void BaseCodeGenerator::GenRubyEventHandlers(EventVector& events)
         m_source->writeLine(code, indent::none);
         m_source->writeLine(ruby_begin_cmt_block, indent::none);
         m_source->writeLine(undefined_handlers);
+        m_source->writeLine("end", indent::none);
         m_source->writeLine(ruby_end_cmt_block, indent::none);
 
         m_header->writeLine("# Event handler functions");

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -180,7 +180,8 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
                     handler.Str(event_name).Str("(:") << event_code << ')';
                 }
             }
-            else if (code.is_ruby() && event->getEventInfo()->get_name() == "wxEVT_SIZE")
+            else if (event->getEventInfo()->get_name() == "wxEVT_SIZE" ||
+                     event->getEventInfo()->get_name() == "wxEVT_GRID_COL_SIZE")
             {
                 // wxRuby3 doesn't allow an id for this event
                 handler.Str(event_name).Str("(:") << event_code << ')';

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -562,7 +562,6 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
 
     // Make certain indentation is reset after all construction code is written
     m_source->ResetIndent();
-    m_source->writeLine("end\n", indent::none);
 
     m_header->ResetIndent();
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a problem with Ruby code generation writing the required `end` before the final comment block. This was preventing any event handlers or any other functions from being part of the class. Now it will write the `end` after the comment block if the file has never been created before. Otherwise, it is up to the user to provide the required `end` for the class.

The other commits fix other problems with Ruby code generation.