### PR TITLE
Support wxGenericStaticBitmap as a subclass

### DIFF
--- a/src/generate/gen_static_bmp.cpp
+++ b/src/generate/gen_static_bmp.cpp
@@ -117,7 +117,9 @@ void StaticBitmapGenerator::GenCppConstruction(Code& code)
         if (node->isLocal())
             code << "auto* ";
 
-        bool use_generic_version = (node->as_string(prop_scale_mode) != "None");
+        bool use_generic_version =
+            (node->as_string(prop_scale_mode) != "None" || node->as_string(prop_subclass) == "wxGenericStaticBitmap");
+
         if (use_generic_version)
             code.NodeName() << " = new wxGenericStaticBitmap(";
         else
@@ -192,7 +194,9 @@ void StaticBitmapGenerator::GenCppConstruction(Code& code)
         if (node->isLocal())
             code << "auto* ";
 
-        bool use_generic_version = (node->as_string(prop_scale_mode) != "None");
+        bool use_generic_version =
+            (node->as_string(prop_scale_mode) != "None" || node->as_string(prop_subclass) == "wxGenericStaticBitmap");
+
         if (use_generic_version)
             code.NodeName() += " = new wxGenericStaticBitmap(";
         else
@@ -251,7 +255,7 @@ bool StaticBitmapGenerator::SettingsCode(Code& code)
 bool StaticBitmapGenerator::GetIncludes(Node* node, std::set<std::string>& set_src, std::set<std::string>& set_hdr,
                                         GenLang /* language */)
 {
-    if (node->as_string(prop_scale_mode) != "None")
+    if (node->as_string(prop_scale_mode) != "None" || node->as_string(prop_subclass) == "wxGenericStaticBitmap")
         InsertGeneratorInclude(node, "#include <wx/generic/statbmpg.h>", set_src, set_hdr);
     else
         InsertGeneratorInclude(node, "#include <wx/statbmp.h>", set_src, set_hdr);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds support for subclassing a wxStaticBitmap using wxGenericStaticBitmap, including adding the required include of `wx/generic/statbmpg.h`. Note that the generic version was already being used if any of the scaling methods were used, so this simply extends that code.

Closes #1582
