### PR TITLE
XRC Test dialog overhaul

### DIFF
--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -1,7 +1,7 @@
 set (file_list_dir ${CMAKE_CURRENT_LIST_DIR})
 
 # wxui/wxui_code.cmake
-# ../internal.cmake
+# ../in.cmake
 
 set (file_list
 
@@ -341,9 +341,12 @@ set (file_list
     internal/msgframe.cpp      # Stores messages
     internal/msg_logging.cpp   # Message logging class
     internal/import_panel.cpp  # Panel to display original imported file
-    internal/xrcpreview.cpp    # Test XRC
     internal/import_panel.cpp  # Panel to display original imported file
     tests/test_xrc_import.cpp  # XRC Import tests
+
+    internal/xrcpreview.cpp           # Generated XrcPreview Dialog code
+    internal/xrcpreview_handlers.cpp  # Handlers for XrcPreview Dialog class
+    internal/xrc_list_dlg.cpp
 
     # Tools
 

--- a/src/internal/import_panel.h
+++ b/src/internal/import_panel.h
@@ -24,6 +24,7 @@ public:
     void Clear();
 
     void SetImportFile(const tt_string& file, int lexer = 5 /* wxSTC_LEX_XML */);
+    const tt_string& GetImportFile() const { return m_import_file; }
 
     void OnNodeSelected(Node* node);
 

--- a/src/internal/xrc_list_dlg.cpp
+++ b/src/internal/xrc_list_dlg.cpp
@@ -9,6 +9,7 @@
 
 #include <wx/button.h>
 #include <wx/sizer.h>
+#include <wx/stattext.h>
 
 #include "xrc_list_dlg.h"
 
@@ -21,6 +22,9 @@ bool XrcListDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     }
 
     auto* dlg_sizer = new wxBoxSizer(wxVERTICAL);
+
+    auto* static_text = new wxStaticText(this, wxID_ANY, "&List of XRC previewable forms:");
+    dlg_sizer->Add(static_text, wxSizerFlags().Border(wxALL));
 
     m_listbox = new wxListBox(this, wxID_ANY);
     m_listbox->SetMinSize(FromDIP(wxSize(200, 175)));
@@ -68,7 +72,7 @@ bool XrcListDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 /////////////////// Non-generated Copyright/License Info ////////////////////
 // Purpose:   Test XRC
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2024 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2024-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -82,11 +86,25 @@ void XrcListDlg::OnInit(wxInitDialogEvent& WXUNUSED(event))
     auto idx_cur_sel = 0;
     for (auto& form: forms)
     {
-        if (form->isGen(gen_wxDialog))
+        // THis list should be sychronized with the list of forms in previews.cpp (MainFrame::OnPreviewXrc)
+        switch (form->getGenName())
         {
-            auto index = m_listbox->Append(form->as_string(prop_class_name), static_cast<void*>(form));
-            if (m_form == wxGetMainFrame()->getSelectedNode())
-                idx_cur_sel = index;
+            case gen_wxDialog:
+            case gen_PanelForm:
+            case gen_wxFrame:
+            case gen_wxWizard:
+            case gen_MenuBar:
+            case gen_RibbonBar:
+            case gen_ToolBar:
+                {
+                    auto index = m_listbox->Append(form->as_string(prop_class_name), static_cast<void*>(form));
+                    if (m_form == wxGetMainFrame()->getSelectedNode())
+                        idx_cur_sel = index;
+                }
+                break;
+
+            default:
+                continue;  // Skip any other types of forms
         }
     }
 

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -158,6 +158,45 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     Bind(wxEVT_INIT_DIALOG, &XrcPreview::OnInit, this);
     m_searchCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &XrcPreview::OnSearch, this);
 
+// Unimplemented Event handler functions
+// Copy any of the following and paste them below the comment block, or to your inherited class.
+
+/*
+void XrcPreview::OnClear(
+{
+    event.Skip();
+}
+void XrcPreview::OnDuplicate(
+{
+    event.Skip();
+}
+void XrcPreview::OnExport(
+{
+    event.Skip();
+}
+void XrcPreview::OnGenerate(
+{
+    event.Skip();
+}
+void XrcPreview::OnImport(
+{
+    event.Skip();
+}
+void XrcPreview::OnInit(
+{
+    event.Skip();
+}
+void XrcPreview::OnPreview(
+{
+    event.Skip();
+}
+void XrcPreview::OnSearch(
+{
+    event.Skip();
+}
+
+*/
+
     return true;
 }
 
@@ -170,337 +209,4 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 // clang-format on
 // ***********************************************
 
