### PR TITLE
wxPerl code generation additions

### DIFF
--- a/src/generate/SUPPORTED.md
+++ b/src/generate/SUPPORTED.md
@@ -47,7 +47,7 @@ The following tables indicate whether or not code is being generated in a specif
 | wxAuiNotebook | yes | ---  | yes    | yes  | --- | ../src/generate/gen_aui_notebook.cpp |
 | wxChoicebook  | yes | ---  | yes    | yes  | --- | ../src/generate/gen_choicebook.cpp   |
 | wxListbook    | yes | ---  | yes    | yes  | --- | ../src/generate/gen_listbook.cpp     |
-| wxNotebook    | yes | ---  | yes    | yes  | yes | ../src/generate/gen_notebook.cpp     |
+| wxNotebook    | yes | yes  | yes    | yes  | yes | ../src/generate/gen_notebook.cpp     |
 | wxSimplebook  | yes | ---  | yes    | yes  | --- | ../src/generate/gen_simplebook.cpp   |
 | wxToolbook    | yes | ---  | yes    | yes  | --- | ../src/generate/gen_toolbook.cpp     |
 | wxTreebook    | yes | ---  | yes    | yes  | yes | ../src/generate/gen_treebook.cpp     |

--- a/src/generate/SUPPORTED.md
+++ b/src/generate/SUPPORTED.md
@@ -44,13 +44,13 @@ The following tables indicate whether or not code is being generated in a specif
 
 | Class         | C++ | Perl | Python | Ruby | XRC | file                                 |
 | ------------- | --- | ---- | ------ | ---- | --- | ------------------------------------ |
-| wxAuiNotebook | yes | ---  | yes    | yes  | --- | ../src/generate/gen_aui_notebook.cpp |
-| wxChoicebook  | yes | ---  | yes    | yes  | --- | ../src/generate/gen_choicebook.cpp   |
-| wxListbook    | yes | ---  | yes    | yes  | --- | ../src/generate/gen_listbook.cpp     |
+| wxAuiNotebook | yes | yes  | yes    | yes  | yes | ../src/generate/gen_aui_notebook.cpp |
+| wxChoicebook  | yes | yes  | yes    | yes  | yes | ../src/generate/gen_choicebook.cpp   |
+| wxListbook    | yes | yes  | yes    | yes  | yes | ../src/generate/gen_listbook.cpp     |
 | wxNotebook    | yes | yes  | yes    | yes  | yes | ../src/generate/gen_notebook.cpp     |
-| wxSimplebook  | yes | ---  | yes    | yes  | --- | ../src/generate/gen_simplebook.cpp   |
-| wxToolbook    | yes | ---  | yes    | yes  | --- | ../src/generate/gen_toolbook.cpp     |
-| wxTreebook    | yes | ---  | yes    | yes  | yes | ../src/generate/gen_treebook.cpp     |
+| wxSimplebook  | yes | no  | yes    | yes  | yes | ../src/generate/gen_simplebook.cpp   |
+| wxToolbook    | yes | yes  | yes    | yes  | yes | ../src/generate/gen_toolbook.cpp     |
+| wxTreebook    | yes | yes  | yes    | yes  | yes | ../src/generate/gen_treebook.cpp     |
 
 ### Forms
 
@@ -185,6 +185,7 @@ The Unsupported lists below are for controls that the language port doesn't supp
 - wxTextCtrl.SetHint()
 - wxTextProofOptions (for wxTextCtrl)
 - wxWindow.FromDIP()
