### PR TITLE
Add coverage and fix C++ code generation for form version of bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - XRC combine_all_forms will now generates a single XRC file containing all forms
 - wxTreebook correctly utilizes images in nested books -- fixed for all generated languages
 - Code generation for SVG images no longer scale the image twice
+- Fix C++ code generation for the form version of bars (toolbars, ribbonbars, menubars)
 
 ## [Released (1.2.1)]
 

--- a/codegen_test/codegen_test.wxui
+++ b/codegen_test/codegen_test.wxui
@@ -2359,5 +2359,76 @@
           flags="wxEXPAND" />
       </node>
     </node>
+    <node
+      class="folder"
+      label="Special Forms">
+      <node
+        class="ToolBar"
+        base_file="form_toolbar">
+        <node
+          class="tool"
+          bitmap="SVG;face-smile.svg;[24,24]"
+          label="" />
+      </node>
+      <node
+        class="AuiToolBar"
+        base_file="form_aui_toolbar">
+        <node
+          class="auitool"
+          bitmap="SVG;face-smile.svg;[24,24]"
+          label="" />
+      </node>
+      <node
+        class="RibbonBar"
+        class_name="RibbonBarTool"
+        base_file="form_ribbonbar_tool"
+        derived_class_name="RibbonBarToolDerived"
+        derived_file="ribbonbartool_derived">
+        <node
+          class="wxRibbonPage"
+          label="Page 1">
+          <node
+            class="wxRibbonPanel"
+            label="Page 1, panel 1">
+            <node
+              class="wxRibbonToolBar">
+              <node
+                class="ribbonTool"
+                bitmap="SVG;face-smile.svg;[24,24]"
+                id="tool1" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node
+        class="RibbonBar"
+        class_name="RibbonBarGallery"
+        base_file="form_ribbonbar_gallery">
+        <node
+          class="wxRibbonPage"
+          label="Page 1">
+          <node
+            class="wxRibbonPanel"
+            label="Page 1, panel 1">
+            <node
+              class="wxRibbonGallery">
+              <node
+                class="ribbonGalleryItem"
+                bitmap="SVG;art/face-smile.svg;[24,24]" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node
+        class="MenuBar"
+        base_file="form_menubar">
+        <node
+          class="wxMenu">
+          <node
+            class="wxMenuItem"
+            bitmap="SVG;face-smile.svg;[24,24]" />
+        </node>
+      </node>
+    </node>
   </node>
 </wxUiEditorData>