-/////////////////// Non-generated Copyright/License Info ////////////////////
-// Purpose:   Test XRC
-// Author:    Ralph Walden
-// Copyright: Copyright (c) 2022-2025 KeyWorks Software (Ralph Walden)
-// License:   Apache License -- see ../../LICENSE
-/////////////////////////////////////////////////////////////////////////////
-
-#if __has_include(<format>)
-    #include <format>
-#endif
-
-#include <wx/filedlg.h>     // wxFileDialog base header
-#include <wx/mstream.h>     // Memory stream classes
-#include <wx/xml/xml.h>     // wxXmlDocument - XML parser & data holder class
-#include <wx/xrc/xmlres.h>  // XML resources
-
-// The following handlers must be explicitly added
-
-#include <wx/xrc/xh_aui.h>             // XRC resource handler for wxAUI
-#include <wx/xrc/xh_auitoolb.h>        // XML resource handler for wxAuiToolBar
-#include <wx/xrc/xh_ribbon.h>          // XML resource handler for wxRibbon related classes
-#include <wx/xrc/xh_richtext.h>        // XML resource handler for wxRichTextCtrl
-#include <wx/xrc/xh_styledtextctrl.h>  // XML resource handler for wxStyledTextCtrl
-
-#include "../import/import_wxsmith.h"  // Import a wxSmith file
-#include "gen_xrc.h"                   // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
-#include "internal/msg_logging.h"      // MsgLogging -- Message logging class
-#include "mainframe.h"                 // MainFrame -- Main window frame
-#include "node.h"                      // Node class
-#include "preferences.h"               // Prefs -- Set/Get wxUiEditor preferences
-#include "project_handler.h"           // ProjectHandler class
-#include "tt_view_vector.h"            // tt_string_vector -- Class for reading and writing line-oriented strings/files
-#include "undo_cmds.h"                 // InsertNodeAction -- Undoable command classes derived from UndoAction
-#include "utils.h"                     // Utility functions that work with properties
-
-#include "pugixml.hpp"
-
-#include "xrc_list_dlg.h"
-
-#include "xrc_list_dlg.h"
-
-const int node_marker = 1;
-
-void MainFrame::OnXrcPreview(wxCommandEvent& /* event */)
-{
-    XrcPreview dlg(this);
-    dlg.ShowModal();
-}
-
-void XrcPreview::OnClear(wxCommandEvent& WXUNUSED(event))
-{
-    m_scintilla->ClearAll();
-}
-
-void XrcPreview::OnGenerate(wxCommandEvent& WXUNUSED(event))
-{
-    XrcListDlg dlg(this);
-    if (dlg.ShowModal() != wxID_OK)
-        return;
-
-    auto form = dlg.get_form();
-
-    if (!form)
-    {
-        wxMessageBox("You need to select a form first.", "XRC Dialog Preview");
-        return;
-    }
-
-    if (!form->isForm())
-    {
-        form = form->getForm();
-    }
-
-    auto doc_str = GenerateXrcStr(form, form->isGen(gen_PanelForm) ? xrc::previewing : 0);
-
-    m_scintilla->ClearAll();
-    m_scintilla->AddTextRaw(doc_str.c_str(), (to_int) doc_str.size());
-    m_scintilla->SetEmptySelection(0);
-
-    tt_view_vector m_view;
-    m_view.ReadString(doc_str);
-
-    std::string search("name=\"");
-
-    if (form->hasProp(prop_id) && form->as_string(prop_id) != "wxID_ANY")
-    {
-        search = form->as_string(prop_id);
-    }
-    else if (form->hasValue(prop_var_name))
-    {
-        search = form->as_string(prop_var_name);
-    }
-    else
-    {
-        search = form->as_string(prop_class_name);
-    }
-
-    m_contents->SetLabelText("Contents: " + search);
-
-    int line = (to_int) m_view.FindLineContaining(search);
-
-    if (!tt::is_found(line))
-        return;
-
-    m_scintilla->MarkerDeleteAll(node_marker);
-    m_scintilla->MarkerAdd(line, node_marker);
-
-    // Unlike GetLineVisible(), this function does ensure that the line is visible.
-    m_scintilla->ScrollToLine(line);
-}
-
-extern bool g_isXrcResourceInitalized;
-
-void XrcPreview::OnPreview(wxCommandEvent& WXUNUSED(event))
-{
-    auto xrc_text = m_scintilla->GetText();
-    wxString dlg_name;
-    auto pos = xrc_text.Find("name=\"");
-    if (!tt::is_found(pos))
-    {
-        wxMessageBox("Could not locate the dialog's name.", "XRC Dialog Preview");
-        return;
-    }
-    pos += (sizeof("name=\"") - 1);
-    while (pos < (to_int) xrc_text.size() && xrc_text[pos] != '"')
-    {
-        dlg_name << xrc_text[pos++];
-    }
-
-    wxMemoryInputStream stream(xrc_text.data(), xrc_text.size());
-    wxXmlParseError err_details;
-    auto xmlDoc = std::make_unique<wxXmlDocument>(wxXmlDocument());
-    if (auto result = xmlDoc->Load(stream, wxXMLDOC_NONE, &err_details); !result)
-    {
-#if __has_include(<format>)
-        std::string msg =
-            std::format(std::locale(""), "Parsing error: {} at line: {}, column: {}, offset: {:L}\n",
-                        err_details.message.ToStdString(), err_details.line, err_details.column, err_details.offset);
-#else
-        wxString msg;
-        msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", err_details.message, err_details.line,
-                   err_details.column, err_details.offset);
-#endif
-        wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
-        return;
-    }
-    if (!xmlDoc->IsOk())
-    {
-        wxMessageBox("Invalid XRC -- wxXmlDocument can't parse it.", "XRC Dialog Preview");
-        return;
-    }
-
-    auto xrc_resource = wxXmlResource::Get();
-    if (!g_isXrcResourceInitalized)
-    {
-        g_isXrcResourceInitalized = true;
-
-        xrc_resource->InitAllHandlers();
-        xrc_resource->AddHandler(new wxRichTextCtrlXmlHandler);
-        xrc_resource->AddHandler(new wxAuiXmlHandler);
-        xrc_resource->AddHandler(new wxAuiToolBarXmlHandler);
-        xrc_resource->AddHandler(new wxRibbonXmlHandler);
-        xrc_resource->AddHandler(new wxStyledTextCtrlXmlHandler);
-    }
-
-    wxString res_name("wxuiDlgPreview");
-
-    if (!xrc_resource->LoadDocument(xmlDoc.release(), res_name))
-    {
-        wxMessageBox("wxWidgets could not parse the XRC data.", "XRC Dialog Preview");
-        return;
-    }
-
-    tt_cwd cwd(true);
-    wxSetWorkingDirectory(Project.ArtDirectory().make_wxString());
-
-    wxDialog dlg;
-    if (xrc_resource->LoadDialog(&dlg, this, dlg_name))
-    {
-        dlg.ShowModal();
-    }
-    else
-    {
-        wxMessageBox(wxString("Could not load ") << dlg_name << " resource.", "XRC Dialog Preview");
-    }
-    xrc_resource->Unload(res_name);
-}
-
-#ifndef SCI_SETKEYWORDS
-    #define SCI_SETKEYWORDS 4005
-    #define SCI_GETTEXT_MSG 2182
-#endif
-
-extern const char* g_xrc_keywords;
-
-void XrcPreview::OnInit(wxInitDialogEvent& event)
-{
-    SetStcColors(m_scintilla, GEN_LANG_XRC, false, true);
-
-    m_scintilla->StyleSetBold(wxSTC_H_TAG, true);
-
-    FontProperty font_prop(UserPrefs.get_CodeDisplayFont().ToStdView());
-    m_scintilla->StyleSetFont(wxSTC_STYLE_DEFAULT, font_prop.GetFont());
-
-    m_scintilla->MarkerDefine(node_marker, wxSTC_MARK_BOOKMARK, wxNullColour, *wxGREEN);
-
-    event.Skip();
-
-    wxCommandEvent dummy;
-    OnGenerate(dummy);
-}
-
-void XrcPreview::OnImport(wxCommandEvent& WXUNUSED(event))
-{
-    auto xrc_text = m_scintilla->GetText();
-    pugi::xml_document doc;
-    {
-        // Place this in a block so that the string is destroyed before we process the XML
-        // document (to save allocated memory).
-        auto result = doc.load_string(xrc_text.utf8_string());
-        if (!result)
-        {
-            wxMessageBox("Error parsing XRC document: " + tt_string(result.description()), "XRC Import Test");
-            return;
-        }
-    }
-
-    auto root = doc.first_child();
-    if (!tt::is_sameas(root.name(), "resource", tt::CASE::either))
-    {
-        wxMessageBox("Invalid XRC -- no resource object", "Import XRC Test");
-        return;
-    }
-
-    g_pMsgLogging->ShowLogger();
-    wxYield();
-
-    MSG_INFO("--- Importing XRC document ---");
-
-    WxSmith doc_import;
-
-    // If this is an actual form rather than the project, then there will only be one child
-    // object, which is the form.
-    for (auto& iter: root.children())
-    {
-        auto new_node = doc_import.CreateXrcNode(iter, nullptr);
-    }
-
-    MSG_INFO("--- Import completed ---");
-}
-
-void XrcPreview::OnExport(wxCommandEvent& WXUNUSED(event))
-{
-    tt_string path = Project.getProjectPath();
-    wxFileDialog dialog(this, "Export Project As XRC", path.make_wxString(), "preview_test.xrc", "XRC File (*.xrc)|*.xrc",
-                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
-
-    if (dialog.ShowModal() == wxID_OK)
-    {
-        tt_string filename = dialog.GetPath().utf8_string();
-
-        std::string buf;
-        buf.reserve(m_scintilla->GetTextLength() + 1);
-        auto len = m_scintilla->GetTextLength() + 1;
-        m_scintilla->SendMsg(SCI_GETTEXT_MSG, len, (wxIntPtr) buf.data());
-
-        pugi::xml_document doc;
-        doc.load_string(buf.c_str());
-
-        if (!doc.save_file(filename))
-        {
-            wxMessageBox(wxString("An unexpected error occurred exporting ") << filename.make_wxString(), "Export XRC");
-        }
-    }
-}
-
-void XrcPreview::OnDuplicate(wxCommandEvent& WXUNUSED(event))
-{
-    auto xrc_text = m_scintilla->GetText();
-    pugi::xml_document doc;
-    {
-        // Place this in a block so that the string is destroyed before we process the XML
-        // document (to save allocated memory).
-        auto result = doc.load_string(xrc_text.utf8_string());
-        if (!result)
-        {
-            wxMessageBox("Error parsing XRC document: " + tt_string(result.description()), "XRC Import Test");
-            return;
-        }
-    }
-
-    auto root = doc.first_child();
-    if (!tt::is_sameas(root.name(), "resource", tt::CASE::either))
-    {
-        wxMessageBox("Invalid XRC -- no resource object", "Import XRC Test");
-        return;
-    }
-
-    WxSmith doc_import;
-
-    auto first_child = root.first_child();
-    auto new_node = doc_import.CreateXrcNode(first_child, nullptr);
-    if (new_node)
-    {
-        Project.FixupDuplicatedNode(new_node.get());
-        tt_string undo_str("duplicate ");
-        undo_str << new_node->declName();
-        wxGetMainFrame()->PushUndoAction(
-            std::make_shared<InsertNodeAction>(new_node.get(), Project.getProjectNode(), undo_str));
-        wxGetMainFrame()->FireCreatedEvent(new_node);
-        wxGetMainFrame()->SelectNode(new_node, evt_flags::fire_event | evt_flags::force_selection);
-    }
-    else
-    {
-        MSG_ERROR("Failed to create node");
-    }
-}
-
-void XrcPreview::OnSearch(wxCommandEvent& event)
-{
-    m_scintilla->SetSelectionStart(m_scintilla->GetSelectionEnd());
-    m_scintilla->SearchAnchor();
-    auto srch_string = event.GetString();
-    auto result = m_scintilla->SearchNext(0, event.GetString());
-
-    if (result == wxSTC_INVALID_POSITION)
-    {
-        wxMessageBox(wxString() << event.GetString() << " not found.", "Not Found", wxICON_ERROR);
-    }
-    else
-    {
-        m_scintilla->EnsureCaretVisible();
-    }
-}
+// Handler code is in xrcpreview_handlers.cpp

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -65,6 +65,10 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     m_btn__export->SetToolTip("Load current contents into XML, then Export to a file of your choice");
     box_sizer_2->Add(m_btn__export, wxSizerFlags().Border(wxALL));
 
+    m_btnCompare = new wxButton(this, wxID_ANY, "Co&mpare...");
+    m_btnCompare->SetToolTip("Only valid if an XRC was imported. Compares original and generated.");
+    box_sizer_2->Add(m_btnCompare, wxSizerFlags().Border(wxALL));
+
     auto* btn3 = new wxButton(this, wxID_ANY, "&Duplicate");
         btn3->SetBitmap(wxArtProvider::GetBitmapBundle(wxART_ADD_BOOKMARK, wxART_MENU));
     btn3->SetToolTip("Load current contents into XML, then Export to a file of your choice");
@@ -150,6 +154,7 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
     // Event handlers
     btn_2->Bind(wxEVT_BUTTON, &XrcPreview::OnClear, this);
+    m_btnCompare->Bind(wxEVT_BUTTON, &XrcPreview::OnCompare, this);
     btn3->Bind(wxEVT_BUTTON, &XrcPreview::OnDuplicate, this);
     m_btn__export->Bind(wxEVT_BUTTON, &XrcPreview::OnExport, this);
     btn_3->Bind(wxEVT_BUTTON, &XrcPreview::OnGenerate, this);
@@ -163,6 +168,10 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 
 /*
 void XrcPreview::OnClear(
+{
+    event.Skip();
+}
+void XrcPreview::OnCompare(
 {
     event.Skip();
 }

--- a/src/internal/xrcpreview.cpp
+++ b/src/internal/xrcpreview.cpp
@@ -55,7 +55,7 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     m_btn_preview->SetToolTip("Use wxXmlResource to load and display the contents");
     box_sizer_2->Add(m_btn_preview, wxSizerFlags().Border(wxALL));
 
-    m_btn_import = new wxButton(this, wxID_ANY, "&Import");
+    m_btn_import = new wxButton(this, wxID_ANY, "&Verify");
         m_btn_import->SetBitmap(wxue_img::bundle_import_svg(16, 16));
     m_btn_import->SetToolTip("Verify that the current contents can be imported");
     box_sizer_2->Add(m_btn_import, wxSizerFlags().Border(wxALL));
@@ -153,8 +153,8 @@ bool XrcPreview::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     btn3->Bind(wxEVT_BUTTON, &XrcPreview::OnDuplicate, this);
     m_btn__export->Bind(wxEVT_BUTTON, &XrcPreview::OnExport, this);
     btn_3->Bind(wxEVT_BUTTON, &XrcPreview::OnGenerate, this);
-    m_btn_import->Bind(wxEVT_BUTTON, &XrcPreview::OnImport, this);
     m_btn_preview->Bind(wxEVT_BUTTON, &XrcPreview::OnPreview, this);
+    m_btn_import->Bind(wxEVT_BUTTON, &XrcPreview::OnVerify, this);
     Bind(wxEVT_INIT_DIALOG, &XrcPreview::OnInit, this);
     m_searchCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &XrcPreview::OnSearch, this);
 
@@ -178,10 +178,6 @@ void XrcPreview::OnGenerate(
 {
     event.Skip();
 }
-void XrcPreview::OnImport(
-{
-    event.Skip();
-}
 void XrcPreview::OnInit(
 {
     event.Skip();
@@ -191,6 +187,10 @@ void XrcPreview::OnPreview(
     event.Skip();
 }
 void XrcPreview::OnSearch(
+{
+    event.Skip();
+}
+void XrcPreview::OnVerify(
 {
     event.Skip();
 }

--- a/src/internal/xrcpreview.h
+++ b/src/internal/xrcpreview.h
@@ -43,10 +43,10 @@ protected:
     void OnDuplicate(wxCommandEvent& event);
     void OnExport(wxCommandEvent& event);
     void OnGenerate(wxCommandEvent& event);
-    void OnImport(wxCommandEvent& event);
     void OnInit(wxInitDialogEvent& event);
     void OnPreview(wxCommandEvent& event);
     void OnSearch(wxCommandEvent& event);
+    void OnVerify(wxCommandEvent& event);
 
     // Class member variables
 

--- a/src/internal/xrcpreview.h
+++ b/src/internal/xrcpreview.h
@@ -21,6 +21,8 @@
 #include <wx/stattext.h>
 #include <wx/stc/stc.h>
 
+class Node;
+
 class XrcPreview : public wxDialog
 {
 public:
@@ -35,11 +37,14 @@ public:
         wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr);
 
+    void Generate(Node* form_node = nullptr);
+
 protected:
 
     // Event handlers
 
     void OnClear(wxCommandEvent& event);
+    void OnCompare(wxCommandEvent& event);
     void OnDuplicate(wxCommandEvent& event);
     void OnExport(wxCommandEvent& event);
     void OnGenerate(wxCommandEvent& event);
@@ -50,6 +55,7 @@ protected:
 
     // Class member variables
 
+    wxButton* m_btnCompare;
     wxButton* m_btn__export;
     wxButton* m_btn_import;
     wxButton* m_btn_preview;
@@ -58,6 +64,8 @@ protected:
     wxStaticText* m_contents;
     wxStaticText* m_staticText;
     wxStyledTextCtrl* m_scintilla;
+
+    Node* m_form_node;
 };
 
 // ************* End of generated code ***********

--- a/src/internal/xrcpreview_handlers.cpp
+++ b/src/internal/xrcpreview_handlers.cpp
@@ -1,0 +1,336 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Handlers for XrcPreview Dialog class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2025 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "xrcpreview.h"
+
+#if __has_include(<format>)
+    #include <format>
+#endif
+
+#include <wx/filedlg.h>     // wxFileDialog base header
+#include <wx/mstream.h>     // Memory stream classes
+#include <wx/xml/xml.h>     // wxXmlDocument - XML parser & data holder class
+#include <wx/xrc/xmlres.h>  // XML resources
+
+// The following handlers must be explicitly added
+
+#include <wx/xrc/xh_aui.h>             // XRC resource handler for wxAUI
+#include <wx/xrc/xh_auitoolb.h>        // XML resource handler for wxAuiToolBar
+#include <wx/xrc/xh_ribbon.h>          // XML resource handler for wxRibbon related classes
+#include <wx/xrc/xh_richtext.h>        // XML resource handler for wxRichTextCtrl
+#include <wx/xrc/xh_styledtextctrl.h>  // XML resource handler for wxStyledTextCtrl
+
+#include "../import/import_wxsmith.h"  // Import a wxSmith file
+#include "gen_xrc.h"                   // BaseCodeGenerator -- Generate Src and Hdr files for Base Class
+#include "internal/msg_logging.h"      // MsgLogging -- Message logging class
+#include "mainframe.h"                 // MainFrame -- Main window frame
+#include "node.h"                      // Node class
+#include "preferences.h"               // Prefs -- Set/Get wxUiEditor preferences
+#include "project_handler.h"           // ProjectHandler class
+#include "tt_view_vector.h"            // tt_string_vector -- Class for reading and writing line-oriented strings/files
+#include "undo_cmds.h"                 // InsertNodeAction -- Undoable command classes derived from UndoAction
+#include "utils.h"                     // Utility functions that work with properties
+
+#include "pugixml.hpp"
+
+#include "xrc_list_dlg.h"
+
+#include "xrc_list_dlg.h"
+
+const int node_marker = 1;
+
+void MainFrame::OnXrcPreview(wxCommandEvent& /* event */)
+{
+    XrcPreview dlg(this);
+    dlg.ShowModal();
+}
+
+#ifndef SCI_SETKEYWORDS
+    #define SCI_SETKEYWORDS 4005
+    #define SCI_GETTEXT_MSG 2182
+#endif
+
+extern const char* g_xrc_keywords;
+
+void XrcPreview::OnInit(wxInitDialogEvent& event)
+{
+    SetStcColors(m_scintilla, GEN_LANG_XRC, false, true);
+
+    m_scintilla->StyleSetBold(wxSTC_H_TAG, true);
+
+    FontProperty font_prop(UserPrefs.get_CodeDisplayFont().ToStdView());
+    m_scintilla->StyleSetFont(wxSTC_STYLE_DEFAULT, font_prop.GetFont());
+
+    m_scintilla->MarkerDefine(node_marker, wxSTC_MARK_BOOKMARK, wxNullColour, *wxGREEN);
+
+    event.Skip();
+
+    wxCommandEvent dummy;
+    OnGenerate(dummy);
+}
+
+void XrcPreview::OnClear(wxCommandEvent& WXUNUSED(event))
+{
+    m_scintilla->ClearAll();
+}
+
+void XrcPreview::OnGenerate(wxCommandEvent& WXUNUSED(event))
+{
+    XrcListDlg dlg(this);
+    if (dlg.ShowModal() != wxID_OK)
+        return;
+
+    auto form = dlg.get_form();
+
+    if (!form)
+    {
+        wxMessageBox("You need to select a form first.", "XRC Dialog Preview");
+        return;
+    }
+
+    if (!form->isForm())
+    {
+        form = form->getForm();
+    }
+
+    auto doc_str = GenerateXrcStr(form, form->isGen(gen_PanelForm) ? xrc::previewing : 0);
+
+    m_scintilla->ClearAll();
+    m_scintilla->AddTextRaw(doc_str.c_str(), (to_int) doc_str.size());
+    m_scintilla->SetEmptySelection(0);
+
+    tt_view_vector m_view;
+    m_view.ReadString(doc_str);
+
+    std::string search("name=\"");
+
+    if (form->hasProp(prop_id) && form->as_string(prop_id) != "wxID_ANY")
+    {
+        search = form->as_string(prop_id);
+    }
+    else if (form->hasValue(prop_var_name))
+    {
+        search = form->as_string(prop_var_name);
+    }
+    else
+    {
+        search = form->as_string(prop_class_name);
+    }
+
+    m_contents->SetLabelText("Contents: " + search);
+
+    int line = (to_int) m_view.FindLineContaining(search);
+
+    if (!tt::is_found(line))
+        return;
+
+    m_scintilla->MarkerDeleteAll(node_marker);
+    m_scintilla->MarkerAdd(line, node_marker);
+
+    // Unlike GetLineVisible(), this function does ensure that the line is visible.
+    m_scintilla->ScrollToLine(line);
+}
+
+extern bool g_isXrcResourceInitalized;
+
+void XrcPreview::OnPreview(wxCommandEvent& WXUNUSED(event))
+{
+    auto xrc_text = m_scintilla->GetText();
+    wxString dlg_name;
+    auto pos = xrc_text.Find("name=\"");
+    if (!tt::is_found(pos))
+    {
+        wxMessageBox("Could not locate the dialog's name.", "XRC Dialog Preview");
+        return;
+    }
+    pos += (sizeof("name=\"") - 1);
+    while (pos < (to_int) xrc_text.size() && xrc_text[pos] != '"')
+    {
+        dlg_name << xrc_text[pos++];
+    }
+
+    wxMemoryInputStream stream(xrc_text.data(), xrc_text.size());
+    wxXmlParseError err_details;
+    auto xmlDoc = std::make_unique<wxXmlDocument>(wxXmlDocument());
+    if (auto result = xmlDoc->Load(stream, wxXMLDOC_NONE, &err_details); !result)
+    {
+#if __has_include(<format>)
+        std::string msg =
+            std::format(std::locale(""), "Parsing error: {} at line: {}, column: {}, offset: {:L}\n",
+                        err_details.message.ToStdString(), err_details.line, err_details.column, err_details.offset);
+#else
+        wxString msg;
+        msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", err_details.message, err_details.line,
+                   err_details.column, err_details.offset);
+#endif
+        wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
+        return;
+    }
+    if (!xmlDoc->IsOk())
+    {
+        wxMessageBox("Invalid XRC -- wxXmlDocument can't parse it.", "XRC Dialog Preview");
+        return;
+    }
+
+    auto xrc_resource = wxXmlResource::Get();
+    if (!g_isXrcResourceInitalized)
+    {
+        g_isXrcResourceInitalized = true;
+
+        xrc_resource->InitAllHandlers();
+        xrc_resource->AddHandler(new wxRichTextCtrlXmlHandler);
+        xrc_resource->AddHandler(new wxAuiXmlHandler);
+        xrc_resource->AddHandler(new wxAuiToolBarXmlHandler);
+        xrc_resource->AddHandler(new wxRibbonXmlHandler);
+        xrc_resource->AddHandler(new wxStyledTextCtrlXmlHandler);
+    }
+
+    wxString res_name("wxuiDlgPreview");
+
+    if (!xrc_resource->LoadDocument(xmlDoc.release(), res_name))
+    {
+        wxMessageBox("wxWidgets could not parse the XRC data.", "XRC Dialog Preview");
+        return;
+    }
+
+    tt_cwd cwd(true);
+    wxSetWorkingDirectory(Project.ArtDirectory().make_wxString());
+
+    wxDialog dlg;
+    if (xrc_resource->LoadDialog(&dlg, this, dlg_name))
+    {
+        dlg.ShowModal();
+    }
+    else
+    {
+        wxMessageBox(wxString("Could not load ") << dlg_name << " resource.", "XRC Dialog Preview");
+    }
+    xrc_resource->Unload(res_name);
+}
+
+void XrcPreview::OnImport(wxCommandEvent& WXUNUSED(event))
+{
+    auto xrc_text = m_scintilla->GetText();
+    pugi::xml_document doc;
+    {
+        // Place this in a block so that the string is destroyed before we process the XML
+        // document (to save allocated memory).
+        auto result = doc.load_string(xrc_text.utf8_string());
+        if (!result)
+        {
+            wxMessageBox("Error parsing XRC document: " + tt_string(result.description()), "XRC Import Test");
+            return;
+        }
+    }
+
+    auto root = doc.first_child();
+    if (!tt::is_sameas(root.name(), "resource", tt::CASE::either))
+    {
+        wxMessageBox("Invalid XRC -- no resource object", "Import XRC Test");
+        return;
+    }
+
+    g_pMsgLogging->ShowLogger();
+    wxYield();
+
+    MSG_INFO("--- Importing XRC document ---");
+
+    WxSmith doc_import;
+
+    // If this is an actual form rather than the project, then there will only be one child
+    // object, which is the form.
+    for (auto& iter: root.children())
+    {
+        auto new_node = doc_import.CreateXrcNode(iter, nullptr);
+    }
+
+    MSG_INFO("--- Import completed ---");
+}
+
+void XrcPreview::OnExport(wxCommandEvent& WXUNUSED(event))
+{
+    tt_string path = Project.getProjectPath();
+    wxFileDialog dialog(this, "Export Project As XRC", path.make_wxString(), "preview_test.xrc", "XRC File (*.xrc)|*.xrc",
+                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+    if (dialog.ShowModal() == wxID_OK)
+    {
+        tt_string filename = dialog.GetPath().utf8_string();
+
+        std::string buf;
+        buf.reserve(m_scintilla->GetTextLength() + 1);
+        auto len = m_scintilla->GetTextLength() + 1;
+        m_scintilla->SendMsg(SCI_GETTEXT_MSG, len, (wxIntPtr) buf.data());
+
+        pugi::xml_document doc;
+        doc.load_string(buf.c_str());
+
+        if (!doc.save_file(filename))
+        {
+            wxMessageBox(wxString("An unexpected error occurred exporting ") << filename.make_wxString(), "Export XRC");
+        }
+    }
+}
+
+void XrcPreview::OnDuplicate(wxCommandEvent& WXUNUSED(event))
+{
+    auto xrc_text = m_scintilla->GetText();
+    pugi::xml_document doc;
+    {
+        // Place this in a block so that the string is destroyed before we process the XML
+        // document (to save allocated memory).
+        auto result = doc.load_string(xrc_text.utf8_string());
+        if (!result)
+        {
+            wxMessageBox("Error parsing XRC document: " + tt_string(result.description()), "XRC Import Test");
+            return;
+        }
+    }
+
+    auto root = doc.first_child();
+    if (!tt::is_sameas(root.name(), "resource", tt::CASE::either))
+    {
+        wxMessageBox("Invalid XRC -- no resource object", "Import XRC Test");
+        return;
+    }
+
+    WxSmith doc_import;
+
+    auto first_child = root.first_child();
+    auto new_node = doc_import.CreateXrcNode(first_child, nullptr);
+    if (new_node)
+    {
+        Project.FixupDuplicatedNode(new_node.get());
+        tt_string undo_str("duplicate ");
+        undo_str << new_node->declName();
+        wxGetMainFrame()->PushUndoAction(
+            std::make_shared<InsertNodeAction>(new_node.get(), Project.getProjectNode(), undo_str));
+        wxGetMainFrame()->FireCreatedEvent(new_node);
+        wxGetMainFrame()->SelectNode(new_node, evt_flags::fire_event | evt_flags::force_selection);
+    }
+    else
+    {
+        MSG_ERROR("Failed to create node");
+    }
+}
+
+void XrcPreview::OnSearch(wxCommandEvent& event)
+{
+    m_scintilla->SetSelectionStart(m_scintilla->GetSelectionEnd());
+    m_scintilla->SearchAnchor();
+    auto srch_string = event.GetString();
+    auto result = m_scintilla->SearchNext(0, event.GetString());
+
+    if (result == wxSTC_INVALID_POSITION)
+    {
+        wxMessageBox(wxString() << event.GetString() << " not found.", "Not Found", wxICON_ERROR);
+    }
+    else
+    {
+        m_scintilla->EnsureCaretVisible();
+    }
+}

--- a/src/internal/xrcpreview_handlers.cpp
+++ b/src/internal/xrcpreview_handlers.cpp
@@ -31,6 +31,7 @@
 #include "tt_view_vector.h"            // tt_string_vector -- Class for reading and writing line-oriented strings/files
 #include "undo_cmds.h"                 // InsertNodeAction -- Undoable command classes derived from UndoAction
 #include "utils.h"                     // Utility functions that work with properties
+#include "xrccompare.h"                // C++/XRC UI Comparison dialog
 
 #include "pugixml.hpp"
 
@@ -72,7 +73,7 @@ void XrcPreview::OnInit(wxInitDialogEvent& event)
     if (wxGetApp().isTestingMenuEnabled())
     {
         const auto& import_file = wxGetFrame().getImportPanel()->GetImportFile();
-        if (tt_string(import_file.extension()).MakeLower() != "xrc")
+        if (tt_string(import_file.extension()).MakeLower() != ".xrc")
             m_btnCompare->Disable();
     }
 }
