### PR TITLE
Check for subclassed non-wx class name

### DIFF
--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -375,6 +375,10 @@ tt_string BaseCodeGenerator::GetDeclaration(Node* node)
                 code.Replace("wxStaticBitmap", "wxGenericStaticBitmap");
         }
     }
+    else if (node->hasValue(prop_subclass))
+    {
+        code << node->as_string(prop_subclass) << "* " << node->getNodeName() << ';';
+    }
     else if (class_name == "CloseButton")
     {
         code << "wxBitmapButton* " << node->getNodeName() << ';';
@@ -456,6 +460,7 @@ tt_string BaseCodeGenerator::GetDeclaration(Node* node)
         }
         code << node->as_string(prop_class_name) << "* " << node->getNodeName() << ';';
     }
+
     else if (class_name.is_sameas("dataViewColumn") || class_name.is_sameas("dataViewListColumn"))
     {
         code << "wxDataViewColumn* " << node->getNodeName() << ';';


### PR DESCRIPTION
Fixes #1561

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the `GetDeclaration()` function so that a check for a sub-classed class_name is done _before_ checking any of the non-wx control names. This fixes the bug in generating custom book pages reported in #1561, as well as half a dozen other controls that would have had the same issue.

Closes #1561