### PR TITLE
sccache

### DIFF
--- a/.github/workflows/build-macos-reusable.yml
+++ b/.github/workflows/build-macos-reusable.yml
@@ -22,9 +22,6 @@ on:
 jobs:
   buildMacOS:
     runs-on: ${{ inputs.runner-type }}
-    env:
-      CCACHE_DIR: ${{github.workspace}}/.ccache
-      CCACHE_CONFIGPATH: ${{github.workspace}}/.ccache/ccache.conf
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -46,32 +43,11 @@ jobs:
     - name: Install dependencies
       if: ${{ !startsWith(inputs.runner-type, 'self-hosted') }}
       run: |
-        brew install ccache
         clang++ --version
         cmake --version
-        ccache --version
 
-    - name: Setup ccache
-      run: |
-        mkdir -p ${{github.workspace}}/.ccache
-        ccache --set-config=cache_dir=${{github.workspace}}/.ccache
-        ccache --set-config=compression=true
-        ccache --set-config=max_size=15G
-        ccache --set-config=sloppiness=pch_defines,time_macros,include_file_mtime,include_file_ctime
-        ccache --set-config=hard_link=true
-        ccache --zero-stats
-        ccache --show-config
-
-    - name: Restore ccache
-      if: ${{ !startsWith(inputs.runner-type, 'self-hosted') }}
-      id: cache-ccache-restore
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{github.workspace}}/.ccache
-        key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-ccache-
-        enableCrossOsArchive: false
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     # Note: FetchContent is intentionally NOT cached. The kwxFetch repo updates
     # weekly from wxWidgets master, and stale cache can cause build failures
@@ -92,13 +68,6 @@ jobs:
     - name: Build wxUiEditor
       run: |
         cmake --build ${{github.workspace}}/build -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) --config ${{inputs.build-type}} --target wxUiEditor
-
-    - name: Save ccache
-      if: ${{ !startsWith(inputs.runner-type, 'self-hosted') && always() && steps.cache-ccache-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
-      with:
-        path: ${{github.workspace}}/.ccache
-        key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ github.sha }}
 
     - name: Build DMG
       if: ${{ inputs.create-setup }}

--- a/.github/workflows/build-unix-reusable.yml
+++ b/.github/workflows/build-unix-reusable.yml
@@ -22,6 +22,8 @@ on:
 jobs:
   buildUnix:
     runs-on: ${{ inputs.runner-type == 'self-hosted' && fromJSON('["self-hosted", "Linux", "X64"]') || 'ubuntu-latest' }}
+    env:
+      SCCACHE_DIR: ${{github.workspace}}/.sccache
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/build-unix-reusable.yml
+++ b/.github/workflows/build-unix-reusable.yml
@@ -22,9 +22,6 @@ on:
 jobs:
   buildUnix:
     runs-on: ${{ inputs.runner-type == 'self-hosted' && fromJSON('["self-hosted", "Linux", "X64"]') || 'ubuntu-latest' }}
-    env:
-      CCACHE_DIR: ${{github.workspace}}/.ccache
-      CCACHE_CONFIGPATH: ${{github.workspace}}/.ccache/ccache.conf
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -48,32 +45,12 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble main'
         sudo apt-get update
-        sudo apt-get install -y libgtk-3-dev ccache clang-20
+        sudo apt-get install -y libgtk-3-dev clang-20
         clang-20 --version
         cmake --version
-        ccache --version
 
-    - name: Setup ccache
-      run: |
-        mkdir -p ${{github.workspace}}/.ccache
-        ccache --set-config=cache_dir=${{github.workspace}}/.ccache
-        ccache --set-config=compression=true
-        ccache --set-config=max_size=15G
-        ccache --set-config=sloppiness=pch_defines,time_macros,include_file_mtime,include_file_ctime
-        ccache --set-config=hard_link=true
-        ccache --zero-stats
-        ccache --show-config
-
-    - name: Restore ccache
-      if: inputs.runner-type != 'self-hosted'
-      id: cache-ccache-restore
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{github.workspace}}/.ccache
-        key: ${{ runner.os }}-ccache-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-ccache-
-        enableCrossOsArchive: false
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     # Note: FetchContent is intentionally NOT cached. The kwxFetch repo updates
     # weekly from wxWidgets master, and stale cache can cause build failures
