### PR TITLE
Add critical LF line ending to all agents that edit

### DIFF
--- a/.github/agents/code_review.agent.md
+++ b/.github/agents/code_review.agent.md
@@ -11,6 +11,13 @@ Conduct thorough code reviews for a senior software engineer, identifying bugs, 
 ## Task
 Review files explicitly added to chat. For .cpp files, check corresponding .h files. Document all issues with line numbers, code snippets, severity, and suggested fixes.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## Project-Specific Knowledge
 
 ### Assertion Macros (ASSERT, ASSERT_MSG, FAIL_MSG)

--- a/.github/agents/complex.agent.md
+++ b/.github/agents/complex.agent.md
@@ -15,6 +15,20 @@ When the user selects a function and asks to reduce complexity:
 3. Extract helpers following the extraction rules
 4. Build and verify after each extraction
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
+### � Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## Tools Usage
 
 **For understanding the function:**

--- a/.github/agents/docs.agent.md
+++ b/.github/agents/docs.agent.md
@@ -7,6 +7,13 @@ tools: ['vscode', 'execute', 'read', 'edit', 'oraios/serena/*']
 
 Create and maintain project documentation for users, contributors, and code folders.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## Tools Usage
 
 **Understand code before documenting:**

--- a/.github/agents/gen_cpp.agent.md
+++ b/.github/agents/gen_cpp.agent.md
@@ -7,6 +7,13 @@ tools: ['vscode', 'execute', 'read', 'edit', 'oraios/serena/*']
 
 Generate C++11 code for wxWidgets 3.2 using the `Code` class for in-memory code generation.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## Tools Usage
 
 **Understand the Code class API:**

--- a/.github/agents/gen_perl.agent.md
+++ b/.github/agents/gen_perl.agent.md
@@ -7,6 +7,13 @@ tools: ['vscode', 'execute', 'read', 'edit', 'oraios/serena/*']
 
 Generate Perl code for wxPerl 3.3 using the `Code` class for in-memory code generation.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## Tools Usage
 
 **Understand the Code class API:**

--- a/.github/agents/gen_python.agent.md
+++ b/.github/agents/gen_python.agent.md
@@ -7,6 +7,13 @@ tools: ['vscode', 'execute', 'read', 'edit', 'oraios/serena/*']
 
 Generate Python code for wxPython 4.2 using the `Code` class for in-memory code generation.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## Tools Usage
 
 **Understand the Code class API:**

--- a/.github/agents/gen_ruby.agent.md
+++ b/.github/agents/gen_ruby.agent.md
@@ -7,6 +7,13 @@ tools: ['vscode', 'execute', 'read', 'edit', 'oraios/serena/*']
 
 Generate Ruby code for wxRuby 1.6.1 using the `Code` class for in-memory code generation.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## Tools Usage
 
 **Understand the Code class API:**

