### PR TITLE
Change where 'end' of the class is written

### DIFF
--- a/src/generate/file_codewriter.cpp
+++ b/src/generate/file_codewriter.cpp
@@ -11,6 +11,7 @@
 
 #include "file_codewriter.h"
 
+#include "code.h"            // Code -- Helper class for generating code
 #include "mainapp.h"         // App -- Main application class
 #include "tt_view_vector.h"  // tt_view_vector -- Class for reading and writing line-oriented strings/files
 
@@ -132,17 +133,13 @@ int FileCodeWriter::WriteFile(GenLang language, int flags, Node* node)
     {
         m_buffer += end_python_perl_ruby_block;
 
-        // If the file has never been written before, then add "end" line that is required to close
-        // the class definition. This is written outside of the comment block, so presumably any
-        // user edits will be made above this line or they will remove it and replace it with their
-        // own "end" line.
+        // If the file has never been written before, then we end the class outside of the closing comment block.
+        // This allows the user to add event handlers or other functionality within the class.
         if (!file_exists)
         {
-            m_buffer += "\nend";
-            if (m_node)
-            {
-                m_buffer += "  # " + m_node->getNodeName();
-            }
+            Code code(node, GEN_LANG_RUBY);
+            code.Eol().Str("end  # end of ").Str(node->getNodeName()).Str(" class");
+            m_buffer += code;
         }
     }
     else if (language == GEN_LANG_RUST)

--- a/src/generate/gen_ruby.cpp
+++ b/src/generate/gen_ruby.cpp
@@ -526,7 +526,6 @@ void BaseCodeGenerator::GenerateRubyClass(PANEL_PAGE panel_type)
     {
         m_source->ResetIndent();
         m_source->writeLine("\tend", indent::none);
-        m_source->writeLine("end", indent::none);
     }
     m_header->ResetIndent();
     m_header->writeLine("end", indent::none);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes where the `end` statement is written in a Ruby file if the file doesn't already exist. The line is now written _after_ the "End of generated code" comment block, and includes a comment indicating the name of the class being ended. Having this line outside of the non-editable code means a user can extend the class with event handlers or anything else they need.