### PR TITLE
Fix missing var_name in wxTextCtrl creation

### DIFF
--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -1141,7 +1141,7 @@ auto Node::FixDuplicateName() -> bool
                     org_name.erase(org_name.size() - 1, 1);
                 }
 
-                std::string new_name;
+                std::string new_name(org_name);
                 for (int i = 2; name_set.contains(new_name); ++i)
                 {
                     new_name.clear();


### PR DESCRIPTION
The var_name was sometimes being left blank when creating a new wxTextCtrl.

Why it wasn't noticed sooner — Commit 2c4c2729a ("Fix blank duplicate name regression") made the identical fix in `GenerateUniqueNameFromBase` but missed this second occurrence in `FixDuplicateName`. The bug was made reachable by the 4f0f754ab refactor that extended `AdjustMemberNameForLanguage` to call `FixDuplicateName` in more code paths.