### PR TITLE
Refactor/update System Header dialog

### DIFF
--- a/src/customprops/sys_header_dlg.cpp
+++ b/src/customprops/sys_header_dlg.cpp
@@ -51,6 +51,7 @@ bool SysHeaderDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title
     auto* box_sizer4 = new wxBoxSizer(wxHORIZONTAL);
 
     m_static_text = new wxStaticText(this, wxID_ANY, "&Include Directory Root:");
+    m_static_text->SetMinSize(FromDIP(wxSize(600, -1)));
     box_sizer4->Add(m_static_text, wxSizerFlags().Border(wxALL));
 
     dlg_sizer->Add(box_sizer4, wxSizerFlags().Border(wxLEFT|wxRIGHT|wxTOP, wxSizerFlags::GetDefaultBorder()));
@@ -82,7 +83,6 @@ bool SysHeaderDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title
     auto* stdBtn = CreateStdDialogButtonSizer(wxOK|wxCANCEL);
     dlg_sizer->Add(CreateSeparatedSizer(stdBtn), wxSizerFlags().Expand().Border(wxALL));
 
-    SetMinSize(FromDIP(wxSize(800, -1)));
     if (pos != wxDefaultPosition)
     {
         SetPosition(FromDIP(pos));
@@ -125,14 +125,16 @@ bool SysHeaderDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title
 
 /////////////////// Non-generated Copyright/License Info ////////////////////
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2024 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2024-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include <wx/arrstr.h>  // wxArrayString
-#include <wx/config.h>  // wxConfig
-#include <wx/dir.h>     // wxDir
-#include <wx/dirdlg.h>  // wxDirDialog
+#include <wx/arrstr.h>    // wxArrayString
+#include <wx/config.h>    // wxConfig
+#include <wx/dir.h>       // wxDir
+#include <wx/dirdlg.h>    // wxDirDialog
+#include <wx/filename.h>  // wxFileName
+#include <wx/tokenzr.h>   // wxTokenizer
 
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -156,20 +158,38 @@ void SysHeaderDlg::OnInit(wxInitDialogEvent& WXUNUSED(event))
 
     if (m_combo_root->GetCount() < 9)
     {
-        wxString wxwin_path;
-        if (wxGetEnv("WXWIN", &wxwin_path))
+        wxString wxwin;
+        if (wxGetEnv("WXWIN", &wxwin))
         {
-            tt_string path = wxwin_path.utf8_string();
-            if (!path.contains("include"))
+            if (wxwin.Last() != wxFILE_SEP_PATH)
             {
-                path.append_filename("include");
+                wxwin += wxFILE_SEP_PATH;
             }
-            m_combo_root->AppendString(path);
+            wxFileName wxwin_path(wxwin);
+            if (wxwin_path.IsOk() && wxwin_path.DirExists())
+            {
+                // check to see if the last directory is "include" and if not, append it
+                if (wxwin_path.GetDirs().Last() != "include")
+                {
+                    wxwin_path.AppendDir("include");
+                }
+                m_combo_root->AppendString(wxwin_path.GetFullPath());
+            }
         }
     }
+
     if (m_combo_root->GetCount() < 9)
     {
         m_combo_root->AppendString(Project.getProjectPath());
+
+        // Add all the directories in the $INCLUDE environment variable
+        wxString include_path;
+        wxGetEnv("INCLUDE", &include_path);
+        auto include_paths = wxStringTokenize(include_path, wxASCII_STR(",;"), wxTOKEN_STRTOK);
+        for (const auto& path: include_paths)
+        {
+            m_combo_root->AppendString(path);
+        }
     }
     m_combo_root->SetSelection(0);
     wxCommandEvent dummy;
@@ -180,22 +200,30 @@ void SysHeaderDlg::OnRootSelected(wxCommandEvent& WXUNUSED(event))
 {
     m_check_list_files->Clear();
     tt_string root_path = m_combo_root->GetStringSelection().utf8_string();
-    if (root_path.empty())
+    if (root_path.empty() || !root_path.dir_exists())
         return;
 
-    // Fill wxCheckListBox with filenames containing .h, .hh, .hpp, or .hxx
-    for (const auto& entry: std::filesystem::recursive_directory_iterator(root_path.make_path()))
+    try
     {
-        if (entry.is_regular_file())
+        // Fill wxCheckListBox with filenames containing .h, .hh, .hpp, or .hxx
+        for (const auto& entry: std::filesystem::recursive_directory_iterator(root_path.make_path()))
         {
-            tt_string file = entry.path().string();
-            auto hdr_ext = file.extension();
-            if (hdr_ext == ".h" || hdr_ext == ".hh" || hdr_ext == ".hpp" || hdr_ext == ".hxx")
+            if (entry.is_regular_file())
             {
-                file.make_relative(root_path);
-                m_check_list_files->Append(file);
+                tt_string file = entry.path().string();
+                auto hdr_ext = file.extension();
+                if (hdr_ext == ".h" || hdr_ext == ".hh" || hdr_ext == ".hpp" || hdr_ext == ".hxx")
+                {
+                    file.make_relative(root_path);
+                    m_check_list_files->Append(file);
+                }
             }
         }
+    }
+    catch (const std::exception& e)
+    {
+        // In Release version, we simply stop adding filenames and return
+        MSG_ERROR(e.what());
     }
 }
 

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -7,6 +7,8 @@
 
 #pragma once  // NOLINT(#pragma once in main file)
 
+#include <wx/filename.h>  // wxFileName
+
 #include <utility>  // for pair<>
 
 #include "gen_enums.h"  // Enumerations for generators
@@ -228,6 +230,8 @@ private:
 
     tt_string m_projectFile;
     tt_string m_projectPath;
+
+    wxFileName m_project_wx_filename;
 
     int m_ProjectVersion;
     int m_OriginalProjectVersion;

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -5341,7 +5341,7 @@
         persist="1"
         style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
         title="Add System Header(s)"
-        minimum_size="800,-1"
+        minimum_size="-1,-1"
         base_file="..\customprops\sys_header_dlg.cpp"
         local_src_includes="node.h;node_prop.h;project_handler.h"
         system_src_includes="wx/filedlg.h"
@@ -5390,7 +5390,8 @@
             <node
               class="wxStaticText"
               label="&amp;Include Directory Root:"
-              var_name="m_static_text" />
+              var_name="m_static_text"
+              minimum_size="600,-1" />
           </node>
           <node
             class="wxBoxSizer"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes changes to how the `SysHeaderDlg` gets initialized, and also updates `OnRootSelected` to catch any exception thrown by `std::filesystem::recursive_directory_iterator`. These two changes should prevent #1560 from crashing -- however since I could not reproduce the problem, it will be up to rossanoparis to verify that it fixes the crash.

Note that the width of the dialog should now be quite a bit wider -- I forced the root combo box width to 600 since resizing the dialog was ignoring the minimum size set for the dialog.

The dialog will now add all $INCLUDE environment directories if the root combo list is < 9 entries.