### PR TITLE
Fix/enhance external and embedded wxWidgets documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - wxPython code will now call CreateStdDialogButtonSizer() and CreateSeparatedSizer to create a wxStdDialogButtonSizer in a Dialog.
 - When a stock id is selected for a control with a _label_ property, and the label text has not been changed since the control was created, the label will be cleared to enable the automatic creation of the label text by the wxWidgets stock id.
 - C++ trivial constructors now use `= default;' instead of `{}`
+- C++ documentation is now always displayed in your default browser since it requires you to verify that you are human and not a bot.
 
 ### Fixed
 - Fixed generation of event handlers in C++ derived classes.

--- a/src/internal/msgframe.cpp
+++ b/src/internal/msgframe.cpp
@@ -377,7 +377,7 @@ void MsgFrame::UpdateNodeInfo()
                 gen_label << "wxWidgets";
             }
             m_hyperlink->SetLabel(gen_label.make_wxString());
-            wxString url("https://docs.wxwidgets.org/trunk/");
+            wxString url("https://docs.wxwidgets.org/latest/");
             auto file = generator->GetHelpURL(cur_sel);
             if (file.size())
             {

--- a/src/internal/msgframe_base.cpp
+++ b/src/internal/msgframe_base.cpp
@@ -119,7 +119,7 @@ bool MsgFrameBase::Create(wxWindow* parent, wxWindowID id, const wxString& title
     static_box_2->Add(m_txt_memory, wxSizerFlags().Border(wxALL));
 
     m_hyperlink = new wxHyperlinkCtrl(static_box_2->GetStaticBox(), wxID_ANY, "wxWidgets Documentation",
-        "https://docs.wxwidgets.org/trunk/");
+        "https://docs.wxwidgets.org/latest/");
     static_box_2->Add(m_hyperlink, wxSizerFlags().Expand().Border(wxALL));
 
     node_sizer->Add(static_box_2, wxSizerFlags().Expand().Border(wxALL));

--- a/src/mainframe_events.cpp
+++ b/src/mainframe_events.cpp
@@ -5,6 +5,7 @@
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
+#include "pch.h"
 #include <wx/aboutdlg.h>     // declaration of wxAboutDialog class
 #include <wx/aui/auibook.h>  // wxaui: wx advanced user interface - notebook
 #include <wx/clipbrd.h>      // wxClipboad class and clipboard functions
@@ -186,6 +187,11 @@ void MainFrame::OnAuiNotebookPageChanged(wxAuiNotebookEvent&)
 
 void MainFrame::OnBrowseDocs(wxCommandEvent& WXUNUSED(event))
 {
+    wxString url;
+    url = (Project.getLangVersion(GEN_LANG_CPLUSPLUS) < 30300) ?
+              "https://docs.wxwidgets.org/3.2.8" :
+              "https://docs.wxwidgets.org/latest";
+
     if (m_selected_node)
     {
         if (auto generator = m_selected_node->getGenerator(); generator)
@@ -193,8 +199,7 @@ void MainFrame::OnBrowseDocs(wxCommandEvent& WXUNUSED(event))
             auto file = generator->GetHelpURL(m_selected_node.get());
             if (file.size())
             {
-                // wxString url("https://docs.wxwidgets.org/trunk/class");
-                wxString url("https://docs.wxwidgets.org/3.2.0/class");
+                url += "/class";
                 if (file.starts_with("group"))
                     url.RemoveLast(sizeof("class") - 1);
                 url << file.make_wxString();
@@ -203,8 +208,7 @@ void MainFrame::OnBrowseDocs(wxCommandEvent& WXUNUSED(event))
             }
         }
     }
-    // wxLaunchDefaultBrowser("https://docs.wxwidgets.org/trunk/");
-    wxLaunchDefaultBrowser("https://docs.wxwidgets.org/3.2.0/");
+    wxLaunchDefaultBrowser(url);
 }
 
 void MainFrame::OnBrowsePython(wxCommandEvent& WXUNUSED(event))

--- a/src/panels/doc_view.cpp
+++ b/src/panels/doc_view.cpp
@@ -125,6 +125,7 @@ void DocViewPanel::ActivatePage()
     wxCommandEvent dummy;
     switch (m_language)
     {
+        case GEN_LANG_PERL:
         case GEN_LANG_CPLUSPLUS:
             OnCPlus(dummy);
             break;

--- a/src/panels/doc_view.cpp
+++ b/src/panels/doc_view.cpp
@@ -74,7 +74,7 @@ bool DocViewPanel::Create(wxWindow* parent, wxWindowID id, const wxPoint& pos, c
 /////////////////// Non-generated Copyright/License Info ////////////////////
 // Purpose:   Panel for displaying docs in wxWebView
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2023-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -159,19 +159,38 @@ void DocViewPanel::OnCPlus(wxCommandEvent& /* event */)
         {
             if (auto file = gen->GetHelpURL(cur_sel); file.size())
             {
-                wxString url("https://docs.wxwidgets.org/3.2.8/class");
-                if (file.starts_with("group"))
-                    url.RemoveLast(sizeof("class") - 1);
+                wxString url;
+                url = (Project.getLangVersion(GEN_LANG_CPLUSPLUS) < 30300) ?
+                          "https://docs.wxwidgets.org/3.2.8" :
+                          "https://docs.wxwidgets.org/latest";
+
+                if (!file.starts_with("group"))
+                    url += "/class";
                 url << file.make_wxString();
 
-                m_webview->LoadURL(url);
+                // Unfortunately, the wxWidgets documentation site now requires a captcha to verify
+                // that the user is not a bot before allowing access to the documentation.
+                // The website does not display at all in the IE embedded view that we use.
+
+                // m_webview->LoadURL(url);
+
+                m_webview->SetPage(
+                    "<html><title>Displaying Documentation in Browser</title>"
+                    "<body>"
+                    "The C++ documentation is not accessible in the embedded browser because"
+                    " the wxWidgets documentation site now requires a captcha to verify"
+                    " that the user is not a bot before allowing access to the documentation."
+                    " Instead, the documentation will be opened in the default web browser."
+                    "</body></html>",
+                    wxEmptyString);
+                wxLaunchDefaultBrowser(url);
                 return;
             }
         }
     }
     m_webview->SetPage("<html><title>Select Node</title>"
-                       "<body>The selected node does not have any specific documentation for this "
-                       "language.</body></html>",
+                       "<body>The selected node does not have any specific documentation for C++."
+                       "</body></html>",
                        wxEmptyString);
 #endif
 }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The help menu changes which C++ documentation is displayed based on the version of wxWidgets the project is defaulting to.

The C++ doc panel can no longer display C++ wxWidgets documentation because it now utilizes a captcha that the IE browser does not display. Instead, it hands the URL to the default browser, with a note in the Doc pane as to why it isn't displaying.

wxPerl doesn't have it's own documentation web site, so the wxWidgets C++ documentation is used instead.