@@ -280,7 +281,28 @@ void XrcPreview::OnDuplicate(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-void XrcPreview::OnCompare(wxCommandEvent& WXUNUSED(event)) {}
+void XrcPreview::OnCompare(wxCommandEvent& WXUNUSED(event))
+{
+    if (!m_form_node->isGen(gen_wxDialog) && !m_form_node->isGen(gen_PanelForm))
+    {
+        wxMessageBox("You can only compare dialogs and panels", "Compare");
+        return;
+    }
+
+    tt_cwd cwd(true);
+    wxSetWorkingDirectory(Project.ArtDirectory().make_wxString());
+
+    XrcCompare dlg_compare;
+    if (!dlg_compare.DoCreate(wxGetMainFrame(), m_form_node, true))
+    {
+        wxMessageBox("Unable to create the XrcCompare dialog box!", "Compare");
+        return;
+    }
+
+    dlg_compare.ShowModal();
+    return;
+}
+
 void XrcPreview::OnSearch(wxCommandEvent& event)
 {
     m_scintilla->SetSelectionStart(m_scintilla->GetSelectionEnd());

--- a/src/internal/xrcpreview_handlers.cpp
+++ b/src/internal/xrcpreview_handlers.cpp
@@ -71,6 +71,13 @@ void XrcPreview::OnInit(wxInitDialogEvent& event)
 
     wxCommandEvent dummy;
     OnGenerate(dummy);
+
+    if (wxGetApp().isTestingMenuEnabled())
+    {
+        const auto& import_file = wxGetFrame().getImportPanel()->GetImportFile();
+        if (tt_string(import_file.extension()).MakeLower() != "xrc")
+            m_btnCompare->Disable();
+    }
 }
 
 void XrcPreview::OnClear(wxCommandEvent& WXUNUSED(event))

--- a/src/internal/xrcpreview_handlers.cpp
+++ b/src/internal/xrcpreview_handlers.cpp
@@ -212,8 +212,9 @@ void XrcPreview::OnPreview(wxCommandEvent& WXUNUSED(event))
     xrc_resource->Unload(res_name);
 }
 
