### PR TITLE
Change how unsupported XRC widget can have a comment to that effect

### DIFF
--- a/src/generate/gen_ctx_help_btn.cpp
+++ b/src/generate/gen_ctx_help_btn.cpp
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   wxContextHelpButton generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2023-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -68,9 +68,26 @@ bool CtxHelpButtonGenerator::GetIncludes(Node* node, std::set<std::string>& set_
     return true;
 }
 
-int CtxHelpButtonGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+int CtxHelpButtonGenerator::GenXrcObject(Node* /* node */, pugi::xml_node& /* object */, size_t /* xrc_flags */)
 {
-    auto item = InitializeXrcObject(node, object);
-    ADD_ITEM_COMMENT(" XRC does not support wxContextHelpButton ")
     return BaseGenerator::xrc_not_supported;
+}
+
+std::optional<tt_string> CtxHelpButtonGenerator::GetWarning(Node* node, GenLang language)
+{
+    switch (language)
+    {
+        case GEN_LANG_XRC:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << " XRC currently does not support wxContextHelpButton ";
+                return msg;
+            }
+        default:
+            return {};
+    }
 }

--- a/src/generate/gen_ctx_help_btn.h
+++ b/src/generate/gen_ctx_help_btn.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   wxContextHelpButton generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2023-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -21,4 +21,5 @@ public:
                      GenLang /* language */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
+    std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };

--- a/src/generate/gen_ribbon_tool.cpp
+++ b/src/generate/gen_ribbon_tool.cpp
@@ -97,6 +97,25 @@ int RibbonToolBarGenerator::GenXrcObject(Node* /* node */, pugi::xml_node& /* ob
     return BaseGenerator::xrc_not_supported;
 }
 
+std::optional<tt_string> RibbonToolBarGenerator::GetWarning(Node* node, GenLang language)
+{
+    switch (language)
+    {
+        case GEN_LANG_XRC:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << " XRC currently does not support wxRibbonToolBar ";
+                return msg;
+            }
+        default:
+            return {};
+    }
+}
+
 //////////////////////////////////////////  RibbonToolGenerator  //////////////////////////////////////////
 
 bool RibbonToolGenerator::ConstructionCode(Code& code)

--- a/src/generate/gen_ribbon_tool.h
+++ b/src/generate/gen_ribbon_tool.h
@@ -24,6 +24,7 @@ public:
                      GenLang /* language */) override;
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
+    std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
 };
 
 class RibbonToolGenerator : public BaseGenerator

--- a/src/generate/gen_xrc.cpp
+++ b/src/generate/gen_xrc.cpp
@@ -51,9 +51,26 @@ int GenXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
 {
     auto generator = node->getNodeDeclaration()->getGenerator();
     auto result = generator->GenXrcObject(node, object, xrc_flags);
-    if (result == BaseGenerator::xrc_not_supported && node->isGen(gen_Project))
+    if (result == BaseGenerator::xrc_not_supported)
     {
-        result = BaseGenerator::xrc_updated;
+        if (node->isGen(gen_Project))
+        {
+            result = BaseGenerator::xrc_updated;
+        }
+        else
+        {
+            auto item = InitializeXrcObject(node, object);
+            auto comment = generator->GetWarning(node, GEN_LANG_XRC);
+            if (comment)
+            {
+                // We need a dummy item to hold the comment but which will not show up in the UI
+                GenXrcObjectAttributes(node, item, "wxBoxSizer");
+
+                object.append_child(pugi::node_comment).set_value(comment->c_str());
+            }
+
+            return BaseGenerator::xrc_form_not_supported;
+        }
     }
 
     if (result == BaseGenerator::xrc_sizer_item_created)

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -62,11 +62,28 @@ bool ScrolledCanvasGenerator::GetIncludes(Node* node, std::set<std::string>& set
     return true;
 }
 
-int ScrolledCanvasGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xrc_flags */)
+int ScrolledCanvasGenerator::GenXrcObject(Node* /* node */, pugi::xml_node& /* object */, size_t /* xrc_flags */)
 {
-    auto item = InitializeXrcObject(node, object);
-    ADD_ITEM_COMMENT(" XRC does not support wxScrolledCanvas (wxScrolled<wxWindow>) ")
-    return BaseGenerator::xrc_updated;
+    return xrc_not_supported;
+}
+
+std::optional<tt_string> ScrolledCanvasGenerator::GetWarning(Node* node, GenLang language)
+{
+    switch (language)
+    {
+        case GEN_LANG_XRC:
+            {
+                tt_string msg;
+                if (auto form = node->getForm(); form && form->hasValue(prop_class_name))
+                {
+                    msg << form->as_string(prop_class_name) << ": ";
+                }
+                msg << " XRC currently does not support wxScrolledCanvas ";
+                return msg;
+            }
+        default:
+            return {};
+    }
 }
 
 //////////////////////////////////////////  ScrolledWindowGenerator  //////////////////////////////////////////

--- a/src/generate/window_widgets.h
+++ b/src/generate/window_widgets.h
@@ -23,7 +23,6 @@ public:
 
     tt_string GetHelpURL(Node*) override { return tt_string("group__group__class__miscwnd.html"); };
     std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
-
 };
 
 class ScrolledWindowGenerator : public BaseGenerator

--- a/src/generate/window_widgets.h
+++ b/src/generate/window_widgets.h
@@ -22,6 +22,8 @@ public:
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
 
     tt_string GetHelpURL(Node*) override { return tt_string("group__group__class__miscwnd.html"); };
+    std::optional<tt_string> GetWarning(Node* node, GenLang language) override;
+
 };
 
 class ScrolledWindowGenerator : public BaseGenerator


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes it possible for generators that XRC doesn't support, to add a comment to the XRC file that will not change the visible UI.

Closes #1552