### PR TITLE
Fix code generation that double-scaled SVG images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - Fixed inconsistent generation of wxScrolledWindow versus wxScrolled<wxPanel> -- wxScrolledWindow is now always used.
 - XRC combine_all_forms will now generates a single XRC file containing all forms
 - wxTreebook correctly utilizes images in nested books -- fixed for all generated languages
+- Code generation for SVG images no longer scale the image twice
 
 ## [Released (1.2.1)]
 

--- a/src/generate/image_gen.cpp
+++ b/src/generate/image_gen.cpp
@@ -294,11 +294,17 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
         {
             // The function name includes the size, but we need to replace the size with a DIP version.
             function_name.erase_from("(");
-            code.Eol().Tab().Str(function_name).Str("(FromDIP(").itoa(svg_size.x).Str("), FromDIP(").itoa(svg_size.y);
-            code += "))";
+            code.Eol().Tab().Str(function_name);
             if (get_bitmap)
             {
+                code.Str("(FromDIP(").itoa(svg_size.x).Str("), FromDIP(").itoa(svg_size.y) += "))";
                 code.Str(".").Add("GetBitmap(").Add("wxDefaultSize)");
+            }
+            else
+            {
+                // For SVG files, just provide the default size, and wxWidgets will scale it before
+                // converting it to a bitmap for rendering.
+                code.Str("(").itoa(svg_size.x).Str(", ").itoa(svg_size.y) += ")";
             }
             return;
         }
@@ -324,7 +330,7 @@ static void GenerateSVGBundle(Code& code, const tt_string_vector& parts, bool ge
         }
         else
         {
-            code.Add("FromDIP(wxSize(").itoa(svg_size.x).Comma().itoa(svg_size.y) += ")))";
+            code.Add("wxSize(").itoa(svg_size.x).Comma().itoa(svg_size.y) += "))";
         }
         return;
     }

--- a/src/internal/msgframe_base.cpp
+++ b/src/internal/msgframe_base.cpp
@@ -67,14 +67,14 @@ bool MsgFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& title
 
     m_tool_bar = CreateToolBar();
     m_tool_bar->AddTool(wxID_SAVEAS, wxEmptyString,
-        wxue_img::bundle_saveas_svg(FromDIP(24), FromDIP(24)));
+        wxue_img::bundle_saveas_svg(24, 24));
 
     m_tool_bar->AddSeparator();
     auto* tool_item_clear = m_tool_bar->AddTool(wxID_ANY, wxEmptyString,
-        wxue_img::bundle_clear_svg(FromDIP(24), FromDIP(24)));
+        wxue_img::bundle_clear_svg(24, 24));
 
     m_tool_bar->AddTool(id_hide, wxEmptyString,
-        wxue_img::bundle_hide_svg(FromDIP(24), FromDIP(24)));
+        wxue_img::bundle_hide_svg(24, 24));
 
     m_tool_bar->Realize();
 

--- a/src/panels/doc_view.cpp
+++ b/src/panels/doc_view.cpp
@@ -36,13 +36,13 @@ bool DocViewPanel::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos, c
 
     m_toolBar->AddSeparator();
     m_toolBar->AddTool(ID_CPLUS, "C++",
-        wxue_img::bundle_cpp_logo_svg(FromDIP(16), FromDIP(16)), wxEmptyString, wxITEM_RADIO);
+        wxue_img::bundle_cpp_logo_svg(16, 16), wxEmptyString, wxITEM_RADIO);
 
     m_toolBar->AddTool(ID_PYTHON, "Python",
-        wxue_img::bundle_python_logo_only_svg(FromDIP(16), FromDIP(16)), wxEmptyString, wxITEM_RADIO);
+        wxue_img::bundle_python_logo_only_svg(16, 16), wxEmptyString, wxITEM_RADIO);
 
     m_toolBar->AddTool(ID_RUBY, "Ruby",
-        wxue_img::bundle_ruby_logo_svg(FromDIP(16), FromDIP(16)), wxEmptyString, wxITEM_RADIO);
+        wxue_img::bundle_ruby_logo_svg(16, 16), wxEmptyString, wxITEM_RADIO);
 
     m_toolBar->Realize();
     m_parent_sizer->Add(m_toolBar, wxSizerFlags().Expand().Border(wxALL));