-void XrcPreview::OnImport(wxCommandEvent& WXUNUSED(event))
+void XrcPreview::OnVerify(wxCommandEvent& WXUNUSED(event))
 {
+    // Verify that the XML in the Scintilla control ia valid by parsing it with PugiXML.
     auto xrc_text = m_scintilla->GetText();
     pugi::xml_document doc;
     {
@@ -222,7 +223,8 @@ void XrcPreview::OnImport(wxCommandEvent& WXUNUSED(event))
         auto result = doc.load_string(xrc_text.utf8_string());
         if (!result)
         {
-            wxMessageBox("Error parsing XRC document: " + tt_string(result.description()), "XRC Import Test");
+            wxMessageBox("Error parsing XML document: " + tt_string(result.description()), "XML Verification Test",
+                         wxOK | wxICON_ERROR);
             return;
         }
     }
@@ -230,25 +232,11 @@ void XrcPreview::OnImport(wxCommandEvent& WXUNUSED(event))
     auto root = doc.first_child();
     if (!tt::is_sameas(root.name(), "resource", tt::CASE::either))
     {
-        wxMessageBox("Invalid XRC -- no resource object", "Import XRC Test");
+        wxMessageBox("Invalid XML -- no resource object", "XML Verification Test", wxOK | wxICON_ERROR);
         return;
     }
 
-    g_pMsgLogging->ShowLogger();
-    wxYield();
-
-    MSG_INFO("--- Importing XRC document ---");
-
-    WxSmith doc_import;
-
-    // If this is an actual form rather than the project, then there will only be one child
-    // object, which is the form.
-    for (auto& iter: root.children())
-    {
-        auto new_node = doc_import.CreateXrcNode(iter, nullptr);
-    }
-
-    MSG_INFO("--- Import completed ---");
+    wxMessageBox("XML in Contents can be parsed.", "XRC Verification Test", wxOK | wxICON_NONE);
 }
 
 void XrcPreview::OnExport(wxCommandEvent& WXUNUSED(event))

