### PR TITLE
Fix bug in SBarFieldsDialog property editor dialog

### DIFF
--- a/src/customprops/sb_fields_prop.cpp
+++ b/src/customprops/sb_fields_prop.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Property editor for status bar fields
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -61,13 +61,19 @@ void SBarFieldsDialog::OnInit(wxInitDialogEvent& WXUNUSED(event))
     auto col_width = m_grid->GetTextExtent("wxSB_NORMAL ");
     m_grid->SetDefaultColSize(col_width.GetWidth(), true);
 
+    const wxString choices[] = {
+        "wxSB_NORMAL",
+        "wxSB_FLAT",
+        "wxSB_RAISED",
+        "wxSB_SUNKEN",
+    };
     for (int row = 0; auto& iter: fields)
     {
-        if (wxGridCellChoiceEditor* editor = static_cast<wxGridCellChoiceEditor*>(m_grid->GetCellEditor(row, 0)); editor)
-            editor->SetParameters("wxSB_NORMAL,wxSB_FLAT,wxSB_RAISED,wxSB_SUNKEN");
+        m_grid->SetCellEditor(row, 0, new wxGridCellChoiceEditor(WXSIZEOF(choices), choices));
         m_grid->SetCellValue(row, 0, iter.style);
         m_grid->SetCellValue(row, 1, iter.width);
-        m_grid->SetRowLabelValue(row, " ");
+        // m_grid->SetRowLabelValue(row, " ");
+        m_grid->SetRowLabelValue(row, tt::itoa(row));
         ++row;
     }
 
@@ -99,7 +105,8 @@ void SBarFieldsDialog::OnOK(wxCommandEvent& event)
     // REVIEW: [Randalphwa - 09-01-2022] This shouldn't be necessary, but in debug builds, we sometimes get
     // a warning about undeleted events. Since none of the other custom property editors have this issue, it's most
     // likely due to something in m_grid.
-    m_grid->GetEventHandler()->DeletePendingEvents();
+    // m_grid->GetEventHandler()->DeletePendingEvents();
+    // GetEventHandler()->DeletePendingEvents();
 
     event.Skip();
 }
@@ -123,9 +130,16 @@ void SBarFieldsDialog::OnNewRow(wxCommandEvent& WXUNUSED(event))
 {
     m_grid->AppendRows(1);
     auto new_row = m_grid->GetNumberRows() - 1;
-    m_grid->SetRowLabelValue(new_row, " ");
+    const wxString choices[] = {
+        "wxSB_NORMAL",
+        "wxSB_FLAT",
+        "wxSB_RAISED",
+        "wxSB_SUNKEN",
+    };
+    m_grid->SetCellEditor(new_row, 0, new wxGridCellChoiceEditor(WXSIZEOF(choices), choices));
+    m_grid->SetRowLabelValue(new_row, tt::itoa(new_row));
     m_grid->SelectRow(new_row);
-    m_grid->SetCellValue(new_row, 0, "wxSB_NORMAL");
+    m_grid->SetCellValue(new_row, 0, choices[0]);
     m_grid->SetCellValue(new_row, 1, "-1");
     Fit();
 }

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -4736,6 +4736,77 @@
       </node>
       <node
         class="wxDialog"
