### PR TITLE
Custom ctrl

### DIFF
--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -98,7 +98,7 @@ bool CustomControl::ConstructionCode(Code& code)
     tt_string parameters(code.view(prop_parameters));
     if (parameters.starts_with('('))
         parameters.erase(0, 1);
-    parameters.Replace("${parent}", code.node()->getParentName(code.get_language()), tt::REPLACE::all);
+    parameters.Replace("${parent}", code.node()->getParentName(code.get_language(), true), tt::REPLACE::all);
     if (code.is_cpp())
     {
         parameters.Replace("self", "this", tt::REPLACE::all);

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -544,11 +544,23 @@ const tt_string& Node::getParentName() const
     return tt_empty_cstr;
 }
 
-tt_string_view Node::getParentName(GenLang lang) const
+tt_string_view Node::getParentName(GenLang lang, bool ignore_sizers) const
 {
-    if (m_parent)
-        return m_parent->getNodeName(lang);
-
+    if (ignore_sizers)
+    {
+        auto parent = getParent();
+        while (parent && parent->isSizer())
+        {
+            parent = parent->getParent();
+        }
+        if (parent)
+            return parent->getNodeName(lang);
+    }
+    else
+    {
+        if (m_parent)
+            return m_parent->getNodeName(lang);
+    }
     return tt_empty_cstr;
 }
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -174,7 +174,7 @@ public:
 
     // May remove prefix based on the language -- e.g., @foo become foo unless the language
     // is GEN_LANG_RUBY
-    tt_string_view getParentName(GenLang lang) const;
+    tt_string_view getParentName(GenLang lang, bool ignore_sizers = false) const;
 
     // Returns this if the node is a form, else walks up node tree to find the parent form.
     Node* getForm() noexcept;


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `ignore_sizers` parameter to `Node::getParentName()` so that the `${parent}` macro can be used instead of `this` or `self` to get a valid parent for constructing a `new` instance of the custom control.

Closes #1578