### PR TITLE
Refactor precompiled header files

### DIFF
--- a/src/customprops/img_props.cpp
+++ b/src/customprops/img_props.cpp
@@ -7,11 +7,10 @@
 
 #include <wx/artprov.h>  // wxArtProvider class
 
-#include "image_handler.h"    // ImageHandler class
-#include "img_props.h"        // ImageProperties
-#include "node.h"             // Node -- Node class
-#include "project_handler.h"  // ProjectHandler class
-#include "utils.h"            // Utility functions that work with properties
+#include "image_handler.h"   // ImageHandler class
+#include "img_props.h"       // ImageProperties
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
+#include "utils.h"           // Utility functions that work with properties
 
 void ImageProperties::InitValues(tt_string_view value)
 {

--- a/src/customprops/include_files_dlg.cpp
+++ b/src/customprops/include_files_dlg.cpp
@@ -119,6 +119,7 @@ bool IncludeFilesDialog::Create(wxWindow* parent, wxWindowID id, const wxString&
 
 #include "sys_header_dlg.h"    // SysHeaderDlg class
 #include "tt_string_vector.h"  // tt_string_vector -- Class for reading and writing line-oriented strings/files
+#include "tt_view_vector.h"    // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 void IncludeFilesDialog::Initialize(NodeProperty* prop)
 {

--- a/src/customprops/pg_image.cpp
+++ b/src/customprops/pg_image.cpp
@@ -27,6 +27,7 @@ using namespace wxue_img;
 #include "pg_point.h"         // CustomPointProperty -- Custom property grid class for wxPoint
 #include "preferences.h"      // Preferences -- Stores user preferences
 #include "project_handler.h"  // ProjectHandler class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 #include "art_ids.cpp"  // wxART_ strings
 

--- a/src/customprops/pg_point.cpp
+++ b/src/customprops/pg_point.cpp
@@ -10,10 +10,10 @@
 
 #include "pg_point.h"
 
-#include "mainframe.h"        // MainFrame -- Main window frame
-#include "node.h"             // Node -- Node class
-#include "project_handler.h"  // ProjectHandler class
-#include "utils.h"            // Utility functions that work with properties
+#include "mainframe.h"       // MainFrame -- Main window frame
+#include "node.h"            // Node -- Node class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
+#include "utils.h"           // Utility functions that work with properties
 
 wxIMPLEMENT_ABSTRACT_CLASS(CustomPointProperty, wxPGProperty);
 

--- a/src/customprops/txt_string_prop.cpp
+++ b/src/customprops/txt_string_prop.cpp
@@ -9,9 +9,9 @@
 
 #include "txt_string_prop.h"
 
-#include "image_handler.h"  // ImageHandler class
-#include "node_prop.h"      // NodeProperty class
-#include "utils.h"          // Miscellaneous utility functions
+#include "node_prop.h"       // NodeProperty class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
+#include "utils.h"           // Miscellaneous utility functions
 
 #include "wxui/editstringdialog_base.h"  // auto-generated: wxui/editstringdialog_base.cpp
 

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -8,9 +8,6 @@
 #pragma once
 
 #include <map>
-#include <unordered_map>
-
-#include "hash_map.h"  // Find std::string_view key in std::unordered_map
 
 namespace GenEnum
 {

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -16,7 +16,8 @@
 
 #include "gen_enums.h"  // Enumerations for generators
 
-#include "node.h"  // Node class
+#include "node.h"              // Node class
+#include "tt_string_vector.h"  // tt_string_vector -- Class for reading and writing line-oriented strings/files
 
 namespace code
 {
@@ -64,6 +65,9 @@ namespace code
 
 // Assume anyone including this header file needs access to the code namespace
 using namespace code;
+
+// Maps tt_string_view to std::string_view, allowing std::string_view comparisons
+using view_map = std::map<tt_string_view, std::string_view, std::less<>>;
 
 extern const view_map g_map_python_prefix;
 extern const view_map g_map_ruby_prefix;

--- a/src/generate/code_add.cpp
+++ b/src/generate/code_add.cpp
@@ -9,8 +9,9 @@
 
 #include "code.h"
 
-#include "preferences.h"  // Prefs -- Set/Get wxUiEditor preferences
-#include "utils.h"        // Miscellaneous utilities
+#include "preferences.h"     // Prefs -- Set/Get wxUiEditor preferences
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
+#include "utils.h"           // Miscellaneous utilities
 
 // clang-format off
 

--- a/src/generate/code_pos_style.cpp
+++ b/src/generate/code_pos_style.cpp
@@ -7,7 +7,8 @@
 
 #include "code.h"
 
-#include "mainframe.h"  // MainFrame class
+#include "mainframe.h"       // MainFrame class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 Code& Code::Pos(GenEnum::PropName prop_name, int enable_dpi_scaling)
 {

--- a/src/generate/file_codewriter.cpp
+++ b/src/generate/file_codewriter.cpp
@@ -11,7 +11,8 @@
 
 #include "file_codewriter.h"
 
-#include "mainapp.h"  // App -- Main application class
+#include "mainapp.h"         // App -- Main application class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 using namespace code;
 

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -17,6 +17,7 @@
 #include "node.h"             // Node class
 #include "project_handler.h"  // ProjectHandler class
 #include "pugixml.hpp"        // xml read/write/create/process
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"            // Utility functions that work with properties
 
 #include "gen_animation.h"

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -16,6 +16,7 @@
 #include "node.h"             // Node class
 #include "node_decl.h"        // NodeDeclaration class
 #include "project_handler.h"  // ProjectHandler class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"            // Utility functions that work with properties
 #include "write_code.h"       // Write code to Scintilla or file
 

--- a/src/generate/gen_base.h
+++ b/src/generate/gen_base.h
@@ -10,6 +10,7 @@
 #include "../panels/base_panel.h"  // BasePanel -- Base class for all code generation panels
 #include "gen_enums.h"             // Enumerations for generators
 #include "gen_xrc.h"               // BaseXrcGenerator -- Generate XRC file
+#include "tt_string_vector.h"      // tt_string_vector -- Class for reading and writing line-oriented strings/files
 
 class Code;
 class Node;

--- a/src/generate/gen_book_utils.cpp
+++ b/src/generate/gen_book_utils.cpp
@@ -10,8 +10,9 @@
 #include "code.h"        // Code -- Helper class for generating code
 #include "gen_common.h"  // Common component functions
 #include "gen_enums.h"
-#include "node.h"       // Node class
-#include "ui_images.h"  // Generated images header
+#include "node.h"            // Node class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
+#include "ui_images.h"       // Generated images header
 #include "utils.h"
 
 #include "gen_book_utils.h"

--- a/src/generate/gen_cmake.cpp
+++ b/src/generate/gen_cmake.cpp
@@ -5,11 +5,10 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include <fstream>
-
 #include "gen_base.h"         // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "node.h"             // Node class
 #include "project_handler.h"  // ProjectHandler class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 int WriteCMakeFile(Node* parent_node, std::vector<tt_string>& updated_files, std::vector<tt_string>& results, int flag)
 {

--- a/src/generate/gen_common.cpp
+++ b/src/generate/gen_common.cpp
@@ -20,6 +20,7 @@
 #include "node.h"             // Node class
 #include "node_creator.h"     // NodeCreator class
 #include "project_handler.h"  // ProjectHandler class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"            // Utility functions that work with properties
 #include "write_code.h"       // WriteCode -- Write code to Scintilla or file
 

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -22,6 +22,7 @@
 #include "image_handler.h"    // ImageHandler class
 #include "node.h"             // Node class
 #include "project_handler.h"  // ProjectHandler class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"            // Miscellaneous utilities
 #include "write_code.h"       // Write code to Scintilla or file
 

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -20,6 +20,7 @@
 #include "file_codewriter.h"                  // FileCodeWriter -- Classs to write code to disk
 #include "lambdas.h"                          // Functions for formatting and storage of lamda events
 #include "project_handler.h"                  // ProjectHandler class
+#include "tt_view_vector.h"                   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 using namespace code;
 

--- a/src/generate/gen_flexgrid_sizer.cpp
+++ b/src/generate/gen_flexgrid_sizer.cpp
@@ -7,14 +7,15 @@
 
 #include <wx/sizer.h>
 
-#include "gen_common.h"     // GeneratorLibrary -- Generator classes
-#include "gen_xrc_utils.h"  // Common XRC generating functions
-#include "mockup_parent.h"  // Top-level MockUp Parent window
-#include "node.h"           // Node class
+#include "gen_flexgrid_sizer.h"
+
+#include "gen_common.h"      // GeneratorLibrary -- Generator classes
+#include "gen_xrc_utils.h"   // Common XRC generating functions
+#include "mockup_parent.h"   // Top-level MockUp Parent window
+#include "node.h"            // Node class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 #include "pugixml.hpp"  // xml read/write/create/process
-
-#include "gen_flexgrid_sizer.h"
 
 wxObject* FlexGridSizerGenerator::CreateMockup(Node* node, wxObject* parent)
 {

--- a/src/generate/gen_gridbag_sizer.cpp
+++ b/src/generate/gen_gridbag_sizer.cpp
@@ -7,14 +7,15 @@
 
 #include <wx/gbsizer.h>
 
-#include "gen_common.h"     // GeneratorLibrary -- Generator classes
-#include "gen_xrc_utils.h"  // Common XRC generating functions
-#include "mockup_parent.h"  // Top-level MockUp Parent window
-#include "node.h"           // Node class
+#include "gen_gridbag_sizer.h"
+
+#include "gen_common.h"      // GeneratorLibrary -- Generator classes
+#include "gen_xrc_utils.h"   // Common XRC generating functions
+#include "mockup_parent.h"   // Top-level MockUp Parent window
+#include "node.h"            // Node class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 #include "pugixml.hpp"  // xml read/write/create/process
-
-#include "gen_gridbag_sizer.h"
 
 wxObject* GridBagSizerGenerator::CreateMockup(Node* node, wxObject* parent)
 {

--- a/src/generate/gen_images_list.cpp
+++ b/src/generate/gen_images_list.cpp
@@ -19,6 +19,7 @@
 #include "mainframe.h"        // MainFrame -- Main window frame
 #include "node.h"             // Node class
 #include "project_handler.h"  // ProjectHandler class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "undo_cmds.h"        // InsertNodeAction -- Undoable command classes derived from UndoAction
 #include "utils.h"            // Utility functions that work with properties
 #include "write_code.h"       // Write code to Scintilla or file

--- a/src/generate/gen_python.cpp
+++ b/src/generate/gen_python.cpp
@@ -20,6 +20,7 @@
 #include "image_handler.h"    // ImageHandler class
 #include "node.h"             // Node class
 #include "project_handler.h"  // ProjectHandler class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"            // Miscellaneous utilities
 #include "write_code.h"       // Write code to Scintilla or file
 

--- a/src/generate/write_code.cpp
+++ b/src/generate/write_code.cpp
@@ -9,7 +9,8 @@
 
 #include "write_code.h"
 
-#include "code.h"  // Code -- Helper class for generating code
+#include "code.h"            // Code -- Helper class for generating code
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 void WriteCode::writeLine(const Code& code)
 {

--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <functional>  // for std::hash
-#include <unordered_map>
 
 struct str_view_hash
 {

--- a/src/import/import_dialogblocks.cpp
+++ b/src/import/import_dialogblocks.cpp
@@ -31,10 +31,11 @@
 
 #include "import_dialogblocks.h"
 
-#include "dlg_msgs.h"      // wxMessageDialog dialogs
-#include "mainapp.h"       // App -- Main application class
-#include "node.h"          // Node class
-#include "node_creator.h"  // NodeCreator class
+#include "dlg_msgs.h"        // wxMessageDialog dialogs
+#include "mainapp.h"         // App -- Main application class
+#include "node.h"            // Node class
+#include "node_creator.h"    // NodeCreator class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 DialogBlocks::DialogBlocks() {}
 

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -5,8 +5,6 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include <fstream>
-#include <iostream>
 #include <set>
 
 #include <frozen/map.h>
@@ -22,6 +20,7 @@
 #include "mainframe.h"       // Main window frame
 #include "node.h"            // Node class
 #include "node_creator.h"    // NodeCreator class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"           // Utility functions that work with properties
 
 #include "import_frmbldr_maps.cpp"  // set_ignore_flags and map_evt_pair

--- a/src/import/import_wxcrafter.cpp
+++ b/src/import/import_wxcrafter.cpp
@@ -6,7 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include <fstream>
-#include <iostream>
 #include <set>
 
 #include <frozen/map.h>
@@ -16,17 +15,16 @@
 #define RAPIDJSON_HAS_STDSTRING 1
 #define RAPIDJSON_ASSERT(x)     ASSERT(x)
 
-#include "rapidjson/rapidjson.h"
-
 #include "import_wxcrafter.h"  // This will include rapidjson/document.h
 
 #include "base_generator.h"  // BaseGenerator -- Base widget generator class
 #include "dlg_msgs.h"        // wxMessageDialog dialogs
 #include "font_prop.h"       // FontProperty class
 #include "gen_enums.h"       // Enumerations for generators
-#include "mainframe.h"       // Main window frame
+#include "mainapp.h"         // MainApp class
 #include "node.h"            // Node class
 #include "node_creator.h"    // NodeCreator class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"           // Utility functions that work with properties
 
 #include "import_crafter_maps.cpp"  // Map of wxCrafter properties to wxUiEditor properties

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -11,6 +11,7 @@
 #include "dlg_msgs.h"        // wxMessageDialog dialogs
 #include "node.h"            // Node class
 #include "node_creator.h"    // NodeCreator class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"           // Utility functions that work with properties
 
 WxGlade::WxGlade() {}

--- a/src/internal/import_panel.h
+++ b/src/internal/import_panel.h
@@ -1,12 +1,15 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Panel to display original imported file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
+#include <wx/fdrepdlg.h>
 #include <wx/panel.h>
 #include <wx/scrolwin.h>  // wxScrolledWindow, wxScrolledControl and wxScrollHelper
+
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 class MainFrame;
 class wxStyledTextCtrl;

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -12,9 +12,11 @@
 #include <wx/persist/toplevel.h>
 #include <wx/sizer.h>
 
-#include "../wxui/ui_images.h"
-
 #include "xrcpreview.h"
+
+#include "../wxui/ui_images.h"
+#include "tt_view_vector.h"    // tt_view_vector -- Class for reading and writing line-oriented strings/files
+
 
 bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     const wxPoint& pos, const wxSize& size, long style, const wxString &name)

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -23,6 +23,8 @@ namespace pugi
 #include "node_event.h"  // NodeEvent and NodeEventInfo classes
 #include "node_prop.h"   // NodeProperty class
 
+#include "hash_map.h"  // Find std::string_view key in std::unordered_map
+
 class wxSizerFlags;
 class wxAnimation;
 struct ImageBundle;

--- a/src/nodes/node_prop.cpp
+++ b/src/nodes/node_prop.cpp
@@ -8,10 +8,11 @@
 #include <array>
 #include <charconv>
 #include <cstdlib>
-#include <sstream>
 
 #include <wx/animate.h>                // wxAnimation and wxAnimationCtrl
 #include <wx/propgrid/propgriddefs.h>  // wxPropertyGrid miscellaneous definitions
+
+#include "node_prop.h"
 
 #include "font_prop.h"        // FontProperty -- FontProperty class
 #include "image_handler.h"    // ImageHandler class
@@ -19,9 +20,8 @@
 #include "node.h"             // Node -- Node class
 #include "node_creator.h"     // NodeCreator class
 #include "project_handler.h"  // ProjectHandler singleton class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"            // Utility functions that work with properties
-
-#include "node_prop.h"
 
 using namespace GenEnum;
 

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -22,6 +22,7 @@
 #include "preferences.h"     // Prefs -- Set/Get wxUiEditor preferences
 #include "propgrid_panel.h"  // PropGridPanel -- PropertyGrid class for node properties and events
 #include "to_casts.h"        // to_int, to_size_t, and to_char classes
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "utils.h"           // Miscellaneous utility functions
 
 #ifndef SCI_SETKEYWORDS

--- a/src/panels/code_display.h
+++ b/src/panels/code_display.h
@@ -11,7 +11,8 @@
 
 #include "codedisplay_base.h"
 
-#include "write_code.h"  // WriteCode -- Write code to Scintilla or file
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
+#include "write_code.h"      // WriteCode -- Write code to Scintilla or file
 
 class wxFindDialogEvent;
 class Node;

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -26,6 +26,7 @@
 #include "preferences.h"      // Prefs -- Set/Get wxUiEditor preferences
 #include "project_handler.h"  // ProjectHandler class
 #include "propgrid_panel.h"   // PropGridPanel -- PropertyGrid class for node properties and events
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "undo_cmds.h"        // Undoable command classes derived from UndoAction
 #include "utils.h"            // Utility functions that work with properties
 

--- a/src/panels/propgrid_modify.cpp
+++ b/src/panels/propgrid_modify.cpp
@@ -11,6 +11,7 @@
 #include "mainframe.h"        // MainFrame -- Main window frame
 #include "node_creator.h"     // NodeCreator -- Class used to create nodes
 #include "project_handler.h"  // ProjectHandler class
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "undo_cmds.h"        // InsertNodeAction -- Undoable command classes derived from UndoAction
 
 void PropGridPanel::modifyProperty(NodeProperty* prop, tt_string_view str)

--- a/src/pch.h
+++ b/src/pch.h
@@ -90,24 +90,9 @@
 #endif
 
 #include <map>
-#include <unordered_map>
-
-#include <set>
-#include <unordered_set>
-
-#include <memory>
-#include <optional>
-#include <stdexcept>
 #include <string>
-#include <string_view>
-#include <vector>
 
-#include "tt/tt.h"  // tt namespace functions and declarations
-
-#include "tt/tt_string.h"         // tt_string -- std::string with additional methods
-#include "tt/tt_string_vector.h"  // tt_string_vector -- Class for reading and writing line-oriented strings/files
-#include "tt/tt_string_view.h"    // tt_string_view -- std::string_view with additional methods
-#include "tt/tt_view_vector.h"    // tt_view_vector -- Class for reading and writing line-oriented strings/files
+#include "tt_string.h"  // tt_string -- std::string with additional methods
 
 #ifndef wxBITMAP_TYPE_SVG
     #define wxBITMAP_TYPE_SVG static_cast<wxBitmapType>(wxBITMAP_TYPE_ANY - 1)
@@ -192,9 +177,6 @@ namespace xrc
         format_indent_with_spaces = 1 << 5,  // indent with spaces instead of tabs
     };
 }  // namespace xrc
-
-// Maps tt_string_view to std::string_view, allowing std::string_view comparisons
-using view_map = std::map<tt_string_view, std::string_view, std::less<>>;
 
 // When chaniging txtVersion, you also need to change the version in wxUiEditor.rc and
 // wxUiEditor.exe.manifest and ../CMakeLists.txt

--- a/src/project/image_handler.cpp
+++ b/src/project/image_handler.cpp
@@ -23,6 +23,7 @@
 #include "node.h"             // Node class
 #include "project_handler.h"  // ProjectHandler -- Project class
 #include "pugixml.hpp"        // xml parser
+#include "tt_view_vector.h"   // tt_view_vector -- Class for reading and writing line-oriented strings/files
 #include "ui_images.h"
 #include "utils.h"  // Miscellaneous utility functions
 

--- a/src/project/image_handler.h
+++ b/src/project/image_handler.h
@@ -12,6 +12,8 @@
 
 #include <wx/bmpbndl.h>  // includes wx/bitmap.h, wxBitmapBundle class interface
 
+#include "tt_string_vector.h"  // tt_string_vector -- Class for reading and writing line-oriented strings/files
+
 class Node;
 class wxAnimation;
 

--- a/src/ui/import_dlg.cpp
+++ b/src/ui/import_dlg.cpp
@@ -11,11 +11,10 @@
 #include <wx/filedlg.h>   // wxFileDialog base header
 #include <wx/filename.h>  // wxFileName - encapsulates a file path
 
-#include "pugixml.hpp"  // xml processing
-
 #include "import_dlg.h"  // auto-generated: import_base.h and import_base.cpp
 
-#include "mainapp.h"  // App -- App class
+#include "mainapp.h"         // App -- App class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 ImportDlg::ImportDlg(wxWindow* parent) : ImportBase(parent) {}
 

--- a/src/utils/font_prop.cpp
+++ b/src/utils/font_prop.cpp
@@ -5,13 +5,14 @@
 // License:   Apache License -- see ../../LICENSE
 //////////////////////////////////////////////////////////////////////////
 
+#include <array>
 #include <charconv>  // for std::to_chars
 #include <cstdlib>   // for std::atof
 
 #include "font_prop.h"
 
-#include "node_creator.h"  // NodeCreator -- Class used to create nodes
-#include "node_prop.h"     // NodeProperty class
+#include "node_prop.h"       // NodeProperty class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
 namespace font
 {

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -13,10 +13,11 @@
 #include <wx/gdicmn.h>   // Common GDI classes, types and declarations
 #include <wx/mstream.h>  // Memory stream classes
 
-#include "mainframe.h"     // MainFrame -- Main window frame
-#include "node.h"          // Node class
-#include "node_creator.h"  // NodeCreator class
-#include "utils.h"         // Utility functions that work with properties
+#include "mainframe.h"       // MainFrame -- Main window frame
+#include "node.h"            // Node class
+#include "node_creator.h"    // NodeCreator class
+#include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
+#include "utils.h"           // Utility functions that work with properties
 
 tt_string DoubleToStr(double val)
 {


### PR DESCRIPTION
This PR primarily removes header files from the precompiled header file that aren't actually used in every source file.

Originally, a lot of common header files were added to the precompiled header file which were used by almost every source file. That had the advantage of reducing the amount of included header files in individual header and source files, as well as slightly decreasing compilation time. However, as the project has added more and more source/header files, there are a lot more files that don't use these header files.

Because this is an open-source project, not only are other developpers welcome to copy source files and use in their own projects, but AI also parses these files and can benefit from knowing which header files are actually required.

It's also worth nothing that a related benefit of doing this change now is that a lot more files end up being checked for unused #included header files.
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