--- a/src/mockup/mockup_preview.cpp
+++ b/src/mockup/mockup_preview.cpp
@@ -19,7 +19,6 @@
 #include "../mockup/mockup_content.h"  // MockupContent -- Mockup of a form's contents
 #include "base_generator.h"            // BaseGenerator -- Base widget generator class
 #include "gen_common.h"                // Common component functions
-#include "mainframe.h"                 // MainFrame -- Main window frame
 #include "node.h"                      // Node class
 #include "utils.h"                     // Utility functions that work with properties
 

--- a/src/previews.cpp
+++ b/src/previews.cpp
@@ -224,6 +224,21 @@ void PreviewXrc(Node* form_node)
 
 void PreviewXrc(std::string& doc_str, GenEnum::GenName gen_name, Node* form_node)
 {
+    pugi::xml_document doc;
+    if (auto result = doc.load_string(doc_str.c_str()); !result)
+    {
+#if __has_include(<format>)
+        std::string msg = std::format(std::locale(""), "Parsing error: {}\n Line: {}, Column: {}, Offset: {:L}\n",
+                                      result.description(), result.line, result.column, result.offset);
+#else
+        wxString msg;
+        msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", result.detailed_msg, result.line,
+                   result.column, result.offset);
+#endif
+        wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
+        return;
+    }
+
     auto* xrc_resource = wxXmlResource::Get();
 
     if (!g_isXrcResourceInitalized)
