### PR TITLE
Add support for Mac x64 and ARM64 builds

### DIFF
--- a/.github/workflows/build-macos-reusable.yml
+++ b/.github/workflows/build-macos-reusable.yml
@@ -1,0 +1,100 @@
+name: "Reusable macOS Build"
+
+on:
+  workflow_call:
+    inputs:
+      create-setup:
+        description: 'Whether to create macOS DMG installer'
+        required: false
+        type: boolean
+        default: false
+      build-type:
+        description: 'Build type (Debug or Release)'
+        required: false
+        type: string
+        default: 'Release'
+      runner-type:
+        description: 'Runner type (self-hosted-arm64 or github-hosted-x64)'
+        required: false
+        type: string
+        default: 'self-hosted-arm64'
+
+jobs:
+  buildMacOS:
+    runs-on: ${{ inputs.runner-type == 'self-hosted-arm64' && fromJSON('["self-hosted", "macOS", "ARM64"]') || 'macos-latest' }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - run: mkdir ${{github.workspace}}/build
+
+    - name: Install dependencies
+      run: |
+        brew install cmake ninja ccache
+        cmake --version
+        ccache --version
+
+    - name: Setup ccache
+      run: |
+        ccache --set-config=cache_dir=${{runner.workspace}}/.ccache
+        ccache --set-config=compression=true
+        ccache --set-config=sloppiness=pch_defines,time_macros,include_file_mtime,include_file_ctime
+        ccache --set-config=hard_link=true
+        ccache --zero-stats
+        ccache --show-config
+
+    - name: Restore ccache
+      id: cache-ccache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{runner.workspace}}/.ccache
+        key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-ccache-
+        enableCrossOsArchive: false
+
+    - name: Restore CMake FetchContent
+      id: cache-fetchcontent-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ${{github.workspace}}/build/_deps
+        key: ${{ runner.os }}-${{ runner.arch }}-fetchcontent-${{ hashFiles('**/CMakeLists.txt', 'CMakePresets.json') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-fetchcontent-
+        enableCrossOsArchive: false
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{inputs.build-type}} -GNinja
+
+    - name: Build wxUiEditor
+      run: cmake --build ${{github.workspace}}/build -j$(($(sysctl -n hw.ncpu) - 2)) --config ${{inputs.build-type}} --target wxUiEditor
+
+    - name: Save ccache
+      if: always() && steps.cache-ccache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{runner.workspace}}/.ccache
+        key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ github.sha }}
+
+    - name: Save CMake FetchContent
+      if: always() && steps.cache-fetchcontent-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{github.workspace}}/build/_deps
+        key: ${{ runner.os }}-${{ runner.arch }}-fetchcontent-${{ hashFiles('**/CMakeLists.txt', 'CMakePresets.json') }}
+
+    - name: Build DMG
+      if: ${{ inputs.create-setup }}
+      run: |
+        cd build
+        cpack -G DragNDrop -C ${{inputs.build-type}}
+
+    - name: Create DMG Artifact
+      if: ${{ inputs.create-setup }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: macOS-DMG-${{ runner.arch }}
+        path: |
+          build/wxUiEditor-*-Darwin.dmg

--- a/.github/workflows/build-macos-setup.yml
+++ b/.github/workflows/build-macos-setup.yml
@@ -1,0 +1,15 @@
+name: "Build macOS Executable"
+
+on:
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  buildMacOS:
+    uses: ./.github/workflows/build-macos-reusable.yml
+    with:
+      create-setup: true
+      build-type: Release
+      runner-type: self-hosted-arm64

--- a/.github/workflows/build-unix-reusable.yml
+++ b/.github/workflows/build-unix-reusable.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   buildUnix:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, ubuntu]  # Either runner, adapts CPUs via nproc
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{inputs.build-type}} -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20
 
     - name: Build wxUiEditor
-      run: cmake --build ${{github.workspace}}/build --config ${{inputs.build-type}} --target wxUiEditor
+      run: cmake --build ${{github.workspace}}/build -j$(($(nproc) - 2)) --config ${{inputs.build-type}} --target wxUiEditor
 
     - name: Save ccache
       if: always() && steps.cache-ccache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -22,3 +22,17 @@ jobs:
     with:
       create-setup: true
       build-type: Release
+
+  buildMacOS-ARM64:
+    uses: ./.github/workflows/build-macos-reusable.yml
+    with:
+      create-setup: true
+      build-type: Release
+      runner-type: self-hosted-arm64
+
+  buildMacOS-x64:
+    uses: ./.github/workflows/build-macos-reusable.yml
+    with:
+      create-setup: true
+      build-type: Release
+      runner-type: github-hosted-x64

--- a/.github/workflows/pr_verify.yml
+++ b/.github/workflows/pr_verify.yml
@@ -38,3 +38,10 @@ jobs:
     with:
       create-setup: false
       build-type: Release
+
+  buildMacOS:
+    uses: ./.github/workflows/build-macos-reusable.yml
+    with:
+      create-setup: false
+      build-type: Release
+      runner-type: self-hosted-arm64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,6 +435,11 @@ set( CPACK_PROJECT_CONFIG_FILE "${PROJECT_BINARY_DIR}/nsis_options.cmake" )
 
 if( WIN32 )
     set( CPACK_GENERATOR ZIP NSIS )
+elseif( APPLE )
+    set( CPACK_GENERATOR DragNDrop )
+    set( CPACK_DMG_VOLUME_NAME "wxUiEditor" )
+    set( CPACK_DMG_FORMAT "UDBZ" )  # Compressed DMG
+    set( CPACK_DMG_BACKGROUND_IMAGE ${CMAKE_CURRENT_LIST_DIR}/src/art_src/wxUiEditor.svg )
 elseif( UNIX )
     set( CPACK_GENERATOR "DEB RPM" )
 endif()


### PR DESCRIPTION
Implement workflows to support building macOS applications for both ARM64 and x64 architectures. This includes the creation of reusable workflows for building and packaging the application as a DMG installer. Adjustments to existing build configurations ensure compatibility across different macOS environments.