@@ -84,13 +61,6 @@ jobs:
 
     - name: Build wxUiEditor
       run: cmake --build ${{github.workspace}}/build -j$(nproc) --config ${{inputs.build-type}} --target wxUiEditor
-
-    - name: Save ccache
-      if: inputs.runner-type != 'self-hosted' && steps.cache-ccache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{github.workspace}}/.ccache
-        key: ${{ runner.os }}-ccache-${{ github.sha }}
 
     - name: Build Setup
       if: ${{ inputs.create-setup }}

--- a/.github/workflows/build-win-reusable.yml
+++ b/.github/workflows/build-win-reusable.yml
@@ -28,6 +28,9 @@ jobs:
 
     - run: mkdir ${{github.workspace}}/build
 
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
     - name: Configure CMake
       run: cmake -G "Visual Studio 17 2022" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{inputs.build-type}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,45 +81,22 @@ configure_file(
     @ONLY
 )
 
-# ###################### ccache support #######################
-find_program(CCACHE_PROGRAM ccache)
-
-if(CCACHE_PROGRAM)
-    message(STATUS "Using ccache: ${CCACHE_PROGRAM}")
-    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
-
-    message(NOTICE "ccache detected. Configure ccache globally for your development environment:")
-    message(NOTICE "  Recommended for all platforms:")
-    message(NOTICE "    ccache --set-config=compression=true")
-    message(NOTICE "    ccache --set-config=max_size=<appropriate for your projects>")
-    message(NOTICE "    ccache --set-config=sloppiness=pch_defines,time_macros,include_file_mtime,include_file_ctime")
-
-    if(MSVC)
-        message(NOTICE "  Required for MSVC:")
-
-        message(NOTICE "    ccache --set-config=pch_external_checksum=true")
-        message(NOTICE "    ccache --set-config=depend_mode=true")
-        message(NOTICE "    ccache --set-config=\"ignore_options=/Zi /Z7 /ZI /FS /Fd*\"")
-    endif()
-
-    message(NOTICE "  Run 'ccache --show-config' to verify current settings")
-    message(NOTICE "  Run 'ccache -s' to monitor cache usage")
+# ###################### sccache #######################
+find_program(SCCACHE_PROGRAM sccache)
+if(SCCACHE_PROGRAM)
+    message(STATUS "sccache found: ${SCCACHE_PROGRAM}")
+    set(CMAKE_C_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}")
+else()
+    message(STATUS "sccache not found; building without a compiler cache")
 endif()
 
 if(MSVC)
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
+
     # /O1 often results in faster code than /O2 due to CPU caching
     string(REPLACE "/O2" "/O1" cl_optimize "${CMAKE_CXX_FLAGS_RELEASE}")
     set(CMAKE_CXX_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C++ Release flags" FORCE)
-
-    # Use /Z7 instead of /Zi to embed debug info in object files. Benefits:
-    # 1. Avoids blocking when parallel compilers write to PDB files (faster multi-core builds)
-    # 2. Required for ccache to cache compilation results
-    # Trade-off: Larger object files, but build speed improvement is significant
-    string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-    string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-    set(CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG} CACHE STRING "C++ Debug flags" FORCE)
-    set(CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG} CACHE STRING "C Debug flags" FORCE)
 
     # Use dynamic runtime (/MD for Release, /MDd for Debug)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")


### PR DESCRIPTION
- **Replace ccache with sccache**
- **Switch runners to use sccache**

Mozilla's sccache is a modern caching system written from the ground up to fully support Mac, Unix, and Windows without needing all the special configurations for Windows that ccache required.
