### PR TITLE
Check sub-books for images in wxTreebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - You can add a menubar or toolbar to a wxFrame that was created without them
 - Fixed inconsistent generation of wxScrolledWindow versus wxScrolled<wxPanel> -- wxScrolledWindow is now always used.
 - XRC combine_all_forms will now generates a single XRC file containing all forms
+- wxTreebook correctly utilizes images in nested books -- fixed for all generated languages
 
 ## [Released (1.2.1)]
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the way an image list is created for a `wxTreebook`. Instead of just looking for the direct children of the book, it recursively checks all child book pages to any level. In theory, someone could create a book underneath a sub book page which would mean those images would be picked up as well, however that would only mean a larger image list then is actually used.

Fixed in all 4 generated languages.

Closes #1596