### PR TITLE
Allow adding a menubar or toolbar to a wxFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - wxPython now places wxTreeListCtrl in the dataview library
 - Fixed code generation for Python and Ruby wxStdDialogButtonSizer events
 - Ruby code generation no longer writes the class `end` line before the final generated comment block
+- You can add a menubar or toolbar to a wxFrame that was created without them
 
 ## [Released (1.2.1)]
 

--- a/src/nodes/node_creator.cpp
+++ b/src/nodes/node_creator.cpp
@@ -274,7 +274,7 @@ Node* NodeCreator::isValidCreateParent(GenName name, Node* parent, bool use_recu
     // Check for widgets which can ONLY have a frame for a parent.
     if (node_decl->isType(type_statusbar) || node_decl->isType(type_menubar) || node_decl->isType(type_toolbar))
     {
-        if (!parent->isType(type_form))
+        if (!parent->isType(type_frame_form))
         {
             return parent->getParent();
         }

--- a/src/nodes/tool_creator.cpp
+++ b/src/nodes/tool_creator.cpp
@@ -114,6 +114,42 @@ static void SetUniqueRibbonToolID(Node* node)
 
 bool Node::createToolNode(GenName name, int pos)
 {
+    if (isGen(gen_wxFrame))
+    {
+        if (name == gen_MenuBar)
+        {
+            bool has_menubar = false;
+            for (auto& iter: getChildNodePtrs())
+            {
+                if (iter->isGen(gen_MenuBar))
+                {
+                    has_menubar = true;
+                    break;
+                }
+            }
+            if (!has_menubar)
+            {
+                name = gen_wxMenuBar;
+            }
+        }
+        else if (name == gen_ToolBar)
+        {
+            bool has_toolbar = false;
+            for (auto& iter: getChildNodePtrs())
+            {
+                if (iter->isGen(gen_ToolBar))
+                {
+                    has_toolbar = true;
+                    break;
+                }
+            }
+            if (!has_toolbar)
+            {
+                name = gen_wxToolBar;
+            }
+        }
+    }
+
     if (isGen(gen_Project))
     {
         // If needed, change the names to the Form version version the normal child version


### PR DESCRIPTION
Only one of each is allowed, but you can now add one if there wasn't one already.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR lets you select a wxFrame and add a menubar or toolbar to it. Previously, if you didn't specify you wanted them when the wxFrame was first created, you couldn't add them.