--- a/src/panels/nav_toolbar.cpp
+++ b/src/panels/nav_toolbar.cpp
@@ -54,15 +54,15 @@ NavToolbar::NavToolbar(wxWindow* parent, wxWindowID id, const wxPoint& pos, cons
     AddStretchableSpace();
 
     AddTool(id_NavCollExpand, wxEmptyString,
-        wxueBundleSVG(wxue_img::nav_coll_expand_svg, 291, 562, FromDIP(wxSize(16, 16))), wxNullBitmap, wxITEM_NORMAL,
+        wxueBundleSVG(wxue_img::nav_coll_expand_svg, 291, 562, wxSize(16, 16)), wxNullBitmap, wxITEM_NORMAL,
         "Collapse siblings, expand children", "Expand selected item, collapse all other items at the same level");
 
     AddTool(id_NavExpand, wxEmptyString,
-        wxueBundleSVG(wxue_img::nav_expand_svg, 270, 494, FromDIP(wxSize(16, 16))), wxNullBitmap, wxITEM_NORMAL,
-        "Expand all children", "Expand selected item and all of it\'s sub-items");
+        wxueBundleSVG(wxue_img::nav_expand_svg, 270, 494, wxSize(16, 16)), wxNullBitmap, wxITEM_NORMAL, "Expand all children",
+        "Expand selected item and all of it\'s sub-items");
 
     AddTool(id_NavCollapse, wxEmptyString,
-        wxueBundleSVG(wxue_img::nav_collapse_svg, 214, 340, FromDIP(wxSize(16, 16))), wxNullBitmap, wxITEM_NORMAL,
+        wxueBundleSVG(wxue_img::nav_collapse_svg, 214, 340, wxSize(16, 16)), wxNullBitmap, wxITEM_NORMAL,
         "Collapse all siblings", "Collapse selected item and all items at the same level");
 
     AddSeparator();

