### PR TITLE
Change Custom params dialog to list optional macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Generic option removed for wxAnimationCtrl. The generic version is automatically generated when a ANI animation file is specified. This will correctly display the file on wxGTK when generating C++ and wxPthon code. wxRuby3 does not support Wx::GenericAnimationCtrl in version 1.0, so only the regular version is generated.
 - derived_class property in the wxWindows category has been changed to subclass to better reflect that the generated class derives from your specified class. The derived_class_name in the various language categories remain unchanged to indicate you derive your class from the generated class.
 - wxRuby3 generated code now supports persistence property (`Wx.persistent_register_and_restore`)
+- The dialog for editing Custom Control parameters now has a drop-down list of all the possible macros you can use
 
 ### Fixed
 - Fixed generation of event handlers in C++ derived classes.

--- a/src/customprops/custom_param_prop.h
+++ b/src/customprops/custom_param_prop.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Derived wxStringProperty class for custom control parameters
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2024-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -10,12 +10,16 @@
 #include <wx/propgrid/editors.h>  // wxPropertyGrid editors
 #include <wx/propgrid/props.h>    // wxPropertyGrid Property Classes
 
-class NodeProperty;
+#include "node_prop.h"  // NodeProperty class
+#include "wxui/grid_property_dlg.h"
 
-class EditParamDialogAdapter : public wxPGEditorDialogAdapter
+class Node;
+class NodeEvent;
+
+class EditParamsDialogAdapter : public wxPGEditorDialogAdapter
 {
 public:
-    EditParamDialogAdapter(NodeProperty* prop) : wxPGEditorDialogAdapter(), m_prop(prop) {}
+    EditParamsDialogAdapter(NodeProperty* prop) : wxPGEditorDialogAdapter(), m_prop(prop) {}
 
     bool DoShowDialog(wxPropertyGrid* WXUNUSED(propGrid), wxPGProperty* WXUNUSED(property)) override;
 
@@ -32,8 +36,37 @@ public:
     const wxPGEditor* DoGetEditorClass() const override { return wxPGEditor_TextCtrlAndButton; }
 
     // Set what happens on button click
-    wxPGEditorDialogAdapter* GetEditorDialog() const override { return new EditParamDialogAdapter(m_prop); }
+    wxPGEditorDialogAdapter* GetEditorDialog() const override { return new EditParamsDialogAdapter(m_prop); }
 
 private:
     NodeProperty* m_prop;
+};
+
+class EditParamsDialog : public GridPropertyDlg
+{
+public:
+    EditParamsDialog(wxWindow* parent, NodeProperty* prop);
+    const wxString& GetResults() { return m_value; }
+
+    struct string_pairs
+    {
+        std::string style;
+        std::string width;
+    };
+
+protected:
+    void OnInit(wxInitDialogEvent& WXUNUSED(event)) override;
+    void OnOK(wxCommandEvent& event) override;
+
+    void OnNewRow(wxCommandEvent& WXUNUSED(event)) override;
+    void OnDeleteRow(wxCommandEvent& WXUNUSED(event)) override;
+    void OnUndoDelete(wxCommandEvent& WXUNUSED(event)) override;
+    void OnUpdateUI(wxUpdateUIEvent& WXUNUSED(event)) override;
+
+private:
+    std::vector<tt_string> m_fields;
+    NodeProperty* m_prop { nullptr };
+
+    wxString m_value;
+    wxString m_deleted_col_0;
 };

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   NodeProperty class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -406,29 +406,37 @@ std::vector<tt_string> NodeProperty::as_vector() const
     return array;
 }
 
-std::vector<tt_string> NodeProperty::as_ArrayString() const
+std::vector<tt_string> NodeProperty::as_ArrayString(char separator) const
 {
-    tt_string_vector result;
-
-    if (m_value.size())
+    if (separator == 0)
     {
-        if (type() == type_stringlist_semi)
+        tt_string_vector result;
+
+        if (m_value.size())
         {
-            result.SetString(m_value, ";", tt::TRIM::both);
-        }
-        else if (type() == type_stringlist_escapes || m_value[0] == '"')
-        {
-            auto view = m_value.view_substr(0, '"', '"');
-            while (view.size() > 0)
+            if (type() == type_stringlist_semi)
             {
-                result.emplace_back(view);
-                view = tt::stepover(view.data() + view.size());
-                view = view.view_substr(0, '"', '"');
+                result.SetString(m_value, ";", tt::TRIM::both);
+            }
+            else if (type() == type_stringlist_escapes || m_value[0] == '"')
+            {
+                auto view = m_value.view_substr(0, '"', '"');
+                while (view.size() > 0)
+                {
+                    result.emplace_back(view);
+                    view = tt::stepover(view.data() + view.size());
+                    view = view.view_substr(0, '"', '"');
+                }
             }
         }
-    }
 
-    return result;
+        return result;
+    }
+    else
+    {
+        tt_string_vector result(m_value, separator, tt::TRIM::both);
+        return result;
+    }
 }
 
 wxArrayString NodeProperty::as_wxArrayString() const

--- a/src/nodes/node_prop.h
+++ b/src/nodes/node_prop.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   NodeProperty class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -113,8 +113,11 @@ public:
     wxSize as_size() const;
     wxArrayString as_wxArrayString() const;
 
-    // Assumes all values are within quotes, or separated by semi-colons
-    std::vector<tt_string> as_ArrayString() const;
+    // Unless separator is set, assumes all values are within quotes,
+    // or separated by semi-colons.
+    //
+    // Specify separator to use a specific character as the separator
+    std::vector<tt_string> as_ArrayString(char separator = 0) const;
 
     // On Windows this will first convert to UTF-16 unless wxUSE_UNICODE_UTF8 is set.
     wxString as_wxString() const { return m_value.make_wxString(); }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the dialog for editing custom control parameters. The new dialog is a grid, where each parameter can be entered manually, or via a drop-down list of macros.