@@ -241,21 +256,6 @@ void PreviewXrc(std::string& doc_str, GenEnum::GenName gen_name, Node* form_node
     // This needs to be outside of the try block so that xrc_resource->Unload(res_name) can
     // be called after the catch block.
     wxString res_name("wxuiPreview");
-
-    pugi::xml_document doc;
-    if (auto result = doc.load_string(doc_str); !result)
-    {
-#if __has_include(<format>)
-        std::string msg = std::format(std::locale(""), "Parsing error: {}\n Line: {}, Column: {}, Offset: {:L}\n",
-                                      result.description(), result.line, result.column, result.offset);
-#else
-        wxString msg;
-        msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", result.detailed_msg, result.line,
-                   result.column, result.offset);
-#endif
-        wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
-        return;
-    }
 
     try
     {

--- a/src/previews.cpp
+++ b/src/previews.cpp
@@ -6,7 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "previews.h"
-#include "gen_enums.h"
 
 #if __has_include(<format>)
     #include <format>
@@ -29,8 +28,9 @@
 #include "../tools/preview_settings.h"  // PreviewSettings
 #include "../ui/xrccompare.h"           // C++/XRC UI Comparison dialog
 
-#include "dlg_msgs.h"           // wxMessageDialog dialogs
-#include "gen_common.h"         // GeneratorLibrary -- Generator classes
+#include "dlg_msgs.h"    // wxMessageDialog dialogs
+#include "gen_common.h"  // GeneratorLibrary -- Generator classes
+#include "gen_enums.h"
 #include "generate/gen_xrc.h"   // Generate XRC file
 #include "mainapp.h"            // App -- Main application class
 #include "mainframe.h"          // MainFrame -- Main window frame
@@ -44,9 +44,6 @@
 // Defined in mockup/mockup_preview.cpp
 void CreateMockupChildren(Node* node, wxWindow* parent, wxObject* parent_object, wxSizer* parent_sizer,
                           wxWindow* form_window);
-
-void PreviewXrc(Node* form_node);
-void Preview(Node* form_node);
 
 bool g_isXrcResourceInitalized { false };
 

--- a/src/previews.h
+++ b/src/previews.h
@@ -9,7 +9,7 @@
 
 class Node;
 
-extern const char* txt_dlg_name; // "_wxue_temp_dlg"
+extern const char* txt_dlg_name;  // "_wxue_temp_dlg"
 
 void PreviewXrc(Node* form_node);
 

--- a/src/previews.h
+++ b/src/previews.h
@@ -1,0 +1,19 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Top level Preview functions
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022-2025 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+class Node;
+
+extern const char* txt_dlg_name; // "_wxue_temp_dlg"
+
+void PreviewXrc(Node* form_node);
+
+// form_node is required for a wxWizard
+void PreviewXrc(std::string& doc_str, GenEnum::GenName gen_name, Node* form_node = nullptr);
+
+void Preview(Node* form_node);

--- a/src/ui/xrccompare.h
+++ b/src/ui/xrccompare.h
@@ -9,10 +9,14 @@
 
 #pragma once
 
+#include <wx/colour.h>
 #include <wx/dialog.h>
+#include <wx/font.h>
 #include <wx/gbsizer.h>
 #include <wx/gdicmn.h>
+#include <wx/settings.h>
 #include <wx/statline.h>
+#include <wx/stattext.h>
 
 class Node;
 
@@ -38,6 +42,8 @@ private:
 
     wxGridBagSizer* m_grid_bag_sizer;
     wxStaticLine* m_static_line;
+    wxStaticText* m_staticTextLeft;
+    wxStaticText* m_staticTextRight;
 
 // ************* End of generated code ***********
 // DO NOT EDIT THIS COMMENT BLOCK!
@@ -46,17 +52,24 @@ private:
 // if the code for this class is re-generated.
 //
 // ***********************************************
-    // ***********************************************
+
+// Following code edited manually
 
 public:
     ~XrcCompare();
 
-    bool DoCreate(wxWindow* parent, Node* node_form);
+    // Call this instead of Create() -- it will directly call Create() and do a bunch of
+    // other initialization related to turnig it into a comparison dialog.
+    //
+    // true for compare_import will compare against a currently imported XRC file.
+    bool DoCreate(wxWindow* parent, Node* node_form, bool compare_import = false);
 
 protected:
     bool InitXrc(Node* form_node);
+    bool InitImport(Node* form_node);
 
 private:
     wxString m_res_name;
     bool m_created { false };
+    bool m_compare_import { false };
 };

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -7785,6 +7785,9 @@
         title="Test XRC"
         minimum_size="1200,1250"
         base_file="..\internal\xrcpreview"
