### PR TITLE
Improve chance that XRC preview will find the artwork.

### DIFF
--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -171,7 +171,7 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 /////////////////// Non-generated Copyright/License Info ////////////////////
 // Purpose:   Test XRC
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2024 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -338,6 +338,9 @@ void XrcPreview::OnPreview(wxCommandEvent& WXUNUSED(event))
         wxMessageBox("wxWidgets could not parse the XRC data.", "XRC Dialog Preview");
         return;
     }
+
+    tt_cwd cwd(true);
+    wxSetWorkingDirectory(Project.ArtDirectory().make_wxString());
 
     wxDialog dlg;
     if (xrc_resource->LoadDialog(&dlg, this, dlg_name))

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -402,6 +402,9 @@ void XrcPreview::OnInit(wxInitDialogEvent& event)
     m_scintilla->MarkerDefine(node_marker, wxSTC_MARK_BOOKMARK, wxNullColour, *wxGREEN);
 
     event.Skip();
+
+    wxCommandEvent dummy;
+    OnGenerate(dummy);
 }
 
 void XrcPreview::OnImport(wxCommandEvent& WXUNUSED(event))

--- a/src/previews.cpp
+++ b/src/previews.cpp
@@ -166,6 +166,9 @@ void Preview(Node* form_node)
             return;
         }
 
+        tt_cwd cwd(true);
+        wxSetWorkingDirectory(Project.ArtDirectory().make_wxString());
+
         XrcCompare dlg_compare;
         if (!dlg_compare.DoCreate(wxGetMainFrame(), form_node))
         {
@@ -255,6 +258,9 @@ void PreviewXrc(Node* form_node)
             wxMessageBox("wxWidgets could not parse the XRC data.", "XRC Preview");
             return;
         }
+
+        tt_cwd cwd(true);
+        wxSetWorkingDirectory(Project.ArtDirectory().make_wxString());
 
         switch (form_node->getGenName())
         {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR sets the current working directory to the Art Directory (or Project file directory if Art Directory hasn't been specified) before previewing XRC files. The generated XML file has no way of knowing where the art files will be relative to the current directory of the app loading the XRC file. By setting the current working directory to the likely location of the art files, this should result in most art work being displayed when previewing XRC content.