--- a/src/wxui/mainframe_base.cpp
+++ b/src/wxui/mainframe_base.cpp
@@ -74,20 +74,20 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(id_DifferentProject, "Different Project...",
-        wxue_img::bundle_wxUiEditor_svg(FromDIP(24), FromDIP(24)), "Different Project... (Ctrl+D)");
+        wxue_img::bundle_wxUiEditor_svg(24, 24), "Different Project... (Ctrl+D)");
 
     m_toolbar->AddTool(wxID_SAVE, "Save",
-        wxueBundleSVG(wxue_img::save_svg, 1064, 2928, FromDIP(wxSize(24, 24))), "Save current project");
+        wxueBundleSVG(wxue_img::save_svg, 1064, 2928, wxSize(24, 24)), "Save current project");
 
     m_toolbar->AddTool(id_GenerateCode, "Generate...",
-        wxue_img::bundle_generate_svg(FromDIP(24), FromDIP(24)), "Generate code...");
+        wxue_img::bundle_generate_svg(24, 24), "Generate code...");
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(wxID_UNDO, wxEmptyString,
-        wxue_img::bundle_undo_svg(FromDIP(24), FromDIP(24)), "Undo");
+        wxue_img::bundle_undo_svg(24, 24), "Undo");
 
     m_toolbar->AddTool(wxID_REDO, wxEmptyString,
-        wxue_img::bundle_redo_svg(FromDIP(24), FromDIP(24)), "Redo");
+        wxue_img::bundle_redo_svg(24, 24), "Redo");
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(wxID_CUT, wxEmptyString, wxArtProvider::GetBitmapBundle(wxART_CUT, wxART_TOOLBAR), "Cut");
@@ -101,52 +101,50 @@ bool MainFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& titl
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(id_AlignLeft, wxEmptyString,
-        wxue_img::bundle_alignleft_svg(FromDIP(24), FromDIP(24)), "Align left", wxITEM_CHECK);
+        wxue_img::bundle_alignleft_svg(24, 24), "Align left", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_AlignCenterHorizontal, wxEmptyString,
-        wxue_img::bundle_aligncenter_svg(FromDIP(24), FromDIP(24)), "Center horizontally", wxITEM_CHECK);
+        wxue_img::bundle_aligncenter_svg(24, 24), "Center horizontally", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_AlignRight, wxEmptyString,
-        wxue_img::bundle_alignright_svg(FromDIP(24), FromDIP(24)), "Align right", wxITEM_CHECK);
+        wxue_img::bundle_alignright_svg(24, 24), "Align right", wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(id_AlignTop, wxEmptyString,
-        wxue_img::bundle_aligntop_svg(FromDIP(24), FromDIP(24)), "Align top", wxITEM_CHECK);
+        wxue_img::bundle_aligntop_svg(24, 24), "Align top", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_AlignCenterVertical, wxEmptyString,
-        wxue_img::bundle_alignvertcenter_svg(FromDIP(24), FromDIP(24)), "Center vertically", wxITEM_CHECK);
+        wxue_img::bundle_alignvertcenter_svg(24, 24), "Center vertically", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_AlignBottom, wxEmptyString,
-        wxue_img::bundle_alignbottom_svg(FromDIP(24), FromDIP(24)), "Align bottom", wxITEM_CHECK);
+        wxue_img::bundle_alignbottom_svg(24, 24), "Align bottom", wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(id_BorderLeft, wxEmptyString,
-        wxue_img::bundle_left_svg(FromDIP(24), FromDIP(24)), "Left border", wxITEM_CHECK);
+        wxue_img::bundle_left_svg(24, 24), "Left border", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_BorderRight, wxEmptyString,
-        wxue_img::bundle_right_svg(FromDIP(24), FromDIP(24)), "Right border", wxITEM_CHECK);
+        wxue_img::bundle_right_svg(24, 24), "Right border", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_BorderTop, wxEmptyString,
-        wxue_img::bundle_top_svg(FromDIP(24), FromDIP(24)), "Top border", wxITEM_CHECK);
+        wxue_img::bundle_top_svg(24, 24), "Top border", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_BorderBottom, wxEmptyString,
-        wxue_img::bundle_bottom_svg(FromDIP(24), FromDIP(24)), "Bottom border", wxITEM_CHECK);
+        wxue_img::bundle_bottom_svg(24, 24), "Bottom border", wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(id_Expand, wxEmptyString,
-        wxueBundleSVG(wxue_img::expand_svg, 648, 1215, FromDIP(wxSize(24, 24))), "Expand to fill the space", wxITEM_CHECK);
+        wxueBundleSVG(wxue_img::expand_svg, 648, 1215, wxSize(24, 24)), "Expand to fill the space", wxITEM_CHECK);
 
     m_toolbar->AddSeparator();
     m_toolbar->AddTool(id_ShowHidden, wxEmptyString,
-        wxueBundleSVG(wxue_img::hidden_svg, 1993, 5117, FromDIP(wxSize(24, 24))), "Show hidden controls in Mockup panel",
-        wxITEM_CHECK);
+        wxueBundleSVG(wxue_img::hidden_svg, 1993, 5117, wxSize(24, 24)), "Show hidden controls in Mockup panel", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_Magnify, wxEmptyString,
-        wxueBundleSVG(wxue_img::magnify_svg, 4117, 13046, FromDIP(wxSize(24, 24))), "Magnify the size of the Mockup window",
-        wxITEM_CHECK);
+        wxueBundleSVG(wxue_img::magnify_svg, 4117, 13046, wxSize(24, 24)), "Magnify the size of the Mockup window", wxITEM_CHECK);
 
     m_toolbar->AddTool(id_PreviewForm, "Preview Form...",
-        wxue_img::bundle_xrc_preview_svg(FromDIP(24), FromDIP(24)), "Preview form using XRC and/or C++", wxITEM_CHECK);
+        wxue_img::bundle_xrc_preview_svg(24, 24), "Preview form using XRC and/or C++", wxITEM_CHECK);
 
     m_toolbar->Realize();
     m_mainframe_sizer->Add(m_toolbar, wxSizerFlags().Expand());


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes code generation for SVG bitmap bundles which were being scaled twice (once by the generated code, and again by wxWidgets). See #1628.

Note that this fixes the extra-large regular toolbar icons in wxUiEditor's UI so that they are now the same size as the ribbon icons (which is what they should be).

Closes #1628