+- wxSimpleBook
 
 # Ruby Unsupported
 

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -767,18 +767,9 @@ Code& Code::AddConstant(tt_string_view text)
 Code& Code::Add(tt_string_view text)
 {
     bool old_linebreak = m_auto_break;
-    if (is_ruby() && text.size())
-    {
-        // Ruby doesn't like breaking the parenthesis for a function call onto the next line,
-        // or the .new function
-        if (text.front() == '.' || text.front() == '(')
-        {
-            old_linebreak = m_auto_break;
-            m_auto_break = false;
-        }
-    }
-
-    if (is_cpp() || text.size() < 3)
+    // Ruby changes the prefix to "Wx::", and Python changes it to "wx."
+    // C++, Perl, and Rust use the constant unmodified.
+    if (is_cpp() || is_perl() || is_rust() || text.size() < 3)
     {
         CheckLineLength(text.size());
         *this += text;
@@ -787,6 +778,16 @@ Code& Code::Add(tt_string_view text)
     {
         if (is_ruby())
         {
+            if (text.size())
+            {
+                // Ruby doesn't like breaking the parenthesis for a function call onto the next line,
+                // or the .new function
+                if (text.front() == '.' || text.front() == '(')
+                {
+                    old_linebreak = m_auto_break;
+                    m_auto_break = false;
+                }
+            }
             if (text == "wxEmptyString")
             {
                 // wxRuby prefers ('') for an empty string instead of the expected Wx::empty_string
@@ -832,6 +833,7 @@ Code& Code::Add(tt_string_view text)
                     *this += '|';
                 if (iter.is_sameprefix("wx") && !is_cpp())
                 {
+#if 0
                     if (is_perl() && (HasPerlMapConstant(text) || set_perl_constants.contains(text)))
                     {
                         CheckLineLength(text.size());
@@ -839,7 +841,7 @@ Code& Code::Add(tt_string_view text)
                         initial_combined_value_set = true;
                         continue;
                     }
-
+#endif
                     if (std::string_view language_prefix = GetLanguagePrefix(text, m_language); language_prefix.size())
                     {
                         // Some languages will have a module added after their standard prefix.

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -996,7 +996,7 @@ Code& Code::Function(tt_string_view text, bool add_operator)
 
 Code& Code::ClassMethod(tt_string_view function_name)
 {
-    if (is_cpp())
+    if (is_cpp() || is_perl())
     {
         *this += "::";
     }
@@ -1018,7 +1018,14 @@ Code& Code::ClassMethod(tt_string_view function_name)
 
 Code& Code::VariableMethod(tt_string_view function_name)
 {
-    *this += '.';
+    if (is_perl())
+    {
+        *this += "->";
+    }
+    else
+    {
+        *this += '.';
+    }
     if (is_ruby())
     {
         *this += ConvertToSnakeCase(function_name);

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -2719,7 +2719,7 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
             {
                 if (point_size <= 0)
                 {
-                    Add("wxSystemSettings").ClassMethod("GetFont(").Add("wxSYS_DEFAULT_GUI_FONT").Str(")");
+                    Class("wxSystemSettings").ClassMethod("GetFont(").Add("wxSYS_DEFAULT_GUI_FONT").Str(")");
                     VariableMethod("GetPointSize()").EndFunction();
                     if (!is_cpp() && more_than_pointsize)
                     {
@@ -2871,7 +2871,7 @@ void Code::GenFontColourSettings()
         }
         if (fg_clr.contains("wx"))
         {
-            Add("wxSystemSettings").ClassMethod("GetColour(").Add(fg_clr) += ")";
+            Class("wxSystemSettings").ClassMethod("GetColour(").Add(fg_clr) += ")";
         }
         else
         {
@@ -2902,7 +2902,7 @@ void Code::GenFontColourSettings()
         }
         if (bg_clr.contains("wx"))
         {
-            Add("wxSystemSettings").ClassMethod("GetColour(").Add(bg_clr) += ")";
+            Class("wxSystemSettings").ClassMethod("GetColour(").Add(bg_clr) += ")";
         }
         else
         {
@@ -2946,7 +2946,7 @@ void Code::GenFontColourSettings()
             FormFunction("GetBookCtrl()").Function("SetBackgroundColour(");
             if (bg_clr.contains("wx"))
             {
-                Add("wxSystemSettings").ClassMethod("GetColour(").Add(bg_clr) += ")";
+                Class("wxSystemSettings").ClassMethod("GetColour(").Add(bg_clr) += ")";
             }
             else
             {

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -615,8 +615,7 @@ Code& Code::CloseBrace(bool all_languages, bool close_ruby)
 
 void Code::OpenFontBrace()
 {
-    // REVIEW: [Randalphwa - 09-26-2024] Will this be needed for wxPerl as well?
-    if (is_cpp())
+    if (is_cpp() || is_perl())
     {
         m_within_font_braces = true;
         Eol(eol_if_needed);
@@ -628,7 +627,7 @@ void Code::OpenFontBrace()
 
 void Code::CloseFontBrace()
 {
-    if (is_cpp())
+    if (is_cpp() || is_perl())
     {
         while (size() && tt::is_whitespace(back()))
             pop_back();
@@ -2599,13 +2598,17 @@ void Code::GenWindowSettings()
 Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
 {
     FontProperty fontprop(m_node->getPropPtr(prop_name));
-    if (is_perl())
-    {
-        // REVIEW: [Randalphwa - 01-07-2025] As of wx-3.005, wxPerl doesn't support wxFontinfo
-        return *this;
-    }
     if (fontprop.isDefGuiFont())
     {
+        std::string font_var_name;
+        if (is_perl())
+        {
+            font_var_name = "$font";
+        }
+        else
+        {
+            font_var_name = "font";
+        }
         OpenFontBrace();
         if (is_cpp())
         {
@@ -2613,159 +2616,182 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
         }
         else
         {
-            Add("font").CreateClass(false, "wxFont");
+            AddIfPerl("my ").Str(font_var_name).CreateClass(false, "wxFont");
         }
-        Add("wxSystemSettings").ClassMethod("GetFont(").Add("wxSYS_DEFAULT_GUI_FONT").Str(")");
+        Class("wxSystemSettings").ClassMethod("GetFont(").Add("wxSYS_DEFAULT_GUI_FONT").Str(")");
         EndFunction();
 
         if (fontprop.GetSymbolSize() != wxFONTSIZE_MEDIUM)
             Eol()
-                .Str("font")
+                .Str(font_var_name)
                 .VariableMethod("SetSymbolicSize(")
                 .Add(font_symbol_pairs.GetValue(fontprop.GetSymbolSize()))
                 .EndFunction();
         if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)
-            Eol().Str("font").VariableMethod("SetStyle(").Add(font_style_pairs.GetValue(fontprop.GetStyle())).EndFunction();
+            Eol()
+                .Str(font_var_name)
+                .VariableMethod("SetStyle(")
+                .Add(font_style_pairs.GetValue(fontprop.GetStyle()))
+                .EndFunction();
         if (fontprop.GetWeight() != wxFONTWEIGHT_NORMAL)
             Eol()
-                .Str("font")
+                .Str(font_var_name)
                 .VariableMethod("SetWeight(")
                 .Add(font_weight_pairs.GetValue(fontprop.GetWeight()))
                 .EndFunction();
         if (fontprop.IsUnderlined())
-            Eol().Str("font").VariableMethod("SetUnderlined(").True().EndFunction();
+            Eol().Str(font_var_name).VariableMethod("SetUnderlined(").True().EndFunction();
         if (fontprop.IsStrikethrough())
-            Eol().Str("font").VariableMethod("SetStrikethrough(").True().EndFunction();
+            Eol().Str(font_var_name).VariableMethod("SetStrikethrough(").True().EndFunction();
         Eol();
 
         if (m_node->isForm())
         {
             if (m_node->isGen(gen_wxPropertySheetDialog))
             {
-                FormFunction("GetBookCtrl()").Function("SetFont(").Add("font").EndFunction();
+                FormFunction("GetBookCtrl()").Function("SetFont(").Str(font_var_name).EndFunction();
             }
             else
             {
-                FormFunction("SetFont(font").EndFunction();
+                FormFunction("SetFont(").Str(font_var_name).EndFunction();
             }
             CloseFontBrace();
         }
         else if (m_node->isGen(gen_wxStyledTextCtrl))
         {
             NodeName().Function("StyleSetFont(").Add("wxSTC_STYLE_DEFAULT");
-            Comma().Str("font").EndFunction();
+            Comma().Str(font_var_name).EndFunction();
             CloseFontBrace();
         }
         else
         {
-            NodeName().Function(font_function).Str("font").EndFunction();
+            NodeName().Function(font_function).Str(font_var_name).EndFunction();
             CloseFontBrace();
         }
     }
     else  // not isDefGuiFont()
     {
-        bool more_than_pointsize =
-            ((fontprop.GetFaceName().size() && fontprop.GetFaceName() != "default") ||
-             fontprop.GetFamily() != wxFONTFAMILY_DEFAULT || fontprop.GetStyle() != wxFONTSTYLE_NORMAL ||
-             fontprop.GetWeight() != wxFONTWEIGHT_NORMAL || fontprop.IsUnderlined() || fontprop.IsStrikethrough());
-
-        const auto point_size = fontprop.GetFractionalPointSize();
-        if (is_cpp())
+        if (is_perl())
         {
             OpenFontBrace();
-            Str("wxFontInfo font_info(");
+            Str("my $font = ");
+            Class("wxFont").Function("new(");
+            itoa(fontprop.GetPointSize()).Comma();
+            Str(font_family_pairs.GetValue(fontprop.GetFamily())).Comma();
+            Str(font_style_pairs.GetValue(fontprop.GetStyle())).Comma();
+            Str(font_weight_pairs.GetValue(fontprop.GetWeight())).Comma();
+            Str(fontprop.IsUnderlined() ? "1" : "0").Comma();
+            QuotedString(fontprop.GetFaceName().utf8_string()).Str(");");
         }
         else
         {
-            Eol(eol_if_needed);
-            if (is_perl())
-            {
-                *this += "my $";
-            }
-            Add("font_info").CreateClass(false, "wxFontInfo");
-        }
+            bool more_than_pointsize =
+                ((fontprop.GetFaceName().size() && fontprop.GetFaceName() != "default") ||
+                 fontprop.GetFamily() != wxFONTFAMILY_DEFAULT || fontprop.GetStyle() != wxFONTSTYLE_NORMAL ||
+                 fontprop.GetWeight() != wxFONTWEIGHT_NORMAL || fontprop.IsUnderlined() || fontprop.IsStrikethrough());
 
-        if (point_size != static_cast<int>(point_size))  // is there a fractional value?
-        {
-            std::array<char, 10> float_str;
-            if (auto [ptr, ec] = std::to_chars(float_str.data(), float_str.data() + float_str.size(), point_size);
-                ec == std::errc())
+            const auto point_size = fontprop.GetFractionalPointSize();
+            if (is_cpp())
             {
-                Str(std::string_view(float_str.data(), ptr - float_str.data())).EndFunction();
+                OpenFontBrace();
+                Str("wxFontInfo font_info(");
             }
-        }
-        else
-        {
-            if (point_size <= 0)
+            else
             {
-                Add("wxSystemSettings").ClassMethod("GetFont(").Add("wxSYS_DEFAULT_GUI_FONT").Str(")");
-                VariableMethod("GetPointSize()").EndFunction();
-                if (!is_cpp() && more_than_pointsize)
+                Eol(eol_if_needed);
+                if (is_perl())
                 {
-                    Eol().Str("font_info");
+                    *this += "my $";
+                }
+                Add("font_info").CreateClass(false, "wxFontInfo");
+            }
+
+            if (point_size != static_cast<int>(point_size))  // is there a fractional value?
+            {
+                std::array<char, 10> float_str;
+                if (auto [ptr, ec] = std::to_chars(float_str.data(), float_str.data() + float_str.size(), point_size);
+                    ec == std::errc())
+                {
+                    Str(std::string_view(float_str.data(), ptr - float_str.data())).EndFunction();
                 }
             }
             else
             {
-                // GetPointSize() will round the result rather than truncating the decimal
-                itoa(fontprop.GetPointSize()).EndFunction();
+                if (point_size <= 0)
+                {
+                    Add("wxSystemSettings").ClassMethod("GetFont(").Add("wxSYS_DEFAULT_GUI_FONT").Str(")");
+                    VariableMethod("GetPointSize()").EndFunction();
+                    if (!is_cpp() && more_than_pointsize)
+                    {
+                        Eol().Str("font_info");
+                    }
+                }
+                else
+                {
+                    // GetPointSize() will round the result rather than truncating the decimal
+                    itoa(fontprop.GetPointSize()).EndFunction();
+                }
             }
-        }
 
-        if (is_cpp())
-        {
-            Eol();
-            if (more_than_pointsize)
+            if (is_cpp())
             {
-                Str("font_info");
+                Eol();
+                if (more_than_pointsize)
+                {
+                    Str("font_info");
+                }
             }
-        }
 
-        if (is_perl())
-        {
-            if (fontprop.GetFaceName().size() && fontprop.GetFaceName() != "default")
+#if defined(_WIN32)
+            // REVIEW: [Randalphwa - 04-18-2025] Currently, wxPerl does support wxFontInfo, but leave this code
+            // in case it is added later.
+            if (is_perl())
             {
-                Eol().Str("$font_info->").Str("FaceName = ");
-                QuotedString(tt_string() << fontprop.GetFaceName().utf8_string()) += ";";
+                if (fontprop.GetFaceName().size() && fontprop.GetFaceName() != "default")
+                {
+                    Eol().Str("$font_info->").Str("FaceName = ");
+                    QuotedString(tt_string() << fontprop.GetFaceName().utf8_string()) += ";";
+                }
+                if (fontprop.GetFamily() != wxFONTFAMILY_DEFAULT)
+                {
+                    Eol().Str("$font_info->").Str("Family = ");
+                    Add(font_family_pairs.GetValue(fontprop.GetFamily())) += ";";
+                }
+                if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)
+                {
+                    Eol().Str("$font_info->").Str("Style = ");
+                    Add(font_style_pairs.GetValue(fontprop.GetStyle())) += ";";
+                }
             }
-            if (fontprop.GetFamily() != wxFONTFAMILY_DEFAULT)
+#endif
+            else
             {
-                Eol().Str("$font_info->").Str("Family = ");
-                Add(font_family_pairs.GetValue(fontprop.GetFamily())) += ";";
+                if (fontprop.GetFaceName().size() && fontprop.GetFaceName() != "default")
+                    VariableMethod("FaceName(").QuotedString(tt_string() << fontprop.GetFaceName().utf8_string()) += ")";
+                if (fontprop.GetFamily() != wxFONTFAMILY_DEFAULT)
+                    VariableMethod("Family(").Add(font_family_pairs.GetValue(fontprop.GetFamily())) += ")";
+                if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)
+                    VariableMethod("Style(").Add(font_style_pairs.GetValue(fontprop.GetStyle())) += ")";
+                if (fontprop.GetWeight() != wxFONTWEIGHT_NORMAL)
+                {
+                    VariableMethod("Weight(").Add(font_weight_pairs.GetValue(fontprop.GetWeight())) += ")";
+                }
+                if (fontprop.IsUnderlined())
+                    VariableMethod("Underlined()");
+                if (fontprop.IsStrikethrough())
+                    VariableMethod("Strikethrough()");
             }
-            if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)
+            if (back() == '.')
             {
-                Eol().Str("$font_info->").Str("Style = ");
-                Add(font_style_pairs.GetValue(fontprop.GetStyle())) += ";";
-            }
-        }
-        else
-        {
-            if (fontprop.GetFaceName().size() && fontprop.GetFaceName() != "default")
-                VariableMethod("FaceName(").QuotedString(tt_string() << fontprop.GetFaceName().utf8_string()) += ")";
-            if (fontprop.GetFamily() != wxFONTFAMILY_DEFAULT)
-                VariableMethod("Family(").Add(font_family_pairs.GetValue(fontprop.GetFamily())) += ")";
-            if (fontprop.GetStyle() != wxFONTSTYLE_NORMAL)
-                VariableMethod("Style(").Add(font_style_pairs.GetValue(fontprop.GetStyle())) += ")";
-            if (fontprop.GetWeight() != wxFONTWEIGHT_NORMAL)
-            {
-                VariableMethod("Weight(").Add(font_weight_pairs.GetValue(fontprop.GetWeight())) += ")";
-            }
-            if (fontprop.IsUnderlined())
-                VariableMethod("Underlined()");
-            if (fontprop.IsStrikethrough())
-                VariableMethod("Strikethrough()");
-        }
-        if (back() == '.')
-        {
-            pop_back();
-        }
-        if (is_cpp())
-        {
-            while (back() == '\t')
                 pop_back();
-            if (back() != '\n')
-                *this += ';';
+            }
+            if (is_cpp())
+            {
+                while (back() == '\t')
+                    pop_back();
+                if (back() != '\n')
+                    *this += ';';
+            }
         }
         Eol(eol_if_needed);
 
@@ -2773,21 +2799,43 @@ Code& Code::GenFont(GenEnum::PropName prop_name, tt_string_view font_function)
         {
             if (m_node->isGen(gen_wxPropertySheetDialog))
             {
-                FormFunction("GetBookCtrl()")
-                    .Function(font_function)
-                    .Object("wxFont")
-                    .Str("font_info")
-                    .Str(")")
-                    .EndFunction();
+                if (!is_perl())
+                {
+                    FormFunction("GetBookCtrl()")
+                        .Function(font_function)
+                        .Object("wxFont")
+                        .Str("font_info")
+                        .Str(")")
+                        .EndFunction();
+                }
+                else
+                {
+                    FormFunction("GetBookCtrl()").Function(font_function).Str("$font").EndFunction();
+                }
             }
             else
             {
-                FormFunction(font_function).Object("wxFont").VarName("font_info", false).Str(")").EndFunction();
+                if (!is_perl())
+                {
+                    FormFunction(font_function).Object("wxFont").VarName("font_info", false).Str(")").EndFunction();
+                }
+                else
+                {
+                    FormFunction(font_function).Str("$font").EndFunction();
+                }
             }
         }
         else
         {
-            NodeName().Function(font_function).Object("wxFont").VarName("font_info", false).Str(")").EndFunction();
+            if (!is_perl())
+            {
+                NodeName().Function(font_function).Object("wxFont").VarName("font_info", false).Str(")").EndFunction();
+            }
+            else
+            {
+                // wxPerl doesn't support wxFontInfo, so use the font creation generated above
+                NodeName().Function(font_function).Str("$font").EndFunction();
+            }
         }
         CloseFontBrace();
     }

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -768,7 +768,10 @@ Code& Code::Add(tt_string_view text)
     bool old_linebreak = m_auto_break;
     // Ruby changes the prefix to "Wx::", and Python changes it to "wx."
     // C++, Perl, and Rust use the constant unmodified.
-    if (is_cpp() || is_perl() || is_rust() || text.size() < 3)
+    //
+    // "wx" is the shortest string that could be changed -- no single letter will ever be changed by
+    // this function.
+    if (is_cpp() || is_perl() || is_rust() || text.size() < (sizeof("wx") - 1))
     {
         CheckLineLength(text.size());
         *this += text;

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -313,7 +313,7 @@ public:
     // Adds ");" or ")"
     Code& EndFunction();
 
-    // Adds wxClass or wx.Class
+    // Adds wxClass, Wx::Class, wx.Class, or any other language-required class name variant.
     Code& Class(tt_string_view text);
 
     // Adds " = "

--- a/src/generate/gen_aui_notebook.cpp
+++ b/src/generate/gen_aui_notebook.cpp
@@ -211,6 +211,11 @@ bool AuiNotebookGenerator::GetImports(Node*, std::set<std::string>& set_imports,
         set_imports.insert("require 'wx/aui'");
         return true;
     }
+    else if (language == GEN_LANG_PERL)
+    {
+        set_imports.insert("use Wx::Aui;");
+        return true;
+    }
     else
     {
     }

--- a/src/generate/gen_book_page.cpp
+++ b/src/generate/gen_book_page.cpp
@@ -371,7 +371,7 @@ bool BookPageGenerator::GetImports(Node* /* node */, std::set<std::string>& set_
 {
     if (language == GEN_LANG_PERL)
     {
-        set_imports.emplace("use Wx qw(wxTAB_TRAVERSAL);");
+        set_imports.emplace("use Wx qw[:panel];");
     }
     return false;
 }

--- a/src/generate/gen_book_page.cpp
+++ b/src/generate/gen_book_page.cpp
@@ -194,6 +194,12 @@ wxObject* BookPageGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool BookPageGenerator::ConstructionCode(Code& code)
 {
+    if (code.is_perl() && code.node()->getParent()->isGen(gen_wxSimplebook))
+    {
+        code += "# Can't add books to wxSimplebook which is not supported in Perl";
+        return true;
+    }
+
     code.AddAuto().NodeName().CreateClass();
 
     Node* node = code.node();

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -598,66 +598,13 @@ bool FrameFormGenerator::AllowPropertyChange(wxPropertyGridEvent* event, NodePro
 // defined in code.cpp
 extern constexpr auto set_perl_constants = frozen::make_set<std::string_view>;
 
-bool FrameFormGenerator::GetImports(Node* node, std::set<std::string>& set_imports, GenLang language)
+bool FrameFormGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports, GenLang language)
 {
     if (language == GEN_LANG_PERL)
     {
-        tt_string constants;
-
-        auto set_constants = [&]()
-        {
-            if (constants.size())
-            {
-                // remove the leading space
-                constants.erase(0, 1);
-                constants.insert(0, "use Wx qw(");
-                constants += ");";
-                set_imports.emplace(constants);
-                constants.clear();
-            }
-        };
-
-        if (isScalingEnabled(node, prop_pos, language) || isScalingEnabled(node, prop_size, language))
-            constants += " wxSIZE_USE_EXISTING";
-        if (node->as_string(prop_style).contains("wxDEFAULT_FRAME_STYLE"))
-            constants += " wxDEFAULT_FRAME_STYLE";
-        if (node->as_string(prop_style).contains("wxCAPTION"))
-            constants += " wxCAPTION";
-        if (node->as_string(prop_style).contains("wxCLOSE_BOX"))
-            constants += " wxCLOSE_BOX";
-        if (node->as_string(prop_style).contains("wxFRAME_TOOL_WINDOW"))
-            constants += " wxFRAME_TOOL_WINDOW";
-        if (node->as_string(prop_style).contains("wxFRAME_NO_TASKBAR"))
-            constants += " wxFRAME_NO_TASKBAR";
-        if (node->as_string(prop_style).contains("wxFRAME_FLOAT_ON_PARENT"))
-            constants += " wxFRAME_FLOAT_ON_PARENT";
-        if (node->as_string(prop_style).contains("wxFRAME_SHAPED"))
-            constants += " wxFRAME_SHAPED";
-        if (node->as_string(prop_style).contains("wxICONIZE"))
-            constants += " wxICONIZE";
-        if (node->as_string(prop_style).contains("wxMINIMIZE_BOX"))
-            constants += " wxMINIMIZE_BOX";
-        if (node->as_string(prop_style).contains("wxMAXIMIZE_BOX"))
-            constants += " wxMAXIMIZE_BOX";
-        if (node->as_string(prop_style).contains("wxRESIZE_BORDER"))
-            constants += " wxRESIZE_BORDER";
-        if (node->as_string(prop_style).contains("wxSYSTEM_MENU"))
-            constants += " wxSYSTEM_MENU";
-        if (node->as_string(prop_style).contains("wxCLIP_CHILDREN"))
-            constants += " wxCLIP_CHILDREN";
-        if (node->as_string(prop_style).contains("wxSTAY_ON_TOP"))
-            constants += " wxSTAY_ON_TOP";
-        if (node->as_string(prop_extra_style).contains("wxFRAME_EX_CONTEXTHELP"))
-            constants += " wxFRAME_EX_CONTEXTHELP";
-        if (node->as_string(prop_extra_style).contains("wxFRAME_EX_METAL"))
-            constants += " wxFRAME_EX_METAL";
-        set_constants();
-
-        if (node->as_string(prop_center) != "no")
-            constants += " wxBOTH wxHORIZONTAL wxVERTICAL";
-        set_constants();
-
-        set_imports.emplace("use base qw(Wx::Frame);");
+        set_imports.emplace("use base qw[Wx::Frame];");
+        set_imports.emplace("use Wx qw[:frame];");
+        set_imports.emplace("use Wx qw[:misc];");  // for wxDefaultPosition and wxDefaultSize
         return true;
     }
 

--- a/src/generate/gen_menuitem.cpp
+++ b/src/generate/gen_menuitem.cpp
@@ -402,34 +402,14 @@ bool MenuItemGenerator::modifyProperty(NodeProperty* prop, tt_string_view value)
     return false;
 }
 
-bool MenuItemGenerator::GetImports(Node* node, std::set<std::string>& set_imports, GenLang language)
+bool MenuItemGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports, GenLang language)
 {
     if (language == GEN_LANG_PERL)
     {
         // REVIEW: [Randalphwa - 01-09-2025] Currently, wxEVT_UPDATE_UI cannot be imported from the
         // Wx::Event module.
         set_imports.emplace("use Wx::Event qw(EVT_MENU);");
-        set_imports.emplace("use Wx qw(wxITEM_NORMAL wxITEM_CHECK wxITEM_RADIO wxITEM_DROPDOWN);");
-
-        tt_string constants;
-        auto parent = node->getParent();
-        for (auto& menu_item: parent->getChildNodePtrs())
-        {
-            if (menu_item->hasValue(prop_stock_id) && menu_item->as_string(prop_stock_id) != "none")
-            {
-                if (constants.size())
-                {
-                    constants += ' ';
-                }
-                constants << menu_item->as_string(prop_stock_id);
-            }
-        }
-        if (constants.size())
-        {
-            constants.insert(0, "use Wx qw(");
-            constants += ");";
-            set_imports.emplace(constants);
-        }
+        set_imports.emplace("use Wx qw[:menu];");
         return true;
     }
     return false;

--- a/src/generate/gen_notebook.cpp
+++ b/src/generate/gen_notebook.cpp
@@ -97,33 +97,7 @@ bool NotebookGenerator::GetImports(Node* node, std::set<std::string>& set_import
 {
     if (language == GEN_LANG_PERL)
     {
-        tt_string styles;
-        if (node->hasValue(prop_tab_position) && node->as_string(prop_tab_position) != "wxBK_DEFAULT")
-        {
-            if (styles.size())
-                styles << ' ';
-            else
-            {
-                styles = "use Wx qw(";
-            }
-            styles << node->as_string(prop_tab_position);
-        }
-        if (node->hasValue(prop_style))
-        {
-            if (styles.size())
-                styles << ' ';
-            else
-            {
-                styles = "use Wx qw(";
-            }
-            styles << node->as_string(prop_style);
-            styles.Replace("|", " ", true, tt::CASE::exact);
-        }
-        if (styles.size())
-        {
-            styles << ");";
-            set_imports.emplace(styles);
-        }
+        set_imports.emplace("use Wx qw[:bookctrl];");
     }
     return false;
 }

--- a/src/generate/gen_notebook.cpp
+++ b/src/generate/gen_notebook.cpp
@@ -93,7 +93,7 @@ void NotebookGenerator::RequiredHandlers(Node* /* node */, std::set<std::string>
     handlers.emplace("wxNotebookXmlHandler");
 }
 
-bool NotebookGenerator::GetImports(Node* node, std::set<std::string>& set_imports, GenLang language)
+bool NotebookGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports, GenLang language)
 {
     if (language == GEN_LANG_PERL)
     {

--- a/src/generate/gen_notebook.cpp
+++ b/src/generate/gen_notebook.cpp
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   wxNotebook generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -91,4 +91,39 @@ int NotebookGenerator::GenXrcObject(Node* node, pugi::xml_node& object, size_t x
 void NotebookGenerator::RequiredHandlers(Node* /* node */, std::set<std::string>& handlers)
 {
     handlers.emplace("wxNotebookXmlHandler");
+}
+
+bool NotebookGenerator::GetImports(Node* node, std::set<std::string>& set_imports, GenLang language)
+{
+    if (language == GEN_LANG_PERL)
+    {
+        tt_string styles;
+        if (node->hasValue(prop_tab_position) && node->as_string(prop_tab_position) != "wxBK_DEFAULT")
+        {
+            if (styles.size())
+                styles << ' ';
+            else
+            {
+                styles = "use Wx qw(";
+            }
+            styles << node->as_string(prop_tab_position);
+        }
+        if (node->hasValue(prop_style))
+        {
+            if (styles.size())
+                styles << ' ';
+            else
+            {
+                styles = "use Wx qw(";
+            }
+            styles << node->as_string(prop_style);
+            styles.Replace("|", " ", true, tt::CASE::exact);
+        }
+        if (styles.size())
+        {
+            styles << ");";
+            set_imports.emplace(styles);
+        }
+    }
+    return false;
 }

--- a/src/generate/gen_notebook.h
+++ b/src/generate/gen_notebook.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Purpose:   wxNotebook generator
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2022 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -23,6 +23,8 @@ public:
 
     int GenXrcObject(Node*, pugi::xml_node& /* object */, size_t /* xrc_flags */) override;
     void RequiredHandlers(Node*, std::set<std::string>& /* handlers */) override;
+
+    bool GetImports(Node*, std::set<std::string>& set_imports, GenLang language) override;
 
 protected:
     void OnPageChanged(wxBookCtrlEvent& event);

--- a/src/generate/gen_panel.cpp
+++ b/src/generate/gen_panel.cpp
@@ -73,7 +73,7 @@ bool PanelGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imp
 {
     if (language == GEN_LANG_PERL)
     {
-        set_imports.emplace("use Wx qw(wxTAB_TRAVERSAL);");
+        set_imports.emplace("use Wx qw[:panel];");
     }
     return false;
 }

--- a/src/generate/gen_perl.cpp
+++ b/src/generate/gen_perl.cpp
@@ -485,7 +485,14 @@ void GatherPerlUsages::ParseNodes(Node* node)
             m_use_expands.emplace("use Wx qw[:systemsettings];");
         }
     }
-
+    if (node->hasValue(prop_foreground_colour) || node->hasValue(prop_background_colour))
+    {
+        if (node->as_string(prop_foreground_colour).contains("wxSYS") ||
+            node->as_string(prop_background_colour).contains("wxSYS"))
+        {
+            m_use_expands.emplace("use Wx qw[:systemsettings];");
+        }
+    }
     if (auto* gen = node->getGenerator(); gen)
     {
         std::set<std::string> imports;

--- a/src/generate/gen_perl.cpp
+++ b/src/generate/gen_perl.cpp
@@ -476,6 +476,17 @@ void GatherPerlUsages::ParseNodes(Node* node)
         m_use_packages.emplace("use Wx::ArtProvider qw[:artid :clientid];");
     }
 
+    if (node->hasValue(prop_font))
+    {
+        m_use_expands.emplace("use Wx qw[:font];");
+        FontProperty fontprop(node->getPropPtr(prop_font));
+        if (fontprop.isDefGuiFont())
+        {
+            // If the font is a default GUI font, then we need to include the wxDefaultGuiFont constant.
+            m_use_expands.emplace("use Wx qw[:systemsettings];");
+        }
+    }
+
     if (auto* gen = node->getGenerator(); gen)
     {
         std::set<std::string> imports;

--- a/src/generate/gen_perl.cpp
+++ b/src/generate/gen_perl.cpp
@@ -66,7 +66,6 @@ $app->MainLoop;
 constexpr auto map_perl_constants = frozen::make_map<GenEnum::PropName, std::string_view>({
 
     { prop_bitmap, "wxNullBitmap" },
-    { prop_id, "wxID_ANY" },
 
 });
 

--- a/src/generate/gen_perl.cpp
+++ b/src/generate/gen_perl.cpp
@@ -222,6 +222,7 @@ void BaseCodeGenerator::GeneratePerlClass(PANEL_PAGE panel_type)
     }
 
     m_source->writeLine();
+    m_source->writeLine("use utf8;");  // required since C++, wxPython, and wxRuby use utf8 by default
     m_source->writeLine("use strict;");
 
     if (m_form_node->isGen(gen_Images))
@@ -397,6 +398,27 @@ bool PerlBundleCode(Code& code, GenEnum::PropName prop)
     {
         code.Add("wxNullBitmap");
         return false;
+    }
+
+    if (parts[IndexType].contains("Art"))
+    {
+        tt_string art_id(parts[IndexArtID]);
+        tt_string art_client;
+        if (auto pos = art_id.find('|'); tt::is_found(pos))
+        {
+            art_client = art_id.subview(pos + 1);
+            art_id.erase(pos);
+        }
+
+        code << "Wx::ArtProvider::GetBitmap(" << art_id;
+        if (art_client.size())
+            code << ", " << art_client;
+        wxSize art_size { 16, 16 };
+        art_size = GetSizeInfo(parts[IndexSize]);
+
+        // Size is a hack for now...
+        code << ", Wx::Size->new(" << art_size.x << ", " << art_size.y << "))";
+        return true;
     }
 
     return false;

--- a/src/generate/gen_simplebook.cpp
+++ b/src/generate/gen_simplebook.cpp
@@ -44,6 +44,11 @@ void SimplebookGenerator::OnPageChanged(wxBookCtrlEvent& event)
 
 bool SimplebookGenerator::ConstructionCode(Code& code)
 {
+    if (code.is_perl())
+    {
+        code += "# wxSimplebook is not supported in Perl";
+        return true;
+    }
     code.AddAuto().NodeName().CreateClass();
     code.ValidParentName().Comma().as_string(prop_id).PosSizeFlags();
 

--- a/src/generate/gen_status_bar.cpp
+++ b/src/generate/gen_status_bar.cpp
@@ -279,8 +279,7 @@ bool StatusBarGenerator::GetImports(Node* /* node */, std::set<std::string>& set
 {
     if (language == GEN_LANG_PERL)
     {
-        // REVIEW: [Randalphwa - 03-02-2025] wxPerl 3.2 doesn't support wxSB_SUNKEN
-        set_imports.emplace("use Wx qw(wxSB_NORMAL wxSB_FLAT wxSB_RAISED);");
+        set_imports.emplace("use Wx qw[:statusbar];");
         return true;
     }
 

--- a/src/generate/gen_text_ctrl.cpp
+++ b/src/generate/gen_text_ctrl.cpp
@@ -310,28 +310,11 @@ void TextCtrlGenerator::RequiredHandlers(Node* /* node */, std::set<std::string>
     handlers.emplace("wxActivityIndicatorXmlHandler");
 }
 
-bool TextCtrlGenerator::GetImports(Node* node, std::set<std::string>& set_imports, GenLang language)
+bool TextCtrlGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports, GenLang language)
 {
     if (language == GEN_LANG_PERL)
     {
-        if (auto& styles = node->as_string(prop_style); styles.contains("wxTE_"))
-        {
-            tt_string constants;
-            tt_string_vector vector(styles, "|", tt::TRIM::both);
-            for (auto& iter: vector)
-            {
-                if (iter.is_sameprefix("wxTE_"))
-                {
-                    if (constants.size())
-                        constants << ' ';
-                    constants << iter;
-                }
-            }
-            constants.insert(0, "use Wx qw(");
-            constants << ");";
-            set_imports.emplace(constants);
-            return true;
-        }
+        set_imports.emplace("use Wx qw[:textctrl];");
     }
 
     return false;

--- a/src/generate/gen_toolbar.cpp
+++ b/src/generate/gen_toolbar.cpp
@@ -503,49 +503,11 @@ void ToolBarGenerator::RequiredHandlers(Node* /* node */, std::set<std::string>&
     handlers.emplace("wxToolBarXmlHandler");
 }
 
-bool ToolBarGenerator::GetImports(Node* node, std::set<std::string>& set_imports, GenLang language)
+bool ToolBarGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports, GenLang language)
 {
     if (language == GEN_LANG_PERL)
     {
-        tt_string constants;
-
-        auto set_constants = [&]()
-        {
-            if (constants.size())
-            {
-                // remove the leading space
-                constants.erase(0, 1);
-                constants.insert(0, "use Wx qw(");
-                constants += ");";
-                set_imports.emplace(constants);
-                constants.clear();
-            }
-        };
-
-        if (node->as_string(prop_style).contains("wxTB_FLAT"))
-            constants += " wxTB_FLAT";
-        if (node->as_string(prop_style).contains("wxTB_DOCKABLE"))
-            constants += " wxTB_DOCKABLE";
-        if (node->as_string(prop_style).contains("wxTB_HORIZONTAL"))
-            constants += " wxTB_HORIZONTAL";
-        if (node->as_string(prop_style).contains("wxTB_VERTICAL"))
-            constants += " wxTB_VERTICAL";
-        if (node->as_string(prop_style).contains("wxTB_TEXT"))
-            constants += " wxTB_TEXT";
-        if (node->as_string(prop_style).contains("wxTB_NOICONS"))
-            constants += " wxTB_NOICONS";
-        if (node->as_string(prop_style).contains("wxTB_NODIVIDER"))
-            constants += " wxTB_NODIVIDER";
-        if (node->as_string(prop_style).contains("wxTB_NOALIGN"))
-            constants += " wxTB_NOALIGN";
-        if (node->as_string(prop_style).contains("wxTB_HORZ_LAYOUT"))
-            constants += " wxTB_HORZ_LAYOUT";
-        if (node->as_string(prop_style).contains("wxTB_HORZ_TEXT"))
-            constants += " wxTB_HORZ_TEXT";
-        set_constants();
-
-        set_imports.emplace("use Wx qw(wxITEM_NORMAL wxITEM_CHECK wxITEM_RADIO wxITEM_DROPDOWN);");
-
+        set_imports.emplace("use Wx qw[:toolbar];");
         return true;
     }
 

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -579,7 +579,7 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
 
 static void GenerateARTBundle(Code& code, const tt_string_vector& parts, bool get_bitmap)
 {
-    code.Add("wxArtProvider");
+    code.Class("wxArtProvider");
     if (get_bitmap)
     {
         code.ClassMethod("GetBitmap(");


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds further improvements to wxPerl code generation. All books are now supported with the exception of wxSimplebook which wxPerl doesn't have a package for. Code generation for fonts is working and there is initial support for wxImageList to support ArtProvider images. That code will ultimately be used as a template for supporting bitmaps.

The use of a long list of constants has mostly been removed in favor of using EXPORT_TAGS. This doesn't have the memory/performance impact that using qw[:everything] would have, but it does significantly reduce the number of `use qw()` lines that we were generating, and ensures that _all_ of the constants for a component are available.

Also note the addition of `use utf8;` -- this is an absolute requirement since all strings in wxUiEditor are assumed to be UTF8 and so no conversion is ever done. C++, wxPython, and wxRuby already assume UTF8 strings, but wxPerl does not without it being explicitly set.