### PR TITLE
Add support for WEBP graphics file format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Added support for wxPopupWindow as a form
 - Any comments you add to a control's `var_comment` property can optionally be written to any generated XRC file (`xrc_add_var_comments` in XRC Settings in the Project file)
 - C++ `use_derived_class` option has a new `pure_virtual_functions` option that will make all non-lambda event handlers pure virtual in the generated base class.
+- Add WEBP support if using wxWidgets 3.3.x
 
 ### Changed
 

--- a/src/customprops/img_string_prop.cpp
+++ b/src/customprops/img_string_prop.cpp
@@ -44,9 +44,41 @@ bool ImageDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid, wxPGProperty* WX
         }
         else
         {
+#ifndef __WXOSX__
             pattern = "Bitmap "
-                      "files|*.png;*.bmp;*.ico;*.xpm|PNG|*.png|XPM|*.xpm|Tiff|*.tif;*.tiff|Bitmaps|"
+                      "files|*.png;*.bmp;*.ico;*.webp;*.xpm|PNG|*.png|Tiff|*.tif;*.tiff|WEBP|*."
+                      "webp|XPM|*.xpm|Bitmaps|"
                       "*.bmp|Icon|*.ico||";
+#else
+            pattern =
+                "Bitmap "
+                "files|*.png;*.bmp;*.ico;*.webp;*.xpm|PNG|*.png|WEBP|*.webp|XPM|*.xpm|Bitmaps|"
+                "*.bmp|Icon|*.ico||";
+#endif
+            bool remove_webp = false;
+            if (Project.getCodePreference() == GEN_LANG_CPLUSPLUS)
+            {
+                // WEBP was added to wxWidgets 3.3.0 -- earlier versions don't support it.
+                remove_webp = (Project.getLangVersion(GEN_LANG_CPLUSPLUS) < 30300);
+            }
+            else if (Project.getCodePreference() == GEN_LANG_PYTHON)
+            {
+                // REVIEW: [Randalphwa - 08-31-2025] Currently, the wxPython dev has stated
+                // wxWidgets 3.3.x will not be supported -- he is waiting for the stable release
+                // (3.4.x). I'm guessing that the version will be wxPython 4.4.x, but until it gets
+                // released, that's uncertain.
+                remove_webp = Project.getLangVersion(GEN_LANG_PYTHON) < 404000;
+            }
+
+            // REVIEW: [Randalphwa - 08-31-2025] wxRuby already supports 3.3.x, and I *think* wxPerl
+            // does as well, but the latter requires testing. If wxRust3 ever exists, it will be
+            // built on 3.3.x or later.
+
+            if (remove_webp)
+            {
+                pattern.Replace("|WEBP|*.webp", "", false);
+                pattern.Replace(";*.webp", "", false);
+            }
         }
 
         wxFileDialog dlg(propGrid->GetPanel(), "Open Image", wxFileName::GetCwd(), wxEmptyString,

--- a/src/generate/gen_base.cpp
+++ b/src/generate/gen_base.cpp
@@ -38,26 +38,29 @@ BaseCodeGenerator::BaseCodeGenerator(GenLang language, Node* form_node)
         ADD_TYPE(wxBITMAP_TYPE_ICO);
         ADD_TYPE(wxBITMAP_TYPE_CUR);
         ADD_TYPE(wxBITMAP_TYPE_XPM);
+        ADD_TYPE(wxBITMAP_TYPE_ICO_RESOURCE);
+#ifndef __WXOSX__
         ADD_TYPE(wxBITMAP_TYPE_TIFF);
+#endif
         ADD_TYPE(wxBITMAP_TYPE_GIF);
         ADD_TYPE(wxBITMAP_TYPE_PNG);
         ADD_TYPE(wxBITMAP_TYPE_JPEG);
         ADD_TYPE(wxBITMAP_TYPE_PNM);
-        ADD_TYPE(wxBITMAP_TYPE_PCX);
         ADD_TYPE(wxBITMAP_TYPE_ANI);
-        ADD_TYPE(wxBITMAP_TYPE_TGA);
+        ADD_TYPE(wxBITMAP_TYPE_WEBP);
 
         g_map_handlers[wxBITMAP_TYPE_ICO] = "wxICOHandler";
         g_map_handlers[wxBITMAP_TYPE_CUR] = "wxCURHandler";
         g_map_handlers[wxBITMAP_TYPE_XPM] = "wxXPMHandler";
+#ifndef __WXOSX__
         g_map_handlers[wxBITMAP_TYPE_TIFF] = "wxTIFFHandler";
+#endif
         g_map_handlers[wxBITMAP_TYPE_GIF] = "wxGIFHandler";
         g_map_handlers[wxBITMAP_TYPE_PNG] = "wxPNGHandler";
         g_map_handlers[wxBITMAP_TYPE_JPEG] = "wxJPEGHandler";
         g_map_handlers[wxBITMAP_TYPE_PNM] = "wxPNMHandler";
-        g_map_handlers[wxBITMAP_TYPE_PCX] = "wxPCXHandler";
         g_map_handlers[wxBITMAP_TYPE_ANI] = "wxANIHandler";
-        g_map_handlers[wxBITMAP_TYPE_TGA] = "wxTGAHandler";
+        g_map_handlers[wxBITMAP_TYPE_WEBP] = "wxWEBPHandler";
     }
 }
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This adds a WEBP handler to wxUiEditor, and for C++ with wxWidgets 3.3 as well as wxRuby3 (which already uses wxWidgets 3.3) it adds support for WEBP as an embedded image.

Closes #1467