### PR TITLE
Change C++ trivial constructor code generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - wxRuby code will now call create_std_dialog_button_sizer() and create_separated_sizer() to create a wxStdDialogButtonSizer in a Dialog.
 - wxPython code will now call CreateStdDialogButtonSizer() and CreateSeparatedSizer to create a wxStdDialogButtonSizer in a Dialog.
 - When a stock id is selected for a control with a _label_ property, and the label text has not been changed since the control was created, the label will be cleared to enable the automatic creation of the label text by the wxWidgets stock id.
+- C++ trivial constructors now use `= default;' instead of `{}`
 
 ### Fixed
 - Fixed generation of event handlers in C++ derived classes.

--- a/src/generate/gen_frame_common.cpp
+++ b/src/generate/gen_frame_common.cpp
@@ -439,7 +439,7 @@ bool FrameCommon::AfterChildrenCode(Code& code, int /* frame_type */)
 bool FrameCommon::HeaderCode(Code& code, int frame_type)
 {
     auto* node = code.node();
-    code.NodeName() += "() {}";
+    code.NodeName() += "() = default;";
     code.Eol().NodeName().Str("(");
     if (frame_type == frame_sdi_doc || frame_type == frame_mdi_doc)
     {

--- a/src/internal/msgframe_base.h
+++ b/src/internal/msgframe_base.h
@@ -36,7 +36,7 @@ public:
         id_warning_msgs
     };
 
-    MsgFrameBase() {}
+    MsgFrameBase() = default;
     MsgFrameBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = "wxUiEditor Messages",
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_FRAME_STYLE|wxTAB_TRAVERSAL, const wxString &name = wxFrameNameStr)

--- a/src/wxui/mainframe_base.h
+++ b/src/wxui/mainframe_base.h
@@ -35,7 +35,7 @@ namespace wxue_img
 class MainFrameBase : public wxFrame
 {
 public:
-    MainFrameBase() {}
+    MainFrameBase() = default;
     MainFrameBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos =
         wxDefaultPosition, const wxSize& size = wxSize(1000, 1000), long style = wxDEFAULT_FRAME_STYLE|wxTAB_TRAVERSAL,
         const wxString &name = wxFrameNameStr)


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes C++ trivial constructors from `{}` to `= default;`. Note the underlying assumption that anyone using wxUiEditor to generate C++ code will be using C++11.

Closes #1643