+        class_name="GridPropertyDlg"
+        title="Property Editor"
+        base_file="grid_property_dlg"
+        source_preamble="// This is the base class for editing multiple-field properties"
+        wxEVT_INIT_DIALOG="OnInit"
+        wxEVT_UPDATE_UI="OnUpdateUI">
+        <node
+          class="wxBoxSizer"
+          orientation="wxVERTICAL"
+          var_name="dlg_sizer"
+          flags="wxEXPAND">
+          <node
+            class="wxBoxSizer">
+            <node
+              class="wxStaticText"
+              label="property label"
+              var_comment="Shown to the left of the toolbar"
+              var_name="m_prop_label"
+              alignment="wxALIGN_CENTER" />
+            <node
+              class="wxToolBar"
+              style="wxTB_HORIZONTAL|wxTB_NODIVIDER">
+              <node
+                class="tool"
+                bitmap="Art;wxART_NEW|wxART_TOOLBAR"
+                id="id_NewRow"
+                label=""
+                var_name="tool_new"
+                wxEVT_TOOL="OnNewRow" />
+              <node
+                class="tool"
+                bitmap="Art;wxART_DELETE|wxART_TOOLBAR"
+                id="id_DeleteRow"
+                label=""
+                var_name="tool_delete"
+                wxEVT_TOOL="OnDeleteRow" />
+              <node
+                class="tool"
+                bitmap="Art;wxART_UNDO|wxART_TOOLBAR"
+                id="id_UndoDeleteRow"
+                label=""
+                var_name="tool_undo_delete"
+                wxEVT_TOOL="OnUndoDelete" />
+            </node>
+          </node>
+          <node
+            class="wxGrid"
+            cell_vert_alignment="wxALIGN_CENTER"
+            col_label_values="name;value"
+            cols="2"
+            drag_row_size="0"
+            rows="1"
+            selection_mode="wxGridSelectRows"
+            flags="wxEXPAND"
+            proportion="1" />
+          <node
+            class="wxStaticText"
+            label="Help text"
+            var_comment="Shown below the grid (initially hidden)"
+            var_name="m_help_text"
+            wrap="300"
+            hidden="1" />
+          <node
+            class="wxStdDialogButtonSizer"
+            flags="wxEXPAND"
+            CancelButtonClicked="OnCancel"
+            OKButtonClicked="OnOK" />
+        </node>
+      </node>
+      <node
+        class="wxDialog"
         class_name="IDEditorDlg"
         title="ID Editor"
         base_file="..\customprops\id_editor_dlg"
@@ -6614,77 +6685,6 @@
         <node
           class="wxStdDialogButtonSizer"
           flags="wxEXPAND"
-          OKButtonClicked="OnOK" />
-      </node>
-    </node>
-    <node
-      class="wxDialog"
-      class_name="GridPropertyDlg"
-      title="Property Editor"
-      base_file="grid_property_dlg"
-      source_preamble="// This is the base class for editing multiple-field properties"
-      wxEVT_INIT_DIALOG="OnInit"
-      wxEVT_UPDATE_UI="OnUpdateUI">
-      <node
-        class="wxBoxSizer"
-        orientation="wxVERTICAL"
-        var_name="dlg_sizer"
-        flags="wxEXPAND">
-        <node
-          class="wxBoxSizer">
-          <node
-            class="wxStaticText"
-            label="property label"
-            var_comment="Shown to the left of the toolbar"
-            var_name="m_prop_label"
-            alignment="wxALIGN_CENTER" />
-          <node
-            class="wxToolBar"
-            style="wxTB_HORIZONTAL|wxTB_NODIVIDER">
-            <node
-              class="tool"
-              bitmap="Art;wxART_NEW|wxART_TOOLBAR"
-              id="id_NewRow"
-              label=""
-              var_name="tool_new"
-              wxEVT_TOOL="OnNewRow" />
-            <node
-              class="tool"
-              bitmap="Art;wxART_DELETE|wxART_TOOLBAR"
-              id="id_DeleteRow"
-              label=""
-              var_name="tool_delete"
-              wxEVT_TOOL="OnDeleteRow" />
-            <node
-              class="tool"
-              bitmap="Art;wxART_UNDO|wxART_TOOLBAR"
-              id="id_UndoDeleteRow"
-              label=""
-              var_name="tool_undo_delete"
-              wxEVT_TOOL="OnUndoDelete" />
-          </node>
-        </node>
-        <node
-          class="wxGrid"
-          cell_vert_alignment="wxALIGN_CENTER"
-          col_label_values="name;value"
-          cols="2"
-          drag_row_size="0"
-          rows="1"
-          selection_mode="wxGridSelectRows"
-          flags="wxEXPAND"
-          proportion="1" />
-        <node
-          class="wxStaticText"
-          label="Help text"
-          var_comment="Shown below the grid (initially hidden)"
-          var_name="m_help_text"
-          wrap="300"
-          hidden="1" />
-        <node
-          class="wxStdDialogButtonSizer"
-          flags="wxEXPAND"
-          CancelButtonClicked="OnCancel"
           OKButtonClicked="OnOK" />
       </node>
     </node>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a bug in the `SBarFieldsDialog` custom property dialog. The dialog was assuming the first cell was a `wxGridCellChoiceEditor` but used a static cast rather than creating and setting the editor. This was resulting in an Assertion error when the dialog was destroyed, and might ultimately have lead to a crash.

In addition, I also set the left column of each row to the row number and moved the location of the dialog into the Custom Property Editors.