### PR TITLE
Convert GridPropertyDlg to an abstract class, fix CustomParamProp  Undo button

### DIFF
--- a/src/customprops/custom_param_prop.cpp
+++ b/src/customprops/custom_param_prop.cpp
@@ -17,7 +17,8 @@ EditParamProperty::EditParamProperty(const wxString& label, NodeProperty* prop) 
 {
 }
 
-EditParamsDialog::EditParamsDialog(wxWindow* parent, NodeProperty* prop) : GridPropertyDlg(parent)
+EditParamsDialog::EditParamsDialog(wxWindow* parent, NodeProperty* prop) :
+    GridPropertyDlgBase(parent)
 {
     m_prop = prop;
 };

--- a/src/customprops/custom_param_prop.cpp
+++ b/src/customprops/custom_param_prop.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Derived wxStringProperty class for custom control parameters
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2021-2023 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2021-2025 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -64,8 +64,7 @@ void EditParamsDialog::OnInit(wxInitDialogEvent& WXUNUSED(event))
         ++row;
     }
 
-    m_grid->DeleteCols(1, 1);                 // Remove the second column
-    m_toolBar->DeleteTool(id_UndoDeleteRow);  // Remove the Undo button
+    m_grid->DeleteCols(1, 1);  // Remove the second column
 
     Fit();
 }
@@ -88,6 +87,7 @@ void EditParamsDialog::OnUpdateUI(wxUpdateUIEvent& WXUNUSED(event))
 {
     auto array = m_grid->GetSelectedRows();
     m_toolBar->EnableTool(id_DeleteRow, array.size() > 0);
+    m_toolBar->EnableTool(id_UndoDeleteRow, m_deleted_col_0.size() > 0);
 }
 
 void EditParamsDialog::OnNewRow(wxCommandEvent& WXUNUSED(event))

--- a/src/customprops/custom_param_prop.h
+++ b/src/customprops/custom_param_prop.h
@@ -46,7 +46,7 @@ private:
     NodeProperty* m_prop;
 };
 
-class EditParamsDialog : public GridPropertyDlg
+class EditParamsDialog : public GridPropertyDlgBase
 {
 public:
     EditParamsDialog(wxWindow* parent, NodeProperty* prop);
@@ -61,6 +61,7 @@ public:
 protected:
     void OnInit(wxInitDialogEvent& WXUNUSED(event)) override;
     void OnOK(wxCommandEvent& event) override;
+    void OnCancel(wxCommandEvent& event) override { event.Skip(); }
 
     void OnNewRow(wxCommandEvent& WXUNUSED(event)) override;
     void OnDeleteRow(wxCommandEvent& WXUNUSED(event)) override;

--- a/src/customprops/rearrange_prop.cpp
+++ b/src/customprops/rearrange_prop.cpp
@@ -20,7 +20,7 @@ RearrangeProperty::RearrangeProperty(const wxString& label, NodeProperty* prop) 
 {
 }
 
-RearrangeDialog::RearrangeDialog(wxWindow* parent, NodeProperty* prop) : GridPropertyDlg(parent)
+RearrangeDialog::RearrangeDialog(wxWindow* parent, NodeProperty* prop) : GridPropertyDlgBase(parent)
 {
     m_prop = prop;
 };

--- a/src/customprops/rearrange_prop.h
+++ b/src/customprops/rearrange_prop.h
@@ -46,7 +46,7 @@ private:
     NodeProperty* m_prop;
 };
 
