### PR TITLE
Custom dpi

### DIFF
--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1715,6 +1715,106 @@ Code& Code::WxSize(wxSize size, int enable_dpi_scaling)
     return *this;
 }
 
+Code& Code::WxPoint(wxPoint position, int enable_dpi_scaling)
+{
+    auto cur_pos = this->size();
+    auto pos_scaling = is_ScalingEnabled(prop_pos, enable_dpi_scaling);
+
+    if (is_ruby())
+    {
+        if (position == wxDefaultPosition)
+        {
+            CheckLineLength((sizeof("Wx::DEFAULT_POSITION") - 1));
+            *this += "Wx::DEFAULT_POSITION";
+            return *this;
+        }
+
+        if (pos_scaling)
+        {
+            CheckLineLength(sizeof(", from_DIP(Wx::Point.new(999, 999))"));
+        }
+        else
+        {
+            CheckLineLength(sizeof("Wx::Point.new(999, 999)"));
+        }
+
+        if (pos_scaling)
+        {
+            FormFunction("FromDIP(");
+            Class("Wx::Point.new(").itoa(position.x).Comma().itoa(position.y) << ')';
+            *this += ')';
+        }
+        else
+        {
+            Class("Wx::Point.new(").itoa(position.x).Comma().itoa(position.y) << ')';
+        }
+
+        if (m_auto_break && this->size() > m_break_at)
+        {
+            InsertLineBreak(cur_pos);
+        }
+
+        return *this;
+    }
+
+    // The following code is for non-Ruby languages
+
+    if (position == wxDefaultPosition)
+    {
+        CheckLineLength((sizeof("DefaultPosition") - 1) + m_language_wxPrefix.size());
+        if (is_perl())
+            *this << "wxDefaultPosition";
+        else
+            *this << m_language_wxPrefix << "DefaultPosition";
+        return *this;
+    }
+
+    if (pos_scaling)
+    {
+        if (is_cpp())
+        {
+            if (Project.is_wxWidgets31())
+            {
+                CheckLineLength(sizeof("wxPoint(999, 999)"));
+                Class("wxPoint(").itoa(position.x).Comma().itoa(position.y) << ')';
+            }
+            else
+            {
+                CheckLineLength(sizeof("FromDIP(wxPoint(999, 999))"));
+                FormFunction("FromDIP(");
+                Class("wxPoint(").itoa(position.x).Comma().itoa(position.y) << ')';
+                *this += ')';
+            }
+        }
+        else if (is_python())
+        {
+            CheckLineLength(sizeof("self.FromDIP(wxPoint(999, 999))"));
+            FormFunction("FromDIP(");
+            Class("wxPoint(").itoa(position.x).Comma().itoa(position.y) << ')';
+            *this += ')';
+        }
+#if GENERATE_NEW_LANG_CODE
+        else if (is_lua())
+        {
+            CheckLineLength(sizeof("wx.wxPoint(999, 999)"));
+            Class("wxPoint(").itoa(size.x).Comma().itoa(size.y) << ')';
+        }
+#endif
+    }
+    else
+    {
+        CheckLineLength(sizeof("wxPoint(999, 999)"));
+        Class("wxPoint(").itoa(position.x).Comma().itoa(position.y) << ')';
+    }
+
+    if (m_auto_break && this->size() > m_break_at)
+    {
+        InsertLineBreak(cur_pos);
+    }
+
+    return *this;
+}
+
 Code& Code::Pos(GenEnum::PropName prop_name, int enable_dpi_scaling)
 {
     auto cur_pos = size();

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -418,6 +418,10 @@ public:
     Code& WxSize(wxSize size, int enable_dpi_scaling = conditional_scaling);
 
     // Will either generate wxPoint(...) or FromDIP(wxPoint(...))
+    // Uses prop_pos to determine scaling if conditional_scaling is set
+    Code& WxPoint(wxPoint position, int enable_dpi_scaling = conditional_scaling);
+
+    // Will either generate wxPoint(...) or FromDIP(wxPoint(...))
     Code& Pos(GenEnum::PropName prop_name = GenEnum::PropName::prop_pos, int enable_dpi_scaling = conditional_scaling);
 
     // Check for pos, size, style, window_style, and window name, and generate code if needed

--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -126,19 +126,13 @@ bool CustomControl::ConstructionCode(Code& code)
             else if (iter.second == prop_pos)
             {
                 auto pos = code.node()->as_wxPoint(prop_pos);
-                if (pos.x == -1 && pos.y == -1)
-                    code_temp.Add("wxDefaultPosition");
-                else
-                    code_temp.Add("wxPoint(") << pos.x << ", " << pos.y << ")";
+                code_temp.WxPoint(pos);
                 parameters.Replace(iter.first, code_temp);
             }
             else if (iter.second == prop_size)
             {
                 auto size = code.node()->as_wxSize(prop_size);
-                if (size.x == -1 && size.y == -1)
-                    code_temp.Add("wxDefaultSize");
-                else
-                    code_temp.Add("wxSize(") << size.x << ", " << size.y << ")";
+                code_temp.WxSize(size);
                 parameters.Replace(iter.first, code_temp);
             }
             else


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds scaling support for ${pos} and ${size} parameters for custom controls.

Closes #1576

## Implementation details

This adds a new `Code::WxPoint()` that can be used to generate code for wxPoint when the dimension is already known. This will use `prop_pos` to determine whether scaling should be used if the default `conditional_scaling` is set. The primary use of this is to scale the ${pos} parameter macro for custom controls.