--- a/codegen_test/generated/codegen.cmake
+++ b/codegen_test/generated/codegen.cmake
@@ -13,6 +13,11 @@ set (wxue_generated_code
     ${CMAKE_CURRENT_LIST_DIR}/wizard.cpp
 
     # Base classes
+    ${CMAKE_CURRENT_LIST_DIR}/form_aui_toolbar.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/form_menubar.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/form_ribbonbar_gallery.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/form_ribbonbar_tool.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/form_toolbar.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mainframe_base.cpp
     ${CMAKE_CURRENT_LIST_DIR}/maintestdialog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tools_dlg.cpp

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -790,7 +790,7 @@ namespace GenEnum
         gen_PanelForm,
         gen_PopupMenu,
         gen_Project,
-        gen_RibbonBar,
+        gen_RibbonBar,  // form version of wxRibbonBar
         gen_StaticCheckboxBoxSizer,
         gen_StaticRadioBtnBoxSizer,
         gen_TextSizer,

--- a/src/generate/code.cpp
+++ b/src/generate/code.cpp
@@ -1192,6 +1192,8 @@ static constexpr GenType s_GenParentTypes[] = {
     type_notebook,
     type_panel,
     type_propgridpage,
+    type_ribbonbar,
+    type_ribbonbar_form,
     type_ribbonpanel,
     type_simplebook,
     type_splitter,

--- a/src/generate/gen_cpp.cpp
+++ b/src/generate/gen_cpp.cpp
@@ -433,12 +433,16 @@ void CppCodeGenerator::GenCppImageFunctions()
     }
     else if (m_NeedImageFunction || m_NeedHeaderFunction || m_NeedSVGFunction)
     {
-        m_source->writeLine("\n#include <wx/mstream.h>  // memory stream classes", indent::none);
+        m_source->writeLine();
+        if (m_NeedSVGFunction)
+            m_source->writeLine("#include <wx/bmpbndl.h>  // wxBitmapBundle class", indent::none);
+        m_source->writeLine("#include <wx/mstream.h>  // memory stream classes", indent::none);
     }
 
     if (m_NeedSVGFunction)
     {
         m_source->writeLine("#include <wx/zstream.h>  // zlib stream classes", indent::none);
+
         m_source->writeLine();
         m_source->writeLine("#include <memory>  // for std::make_unique", indent::none);
     }

--- a/src/generate/gen_ribbon_page.cpp
+++ b/src/generate/gen_ribbon_page.cpp
@@ -32,7 +32,7 @@ wxObject* RibbonPageGenerator::CreateMockup(Node* node, wxObject* parent)
 bool RibbonPageGenerator::ConstructionCode(Code& code)
 {
     code.AddAuto().NodeName();
-    code.CreateClass().ParentName().Comma().as_string(prop_id);
+    code.CreateClass().ValidParentName().Comma().as_string(prop_id);
     code.Comma().QuotedString(prop_label);
     if (code.hasValue(prop_bitmap))
     {

--- a/src/generate/menu_widgets.cpp
+++ b/src/generate/menu_widgets.cpp
@@ -310,7 +310,7 @@ bool MenuBarFormGenerator::ConstructionCode(Code& code)
 
 bool MenuBarFormGenerator::HeaderCode(Code& code)
 {
-    code.NodeName().Str("long style = ").Style().EndFunction();
+    code.NodeName().Str("(long style = ").Style().EndFunction();
 
     return true;
 }

--- a/src/newdialogs/new_ribbon.cpp
+++ b/src/newdialogs/new_ribbon.cpp
@@ -128,7 +128,7 @@ bool NewRibbon::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 /////////////////// Non-generated Copyright/License Info ////////////////////
 // Purpose:   Dialog for creating a new wxRibbonBar
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -140,6 +140,7 @@ bool NewRibbon::Create(wxWindow* parent, wxWindowID id, const wxString& title,
 #include "node_creator.h"            // NodeCreator -- Class used to create nodes
 #include "project_handler.h"         // ProjectHandler class
 #include "undo_cmds.h"               // InsertNodeAction -- Undoable command classes derived from UndoAction
+#include "utils.h"                   // Miscellaneous utilities
 
 void NewRibbon::OnInit(wxInitDialogEvent& event)
 {
@@ -191,6 +192,7 @@ void NewRibbon::createNode()
             ribbon_panel->adoptChild(tool_bar);
             auto tool = NodeCreation.createNode(gen_ribbonTool, tool_bar.get()).first;
             tool_bar->adoptChild(tool);
+            SetUniqueRibbonToolID(tool.get());
         }
         else if (m_panel_type == "Button")
         {

--- a/src/nodes/tool_creator.cpp
+++ b/src/nodes/tool_creator.cpp
@@ -5,6 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
+#include "gen_enums.h"
 #include "node.h"
 
 #include "../panels/nav_panel.h"     // NavigationPanel -- Navigation Panel
@@ -61,10 +62,10 @@ static void PostProcessPanel(Node* panel_node)
     }
 }
 
-static void SetUniqueRibbonToolID(Node* node)
+void SetUniqueRibbonToolID(Node* node)
 {
     auto* bar_parent = node->getParent();
-    while (bar_parent && !bar_parent->isGen(gen_wxRibbonBar))
+    while (bar_parent && (!bar_parent->isGen(gen_wxRibbonBar) && !bar_parent->isGen(GenEnum::gen_RibbonBar)))
     {
         bar_parent = bar_parent->getParent();
     }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -98,3 +98,6 @@ ClassOverrideType GetClassOverrideType(Node* node);
 // This will set the lexer and colors taking into account the user's preferences for dark
 // mode, and specific language colors
 void SetStcColors(wxStyledTextCtrl* stc, GenLang language, bool set_lexer = true, bool add_keywords = true);
+
+// Call this after creating a wxRibbonBar tool in order to ensure that it has a unique ID/
+void SetUniqueRibbonToolID(Node* node);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Neither `codegen_test` nor the `wxUiTesting` repository cover testing of form versions of bars (toolbars, ribbonbars, menubars). As code generation has evolved, code generation errors have crept in without being detected due to lack of coverage. This PR adds coverage to codegen_test, and fixes the various bugs that were uncovered.