-class RearrangeDialog : public GridPropertyDlg
+class RearrangeDialog : public GridPropertyDlgBase
 {
 public:
     RearrangeDialog(wxWindow* parent, NodeProperty* prop);

--- a/src/customprops/sb_fields_prop.cpp
+++ b/src/customprops/sb_fields_prop.cpp
@@ -20,7 +20,8 @@ SBarFieldsProperty::SBarFieldsProperty(const wxString& label, NodeProperty* prop
 {
 }
 
-SBarFieldsDialog::SBarFieldsDialog(wxWindow* parent, NodeProperty* prop) : GridPropertyDlg(parent)
+SBarFieldsDialog::SBarFieldsDialog(wxWindow* parent, NodeProperty* prop) :
+    GridPropertyDlgBase(parent)
 {
     m_prop = prop;
 };

--- a/src/customprops/sb_fields_prop.h
+++ b/src/customprops/sb_fields_prop.h
@@ -46,7 +46,7 @@ private:
     NodeProperty* m_prop;
 };
 
-class SBarFieldsDialog : public GridPropertyDlg
+class SBarFieldsDialog : public GridPropertyDlgBase
 {
 public:
     SBarFieldsDialog(wxWindow* parent, NodeProperty* prop);

--- a/src/customprops/sizer_grow_columns.cpp
+++ b/src/customprops/sizer_grow_columns.cpp
@@ -17,7 +17,8 @@ GrowColumnsProperty::GrowColumnsProperty(const wxString& label, NodeProperty* pr
 {
 }
 
-GrowColumnsDialog::GrowColumnsDialog(wxWindow* parent, NodeProperty* prop) : GridPropertyDlg(parent)
+GrowColumnsDialog::GrowColumnsDialog(wxWindow* parent, NodeProperty* prop) :
+    GridPropertyDlgBase(parent)
 {
     m_prop = prop;
 };

--- a/src/customprops/sizer_grow_columns.h
+++ b/src/customprops/sizer_grow_columns.h
@@ -46,7 +46,7 @@ private:
     NodeProperty* m_prop;
 };
 
-class GrowColumnsDialog : public GridPropertyDlg
+class GrowColumnsDialog : public GridPropertyDlgBase
 {
 public:
     GrowColumnsDialog(wxWindow* parent, NodeProperty* prop);
@@ -59,6 +59,9 @@ protected:
     void OnNewRow(wxCommandEvent& WXUNUSED(event)) override;
     void OnDeleteRow(wxCommandEvent& WXUNUSED(event)) override;
     void OnUpdateUI(wxUpdateUIEvent& WXUNUSED(event)) override;
+
+    void OnCancel(wxCommandEvent& event) override { event.Skip(); }
+    void OnUndoDelete(wxCommandEvent& event) override { event.Skip(); }
 
 private:
     struct GrowColumnsEntry

--- a/src/customprops/sizer_grow_rows.cpp
+++ b/src/customprops/sizer_grow_rows.cpp
@@ -17,7 +17,7 @@ GrowRowsProperty::GrowRowsProperty(const wxString& label, NodeProperty* prop) :
 {
 }
 
-GrowRowsDialog::GrowRowsDialog(wxWindow* parent, NodeProperty* prop) : GridPropertyDlg(parent)
+GrowRowsDialog::GrowRowsDialog(wxWindow* parent, NodeProperty* prop) : GridPropertyDlgBase(parent)
 {
     m_prop = prop;
 };

--- a/src/customprops/sizer_grow_rows.h
+++ b/src/customprops/sizer_grow_rows.h
@@ -46,7 +46,7 @@ private:
     NodeProperty* m_prop;
 };
 
-class GrowRowsDialog : public GridPropertyDlg
+class GrowRowsDialog : public GridPropertyDlgBase
 {
 public:
     GrowRowsDialog(wxWindow* parent, NodeProperty* prop);
@@ -59,6 +59,9 @@ protected:
     void OnNewRow(wxCommandEvent& WXUNUSED(event)) override;
     void OnDeleteRow(wxCommandEvent& WXUNUSED(event)) override;
     void OnUpdateUI(wxUpdateUIEvent& WXUNUSED(event)) override;
+
+    void OnCancel(wxCommandEvent& event) override { event.Skip(); }
+    void OnUndoDelete(wxCommandEvent& event) override { event.Skip(); }
 
 private:
     struct GrowRowsEntry

--- a/src/gen_enums.h
+++ b/src/gen_enums.h
@@ -42,9 +42,11 @@ namespace GenEnum
 
         // "_escapes" makes it possible for the user to include \n, \t, \r, and "\" in the string
 
-        type_string_code_grow_columns,  // uses GridPropertyDlg to edit a list of growable columns
-        type_string_code_grow_rows,     // uses GridPropertyDlg to edit a list of growable rows
-        type_string_code_cstm_param,    // uses GridPropertyDlg to edit a list of custom parameters
+        type_string_code_grow_columns,  // uses GridPropertyDlgBase to edit a list of growable
+                                        // columns
+        type_string_code_grow_rows,     // uses GridPropertyDlgBase to edit a list of growable rows
+        type_string_code_cstm_param,    // uses GridPropertyDlgBase to edit a list of custom
+                                        // parameters
         type_string_code_single,   // includes single-line custom editor, does not process escapes
         type_string_edit,          // includes a button that triggers a small text editor dialog
         type_string_edit_escapes,  // includes editor dialog and also escapes characters

--- a/src/wxui/grid_property_dlg.cpp
+++ b/src/wxui/grid_property_dlg.cpp
@@ -18,7 +18,7 @@
 
 #include "grid_property_dlg.h"
 
-bool GridPropertyDlg::Create(wxWindow* parent, wxWindowID id, const wxString& title,
+bool GridPropertyDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& title,
     const wxPoint& pos, const wxSize& size, long style, const wxString &name)
 {
     // Scaling of pos and size are handled after the dialog
@@ -98,13 +98,13 @@ bool GridPropertyDlg::Create(wxWindow* parent, wxWindowID id, const wxString& ti
     Centre(wxBOTH);
 
     // Event handlers
-    Bind(wxEVT_BUTTON, &GridPropertyDlg::OnCancel, this, wxID_CANCEL);
-    Bind(wxEVT_BUTTON, &GridPropertyDlg::OnOK, this, wxID_OK);
-    Bind(wxEVT_INIT_DIALOG, &GridPropertyDlg::OnInit, this);
-    Bind(wxEVT_TOOL, &GridPropertyDlg::OnDeleteRow, this, id_DeleteRow);
-    Bind(wxEVT_TOOL, &GridPropertyDlg::OnNewRow, this, id_NewRow);
-    Bind(wxEVT_TOOL, &GridPropertyDlg::OnUndoDelete, this, id_UndoDeleteRow);
-    Bind(wxEVT_UPDATE_UI, &GridPropertyDlg::OnUpdateUI, this);
+    Bind(wxEVT_BUTTON, &GridPropertyDlgBase::OnCancel, this, wxID_CANCEL);
+    Bind(wxEVT_BUTTON, &GridPropertyDlgBase::OnOK, this, wxID_OK);
+    Bind(wxEVT_INIT_DIALOG, &GridPropertyDlgBase::OnInit, this);
+    Bind(wxEVT_TOOL, &GridPropertyDlgBase::OnDeleteRow, this, id_DeleteRow);
+    Bind(wxEVT_TOOL, &GridPropertyDlgBase::OnNewRow, this, id_NewRow);
+    Bind(wxEVT_TOOL, &GridPropertyDlgBase::OnUndoDelete, this, id_UndoDeleteRow);
+    Bind(wxEVT_UPDATE_UI, &GridPropertyDlgBase::OnUpdateUI, this);
 
     return true;
 }

--- a/src/wxui/grid_property_dlg.h
+++ b/src/wxui/grid_property_dlg.h
@@ -16,7 +16,7 @@
 #include <wx/stattext.h>
 #include <wx/toolbar.h>
 
-class GridPropertyDlg : public wxDialog
+class GridPropertyDlgBase : public wxDialog
 {
 public:
     enum
@@ -26,8 +26,8 @@ public:
         id_UndoDeleteRow
     };
 
-    GridPropertyDlg() {}
-    GridPropertyDlg(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "Property Editor",
+    GridPropertyDlgBase() {}
+    GridPropertyDlgBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = "Property Editor",
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
         long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
     {
@@ -41,13 +41,13 @@ protected:
 
     // Virtual event handlers -- override them in your derived class
 
-    virtual void OnCancel(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnDeleteRow(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnInit(wxInitDialogEvent& event) { event.Skip(); }
-    virtual void OnNewRow(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnOK(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnUndoDelete(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnUpdateUI(wxUpdateUIEvent& event) { event.Skip(); }
+    virtual void OnCancel(wxCommandEvent& event) = 0;
+    virtual void OnDeleteRow(wxCommandEvent& event) = 0;
+    virtual void OnInit(wxInitDialogEvent& event) = 0;
+    virtual void OnNewRow(wxCommandEvent& event) = 0;
+    virtual void OnOK(wxCommandEvent& event) = 0;
+    virtual void OnUndoDelete(wxCommandEvent& event) = 0;
+    virtual void OnUpdateUI(wxUpdateUIEvent& event) = 0;
 
     // Class member variables
 

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -4732,10 +4732,13 @@
       </node>
       <node
         class="wxDialog"
-        class_name="GridPropertyDlg"
+        class_name="GridPropertyDlgBase"
         title="Property Editor"
         base_file="grid_property_dlg"
         source_preamble="// This is the base class for editing multiple-field properties"
+        derived_class_name="GridPropertyDlg"
+        derived_file="gridpropertydlg_derived"
+        pure_virtual_functions="1"
         wxEVT_INIT_DIALOG="OnInit"
         wxEVT_UPDATE_UI="OnUpdateUI">
         <node


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This utilizes the new ability to create an abstract class, converting `GridPropertyDlg` in an abstract class. This also disables rather then deletes the Undo toolbar button in the CustomParamProp dialog when no Undo is available.