### PR TITLE
Clang tidy

### DIFF
--- a/src/generate/gen_ctx_menu.cpp
+++ b/src/generate/gen_ctx_menu.cpp
@@ -73,7 +73,7 @@ bool CtxMenuGenerator::AfterChildrenCode(Code& code)
     if (code.is_cpp())
     {
         code.Add("wxMenu ctx_menu").Str(code.is_cpp() ? ";" : "");
-        code.Eol().Str("auto p_ctx_menu = &ctx_menu;  // convenience variable for the auto-generated code");
+        code.Eol().Str("auto* p_ctx_menu = &ctx_menu;  // convenience variable for the auto-generated code");
     }
     else
     {

--- a/src/generate/gen_derived.cpp
+++ b/src/generate/gen_derived.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Generate the C++ derived class source and header file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2024 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -26,12 +26,12 @@
 
 #include "gen_base.h"
 
-#include "../customprops/eventhandler_dlg.h"  // EventHandlerDlg static functions
-#include "node.h"                             // Node class
-#include "node_creator.h"                     // NodeCreator class
-#include "project_handler.h"                  // ProjectHandler class
-
-#include "write_code.h"  // Write code to Scintilla or file
+#include "code.h"              // Code -- Helper class for generating code
+#include "eventhandler_dlg.h"  // EventHandlerDlg static functions
+#include "node.h"              // Node class
+#include "node_creator.h"      // NodeCreator class
+#include "project_handler.h"   // ProjectHandler class
+#include "write_code.h"        // Write code to Scintilla or file
 
 // clang-format off
 
@@ -413,26 +413,23 @@ int BaseCodeGenerator::GenerateDerivedClass(Node* project, Node* form, PANEL_PAG
                     }
                     else if (close_type_button)
                     {
-                        m_source->writeLine("if (!Validate() || !TransferDataFromWindow())");
-                        m_source->Indent();
-                        m_source->writeLine("return;");
-                        m_source->Unindent();
-                        m_source->writeLine();
-                        m_source->writeLine("if (IsModal())");
+                        Code code(m_form_node, GEN_LANG_CPLUSPLUS);
+                        code.Str("if (!Validate() || !TransferDataFromWindow())");
+                        code.OpenBrace();
+                        code.Str("return;");
+                        code.CloseBrace();
 
-                        m_source->Indent();
-                        m_source->writeLine("EndModal(wxID_OK);");
-                        m_source->Unindent();
+                        code.Eol().Eol(eol_always).Str("if (IsModal())");
+                        code.OpenBrace();
+                        code.Str("EndModal(wxID_OK);");
+                        code.CloseBrace();
 
-                        m_source->writeLine("else");
-                        m_source->writeLine("{");
-
-                        m_source->Indent();
-                        m_source->writeLine("    SetReturnCode(wxID_OK);");
-                        m_source->writeLine("    Show(false);");
-                        m_source->Unindent();
-
-                        m_source->writeLine("}");
+                        code.Eol().Str("else");
+                        code.OpenBrace();
+                        code.Str("SetReturnCode(wxID_OK);");
+                        code.Eol().Str("Show(false);");
+                        code.CloseBrace();
+                        m_source->writeLine(code);
 
                         if (m_form_node->as_bool(prop_persist))
                         {

--- a/src/generate/gen_dialog.cpp
+++ b/src/generate/gen_dialog.cpp
@@ -87,7 +87,7 @@ bool DialogFormGenerator::ConstructionCode(Code& code)
                 code += ' ';
         }
         code += "parent, id, title, pos, size, style, name))";
-        code.Eol().Tab() += "return false;\n";
+        code.OpenBrace().Str("return false;").CloseBrace();
     }
     else if (code.is_python())
     {

--- a/src/generate/gen_frame.cpp
+++ b/src/generate/gen_frame.cpp
@@ -10,6 +10,7 @@
 
 #include <frozen/set.h>
 
+#include "code.h"
 #include "gen_base.h"       // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
 #include "gen_common.h"     // GeneratorLibrary -- Generator classes
 #include "gen_xrc_utils.h"  // Common XRC generating functions
@@ -218,7 +219,7 @@ bool FrameFormGenerator::SettingsCode(Code& code)
                 code += ' ';
         }
         code += "parent, id, title, pos, size, style, name))";
-        code.Eol().Tab() += "return false;\n";
+        code.Eol().OpenBrace().Str("return false;").CloseBrace().Eol(eol_always);
     }
     else if (code.is_python())
     {

--- a/src/generate/gen_panel_form.cpp
+++ b/src/generate/gen_panel_form.cpp
@@ -132,7 +132,7 @@ bool PanelFormGenerator::SettingsCode(Code& code)
         else
             code += "wxPanel";
         code += "::Create(parent, id, pos, size, style, name))";
-        code.Eol().Tab().Str("return false;\n");
+        code.Eol().OpenBrace().Str("return false;").CloseBrace().Eol(eol_always);
     }
     else if (code.is_python())
     {

--- a/src/generate/gen_propsheet_dlg.cpp
+++ b/src/generate/gen_propsheet_dlg.cpp
@@ -113,7 +113,7 @@ bool PropSheetDlgGenerator::ConstructionCode(Code& code)
         else
             code += "wxPropertySheetDialog";
         code += "::Create(parent, id, title, pos, size, style, name))";
-        code.Eol().Tab() += "return false;\n";
+        code.Eol().OpenBrace().Str("return false;").CloseBrace().Eol(eol_always);
 
         code.Eol().Str("CreateButtons(").Add(prop_buttons).EndFunction();
     }

--- a/src/generate/gen_wizard.cpp
+++ b/src/generate/gen_wizard.cpp
@@ -177,7 +177,7 @@ bool WizardFormGenerator::SettingsCode(Code& code)
         if (code.is_cpp())
         {
             code.Comma().Str("pos").Comma().Str("style))");
-            code.Eol().Tab().Str("return;");
+            code.Eol().OpenBrace().Str("return;").CloseBrace();
         }
         else
         {
@@ -190,7 +190,7 @@ bool WizardFormGenerator::SettingsCode(Code& code)
         if (code.is_cpp())
         {
             code.Eol(eol_if_needed).FormFunction("if (!Create(").Str("parent, id, title, wxNullBitmap, pos, style))");
-            code.Eol().Tab().Str("return;");
+            code.Eol().OpenBrace().Str("return;").CloseBrace();
         }
         else if (code.is_python())
         {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR slightly changes some C++ code generation to avoid warnings when the resultant code is parsed by clang-tidy. The two changes are to use {} braces after conditionals even if only one line of code follows the conditional. While that doesn't actually matter as long as the code is being generated, if it is copied, then it really should be in braces in case the user wants to add additional code before our generated line.

The other change is to use `auto*` instead of `auto` for clarity. This handles some of the direct cases -- note that `Code::AddAuto()` already does this.