+        header_preamble="class Node;"
+        class_members="&quot;Node* m_form_node;&quot;"
+        class_methods="&quot;void Generate(Node* form_node = nullptr);&quot;"
         derived_class_name="XrcPreview"
         derived_file="xrcpreview"
         use_derived_class="0"
@@ -7852,6 +7855,12 @@
                 bitmap="Art;wxART_FILE_SAVE_AS|wxART_MENU"
                 tooltip="Load current contents into XML, then Export to a file of your choice"
                 wxEVT_BUTTON="OnExport" />
+              <node
+                class="wxButton"
+                label="Co&amp;mpare..."
+                var_name="m_btnCompare"
+                tooltip="Only valid if an XRC was imported. Compares original and generated."
+                wxEVT_BUTTON="OnCompare" />
               <node
                 class="wxButton"
                 class_access="none"

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -7216,9 +7216,8 @@
           borders="wxTOP|wxRIGHT|wxLEFT">
           <node
             class="wxStaticText"
-            class_access="none"
             label="C++ Generated"
-            var_name="staticText"
+            var_name="m_staticTextLeft"
             font="default family,9,,,underlined"
             foreground_colour="255,0,0" />
         </node>
@@ -7239,9 +7238,8 @@
           column="2">
           <node
             class="wxStaticText"
