### PR TITLE
Standardize wxScrolled... code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Fixed code generation for Python and Ruby wxStdDialogButtonSizer events
 - Ruby code generation no longer writes the class `end` line before the final generated comment block
 - You can add a menubar or toolbar to a wxFrame that was created without them
+- Fixed inconsistent generation of wxScrolledWindow versus wxScrolled<wxPanel> -- wxScrolledWindow is now always used.
 
 ## [Released (1.2.1)]
 

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Scroll window component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -30,7 +30,7 @@ bool ScrolledCanvasGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.AddAuto().NodeName().Str(" = new wxScrolled<wxWindow>(");
+        code.AddAuto().NodeName().Str(" = new wxScrolledCanvas(");
         code.ValidParentName().Comma().as_string(prop_id);
         code.PosSizeFlags();
     }
@@ -62,11 +62,18 @@ bool ScrolledCanvasGenerator::GetIncludes(Node* node, std::set<std::string>& set
     return true;
 }
 
+int ScrolledCanvasGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+{
+    auto item = InitializeXrcObject(node, object);
+    ADD_ITEM_COMMENT(" XRC does not support wxScrolledCanvas (wxScrolled<wxWindow>) ")
+    return BaseGenerator::xrc_updated;
+}
+
 //////////////////////////////////////////  ScrolledWindowGenerator  //////////////////////////////////////////
 
 wxObject* ScrolledWindowGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    auto widget = new wxScrolled<wxPanel>(wxStaticCast(parent, wxWindow), wxID_ANY, DlgPoint(node, prop_pos),
+    auto widget = new wxScrolledWindow(wxStaticCast(parent, wxWindow), wxID_ANY, DlgPoint(node, prop_pos),
                                           DlgSize(node, prop_size), GetStyleInt(node));
     widget->SetScrollRate(node->as_int(prop_scroll_rate_x), node->as_int(prop_scroll_rate_y));
 
@@ -79,7 +86,7 @@ bool ScrolledWindowGenerator::ConstructionCode(Code& code)
 {
     if (code.is_cpp())
     {
-        code.AddAuto().NodeName().Str(" = new wxScrolled<wxPanel>(");
+        code.AddAuto().NodeName().Str(" = new wxScrolledWindow(");
         code.ValidParentName().Comma().as_string(prop_id);
         code.PosSizeFlags();
     }

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -74,7 +74,7 @@ int ScrolledCanvasGenerator::GenXrcObject(Node* node, pugi::xml_node& object, si
 wxObject* ScrolledWindowGenerator::CreateMockup(Node* node, wxObject* parent)
 {
     auto widget = new wxScrolledWindow(wxStaticCast(parent, wxWindow), wxID_ANY, DlgPoint(node, prop_pos),
-                                          DlgSize(node, prop_size), GetStyleInt(node));
+                                       DlgSize(node, prop_size), GetStyleInt(node));
     widget->SetScrollRate(node->as_int(prop_scroll_rate_x), node->as_int(prop_scroll_rate_y));
 
     widget->Bind(wxEVT_LEFT_DOWN, &BaseGenerator::OnLeftClick, this);

--- a/src/generate/window_widgets.h
+++ b/src/generate/window_widgets.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Scroll window component classes
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -19,6 +19,7 @@ public:
 
     bool GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr,
                      GenLang /* language */) override;
+    int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 
     tt_string GetHelpURL(Node*) override { return tt_string("group__group__class__miscwnd.html"); };
 };

--- a/src/panels/ribbon_tools.cpp
+++ b/src/panels/ribbon_tools.cpp
@@ -285,8 +285,8 @@ void RibbonPanel::OnDropDown(wxRibbonToolBarEvent& event)
         case NewScrolled:
             {
                 wxMenu menu;
-                menu.Append(gen_wxScrolledWindow, "Insert wxScrolled<wxPanel> (wxScrolledWindow)");
-                menu.Append(gen_wxScrolledCanvas, "Insert wxScrolled<wxWindow> (wxScrolledCanvas)");
+                menu.Append(gen_wxScrolledWindow, "Insert wxScrolledWindow");
+                menu.Append(gen_wxScrolledCanvas, "Insert wxScrolledCanvas");
 
                 menu.Bind(wxEVT_MENU, &RibbonPanel::OnMenuEvent, this, wxID_ANY);
                 event.PopupMenu(&menu);


### PR DESCRIPTION
Fixes #1551

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR switches code generation to always generate `wxScrolledWindow` and `wxScrolledCanvas` instead of their template versions. See #1551 for details.