### PR TITLE
Switch to Ubuntu 24.04 for Unix builds

### DIFF
--- a/.github/workflows/build-ubuntu-setup.yml
+++ b/.github/workflows/build-ubuntu-setup.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   buildUnix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -19,14 +19,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build libgtk-3-dev
-
-    - name: Install GCC 11.4
-      run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get update
-        sudo apt-get install gcc-11 g++-11 -y
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11
         gcc --version
+        cmake --version
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -47,7 +47,7 @@ jobs:
 
 
   buildUnix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -58,14 +58,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build libgtk-3-dev
-
-    - name: Install GCC 11.4
-      run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get update
-        sudo apt-get install gcc-11 g++-11 -y
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11
         gcc --version
+        cmake --version
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes how the Unix setup gets built. The runner is now set to Ubuntu 24.04 which will uses gcc 13.3. This is done because github is removing support for Ubuntu 20.04 in April of 2025. 24.04 was chosen because gcc-compiled binaries on 24 should run on 22, and this saves us from having to update the runner for 4 years instead of 2 years.