### PR TITLE
Fix ContextHelp menu Lambda event handler formatting

### DIFF
--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -14,7 +14,6 @@
 #include "node.h"             // Node class
 #include "node_creator.h"     // NodeCreator -- Class used to create nodes
 #include "node_event.h"       // NodeEventInfo -- NodeEvent and NodeEventInfo classes
-#include "preferences.h"      // Prefs -- Set/Get wxUiEditor preferences
 #include "project_handler.h"  // ProjectHandler class
 #include "utils.h"            // Miscellaneous utilities
 
@@ -75,6 +74,9 @@ EventHandlerDlg::EventHandlerDlg(wxWindow* parent, NodeEvent* event) : EventHand
     m_is_haskell_enabled = (m_gen_languages & GEN_LANG_HASKELL);
     m_is_lua_enabled = (m_gen_languages & GEN_LANG_LUA);
 #endif  // GENERATE_NEW_LANG_CODE
+
+    // Now that we've determined which languages are enabled, we can remove any pages
+    // for languages that are not used in this project.
 
     m_code_preference = Project.getCodePreference(event->getNode());
 
@@ -203,6 +205,9 @@ EventHandlerDlg::EventHandlerDlg(wxWindow* parent, NodeEvent* event) : EventHand
     auto form = event->getNode()->getForm();
     if (form)
     {
+        // For the panels that support lambdas, set the keywords for the scintilla control that
+        // will be used to edit the lambda function.
+
         if (m_is_cpp_enabled)
         {
             std::set<std::string> variables;
@@ -377,10 +382,8 @@ void EventHandlerDlg::OnInit(wxInitDialogEvent& WXUNUSED(event))
                     m_cpp_radio_use_lambda->SetValue(true);
                     m_cpp_lambda_box->GetStaticBox()->Enable(true);
 
-                    if (value.contains("this"))
-                        m_check_capture_this->SetValue(true);
-                    if (value.contains("& event)"))
-                        m_check_include_event->SetValue(true);
+                    m_check_capture_this->SetValue(value.contains("this"));
+                    m_check_include_event->SetValue(value.contains("& event)"));
 
                     if (auto pos = value.find('{'); tt::is_found(pos))
                     {

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1824,3 +1824,52 @@ Code& Code::False()
 
     return *this;
 }
+
+Code& Code::ExpandEventLambda(tt_string lambda)
+{
+    lambda.LeftTrim();
+    lambda.Replace("@@", "\n", tt::REPLACE::all);
+    lambda.RightTrim();
+
+    if (is_cpp())
+    {
+        Indent(1);
+        Eol();
+        tt_string_vector lines(lambda, '\n');
+
+        for (auto& line: lines)
+        {
+            if (line.contains("}"))
+            {
+                Unindent(1);
+                if (back() == '\t')
+                {
+                    pop_back();
+                }
+                Str(line);
+            }
+            else if (line.contains("{"))
+            {
+                Str(line);
+                Indent();
+            }
+            else
+            {
+                Str(line);
+            }
+            Eol();
+        }
+        Unindent(1);
+        // The caller will be adding a comma, which should appear after the closing brace
+        while (back() == '\t')
+        {
+            pop_back();
+        }
+        while (back() == '\n')
+        {
+            pop_back();
+        }
+    }
+
+    return *this;
+}

--- a/src/generate/code.h
+++ b/src/generate/code.h
@@ -537,6 +537,10 @@ public:
     // list.
     void AddPublicRubyMembers();
 
+    // This will expand a lamda function according to the current language.
+    // Note that it takes a copy of the lambda string since it needs to modify it.
+    Code& ExpandEventLambda(tt_string lambda);
+
 protected:
     void InsertLineBreak(size_t cur_pos);
     // Prefix with a period, lowercase for wxRuby, and add open parenthesis

--- a/src/generate/gen_ctx_menu.cpp
+++ b/src/generate/gen_ctx_menu.cpp
@@ -117,7 +117,6 @@ bool CtxMenuGenerator::AfterChildrenCode(Code& code)
             if (generator->GenEvent(event_code, iter, code.node()->getParentName(code.get_language()).as_str());
                 event_code.size())
             {
-                event_code.GetCode().Replace("\t", "\t\t", true);
                 code.Eol(eol_if_needed).Str("ctx_menu.") += event_code.GetCode();
             }
         }

--- a/src/generate/gen_events.cpp
+++ b/src/generate/gen_events.cpp
@@ -111,12 +111,10 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
     {
         if (code.is_cpp())
         {
-            handler << event->get_name() << ',' << event_code;
-            // Put the lambda expression on it's own line
-            handler.GetCode().Replace("[", "\n\t[");
-            comma = ",\n\t";
-            ExpandLambda(handler.GetCode());
+            handler << event->get_name() << ',';
+            handler.ExpandEventLambda(event_code);
             is_lambda = true;
+            comma = ",\n\t";
         }
         else if (code.is_python())
         {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR correctly sets/clears the `this` checkbox in the C++ lambda event handler dialog. It also fixes the formatting of lambdas being used as event handlers in a ContextHelp menu.

I added `Code::ExpandEventLambda()` -- currently this is only known to work on ContextHelp lambdas, but it would in a future PR I hope to combine the multiple places we generate these lambdas and hopefully run them all through this function instead.