### PR TITLE
Remove conditional for std::format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You will need a C++20 compliant compiler to build **wxUiEditor**. To build using
     cmake --build build --config Release --target wxUiEditor
 ```
 
-For Unix builds, you currently need a minimum of gcc 11.4 to be able to compile the sources. After building, you can can change to the build/ directory and run `cpack -G DEB -C Release` or `cpack -G RPM -C Release` to create a Ubuntu or Fedora package.
+For Unix builds, you currently need a minimum of gcc 13.1 or clang 15 to be able to compile the sources. Note that unlike gcc, clang requires libc++17 to be installed (ships with Ubuntu 24.04). After building, you can can change to the build/ directory and run `cpack -G DEB -C Release` or `cpack -G RPM -C Release` to create a Ubuntu or Fedora package.
 
 See [Developer notes](docs/DEV_NOTES.md) if you want information about contributing to the project.
 

--- a/src/import/import_xml.cpp
+++ b/src/import/import_xml.cpp
@@ -7,6 +7,8 @@
 
 #include <frozen/map.h>
 
+#include <format>
+
 #include "import_xml.h"
 
 #include "base_generator.h"  // BaseGenerator -- Base Generator class
@@ -140,14 +142,8 @@ std::optional<pugi::xml_document> ImportXML::LoadDocFile(const tt_string& file)
 
     if (auto result = doc.load_file_string(file); !result)
     {
-#if __has_include(<format>)
         std::string msg = std::format(std::locale(""), "Parsing error: {}\n Line: {}, Column: {}, Offset: {:L}\n",
                                       result.description(), result.line, result.column, result.offset);
-#else
-        wxString msg;
-        msg.Format("Parsing error: %s\n Line: %d, Column: %d, Offset: %ld\n", result.detailed_msg, result.line,
-                   result.column, result.offset);
-#endif
         wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
         return {};
     }

--- a/src/internal/xrcpreview_handlers.cpp
+++ b/src/internal/xrcpreview_handlers.cpp
@@ -7,6 +7,8 @@
 
 #include "xrcpreview.h"
 
+#include <format>
+
 #include <wx/filedlg.h>     // wxFileDialog base header
 #include <wx/mstream.h>     // Memory stream classes
 #include <wx/xml/xml.h>     // wxXmlDocument - XML parser & data holder class
@@ -172,14 +174,8 @@ void XrcPreview::OnVerify(wxCommandEvent& WXUNUSED(event))
         auto xrc_text = m_scintilla->GetText().utf8_string();
         if (auto result = doc.load_string(xrc_text); !result)
         {
-#if __has_include(<format>)
             std::string msg = std::format(std::locale(""), "Parsing error: {}\n Line: {}, Column: {}, Offset: {:L}\n",
                                           result.description(), result.line, result.column, result.offset);
-#else
-            wxString msg;
-            msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", result.detailed_msg, result.line,
-                       result.column, result.offset);
-#endif
             wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
 
             return;
@@ -211,14 +207,8 @@ void XrcPreview::OnExport(wxCommandEvent& WXUNUSED(event))
         pugi::xml_document doc;
         if (auto result = doc.load_string(xrc_text); !result)
         {
-#if __has_include(<format>)
             std::string msg = std::format(std::locale(""), "Parsing error: {}\n Line: {}, Column: {}, Offset: {:L}\n",
                                           result.description(), result.line, result.column, result.offset);
-#else
-            wxString msg;
-            msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", result.detailed_msg, result.line,
-                       result.column, result.offset);
-#endif
             wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
 
             return;
@@ -240,14 +230,8 @@ void XrcPreview::OnDuplicate(wxCommandEvent& WXUNUSED(event))
         auto xrc_text = m_scintilla->GetText().utf8_string();
         if (auto result = doc.load_string(xrc_text); !result)
         {
-#if __has_include(<format>)
             std::string msg = std::format(std::locale(""), "Parsing error: {}\n Line: {}, Column: {}, Offset: {:L}\n",
                                           result.description(), result.line, result.column, result.offset);
-#else
-            wxString msg;
-            msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", result.detailed_msg, result.line,
-                       result.column, result.offset);
-#endif
             wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
 
             return;

--- a/src/previews.cpp
+++ b/src/previews.cpp
@@ -7,9 +7,7 @@
 
 #include "previews.h"
 
-#if __has_include(<format>)
-    #include <format>
-#endif
+#include <format>
 
 #include <wx/aui/auibook.h>  // wxaui: wx advanced user interface - notebook
 #include <wx/mstream.h>      // Memory stream classes
@@ -224,14 +222,8 @@ void PreviewXrc(std::string& doc_str, GenEnum::GenName gen_name, Node* form_node
     pugi::xml_document doc;
     if (auto result = doc.load_string(doc_str.c_str()); !result)
     {
-#if __has_include(<format>)
         std::string msg = std::format(std::locale(""), "Parsing error: {}\n Line: {}, Column: {}, Offset: {:L}\n",
                                       result.description(), result.line, result.column, result.offset);
-#else
-        wxString msg;
-        msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", result.detailed_msg, result.line,
-                   result.column, result.offset);
-#endif
         wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
         return;
     }
@@ -264,15 +256,9 @@ void PreviewXrc(std::string& doc_str, GenEnum::GenName gen_name, Node* form_node
         // the XML string and would would have exited this function if there were any errors.
         if (auto result = xmlDoc->Load(stream, wxXMLDOC_NONE, &err_details); !result)
         {
-#if __has_include(<format>)
             std::string msg =
                 std::format(std::locale(""), "Parsing error: {} at line: {}, column: {}, offset: {:L}\n",
                             err_details.message.ToStdString(), err_details.line, err_details.column, err_details.offset);
-#else
-            wxString msg;
-            msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\n", err_details.message, err_details.line,
-                       err_details.column, err_details.offset);
-#endif
             wxMessageDialog(wxGetMainFrame()->getWindow(), msg, "Parsing Error", wxOK | wxICON_ERROR).ShowModal();
             return;
         }

--- a/src/project/data_handler.cpp
+++ b/src/project/data_handler.cpp
@@ -5,10 +5,6 @@
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#if __has_include(<format>)
-    #include <format>
-#endif
-
 #include "data_handler.h"
 
 #include <wx/utils.h>  // For wxBusyCursor
@@ -29,8 +25,6 @@
 #include "project_handler.h"  // ProjectHandler class
 #include "utils.h"            // Miscellaneous utility functions
 #include "write_code.h"       // Write code to Scintilla or file
-
-#include "../generate/gen_data_list.h"  // DataGenerator -- Data List generator
 
 // Normally, wxMemoryInputStream inputStream, wxZlibOutputStream outputStream
 bool CopyStreamData(wxInputStream* inputStream, wxOutputStream* outputStream, size_t compressed_size);

--- a/src/pugixml/pugixml.cpp
+++ b/src/pugixml/pugixml.cpp
@@ -49,9 +49,7 @@ using namespace pugi;
 #include <stdlib.h>
 #include <string.h>
 
-#if __has_include(<format>)
-    #include <format>
-#endif
+#include <format>
 
 #include <cstring>
 #include <fstream>
@@ -6819,18 +6817,9 @@ namespace pugi
                 if (line_offset >= result.offset)
                 {
                     result.column = line_offset - result.offset;
-#if __has_include(<format>)
-                    // The advantage of std::format is that it will format the line number
-                    // with locale-specific separators
                     result.detailed_msg =
                         std::format(std::locale(""), "Parsing error: {} at line: {}, column: {}, offset: {:L}",
                                     result.description(), result.line, result.column, result.offset);
-#else
-                    wxString msg;
-                    msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld", result.description(), result.line,
-                               result.column, result.offset);
-                    result.detailed_msg = msg.utf8_string();
-#endif
 
                     break;
                 }
@@ -6885,19 +6874,11 @@ namespace pugi
                     if (line_offset >= result.offset)
                     {
                         result.column = line_offset - result.offset;
-#if __has_include(<format>)
                         // The advantage of std::format is that it will format the line number
                         // with locale-specific separators
                         result.detailed_msg = std::format(
                             std::locale(""), "Parsing error: {} at line: {}, column: {}, offset: {:L}\nFile: {}\n",
                             result.description(), result.line, result.column, result.offset, path.c_str());
-#else
-                        wxString msg;
-                        msg.Format("Parsing error: %s at line: %d, column: %d, offset: %ld\nFile: %s\n",
-                                   result.description(), result.line, result.column, result.offset, path.c_str());
-                        result.detailed_msg = msg.utf8_string();
-#endif
-
                         break;
                     }
                 }


### PR DESCRIPTION
This now requires Visual Studio 16.10 or gcc 13.1.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR removes the conditionals around `std::format`. That means that gcc must now be 13.1 or later, and Visual Studio must be 16.10 or later in order to compile.

Note that github actions use Ubuntu 24.04 which comes with gcc 13.3 -- so this has now impact on Daily builds.

The main advantage for wxUiEditor to use std::format is that it will format numbers with locale-specific separators. E.g., `1024` gets formatted as `1,024`.