--- a/.github/agents/modern.agent.md
+++ b/.github/agents/modern.agent.md
@@ -22,7 +22,7 @@ Modernize C++ files: fix clang-tidy warnings (items 1-7), apply C++23 patterns (
 - These are code appearance/style improvements to resolve lint warnings only
 - When in doubt, leave the code unchanged
 
-### � Line Endings (ABSOLUTE)
+### 🔴 Line Endings (ABSOLUTE)
 **ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
 - All files in this project use Unix-style line endings (LF only)
 - This applies even when running on Windows

--- a/.github/agents/powershell.agent.md
+++ b/.github/agents/powershell.agent.md
@@ -11,6 +11,13 @@ You are a PowerShell scripting specialist focused on creating robust, idiomatic 
 ## Task
 Create PowerShell scripts for testing, building, code generation verification, CI/CD tasks, and development automation. Focus on wxUiEditor build workflows and related test harnesses.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## PowerShell Best Practices
 
 ### Language Standards

--- a/.github/agents/wxperl.agent.md
+++ b/.github/agents/wxperl.agent.md
@@ -11,6 +11,13 @@ You are an expert wxPerl and Perl GUI development agent using modern Perl practi
 ## Task
 Develop, modify, or analyze wxPerl applications using wxPerl 3.3 and modern Perl best practices. Write idiomatic Perl code that leverages the wxWidgets framework through the wxPerl bindings.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## wxPerl 3.3 Framework
 
 ### Core Concepts

--- a/.github/agents/wxpython.agent.md
+++ b/.github/agents/wxpython.agent.md
@@ -11,6 +11,13 @@ You are an expert wxPython and Python GUI development agent using modern Python 
 ## Task
 Develop, modify, or analyze wxPython applications using wxPython 4.2 and modern Python best practices. Write idiomatic Python code that leverages the wxWidgets framework through the wxPython bindings.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## wxPython 4.2 Framework
 
 ### Core Concepts

--- a/.github/agents/wxruby.agent.md
+++ b/.github/agents/wxruby.agent.md
@@ -11,6 +11,13 @@ You are an expert wxRuby and Ruby GUI development agent using modern Ruby practi
 ## Task
 Develop, modify, or analyze wxRuby applications using wxRuby 1.6.1+ and modern Ruby best practices. Write idiomatic Ruby code that leverages the wxWidgets framework through the wxRuby bindings.
 
+### 🔴 Line Endings (ABSOLUTE)
+**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
+- All files in this project use Unix-style line endings (LF only)
+- This applies even when running on Windows
+- When creating or editing files, ensure line endings remain LF
+- Do not convert existing LF line endings to CRLF
+
 ## wxRuby Framework
 
 ### Core Concepts

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,7 @@ When the user types "fix" and has selected a comment line:
 - Auto-generated sections will be overwritten
 - Add modifications AFTER the `// End of generated code` marker only
 
-### � Line Endings (ABSOLUTE)
+### 🔴 Line Endings (ABSOLUTE)
 **ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
 - All files in this project use Unix-style line endings (LF only)
 - This applies even when running on Windows

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -448,19 +448,15 @@ set ( agents
     ../.github/agents/gen_python.agent.md
     ../.github/agents/gen_ruby.agent.md
     ../.github/agents/pullrequest.agent.md
-
-# private agents
-    ../../Junctions/agents/agent_editor.agent.md
-    ../../Junctions/agents/ai_comments.agent.md
-    ../../Junctions/agents/code_review.agent.md
-    ../../Junctions/agents/issue.agent.md
-    ../../Junctions/agents/lint_fixer.agent.md
-    ../../Junctions/agents/modern.agent.md
-    ../../Junctions/agents/powershell.agent.md
-    ../../Junctions/agents/ttx.agent.md
-    ../../Junctions/agents/wxperl.agent.md
-    ../../Junctions/agents/wxpython.agent.md
-    ../../Junctions/agents/wxruby.agent.md
+    ../.github//agents/agent_editor.agent.md
+    ../.github//agents/ai_comments.agent.md
+    ../.github//agents/code_review.agent.md
+    ../.github//agents/issue.agent.md
+    ../.github//agents/modern.agent.md
+    ../.github//agents/powershell.agent.md
+    ../.github//agents/wxperl.agent.md
+    ../.github//agents/wxpython.agent.md
+    ../.github//agents/wxruby.agent.md
 )
 
 # ============================================================================


### PR DESCRIPTION
Agents default to using CRLF on Windows, but *all* KeyWorks Software projects use LF line endings, and PR validation will often fail if line endings are changed.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Adds:

```markdown
### 🔴 Line Endings (ABSOLUTE)
**ALWAYS use LF (`\n`) line endings, NEVER CRLF (`\r\n`)**
- All files in this project use Unix-style line endings (LF only)
- This applies even when running on Windows
- When creating or editing files, ensure line endings remain LF
- Do not convert existing LF line endings to CRLF
```