-            class_access="none"
             label="XRC Generated"
-            var_name="staticText_2"
+            var_name="m_staticTextRight"
             font="default family,9,,,underlined"
             foreground_colour="0,128,0"
             column="2" />

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -7840,11 +7840,11 @@
                 wxEVT_BUTTON="OnPreview" />
               <node
                 class="wxButton"
-                label="&amp;Import"
+                label="&amp;Verify"
                 var_name="m_btn_import"
                 bitmap="SVG;import.svg;[16,16]"
                 tooltip="Verify that the current contents can be imported"
-                wxEVT_BUTTON="OnImport" />
+                wxEVT_BUTTON="OnVerify" />
               <node
                 class="wxButton"
                 label="&amp;Export..."
@@ -8393,6 +8393,11 @@
           class="wxBoxSizer"
           orientation="wxVERTICAL"
           var_name="dlg_sizer">
+          <node
+            class="wxStaticText"
+            class_access="none"
+            label="&amp;List of XRC previewable forms:"
+            var_name="static_text" />
           <node
             class="wxListBox"
             minimum_size="200,175"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR overhauls the `Test XRC` dialog. The Generate button now supports any form that we can display after converting it to XRC (previously, only a dialog could be displayed). The Import button was changed to Verify, since all it does is verify that the generated/hand edited XML is valid. If the project was created by Importing an XRC file, then a new Compare button shows a side-by-side comparison of the Imported XRC versus the Generated XRC. This should make it easy to spot problems in either importing or generating XRC files.