### PR TITLE
Fix overlapping event ids with conflict

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -80,7 +80,7 @@ using namespace GenEnum;
 
 enum
 {
-    IDM_IMPORT_WINRES = wxID_HIGHEST + 500,
+    IDM_IMPORT_WINRES = START_TESTING_IDS,
 
     id_TestSwitch,
     id_CodeDiffDlg,
@@ -119,7 +119,7 @@ enum
 
 const char* txtEmptyProject = "Empty Project";
 
-MainFrame::MainFrame() : MainFrameBase(nullptr), m_findData(wxFR_DOWN), m_ImportHistory(9, wxID_FILE1 + 1000)
+MainFrame::MainFrame() : MainFrameBase(nullptr), m_findData(wxFR_DOWN), m_ImportHistory(9, START_IMPORT_FILE_IDS)
 {
     m_dpi_menu_size = FromDIP(wxSize(16, 16));
     m_dpi_toolbar_size = FromDIP(wxSize(16, 16));
@@ -252,7 +252,7 @@ MainFrame::MainFrame() : MainFrameBase(nullptr), m_findData(wxFR_DOWN), m_Import
         m_ImportHistory.AddFilesToMenu();
         config->SetPath("/");
 
-        Bind(wxEVT_MENU, &MainFrame::OnImportRecent, this, wxID_FILE1 + 1000, wxID_FILE9 + 1000);
+        Bind(wxEVT_MENU, &MainFrame::OnImportRecent, this, START_IMPORT_FILE_IDS, START_IMPORT_FILE_IDS + 9);
     }
 
 #if defined(_DEBUG)
@@ -824,7 +824,7 @@ void MainFrame::OnOpenRecentProject(wxCommandEvent& event)
 
 void MainFrame::OnImportRecent(wxCommandEvent& event)
 {
-    tt_string file = m_ImportHistory.GetHistoryFile(event.GetId() - (wxID_FILE1 + 1000)).utf8_string();
+    tt_string file = m_ImportHistory.GetHistoryFile(event.GetId() - (START_IMPORT_FILE_IDS)).utf8_string();
 
     if (!SaveWarning())
         return;

--- a/src/panels/doc_view.h
+++ b/src/panels/doc_view.h
@@ -24,7 +24,7 @@ class DocViewPanel : public wxPanel
 public:
     enum
     {
-        ID_CPLUS = wxID_HIGHEST + 1,
+        ID_CPLUS = START_DOCVIEW_IDS,
         ID_PYTHON,
         ID_RUBY
     };

--- a/src/panels/nav_toolbar.h
+++ b/src/panels/nav_toolbar.h
@@ -27,7 +27,7 @@ class NavToolbar : public wxToolBar
 public:
     enum
     {
-        id_NavCollExpand = wxID_HIGHEST + 1,
+        id_NavCollExpand = START_NAVTOOL_IDS,
         id_NavCollapse,
         id_NavExpand,
         id_NavMoveDown,

--- a/src/pch.h
+++ b/src/pch.h
@@ -118,6 +118,16 @@
 // out of the conditional block.
 #define GENERATE_NEW_LANG_CODE 0
 
+// To prevent accidentally overlapping event ids, all starting values for enumerated id values
+// should use one of these defines.
+
+#define START_RIBBON_IDS      wxID_HIGHEST + 1
+#define START_MAINFRAME_IDS   wxID_HIGHEST + 1000
+#define START_NAVTOOL_IDS     wxID_HIGHEST + 2000
+#define START_DOCVIEW_IDS     wxID_HIGHEST + 3000
+#define START_TESTING_IDS     wxID_HIGHEST + 4000
+#define START_IMPORT_FILE_IDS wxID_HIGHEST + 5000
+
 enum class MoveDirection
 {
     Up = 1,

--- a/src/wxui/ribbon_ids.h
+++ b/src/wxui/ribbon_ids.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   ribbon panel ids
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2023-2024 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2023-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -13,7 +13,7 @@
 
 enum
 {
-    NewPopupWin = wxID_HIGHEST + 1,
+    NewPopupWin = START_RIBBON_IDS + 100,
     NewCheckbox,
     NewButton,
     NewSpin,

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -595,6 +595,7 @@
         class_name="MainFrameBase"
         base_file="mainframe_base"
         generate_ids="0"
+        initial_enum_string="START_MAINFRAME_IDS"
         local_src_includes="mainframe.h;project_handler.h"
         derived_class_name="MainFrame"
         minimum_size="800,800"
@@ -2400,6 +2401,7 @@
         class_name="NavToolbar"
         style="wxTB_FLAT|wxTB_HORIZONTAL"
         base_file="..\panels\nav_toolbar"
+        initial_enum_string="START_NAVTOOL_IDS"
         local_src_includes="mainframe.h;project_handler.h"
         private_members="0"
         use_derived_class="0">
@@ -2473,6 +2475,7 @@
         size="-1,-1"
         base_file="ribbonpanel_base"
         generate_ids="0"
+        initial_enum_string="START_RIBBON_IDS"
         source_preamble="#include &quot;ribbon_ids.h&quot;@@#include &quot;gen_enums.h&quot;     // Enumerations for generators@@@@using namespace GenEnum;"
         derived_class_name="RibbonPanel">
         <node
@@ -3350,6 +3353,7 @@
         class_name="DocViewPanel"
         window_style="0"
         base_file="..\panels\doc_view.cpp"
+        initial_enum_string="START_DOCVIEW_IDS"
         header_preamble="class CustomEvent;@@class wxWebView;@@class MainFrame;"
         no_closing_brace="1"
         derived_class_name="DocView"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
wxUiEditor utilizes multiple ranges of ids that get passed to event handlers. Inevitably, code in one place wasn't aware of an id range in a different place, causing an id overlap resulting in the wrong event handler being called. This PR fixes that bug, and changes all enumerated id starting values to one of the new `#defines` in pch.h. As long as these values are used (or new ones added to the list), it will prevent any future conflicts.