### PR TITLE
GenLang

### DIFF
--- a/src/customprops/code_string_prop.cpp
+++ b/src/customprops/code_string_prop.cpp
@@ -34,7 +34,7 @@ EditCodeDialog::EditCodeDialog(wxWindow* parent, NodeProperty* prop) : EditCodeD
 {
     SetTitle((wxue::string() << prop->get_DeclName() << " property editor").wx());
     m_value = prop->as_wxString();
-    SetStcColors(m_stc, GEN_LANG_CPLUSPLUS);
+    SetStcColors(m_stc, GenLang::cplusplus);
 };
 
 void EditCodeDialog::OnInit(wxInitDialogEvent& /* event unused */)

--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -41,24 +41,24 @@ EventHandlerDlg::EventHandlerDlg(wxWindow* parent, NodeEvent* event) :
     m_ruby_page(EVENT_PAGE_RUBY), m_gen_languages(Project.get_GenerateLanguages()),
     m_code_preference(Project.get_CodePreference(event->getNode()))
 {
-    m_is_cpp_enabled = (m_gen_languages & GEN_LANG_CPLUSPLUS);
-    m_is_python_enabled = (m_gen_languages & GEN_LANG_PYTHON);
-    m_is_ruby_enabled = (m_gen_languages & GEN_LANG_RUBY);
-    m_is_fortran_enabled = (m_gen_languages & GEN_LANG_FORTRAN);
-    m_is_go_enabled = (m_gen_languages & GEN_LANG_GO);
-    m_is_julia_enabled = (m_gen_languages & GEN_LANG_JULIA);
-    m_is_luajit_enabled = (m_gen_languages & GEN_LANG_LUAJIT);
-    m_is_typescript_enabled = (m_gen_languages & GEN_LANG_TYPESCRIPT);
+    m_is_cpp_enabled = (m_gen_languages & GenLang::cplusplus);
+    m_is_python_enabled = (m_gen_languages & GenLang::python);
+    m_is_ruby_enabled = (m_gen_languages & GenLang::ruby);
+    m_is_fortran_enabled = (m_gen_languages & GenLang::fortran);
+    m_is_go_enabled = (m_gen_languages & GenLang::go);
+    m_is_julia_enabled = (m_gen_languages & GenLang::julia);
+    m_is_luajit_enabled = (m_gen_languages & GenLang::luajit);
+    m_is_typescript_enabled = (m_gen_languages & GenLang::typescript);
 
     m_value = event->get_value().wx();
     if (m_is_cpp_enabled)
     {
-        SetStcColors(m_cpp_stc_lambda, GEN_LANG_CPLUSPLUS);
+        SetStcColors(m_cpp_stc_lambda, GenLang::cplusplus);
     }
 
     if (m_is_ruby_enabled)
     {
-        SetStcColors(m_ruby_stc_lambda, GEN_LANG_RUBY);
+        SetStcColors(m_ruby_stc_lambda, GenLang::ruby);
     }
 
     Node* form = event->getNode()->get_Form();
@@ -123,37 +123,37 @@ EventHandlerDlg::EventHandlerDlg(wxWindow* parent, NodeEvent* event) :
         }
     }
 
-    if (m_code_preference == GEN_LANG_CPLUSPLUS)
+    if (m_code_preference == GenLang::cplusplus)
     {
         m_notebook->SetSelection(EVENT_PAGE_CPP);
     }
 
-    else if (m_code_preference == GEN_LANG_PYTHON)
+    else if (m_code_preference == GenLang::python)
     {
         m_notebook->SetSelection(m_python_page);
     }
-    else if (m_code_preference == GEN_LANG_RUBY)
+    else if (m_code_preference == GenLang::ruby)
     {
         m_notebook->SetSelection(m_ruby_page);
     }
 
-    else if (m_code_preference == GEN_LANG_FORTRAN)
+    else if (m_code_preference == GenLang::fortran)
     {
         m_notebook->SetSelection(EVENT_PAGE_FORTRAN);
     }
-    else if (m_code_preference == GEN_LANG_GO)
+    else if (m_code_preference == GenLang::go)
     {
         m_notebook->SetSelection(EVENT_PAGE_GO);
     }
-    else if (m_code_preference == GEN_LANG_JULIA)
+    else if (m_code_preference == GenLang::julia)
     {
         m_notebook->SetSelection(EVENT_PAGE_JULIA);
     }
-    else if (m_code_preference == GEN_LANG_LUAJIT)
+    else if (m_code_preference == GenLang::luajit)
     {
         m_notebook->SetSelection(EVENT_PAGE_LUA);
     }
-    else if (m_code_preference == GEN_LANG_TYPESCRIPT)
+    else if (m_code_preference == GenLang::typescript)
     {
         m_notebook->SetSelection(EVENT_PAGE_TYPESCRIPT);
     }
@@ -540,18 +540,18 @@ void EventHandlerDlg::OnDefault(wxCommandEvent& /* event unused */)
 void EventHandlerDlg::FormatBindText()
 {
     const int page = m_notebook->GetSelection();
-    GenLang language = GEN_LANG_CPLUSPLUS;
+    GenLang language = GenLang::cplusplus;
     if (m_is_cpp_enabled && page == EVENT_PAGE_CPP)
     {
-        language = GEN_LANG_CPLUSPLUS;
+        language = GenLang::cplusplus;
     }
     else if (m_is_python_enabled && page == m_python_page)
     {
-        language = GEN_LANG_PYTHON;
+        language = GenLang::python;
     }
     else if (m_is_ruby_enabled && page == m_ruby_page)
     {
-        language = GEN_LANG_RUBY;
+        language = GenLang::ruby;
     }
     else
     {
@@ -560,7 +560,7 @@ void EventHandlerDlg::FormatBindText()
 
     Code handler(m_event->getNode(), language);
 
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         if (m_cpp_radio_use_function->GetValue())
         {
@@ -594,7 +594,7 @@ void EventHandlerDlg::FormatBindText()
             handler += ") { body }";
         }
     }
-    else if (language == GEN_LANG_PYTHON)
+    else if (language == GenLang::python)
     {
         if (m_py_radio_use_function->GetValue())
         {
@@ -608,7 +608,7 @@ void EventHandlerDlg::FormatBindText()
             handler += "body";
         }
     }
-    else if (language == GEN_LANG_RUBY)
+    else if (language == GenLang::ruby)
     {
         wxue::string event_name = m_event->get_name();
         // remove "wx" prefix, make the rest of the name lower case

--- a/src/customprops/eventhandler_dlg.h
+++ b/src/customprops/eventhandler_dlg.h
@@ -103,7 +103,7 @@ private:
     int m_python_page;
     int m_ruby_page;
 
-    size_t m_gen_languages;     // set by Project.get_GenerateLanguages()
+    GenLang m_gen_languages;    // set by Project.get_GenerateLanguages()
     GenLang m_code_preference;  // This will be one of the GEN_LANG values
 
     bool m_is_cpp_enabled { false };

--- a/src/customprops/html_string_prop.cpp
+++ b/src/customprops/html_string_prop.cpp
@@ -27,7 +27,7 @@ EditHtmlDialog::EditHtmlDialog(wxWindow* parent, NodeProperty* prop) : EditHtmlD
     SetTitle(wxString(prop->get_DeclName()) + " property editor");
     m_value = prop->as_wxString();
 
-    SetStcColors(m_scintilla, GEN_LANG_XML, false, false);
+    SetStcColors(m_scintilla, GenLang::xml, false, false);
 };
 
 auto EditHtmlDialog::OnInit([[maybe_unused]] wxInitDialogEvent& event) -> void

--- a/src/customprops/img_string_prop.cpp
+++ b/src/customprops/img_string_prop.cpp
@@ -59,19 +59,19 @@
                 "*.bmp|Icon|*.ico||";
 #endif
             bool remove_webp = false;
-            if (Project.get_CodePreference() == GEN_LANG_CPLUSPLUS)
+            if (Project.get_CodePreference() == GenLang::cplusplus)
             {
                 // WEBP was added to wxWidgets 3.3.0 -- earlier versions don't support it.
                 remove_webp =
-                    (Project.get_LangVersion(GEN_LANG_CPLUSPLUS) < CPP_WIDGETS_VERSION_3_3_0);
+                    (Project.get_LangVersion(GenLang::cplusplus) < CPP_WIDGETS_VERSION_3_3_0);
             }
-            else if (Project.get_CodePreference() == GEN_LANG_PYTHON)
+            else if (Project.get_CodePreference() == GenLang::python)
             {
                 // REVIEW: [Randalphwa - 08-31-2025] Currently, the wxPython dev has stated
                 // wxWidgets 3.3.x will not be supported -- he is waiting for the stable release
                 // (3.4.x). I'm guessing that the version will be wxPython 4.4.x, but until it gets
                 // released, that's uncertain.
-                remove_webp = Project.get_LangVersion(GEN_LANG_PYTHON) < 404000;
+                remove_webp = Project.get_LangVersion(GenLang::python) < 404000;
             }
             if (remove_webp)
             {

--- a/src/customprops/include_files_dlg.cpp
+++ b/src/customprops/include_files_dlg.cpp
@@ -137,11 +137,11 @@ auto IncludeFilesDialog::Initialize(NodeProperty* prop) -> void
 {
     m_prop = prop;
     if (m_prop->isProp(prop_relative_require_list))
-        m_language = GEN_LANG_RUBY;
+        m_language = GenLang::ruby;
     else if (m_prop->isProp(prop_python_import_list))
-        m_language = GEN_LANG_PYTHON;
+        m_language = GenLang::python;
     else
-        m_language = GEN_LANG_CPLUSPLUS;
+        m_language = GenLang::cplusplus;
 }
 
 auto IncludeFilesDialog::SetButtonsEnableState(bool set_ok_btn) -> void

--- a/src/customprops/include_files_dlg.h
+++ b/src/customprops/include_files_dlg.h
@@ -72,7 +72,7 @@ private:
 
     NodeProperty* m_prop { nullptr };
 
-    GenLang m_language = GEN_LANG_CPLUSPLUS;
+    GenLang m_language = GenLang::cplusplus;
 };
 
 // ************* End of generated code ***********

--- a/src/customprops/sys_header_dlg.h
+++ b/src/customprops/sys_header_dlg.h
@@ -73,7 +73,7 @@ private:
 
     NodeProperty* m_prop { nullptr };
 
-    int m_language = GEN_LANG_CPLUSPLUS;
+    int m_language = std::to_underlying(GenLang::cplusplus);
 
     wxFileHistory m_FileHistory;
 };

--- a/src/customprops/tt_file_property.cpp
+++ b/src/customprops/tt_file_property.cpp
@@ -176,7 +176,7 @@ bool ttFileProperty::DisplayEditorDialog(wxPropertyGrid* propGrid, wxVariant& va
             else
             {
                 auto result =
-                    Project.GetOutputPath(m_prop->getNode()->get_Form(), GEN_LANG_CPLUSPLUS);
+                    Project.GetOutputPath(m_prop->getNode()->get_Form(), GenLang::cplusplus);
                 if (!result.second)
                 {
                     root_path.AssignDir(result.first);

--- a/src/generate/base_generator.cpp
+++ b/src/generate/base_generator.cpp
@@ -960,9 +960,9 @@ auto BaseGenerator::isLanguagePropSupported(Node* node, GenLang language, GenEnu
     {
         switch (language)
         {
-            case GEN_LANG_PYTHON:
+            case GenLang::python:
                 return "persist is not supported in Python";
-            case GEN_LANG_XRC:
+            case GenLang::xrc:
                 return "persist is not supported in XRC";
             default:
                 return {};

--- a/src/generate/dataview_widgets.cpp
+++ b/src/generate/dataview_widgets.cpp
@@ -207,7 +207,7 @@ void DataViewCtrl::RequiredHandlers(Node* /* node */, std::set<std::string>& han
 
 std::pair<bool, wxue::string> DataViewCtrl::isLanguageVersionSupported(GenLang language)
 {
-    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+    if (language == GenLang::none || (language & (GenLang::cplusplus | GenLang::python)))
     {
         return { true, {} };
     }
@@ -220,7 +220,7 @@ std::optional<wxue::string> DataViewCtrl::GetWarning(Node* node, GenLang languag
 {
     switch (language)
     {
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             if (!wxGetApp().isCoverageTesting())
             {
                 wxue::string msg;
@@ -366,7 +366,7 @@ void DataViewListCtrl::RequiredHandlers(Node* /* node */, std::set<std::string>&
 
 std::pair<bool, wxue::string> DataViewListCtrl::isLanguageVersionSupported(GenLang language)
 {
-    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+    if (language == GenLang::none || (language & (GenLang::cplusplus | GenLang::python)))
     {
         return { true, {} };
     }
@@ -379,7 +379,7 @@ std::optional<wxue::string> DataViewListCtrl::GetWarning(Node* node, GenLang lan
 {
     switch (language)
     {
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             if (!wxGetApp().isCoverageTesting())
             {
                 wxue::string msg;
@@ -426,7 +426,7 @@ bool DataViewTreeCtrl::GetIncludes(Node* node, std::set<std::string>& set_src,
 
 std::pair<bool, wxue::string> DataViewTreeCtrl::isLanguageVersionSupported(GenLang language)
 {
-    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+    if (language == GenLang::none || (language & (GenLang::cplusplus | GenLang::python)))
     {
         return { true, {} };
     }
@@ -439,7 +439,7 @@ std::optional<wxue::string> DataViewTreeCtrl::GetWarning(Node* node, GenLang lan
 {
     switch (language)
     {
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             if (!wxGetApp().isCoverageTesting())
             {
                 wxue::string msg;
@@ -525,7 +525,7 @@ bool DataViewColumn::ConstructionCode(Code& code)
 
 std::pair<bool, wxue::string> DataViewColumn::isLanguageVersionSupported(GenLang language)
 {
-    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+    if (language == GenLang::none || (language & (GenLang::cplusplus | GenLang::python)))
     {
         return { true, {} };
     };
@@ -538,7 +538,7 @@ std::optional<wxue::string> DataViewColumn::GetWarning(Node* node, GenLang langu
 {
     switch (language)
     {
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             {
                 wxue::string msg;
                 if (auto* form = node->get_Form(); form && form->HasValue(prop_class_name))
@@ -588,7 +588,7 @@ bool DataViewListColumn::ConstructionCode(Code& code)
 
 std::pair<bool, wxue::string> DataViewListColumn::isLanguageVersionSupported(GenLang language)
 {
-    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+    if (language == GenLang::none || (language & (GenLang::cplusplus | GenLang::python)))
     {
         return { true, {} };
     }
@@ -601,7 +601,7 @@ std::optional<wxue::string> DataViewListColumn::GetWarning(Node* node, GenLang l
 {
     switch (language)
     {
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             {
                 wxue::string msg;
                 if (auto* form = node->get_Form(); form && form->HasValue(prop_class_name))

--- a/src/generate/gen_animation.cpp
+++ b/src/generate/gen_animation.cpp
@@ -66,7 +66,7 @@ wxObject* AnimationGenerator::CreateMockup(Node* node, wxObject* parent)
 
 bool AnimationGenerator::ConstructionCode(Code& code)
 {
-    if (code.get_language() == GEN_LANG_RUBY)
+    if (code.get_language() == GenLang::ruby)
     {
         // wxRuby3 1.0.0 doesn't support the generic version of wxAnimationCtrl
         code.AddAuto().NodeName().CreateClass();

--- a/src/generate/gen_aui_notebook.cpp
+++ b/src/generate/gen_aui_notebook.cpp
@@ -221,7 +221,7 @@ void AuiNotebookGenerator::RequiredHandlers(Node* /* node */, std::set<std::stri
 bool AuiNotebookGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                       GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/aui'");
         return true;

--- a/src/generate/gen_aui_toolbar.cpp
+++ b/src/generate/gen_aui_toolbar.cpp
@@ -337,7 +337,7 @@ void AuiToolBarFormGenerator::RequiredHandlers(Node* /* node */, std::set<std::s
 bool AuiToolBarFormGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                          GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/aui'");
         return true;
@@ -560,7 +560,7 @@ void AuiToolBarGenerator::RequiredHandlers(Node* /* node */, std::set<std::strin
 bool AuiToolBarGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                      GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/aui'");
         return true;

--- a/src/generate/gen_banner_window.cpp
+++ b/src/generate/gen_banner_window.cpp
@@ -22,7 +22,7 @@
 
 wxObject* BannerWindowGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    if (Project.get_CodePreference() == GEN_LANG_RUBY)
+    if (Project.get_CodePreference() == GenLang::ruby)
     {
         auto* widget = new wxStaticText(
             wxStaticCast(parent, wxWindow), wxID_ANY, "wxBannerWindow not available in wxRuby3",

--- a/src/generate/gen_ctx_help_btn.cpp
+++ b/src/generate/gen_ctx_help_btn.cpp
@@ -88,7 +88,7 @@ std::optional<wxue::string> CtxHelpButtonGenerator::GetWarning(Node* node, GenLa
 {
     switch (language)
     {
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             {
                 wxue::string msg;
                 if (auto* form = node->get_Form(); form && form->HasValue(prop_class_name))

--- a/src/generate/gen_custom_ctrl.cpp
+++ b/src/generate/gen_custom_ctrl.cpp
@@ -221,7 +221,7 @@ int CustomControl::GenXrcObject(Node* node, pugi::xml_node& object, size_t /* xr
 bool CustomControl::GetIncludes(Node* node, std::set<std::string>& set_src,
                                 std::set<std::string>& set_hdr, GenLang language)
 {
-    if (node->HasValue(prop_header) && language == GEN_LANG_CPLUSPLUS)
+    if (node->HasValue(prop_header) && language == GenLang::cplusplus)
     {
         wxue::string_view cur_value = node->as_string(prop_header);
         if (cur_value.starts_with("#"))

--- a/src/generate/gen_frame_common.cpp
+++ b/src/generate/gen_frame_common.cpp
@@ -260,19 +260,19 @@ bool FrameCommon::ConstructionCode(Code& code, int frame_type)
     {
         switch (code.get_language())
         {
-            case GEN_LANG_FORTRAN:
+            case GenLang::fortran:
                 ConstructionCodeFortran(code, frame_type);
                 break;
-            case GEN_LANG_GO:
+            case GenLang::go:
                 ConstructionCodeGo(code, frame_type);
                 break;
-            case GEN_LANG_JULIA:
+            case GenLang::julia:
                 ConstructionCodeJulia(code, frame_type);
                 break;
-            case GEN_LANG_LUAJIT:
+            case GenLang::luajit:
                 ConstructionCodeLuaJIT(code, frame_type);
                 break;
-            case GEN_LANG_TYPESCRIPT:
+            case GenLang::typescript:
                 ConstructionCodeTypeScript(code, frame_type);
                 break;
             default:

--- a/src/generate/gen_grid.cpp
+++ b/src/generate/gen_grid.cpp
@@ -500,7 +500,7 @@ void GridGenerator::RequiredHandlers(Node* /* node */, std::set<std::string>& ha
 bool GridGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/grid'");
         return true;

--- a/src/generate/gen_html_listbox.cpp
+++ b/src/generate/gen_html_listbox.cpp
@@ -148,7 +148,7 @@ bool HtmlListBoxGenerator::GetIncludes(Node* node, std::set<std::string>& set_sr
 bool HtmlListBoxGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                       GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/html'");
         return true;

--- a/src/generate/gen_html_window.cpp
+++ b/src/generate/gen_html_window.cpp
@@ -183,7 +183,7 @@ auto HtmlWindowGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 auto HtmlWindowGenerator::GetImports(Node* /*unused*/, std::set<std::string>& set_imports,
                                      GenLang language) -> bool
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/html'");
         return true;

--- a/src/generate/gen_hyperlink.cpp
+++ b/src/generate/gen_hyperlink.cpp
@@ -68,7 +68,7 @@ bool HyperlinkGenerator::ConstructionCode(Code& code)
     if (!code.IsTrue(prop_underlined) ||
         code.node()->as_string(prop_subclass).starts_with("wxGeneric"))
     {
-        if (code.is_cpp() || (code.is_ruby() && Project.get_LangVersion(GEN_LANG_RUBY) >= 10505))
+        if (code.is_cpp() || (code.is_ruby() && Project.get_LangVersion(GenLang::ruby) >= 10505))
         {
             use_generic_version = true;
         }

--- a/src/generate/gen_infobar.cpp
+++ b/src/generate/gen_infobar.cpp
@@ -20,7 +20,7 @@
 
 wxObject* InfoBarGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    if (Project.get_CodePreference() == GEN_LANG_RUBY)
+    if (Project.get_CodePreference() == GenLang::ruby)
     {
         auto* widget = new wxStaticText(wxStaticCast(parent, wxWindow), wxID_ANY,
                                         "wxInfoBar not available in wxRuby3", wxDefaultPosition,

--- a/src/generate/gen_popup_win.cpp
+++ b/src/generate/gen_popup_win.cpp
@@ -329,8 +329,8 @@ bool PopupWinBaseGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
 
 std::pair<bool, wxue::string> PopupWinBaseGenerator::isLanguageVersionSupported(GenLang language)
 {
-    if (language == GEN_LANG_NONE ||
-        (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON | GEN_LANG_RUBY)))
+    if (language == GenLang::none ||
+        (language & (GenLang::cplusplus | GenLang::python | GenLang::ruby)))
     {
         return { true, {} };
     }

--- a/src/generate/gen_prop_grid.cpp
+++ b/src/generate/gen_prop_grid.cpp
@@ -66,7 +66,7 @@ bool PropertyGridGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
 bool PropertyGridGenerator::GetImports([[maybe_unused]] Node* node,
                                        std::set<std::string>& set_imports, GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/pg'");
         return true;

--- a/src/generate/gen_prop_grid_mgr.cpp
+++ b/src/generate/gen_prop_grid_mgr.cpp
@@ -129,7 +129,7 @@ bool PropertyGridManagerGenerator::AfterChildrenCode(Code& code)
 bool PropertyGridManagerGenerator::GetImports([[maybe_unused]] Node* node,
                                               std::set<std::string>& set_imports, GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/pg'");
         return true;

--- a/src/generate/gen_rearrange.cpp
+++ b/src/generate/gen_rearrange.cpp
@@ -19,11 +19,11 @@
 
 wxObject* RearrangeCtrlGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    if (Project.get_CodePreference() == GEN_LANG_RUBY ||
-        Project.get_CodePreference() == GEN_LANG_XRC)
+    if (Project.get_CodePreference() == GenLang::ruby ||
+        Project.get_CodePreference() == GenLang::xrc)
     {
         wxString msg = "wxRearrangeCtrl not available in ";
-        if (Project.get_CodePreference() == GEN_LANG_RUBY)
+        if (Project.get_CodePreference() == GenLang::ruby)
         {
             msg += "wxRuby3";
         }

--- a/src/generate/gen_results.cpp
+++ b/src/generate/gen_results.cpp
@@ -120,7 +120,7 @@ auto GenResults::SetDisplayTarget(Node* startNode, GenLang language, WriteCode* 
 
     // Validate: must be exactly one language (not multiple bits set)
     // Count bits set in language
-    auto lang_bits = static_cast<std::uint16_t>(language);
+    auto lang_bits = static_cast<unsigned int>(language);
     if (lang_bits == 0 || (lang_bits & (lang_bits - 1)) != 0)
     {
         // Either no language or multiple languages specified
@@ -311,44 +311,45 @@ auto GenResults::GenerateForDisplay() -> bool
     std::unique_ptr<BaseCodeGenerator> code_generator;
     switch (m_languages)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             code_generator = std::make_unique<CppCodeGenerator>(form);
             break;
 
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             code_generator = std::make_unique<PythonCodeGenerator>(form);
             break;
 
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             code_generator = std::make_unique<RubyCodeGenerator>(form);
             break;
 
-        case GEN_LANG_FORTRAN:
+        case GenLang::fortran:
             code_generator = std::make_unique<FortranCodeGenerator>(form);
             break;
 
-        case GEN_LANG_GO:
+        case GenLang::go:
             code_generator = std::make_unique<GoCodeGenerator>(form);
             break;
 
-        case GEN_LANG_JULIA:
+        case GenLang::julia:
             code_generator = std::make_unique<JuliaCodeGenerator>(form);
             break;
 
-        case GEN_LANG_LUAJIT:
+        case GenLang::luajit:
             code_generator = std::make_unique<LuaJITCodeGenerator>(form);
             break;
 
-        case GEN_LANG_TYPESCRIPT:
+        case GenLang::typescript:
             code_generator = std::make_unique<TypeScriptCodeGenerator>(form);
             break;
 
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             code_generator = std::make_unique<XrcCodeGenerator>(form);
             break;
 
         default:
-            FAIL_MSG(wxString() << "Unknown language for GenerateForDisplay: " << m_languages);
+            FAIL_MSG(wxString() << "Unknown language for GenerateForDisplay: "
+                                << std::to_underlying(m_languages));
             return false;
     }
 
@@ -405,7 +406,7 @@ void GenResults::Clear()
     // Reset new Phase 1 members
     m_mode = Mode::generate_and_write;
     m_scope = Scope::unknown;
-    m_languages = GEN_LANG_NONE;
+    m_languages = GenLang::none;
     m_target_nodes.clear();
     m_start_node = nullptr;
     m_display_src = nullptr;
@@ -448,11 +449,11 @@ auto GenResults::GenerateLanguageFiles(GenLang language, bool comparison_only) -
     // C++ uses GenerateCppFiles which handles CMake + loops through forms via GenerateCppForm
     // XRC combined mode uses GenerateCombinedXrcFile
 
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         generate_result = GenerateCppFiles(comparison_only);
     }
-    else if (language == GEN_LANG_XRC)
+    else if (language == GenLang::xrc)
     {
         // Handle XRC combined forms mode separately - it requires special handling
         if (Project.as_bool(prop_combine_all_forms))
@@ -572,13 +573,13 @@ auto GenResults::GenerateLanguageForm(std::string_view /* class_name */, Node* f
     }
 
     // C++ requires special handling for both header and source files
-    if (m_languages == GEN_LANG_CPLUSPLUS)
+    if (m_languages == GenLang::cplusplus)
     {
         return GenerateCppForm(form, comparison_only);
     }
 
     // XRC doesn't support certain form types
-    if (m_languages == GEN_LANG_XRC)
+    if (m_languages == GenLang::xrc)
     {
         if (form->is_Gen(gen_Images) || form->is_Gen(gen_Data) ||
             form->is_Gen(gen_wxPopupTransientWindow))
@@ -597,41 +598,41 @@ auto GenResults::GenerateLanguageForm(std::string_view /* class_name */, Node* f
     std::unique_ptr<BaseCodeGenerator> code_generator;
     switch (m_languages)
     {
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             code_generator = std::make_unique<PythonCodeGenerator>(form);
             break;
 
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             code_generator = std::make_unique<RubyCodeGenerator>(form);
             break;
 
-        case GEN_LANG_FORTRAN:
+        case GenLang::fortran:
             code_generator = std::make_unique<FortranCodeGenerator>(form);
             break;
 
-        case GEN_LANG_GO:
+        case GenLang::go:
             code_generator = std::make_unique<GoCodeGenerator>(form);
             break;
 
-        case GEN_LANG_JULIA:
+        case GenLang::julia:
             code_generator = std::make_unique<JuliaCodeGenerator>(form);
             break;
 
-        case GEN_LANG_LUAJIT:
+        case GenLang::luajit:
             code_generator = std::make_unique<LuaJITCodeGenerator>(form);
             break;
 
-        case GEN_LANG_TYPESCRIPT:
+        case GenLang::typescript:
             code_generator = std::make_unique<TypeScriptCodeGenerator>(form);
             break;
 
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             code_generator = std::make_unique<XrcCodeGenerator>(form);
             break;
 
         default:
             FAIL_MSG(wxString() << "GenerateLanguageForm called with unsupported language: "
-                                << m_languages);
+                                << std::to_underlying(m_languages));
             return false;
     }
 
@@ -639,33 +640,33 @@ auto GenResults::GenerateLanguageForm(std::string_view /* class_name */, Node* f
     std::string_view file_ext;
     switch (m_languages)
     {
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             file_ext = ".py";
             break;
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             file_ext = ".rb";
             break;
-        case GEN_LANG_FORTRAN:
+        case GenLang::fortran:
             file_ext = ".f90";
             break;
-        case GEN_LANG_GO:
+        case GenLang::go:
             file_ext = ".go";
             break;
-        case GEN_LANG_JULIA:
+        case GenLang::julia:
             file_ext = ".jl";
             break;
-        case GEN_LANG_LUAJIT:
+        case GenLang::luajit:
             file_ext = ".lua";
             break;
-        case GEN_LANG_TYPESCRIPT:
+        case GenLang::typescript:
             file_ext = ".ts";
             break;
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             file_ext = ".xrc";
             break;
         default:
             FAIL_MSG(wxString() << "Unexpected m_languages value in extension switch: "
-                                << m_languages);
+                                << std::to_underlying(m_languages));
             return false;
     }
 
@@ -683,7 +684,7 @@ auto GenResults::GenerateLanguageForm(std::string_view /* class_name */, Node* f
 
     // Generate code into the FileCodeWriter buffer
     // m_languages should be a single language at this point (set in Generate() loop)
-    ASSERT_MSG(m_languages != GEN_LANG_CPLUSPLUS && m_languages != GEN_LANG_NONE,
+    ASSERT_MSG(m_languages != GenLang::cplusplus && m_languages != GenLang::none,
                "GenerateLanguageForm expects a single non-C++ language");
     code_generator->GenerateClass(m_languages);
 
@@ -749,7 +750,7 @@ auto GenResults::GenerateCppForm(Node* form, bool comparison_only, wxProgressDia
         return false;
     }
 
-    auto [path, has_base_file] = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
+    auto [path, has_base_file] = Project.GetOutputPath(form, GenLang::cplusplus);
     if (!has_base_file)
     {
         return false;  // No output path configured for this form
@@ -784,9 +785,9 @@ auto GenResults::GenerateCppForm(Node* form, bool comparison_only, wxProgressDia
     codegen.SetSrcWriteCode(src_cw.get());
 
     // Generate code into both buffers
-    // m_languages should be GEN_LANG_CPLUSPLUS at this point (set in Generate() loop)
-    ASSERT_MSG(m_languages == GEN_LANG_CPLUSPLUS,
-               "GenerateCppForm expects m_languages to be GEN_LANG_CPLUSPLUS");
+    // m_languages should be GenLang::cplusplus at this point (set in Generate() loop)
+    ASSERT_MSG(m_languages == GenLang::cplusplus,
+               "GenerateCppForm expects m_languages to be GenLang::cplusplus");
     codegen.GenerateClass(m_languages, PANEL_PAGE::NOT_PANEL, progress);
 
     bool any_updated = false;
@@ -1019,7 +1020,7 @@ void GenResults::RemoveFormsWithoutOutputPath(std::vector<Node*>& forms)
 auto GenResults::GenerateCombinedFile(GenLang language) -> bool
 {
     // Validate: must be exactly one language (not multiple bits set)
-    auto lang_bits = static_cast<std::uint16_t>(language);
+    auto lang_bits = static_cast<unsigned int>(language);
     if (lang_bits == 0 || (lang_bits & (lang_bits - 1)) != 0)
     {
         FAIL_MSG("GenerateCombinedFile called with no language or multiple languages specified");
@@ -1027,10 +1028,10 @@ auto GenResults::GenerateCombinedFile(GenLang language) -> bool
     }
 
     // Currently only XRC is supported for combined file generation
-    if (language != GEN_LANG_XRC)
+    if (language != GenLang::xrc)
     {
         // Future: Add support for Python, Ruby, Perl
-        FAIL_MSG("GenerateCombinedFile currently only supports GEN_LANG_XRC");
+        FAIL_MSG("GenerateCombinedFile currently only supports GenLang::xrc");
         return false;
     }
 

--- a/src/generate/gen_results.h
+++ b/src/generate/gen_results.h
@@ -39,7 +39,7 @@ public:
     [[nodiscard]] auto GetMode() const { return m_mode; }
 
     // Set languages to generate (GenLang values are bit flags, can be combined)
-    // e.g., SetLanguages(GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)
+    // e.g., SetLanguages(GenLang::cplusplus | GenLang::python)
     void SetLanguages(GenLang languages) { m_languages = languages; }
     [[nodiscard]] auto GetLanguages() const { return m_languages; }
 
@@ -73,7 +73,7 @@ public:
     // Generate all forms into a single combined output file for the specified language.
     // language: must be exactly one language (error if multiple bits set)
     // Requires SetCombinedOutputPath() or project prop_combined_xrc_file to be set.
-    // Currently supports GEN_LANG_XRC. Future: Python, Ruby, Perl.
+    // Currently supports GenLang::xrc. Future: Python, Ruby, Perl.
     // Returns true if file was written/needs updating, false otherwise.
     [[nodiscard]] auto GenerateCombinedFile(GenLang language) -> bool;
 
@@ -162,7 +162,7 @@ private:
     // Class members
     Mode m_mode { Mode::generate_and_write };
     Scope m_scope { Scope::unknown };
-    GenLang m_languages { 0 };  // Bit flags for languages to generate
+    GenLang m_languages { GenLang::none };  // Bit flags for languages to generate
 
     std::vector<Node*> m_target_nodes;  // Forms to process
     Node* m_start_node { nullptr };     // Original node passed to SetNodes()
@@ -195,11 +195,11 @@ private:
 };
 
 // DEPRECATED: Use GenResults::Generate() with SetNodes(ProjectNode),
-// SetLanguages(GEN_LANG_CPLUSPLUS). If pClassList is non-null, it must contain the base class name
+// SetLanguages(GenLang::cplusplus). If pClassList is non-null, it must contain the base class name
 // of every form that needs updating.
 //
 // ../generate/gen_codefiles.cpp
-[[deprecated("Use GenResults::Generate() with SetNodes(), SetLanguages(GEN_LANG_CPLUSPLUS)")]]
+[[deprecated("Use GenResults::Generate() with SetNodes(), SetLanguages(GenLang::cplusplus)")]]
 auto GenerateCppFiles(GenResults& results, std::vector<std::string>* pClassList = nullptr) -> bool;
 
 // ../generate/gen_codefiles.cpp

--- a/src/generate/gen_ribbon_bar.cpp
+++ b/src/generate/gen_ribbon_bar.cpp
@@ -247,7 +247,7 @@ bool RibbonBarFormGenerator::GetIncludes(Node* node, std::set<std::string>& set_
 bool RibbonBarFormGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                         GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/rbn'");
         return true;
@@ -420,7 +420,7 @@ void RibbonBarGenerator::RequiredHandlers(Node* /* node */, std::set<std::string
 bool RibbonBarGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                     GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/rbn'");
         return true;

--- a/src/generate/gen_ribbon_button.cpp
+++ b/src/generate/gen_ribbon_button.cpp
@@ -83,7 +83,7 @@ bool RibbonButtonGenerator::ConstructionCode(Code& code)
 
     const wxue::StringVector parts(code.node()->as_string(prop_bitmap), BMP_PROP_SEPARATOR,
                                    wxue::TRIM::both);
-    if (code.is_cpp() && Project.get_LangVersion(GEN_LANG_CPLUSPLUS) >= CPP_WIDGETS_VERSION_3_3_0)
+    if (code.is_cpp() && Project.get_LangVersion(GenLang::cplusplus) >= CPP_WIDGETS_VERSION_3_3_0)
     {
         code.GenerateBundleParameter(parts, false);
     }

--- a/src/generate/gen_ribbon_gallery.cpp
+++ b/src/generate/gen_ribbon_gallery.cpp
@@ -132,7 +132,7 @@ void RibbonGalleryGenerator::GenerateGalleryItems(Node* gallery_node, WriteCode*
     const bool check_size = (gallery_size != wxDefaultSize);
 
     // Open brace scope (C++ only)
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         source->writeLine("{");
         source->Indent();
@@ -191,7 +191,7 @@ void RibbonGalleryGenerator::GenerateGalleryItems(Node* gallery_node, WriteCode*
             // Assign the bitmap expression to bmp, wrapping in wxBitmap() to handle
             // both wxBitmap and wxImage return types from GenerateBundleParameter.
             item_code << "bmp = wxBitmap(";
-            if (Project.get_LangVersion(GEN_LANG_CPLUSPLUS) >= CPP_WIDGETS_VERSION_3_3_0)
+            if (Project.get_LangVersion(GenLang::cplusplus) >= CPP_WIDGETS_VERSION_3_3_0)
             {
                 item_code.GenerateBundleParameter(parts, false);
                 item_code << ".GetBitmap(gallery_size)";
@@ -265,7 +265,7 @@ void RibbonGalleryGenerator::GenerateGalleryItems(Node* gallery_node, WriteCode*
     }
 
     // Close brace scope (C++ only)
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         source->Unindent();
         source->writeLine("}");
@@ -300,7 +300,7 @@ bool RibbonGalleryItemGenerator::ConstructionCode(Code& code)
     // REVIEW: [Randalphwa - 04-17-2026] Technically, this is in 3.3.3, but we don't currently
     // support that level of granularity for wxWidgets versions, so we'll just use 3.3.0 as the
     // cutoff for bundle support in C++.
-    if (code.is_cpp() && Project.get_LangVersion(GEN_LANG_CPLUSPLUS) >= CPP_WIDGETS_VERSION_3_3_0)
+    if (code.is_cpp() && Project.get_LangVersion(GenLang::cplusplus) >= CPP_WIDGETS_VERSION_3_3_0)
     {
         code.GenerateBundleParameter(parts, false);
     }

--- a/src/generate/gen_ribbon_page.cpp
+++ b/src/generate/gen_ribbon_page.cpp
@@ -46,7 +46,7 @@ bool RibbonPageGenerator::ConstructionCode(Code& code)
         const wxue::StringVector parts(code.node()->as_string(prop_bitmap), BMP_PROP_SEPARATOR,
                                        wxue::TRIM::both);
         if (code.is_cpp() &&
-            Project.get_LangVersion(GEN_LANG_CPLUSPLUS) >= CPP_WIDGETS_VERSION_3_3_0)
+            Project.get_LangVersion(GenLang::cplusplus) >= CPP_WIDGETS_VERSION_3_3_0)
         {
             code.GenerateBundleParameter(parts, false);
         }
@@ -135,7 +135,7 @@ bool RibbonPanelGenerator::ConstructionCode(Code& code)
         const wxue::StringVector parts(code.node()->as_string(prop_bitmap), BMP_PROP_SEPARATOR,
                                        wxue::TRIM::both);
         if (code.is_cpp() &&
-            Project.get_LangVersion(GEN_LANG_CPLUSPLUS) >= CPP_WIDGETS_VERSION_3_3_0)
+            Project.get_LangVersion(GenLang::cplusplus) >= CPP_WIDGETS_VERSION_3_3_0)
         {
             code.GenerateBundleParameter(parts, false);
         }

--- a/src/generate/gen_ribbon_tool.cpp
+++ b/src/generate/gen_ribbon_tool.cpp
@@ -105,7 +105,7 @@ std::optional<wxue::string> RibbonToolBarGenerator::GetWarning(Node* node, GenLa
 {
     switch (language)
     {
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             {
                 wxue::string message;
                 if (const Node* form = node->get_Form(); form && form->HasValue(prop_class_name))
@@ -129,7 +129,7 @@ bool RibbonToolGenerator::ConstructionCode(Code& code)
 
     const wxue::StringVector parts(code.node()->as_string(prop_bitmap), BMP_PROP_SEPARATOR,
                                    wxue::TRIM::both);
-    if (code.is_cpp() && Project.get_LangVersion(GEN_LANG_CPLUSPLUS) >= CPP_WIDGETS_VERSION_3_3_0)
+    if (code.is_cpp() && Project.get_LangVersion(GenLang::cplusplus) >= CPP_WIDGETS_VERSION_3_3_0)
 
     {
         code.GenerateBundleParameter(parts, false);

--- a/src/generate/gen_rich_text.cpp
+++ b/src/generate/gen_rich_text.cpp
@@ -100,7 +100,7 @@ bool RichTextCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
 bool RichTextCtrlGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                        GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/rtc'");
         return true;

--- a/src/generate/gen_spin_ctrl.cpp
+++ b/src/generate/gen_spin_ctrl.cpp
@@ -176,7 +176,7 @@ bool SpinCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
 
 wxObject* SpinCtrlDoubleGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    if (Project.get_CodePreference() == GEN_LANG_RUBY)
+    if (Project.get_CodePreference() == GenLang::ruby)
     {
         auto* widget = new wxStaticText(
             wxStaticCast(parent, wxWindow), wxID_ANY, "wxSpinCtrlDouble not available in wxRuby3",

--- a/src/generate/gen_statchkbox_sizer.cpp
+++ b/src/generate/gen_statchkbox_sizer.cpp
@@ -29,7 +29,7 @@ wxObject* StaticCheckboxBoxSizerGenerator::CreateMockup(Node* node, wxObject* pa
     // display the checkbox since Python doesn't support it.
     // Note: macOS doesn't support using a control as a wxStaticBox label
 #if !defined(__WXOSX__)
-    if (Project.get_CodePreference() != GEN_LANG_PYTHON ||
+    if (Project.get_CodePreference() != GenLang::python ||
         (Project.HasValue(prop_code_preference) && wxGetApp().isTestingMenuEnabled()))
     {
         long style_value = 0;
@@ -375,7 +375,7 @@ std::optional<wxue::string> StaticCheckboxBoxSizerGenerator::GetWarning(Node* no
 {
     switch (language)
     {
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             if (!wxGetApp().isCoverageTesting())
             {
                 wxue::string msg;
@@ -387,7 +387,7 @@ std::optional<wxue::string> StaticCheckboxBoxSizerGenerator::GetWarning(Node* no
                 return msg;
             }
 
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             return {};
 
         default:

--- a/src/generate/gen_statradiobox_sizer.cpp
+++ b/src/generate/gen_statradiobox_sizer.cpp
@@ -358,7 +358,7 @@ std::optional<wxue::string> StaticRadioBtnBoxSizerGenerator::GetWarning(Node* no
 {
     switch (language)
     {
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             if (!wxGetApp().isCoverageTesting())
             {
                 wxue::string msg;
@@ -370,7 +370,7 @@ std::optional<wxue::string> StaticRadioBtnBoxSizerGenerator::GetWarning(Node* no
                 return msg;
             }
 
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             return {};
 
         default:

--- a/src/generate/gen_std_dlgbtn_sizer.cpp
+++ b/src/generate/gen_std_dlgbtn_sizer.cpp
@@ -480,16 +480,17 @@ namespace
     {
         switch (language)
         {
-            case GEN_LANG_CPLUSPLUS:
+            case GenLang::cplusplus:
                 return EventHandlerDlg::GetCppValue(value);
-            case GEN_LANG_PYTHON:
+            case GenLang::python:
                 return EventHandlerDlg::GetPythonValue(value);
-            case GEN_LANG_RUBY:
+            case GenLang::ruby:
                 return EventHandlerDlg::GetRubyValue(value);
 
             default:
-                FAIL_MSG(wxue::string() << "No event handlers for " << GenLangToString(language)
-                                        << " (" << language << ")");
+                FAIL_MSG(wxue::string()
+                         << "No event handlers for " << GenLangToString(language) << " ("
+                         << static_cast<int>(std::to_underlying(language)) << ")");
                 return EventHandlerDlg::GetCppValue(value);
         }
     }
@@ -610,7 +611,7 @@ namespace
     {
         const auto& event_name = event->get_name();
         const auto is_script_lang =
-            (code.get_language() == GEN_LANG_PYTHON || code.get_language() == GEN_LANG_RUBY);
+            (code.get_language() == GenLang::python || code.get_language() == GenLang::ruby);
 
         if (is_script_lang)
         {

--- a/src/generate/gen_styled_text.cpp
+++ b/src/generate/gen_styled_text.cpp
@@ -1361,7 +1361,7 @@ void StyledTextGenerator::RequiredHandlers(Node* /* node */, std::set<std::strin
 bool StyledTextGenerator::GetImports(Node* /* node */, std::set<std::string>& set_imports,
                                      GenLang language)
 {
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         set_imports.insert("require 'wx/stc'");
         return true;

--- a/src/generate/gen_tree_list.cpp
+++ b/src/generate/gen_tree_list.cpp
@@ -57,8 +57,8 @@ bool TreeListCtrlGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
 
 void TreeListCtrlGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& class_name)
 {
-    if (code.get_language() == GEN_LANG_NONE ||
-        (code.get_language() & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+    if (code.get_language() == GenLang::none ||
+        (code.get_language() & (GenLang::cplusplus | GenLang::python)))
     {
         BaseGenerator::GenEvent(code, event, class_name);
     }
@@ -70,7 +70,7 @@ std::optional<wxue::string> TreeListCtrlGenerator::GetWarning(Node* node, GenLan
 {
     switch (language)
     {
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             if (!wxGetApp().isCoverageTesting())
             {
                 wxue::string msg;
@@ -88,7 +88,7 @@ std::optional<wxue::string> TreeListCtrlGenerator::GetWarning(Node* node, GenLan
 
 std::pair<bool, wxue::string> TreeListCtrlGenerator::isLanguageVersionSupported(GenLang language)
 {
-    if (language == GEN_LANG_NONE || (language & (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON)))
+    if (language == GenLang::none || (language & (GenLang::cplusplus | GenLang::python)))
     {
         return { true, {} };
     }

--- a/src/generate/gen_web_view.cpp
+++ b/src/generate/gen_web_view.cpp
@@ -19,11 +19,11 @@
 
 wxObject* WebViewGenerator::CreateMockup(Node* node, wxObject* parent)
 {
-    if (Project.get_CodePreference() == GEN_LANG_RUBY ||
-        Project.get_CodePreference() == GEN_LANG_XRC)
+    if (Project.get_CodePreference() == GenLang::ruby ||
+        Project.get_CodePreference() == GenLang::xrc)
     {
         wxString msg = "wxWebView not available in ";
-        if (Project.get_CodePreference() == GEN_LANG_RUBY)
+        if (Project.get_CodePreference() == GenLang::ruby)
         {
             msg += "wxRuby3";
         }
@@ -97,7 +97,7 @@ std::optional<wxue::string> WebViewGenerator::GetWarning(Node* node, GenLang lan
 {
     switch (language)
     {
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             {
                 wxue::string msg;
                 if (auto* form = node->get_Form(); form && form->HasValue(prop_class_name))

--- a/src/generate/mdi/gen_doc_textctrl.cpp
+++ b/src/generate/mdi/gen_doc_textctrl.cpp
@@ -96,7 +96,7 @@ auto TextDocGenerator::GetIncludes([[maybe_unused]] Node* node, std::set<std::st
                                    [[maybe_unused]] std::set<std::string>& set_hdr,
                                    GenLang language) -> bool
 {
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         set_src.insert("#include <iostream");
         return true;

--- a/src/generate/mdi/gen_doc_view_app.cpp
+++ b/src/generate/mdi/gen_doc_view_app.cpp
@@ -191,7 +191,7 @@ auto DocViewAppGenerator::AfterConstructionCode(Code& code) -> bool
             std::string line = wxline.ToStdString();
             utils::replace_in_line(line, "%class%", class_name, true);
             utils::replace_in_line(line, "%document_menu%",
-                                   code.node()->get_NodeName(GEN_LANG_CPLUSPLUS), true);
+                                   code.node()->get_NodeName(GenLang::cplusplus), true);
             if (is_mdi)
             {
                 utils::replace_in_line(line, "wxAuiMDIChildFrame", "wxDocMDIChildFrame", true);
@@ -302,7 +302,7 @@ auto DocViewAppGenerator::GetIncludes(Node* node, std::set<std::string>& set_src
 {
     set_hdr.insert("#include <wx/app.h>");
 
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         if (node->as_string(prop_kind) == "AUI")
         {

--- a/src/generate/mdi/gen_view_textctrl.cpp
+++ b/src/generate/mdi/gen_view_textctrl.cpp
@@ -90,7 +90,7 @@ auto TextViewGenerator::ConstructionCode(Code& code) -> bool
 auto TextViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
                                     std::set<std::string>& set_hdr, GenLang language) -> bool
 {
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         set_src.insert("#include <wx/docmdi.h>");
         set_hdr.insert("#include <wx/docview.h>");

--- a/src/generate/window_widgets.cpp
+++ b/src/generate/window_widgets.cpp
@@ -75,7 +75,7 @@ std::optional<wxue::string> ScrolledCanvasGenerator::GetWarning(Node* node, GenL
 {
     switch (language)
     {
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             {
                 wxue::string msg;
                 if (auto* form = node->get_Form(); form && form->HasValue(prop_class_name))

--- a/src/generate/writers/code.cpp
+++ b/src/generate/writers/code.cpp
@@ -249,14 +249,14 @@ constexpr size_t DEFAULT_LINE_LENGTH = 90;         // NOLINT (magic number)
 {
     switch (language)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             return Project.as_size_t(prop_cpp_line_length);
 
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             return Project.as_size_t(prop_python_line_length);
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             return Project.as_size_t(prop_ruby_line_length);
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             return XRC_LINE_LENGTH;
         default:
             return DEFAULT_LINE_LENGTH;
@@ -281,7 +281,7 @@ auto Code::GetLanguagePrefix(std::string_view candidate, GenLang language) -> st
 
     switch (language)
     {
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             if (auto result = find_prefix_match(s_short_python_map, candidate))
             {
                 return *result;
@@ -293,7 +293,7 @@ auto Code::GetLanguagePrefix(std::string_view candidate, GenLang language) -> st
             }
             break;
 
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             if (auto result = find_prefix_match(s_short_ruby_map, candidate))
             {
                 return *result;
@@ -304,7 +304,7 @@ auto Code::GetLanguagePrefix(std::string_view candidate, GenLang language) -> st
             }
             break;
 
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             FAIL_MSG("Don't call GetLanguagePrefix() for C++ code!");
             return {};
 

--- a/src/generate/writers/code.h
+++ b/src/generate/writers/code.h
@@ -87,8 +87,8 @@ public:
     static constexpr int DEFAULT_BREAK_LENGTH = 80;
     static constexpr int MIN_BREAK_LENGTH = 10;
 
-    Code(Node* node, GenLang language = GEN_LANG_CPLUSPLUS);
-    void Init(Node* node, GenLang language = GEN_LANG_CPLUSPLUS);
+    Code(Node* node, GenLang language = GenLang::cplusplus);
+    void Init(Node* node, GenLang language = GenLang::cplusplus);
 
     auto GetCode() -> wxue::string& { return *this; }
     [[nodiscard]] auto GetView() const -> wxue::string_view { return *this; }
@@ -109,9 +109,9 @@ public:
         }
     }
 
-    [[nodiscard]] auto is_cpp() const -> bool { return m_language == GEN_LANG_CPLUSPLUS; }
-    [[nodiscard]] auto is_python() const -> bool { return m_language == GEN_LANG_PYTHON; }
-    [[nodiscard]] auto is_ruby() const -> bool { return m_language == GEN_LANG_RUBY; }
+    [[nodiscard]] auto is_cpp() const -> bool { return m_language == GenLang::cplusplus; }
+    [[nodiscard]] auto is_python() const -> bool { return m_language == GenLang::python; }
+    [[nodiscard]] auto is_ruby() const -> bool { return m_language == GenLang::ruby; }
 
     // Returns true if the language is an FFI-based language (Fortran, Go, Julia, LuaJIT,
     // TypeScript)

--- a/src/generate/writers/code_bundle.cpp
+++ b/src/generate/writers/code_bundle.cpp
@@ -28,11 +28,11 @@ Code& Code::Bundle(GenEnum::PropName prop_name)
     {
         switch (m_language)
         {
-            case GEN_LANG_PYTHON:
+            case GenLang::python:
                 BundlePython(parts);
                 break;
 
-            case GEN_LANG_RUBY:
+            case GenLang::ruby:
                 BundleRuby(parts);
                 break;
 
@@ -382,7 +382,7 @@ void Code::BundleRuby(const wxue::StringVector& parts)
         }
         else if (bundle->lst_filenames.size() == 1)
         {
-            auto path = Project.get_BaseDirectory(node(), GEN_LANG_RUBY);
+            auto path = Project.get_BaseDirectory(node(), GenLang::ruby);
 
             wxue::string name(bundle->lst_filenames[0]);
             name.make_absolute();
@@ -394,7 +394,7 @@ void Code::BundleRuby(const wxue::StringVector& parts)
         }
         else if (bundle->lst_filenames.size() == 2)
         {
-            auto path = Project.get_BaseDirectory(node(), GEN_LANG_RUBY);
+            auto path = Project.get_BaseDirectory(node(), GenLang::ruby);
 
             wxue::string name(bundle->lst_filenames[0]);
             name.make_absolute();

--- a/src/generate/writers/file_codewriter.cpp
+++ b/src/generate/writers/file_codewriter.cpp
@@ -113,7 +113,7 @@ auto FileCodeWriter::WriteFile(GenLang language, int flags,
     // there's an 'end' statement in the original. User may have modified or removed the
     // comment, added blank lines, or added their own content - none require an update.
     // This handles all size comparisons (same size, larger, or smaller original) in one place.
-    if (m_language == GEN_LANG_RUBY && m_fake_content_pos > 0 &&
+    if (m_language == GenLang::ruby && m_fake_content_pos > 0 &&
         m_org_buffer.size() >= m_fake_content_pos)
     {
         // Compare up to the end of </auto-generated> line (before fake content)
@@ -142,7 +142,7 @@ auto FileCodeWriter::WriteFile(GenLang language, int flags,
     }
 
     // ========== BRANCH 2b: Handle non-Ruby files where original is larger ==========
-    if (m_language != GEN_LANG_RUBY && m_org_buffer.size() > m_buffer.size())
+    if (m_language != GenLang::ruby && m_org_buffer.size() > m_buffer.size())
     {
         // Non-Ruby languages: Original file has more content than our buffer.
         // Check if our new buffer matches the beginning portion of the original.
@@ -157,7 +157,7 @@ auto FileCodeWriter::WriteFile(GenLang language, int flags,
     }
 
     // ========== BRANCH 2c: Handle non-Ruby files where buffers are same size ==========
-    if (m_language != GEN_LANG_RUBY && m_org_buffer.size() == m_buffer.size())
+    if (m_language != GenLang::ruby && m_org_buffer.size() == m_buffer.size())
     {
         // Non-Ruby, same size but different content - try to append original user content.
         auto begin_user_content = m_buffer.size();
@@ -234,15 +234,15 @@ auto FileCodeWriter::WriteFile(GenLang language, int flags,
 
 [[nodiscard]] auto FileCodeWriter::GetCommentLineToFind(GenLang language) -> std::string_view
 {
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         return GetCppEndCommentLine();
     }
-    if (language == GEN_LANG_PYTHON)
+    if (language == GenLang::python)
     {
         return GetPythonEndCommentLine();
     }
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         return GetRubyEndCommentLine();
     }
@@ -252,15 +252,15 @@ auto FileCodeWriter::WriteFile(GenLang language, int flags,
 
 [[nodiscard]] auto FileCodeWriter::GetBlockLength(GenLang language) -> size_t
 {
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         return GetCppEndBlockLength();
     }
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         return GetRubyEndBlockLength();
     }
-    if (language == GEN_LANG_PYTHON)
+    if (language == GenLang::python)
     {
         return GetPythonEndBlockLength();
     }
@@ -396,7 +396,7 @@ void FileCodeWriter::AppendCppEndBlock()
         // file has content after the comment block that should be preserved instead.
         if (m_node)
         {
-            Code code(m_node, GEN_LANG_CPLUSPLUS);
+            Code code(m_node, GenLang::cplusplus);
             code.Eol().Eol(eol_always).Str("};").Eol();
             m_buffer += code;
         }
@@ -424,7 +424,7 @@ void FileCodeWriter::AppendRubyEndBlock()
     {
         // Always add the 'end' statement here - it will be removed later if the original
         // file has content after the comment block that should be preserved instead.
-        Code code(m_node, GEN_LANG_RUBY);
+        Code code(m_node, GenLang::ruby);
         code.Eol().Str("end  # end of ").Str(m_node->get_NodeName()).Str(" class").Eol();
         m_buffer += code;
     }
@@ -438,13 +438,13 @@ void FileCodeWriter::AppendEndOfFileBlock()
 {
     switch (m_language)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             AppendCppEndBlock();
             break;
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             AppendPythonEndBlock();
             break;
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             AppendRubyEndBlock();
             break;
         default:
@@ -454,7 +454,7 @@ void FileCodeWriter::AppendEndOfFileBlock()
 
 void FileCodeWriter::AppendMissingCommentBlockWarning()
 {
-    const auto* const comment_char = (m_language == GEN_LANG_CPLUSPLUS) ? "//" : "#";
+    const auto* const comment_char = (m_language == GenLang::cplusplus) ? "//" : "#";
 
     m_buffer += "\n";
     m_buffer += comment_char;

--- a/src/generate/writers/file_codewriter.h
+++ b/src/generate/writers/file_codewriter.h
@@ -108,7 +108,7 @@ private:
     Node* m_node { nullptr };
 
     // Shared state between helper methods
-    GenLang m_language { GEN_LANG_NONE };
+    GenLang m_language { GenLang::none };
     int m_flags { 0 };
     bool m_file_exists { false };
     size_t m_block_length { 0 };

--- a/src/generate/writers/gen_base.h
+++ b/src/generate/writers/gen_base.h
@@ -193,7 +193,7 @@ protected:
 
     PANEL_PAGE m_panel_type { PANEL_PAGE::NOT_PANEL };
 
-    GenLang m_language { GEN_LANG_CPLUSPLUS };
+    GenLang m_language { GenLang::cplusplus };
     std::unique_ptr<LanguageStrategy> m_strategy;
 
     bool m_is_derived_class { true };

--- a/src/generate/writers/gen_cmake.cpp
+++ b/src/generate/writers/gen_cmake.cpp
@@ -168,7 +168,7 @@ int WriteCMakeFile(Node* parent_node, GenResults& results, int flag)
                 }
             }
 
-            auto [path, has_base_file] = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
+            auto [path, has_base_file] = Project.GetOutputPath(form, GenLang::cplusplus);
             if (!has_base_file)
             {
                 // No file was specified. It's unlikely this would actually happen given the

--- a/src/generate/writers/gen_codefiles.cpp
+++ b/src/generate/writers/gen_codefiles.cpp
@@ -105,7 +105,7 @@ auto GenInheritedClass(GenResults& results) -> void
             {
                 flags |= flag_add_closing_brace;
             }
-            retval = h_cw->WriteFile(GEN_LANG_CPLUSPLUS, flags);
+            retval = h_cw->WriteFile(GenLang::cplusplus, flags);
             if (retval == result::fail)
             {
                 results.GetMsgs().emplace_back(
@@ -140,7 +140,7 @@ auto GenInheritedClass(GenResults& results) -> void
                 flags |= flag_add_closing_brace;
             }
 
-            retval = h_cw->WriteFile(GEN_LANG_CPLUSPLUS, flags);
+            retval = h_cw->WriteFile(GenLang::cplusplus, flags);
         }
 
         if (retval == result::fail)
@@ -158,7 +158,7 @@ auto GenInheritedClass(GenResults& results) -> void
         }
 
         path.replace_extension(source_ext);
-        retval = cpp_cw->WriteFile(GEN_LANG_CPLUSPLUS, flag_no_ui);
+        retval = cpp_cw->WriteFile(GenLang::cplusplus, flag_no_ui);
         if (retval == result::fail)
         {
             results.GetMsgs().emplace_back(

--- a/src/generate/writers/gen_construction.cpp
+++ b/src/generate/writers/gen_construction.cpp
@@ -39,16 +39,16 @@ auto BaseCodeGenerator::GenConstruction(Node* node) -> void
 {
     if (auto& disable_langs = node->as_string(prop_disable_language); disable_langs.size())
     {
-        if (m_language == GEN_LANG_CPLUSPLUS && disable_langs.contains("C++"))
+        if (m_language == GenLang::cplusplus && disable_langs.contains("C++"))
         {
             return;
         }
 
-        if (m_language == GEN_LANG_PYTHON && disable_langs.contains("wxPython"))
+        if (m_language == GenLang::python && disable_langs.contains("wxPython"))
         {
             return;
         }
-        if (m_language == GEN_LANG_RUBY && disable_langs.contains("wxRuby"))
+        if (m_language == GenLang::ruby && disable_langs.contains("wxRuby"))
         {
             return;
         }
@@ -81,13 +81,13 @@ auto BaseCodeGenerator::GenConstruction(Node* node) -> void
     if (node->HasValue(prop_platforms) && node->as_string(prop_platforms) != "Windows|Unix|Mac")
     {
         BeginPlatformCode(gen_code, node->as_string(prop_platforms));
-        if (m_language != GEN_LANG_PYTHON)
+        if (m_language != GenLang::python)
         {
             gen_code.Eol();
         }
         m_source->writeLine(gen_code);
         gen_code.clear();
-        if (m_language == GEN_LANG_PYTHON || m_language == GEN_LANG_RUBY)
+        if (m_language == GenLang::python || m_language == GenLang::ruby)
         {
             m_source->Indent();
             m_source->SetLastLineBlank();
@@ -155,7 +155,7 @@ auto BaseCodeGenerator::GenConstruction(Node* node) -> void
 
     if (parent->is_Sizer())
     {
-        if (node->is_Gen(gen_wxFileCtrl) && m_language == GEN_LANG_RUBY &&
+        if (node->is_Gen(gen_wxFileCtrl) && m_language == GenLang::ruby &&
             Project.get_ProjectNode()->as_string(prop_wxRuby_version) == "0.9.0")
         {
         }
@@ -357,7 +357,7 @@ auto BaseCodeGenerator::EndPlatformCode() -> void
 
 auto BaseCodeGenerator::BeginBrace() -> void
 {
-    if (m_language == GEN_LANG_CPLUSPLUS)
+    if (m_language == GenLang::cplusplus)
     {
         m_source->writeLine("{");
         m_source->Indent();
@@ -366,7 +366,7 @@ auto BaseCodeGenerator::BeginBrace() -> void
 
 auto BaseCodeGenerator::EndBrace() -> void
 {
-    if (m_language == GEN_LANG_CPLUSPLUS)
+    if (m_language == GenLang::cplusplus)
     {
         m_source->Unindent();
         m_source->writeLine("}");
@@ -382,7 +382,7 @@ auto BaseCodeGenerator::GenSettings(Node* node, bool within_brace) -> void
     {
         if (code.size())
         {
-            if ((m_language == GEN_LANG_CPLUSPLUS) && within_brace)
+            if ((m_language == GenLang::cplusplus) && within_brace)
             {
                 m_source->Indent();
                 m_source->writeLine(code);
@@ -420,16 +420,16 @@ bool BaseCodeGenerator::GenAfterChildren(Node* node, bool need_closing_brace)
 
     if (auto& disable_langs = node->as_string(prop_disable_language); disable_langs.size())
     {
-        if (m_language == GEN_LANG_CPLUSPLUS && disable_langs.contains("C++"))
+        if (m_language == GenLang::cplusplus && disable_langs.contains("C++"))
         {
             return false;
         }
 
-        if (m_language == GEN_LANG_PYTHON && disable_langs.contains("wxPython"))
+        if (m_language == GenLang::python && disable_langs.contains("wxPython"))
         {
             return false;
         }
-        if (m_language == GEN_LANG_RUBY && disable_langs.contains("wxRuby"))
+        if (m_language == GenLang::ruby && disable_langs.contains("wxRuby"))
         {
             return false;
         }
@@ -496,7 +496,7 @@ bool BaseCodeGenerator::GenAfterChildren(Node* node, bool need_closing_brace)
             if (need_closing_brace)
             {
                 m_source->writeLine(gen_code.GetCode(), indent::auto_keep_whitespace);
-                if (m_language == GEN_LANG_CPLUSPLUS)
+                if (m_language == GenLang::cplusplus)
                 {
                     m_source->writeLine("}");
                 }
@@ -608,7 +608,7 @@ auto BaseCodeGenerator::GenParentSizer(Node* node, bool need_closing_brace) -> v
     if (need_closing_brace)
     {
         m_source->writeLine(code.GetCode(), indent::auto_keep_whitespace);
-        if (m_language == GEN_LANG_CPLUSPLUS)
+        if (m_language == GenLang::cplusplus)
         {
             m_source->writeLine("}");
         }

--- a/src/generate/writers/gen_cpp.cpp
+++ b/src/generate/writers/gen_cpp.cpp
@@ -130,7 +130,7 @@ void MainFrame::OnGenSingleCpp(wxCommandEvent& /* event unused */)
 
     GenResults results;
     results.SetNodes(form);
-    results.SetLanguages(GEN_LANG_CPLUSPLUS);
+    results.SetLanguages(GenLang::cplusplus);
     results.SetMode(GenResults::Mode::generate_and_write);
     std::ignore = results.Generate();
 
@@ -169,7 +169,7 @@ void GenCppForm(GenData& gen_data, Node* form)
     const auto& source_ext = gen_data.get_source_ext();
     const auto& header_ext = gen_data.get_header_ext();
 
-    auto [path, has_base_file] = Project.GetOutputPath(form, GEN_LANG_CPLUSPLUS);
+    auto [path, has_base_file] = Project.GetOutputPath(form, GenLang::cplusplus);
     if (!has_base_file)
     {
         wxue::string msg("No filename specified for ");
@@ -209,7 +209,7 @@ void GenCppForm(GenData& gen_data, Node* form)
     {
         flags |= flag_add_closing_brace;
     }
-    auto retval = h_cw->WriteFile(GEN_LANG_CPLUSPLUS, flags, form);
+    auto retval = h_cw->WriteFile(GenLang::cplusplus, flags, form);
     if (form->as_bool(prop_no_closing_brace))
     {
         flags = flags & ~flag_add_closing_brace;
@@ -250,7 +250,7 @@ void GenCppForm(GenData& gen_data, Node* form)
     }
 
     path.replace_extension(source_ext);
-    retval = cpp_cw->WriteFile(GEN_LANG_CPLUSPLUS, flags, form);
+    retval = cpp_cw->WriteFile(GenLang::cplusplus, flags, form);
 
     if (retval > 0)
     {
@@ -452,7 +452,7 @@ void CppCodeGenerator::GenCppImageFunctions()
 
     if (m_embedded_images.size())
     {
-        Code code(m_form_node, GEN_LANG_CPLUSPLUS);
+        Code code(m_form_node, GenLang::cplusplus);
         WriteImagePreConstruction(code);
         if (code.size())
         {
@@ -464,13 +464,13 @@ void CppCodeGenerator::GenCppImageFunctions()
 
     if (m_embedded_images.size())
     {
-        Code code(m_form_node, GEN_LANG_CPLUSPLUS);
+        Code code(m_form_node, GenLang::cplusplus);
         WriteImageConstruction(code);
     }
 }
 
 CppCodeGenerator::CppCodeGenerator(Node* form_node) :
-    BaseCodeGenerator(GEN_LANG_CPLUSPLUS, form_node)
+    BaseCodeGenerator(GenLang::cplusplus, form_node)
 {
 }
 
@@ -486,7 +486,7 @@ void CppCodeGenerator::InitializeGenerationState()
     SetImagesForm();
     if (m_ImagesForm && m_ImagesForm->HasValue(prop_base_file))
     {
-        auto [path, has_base_file] = Project.GetOutputPath(m_ImagesForm, GEN_LANG_CPLUSPLUS);
+        auto [path, has_base_file] = Project.GetOutputPath(m_ImagesForm, GenLang::cplusplus);
         if (has_base_file)
         {
             path.make_relative(Project.get_BaseDirectory(m_form_node).make_absolute());
@@ -509,7 +509,7 @@ auto CppCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_type,
 {
     m_language = language;
     m_panel_type = panel_type;
-    ASSERT(m_language == GEN_LANG_CPLUSPLUS)
+    ASSERT(m_language == GenLang::cplusplus)
     if (m_form_node->is_Gen(gen_Data))
     {
         GenerateDataClassConstructor(panel_type);
@@ -1089,11 +1089,11 @@ void CppCodeGenerator::GenerateConstructorClosing(Code& code, BaseGenerator* gen
 
 void CppCodeGenerator::GenerateCppClassConstructor()
 {
-    ASSERT(m_language == GEN_LANG_CPLUSPLUS);
+    ASSERT(m_language == GenLang::cplusplus);
     m_source->writeLine();
 
     auto* generator = m_form_node->get_Generator();
-    Code code(m_form_node, GEN_LANG_CPLUSPLUS);
+    Code code(m_form_node, GenLang::cplusplus);
 
     GenerateConstructionPreamble(code, generator);
     GenerateChildrenAndEvents(code, generator);
@@ -1102,7 +1102,7 @@ void CppCodeGenerator::GenerateCppClassConstructor()
 
 void CppCodeGenerator::GenerateCppHandlers()
 {
-    ASSERT(m_language == GEN_LANG_CPLUSPLUS);
+    ASSERT(m_language == GenLang::cplusplus);
 
     if (m_embedded_images.size())
     {
@@ -1141,7 +1141,7 @@ auto CppCodeGenerator::CollectUserEventHandlers(std::unordered_set<std::string>&
 #endif  // _DEBUG
     {
         wxue::ViewVector org_file;
-        auto [path, has_base_file] = Project.GetOutputPath(m_form_node, GEN_LANG_CPLUSPLUS);
+        auto [path, has_base_file] = Project.GetOutputPath(m_form_node, GenLang::cplusplus);
 
         if (has_base_file && path.extension().empty())
         {
@@ -1255,7 +1255,7 @@ void CppCodeGenerator::GenUnhandledEvents(EventVector& events)
     // generate each function once.
     std::unordered_set<std::string> code_lines;
 
-    Code code(m_form_node, GEN_LANG_CPLUSPLUS);
+    Code code(m_form_node, GenLang::cplusplus);
     auto sort_event_handlers = [](NodeEvent* event_a, NodeEvent* event_b)
     {
         return (EventHandlerDlg::GetCppValue(event_a->get_value()) <
@@ -1348,7 +1348,7 @@ void CppCodeGenerator::GenUnhandledEvents(EventVector& events)
 // This should only be called to generate C++ code.
 void CppCodeGenerator::GenCppEnumIds(Node* class_node)
 {
-    ASSERT(m_language == GEN_LANG_CPLUSPLUS);
+    ASSERT(m_language == GenLang::cplusplus);
 
     if (!class_node->as_bool(prop_generate_ids))
     {
@@ -1422,7 +1422,7 @@ void CppCodeGenerator::GenCppEnumIds(Node* class_node)
 
 void CppCodeGenerator::GenerateDataClassConstructor(PANEL_PAGE panel_type)
 {
-    Code code(m_form_node, GEN_LANG_CPLUSPLUS);
+    Code code(m_form_node, GenLang::cplusplus);
 
     m_panel_type = panel_type;
 
@@ -1439,7 +1439,7 @@ void CppCodeGenerator::GenerateDataClassConstructor(PANEL_PAGE panel_type)
         m_source->writeLine(txt_SlashCmtBlock);
     }
 
-    auto [path, has_base_file] = Project.GetOutputPath(m_form_node, GEN_LANG_CPLUSPLUS);
+    auto [path, has_base_file] = Project.GetOutputPath(m_form_node, GenLang::cplusplus);
     m_baseFullPath = path;
     if (has_base_file)
     {

--- a/src/generate/writers/gen_cpp.h
+++ b/src/generate/writers/gen_cpp.h
@@ -17,7 +17,7 @@ public:
     CppCodeGenerator(Node* form_node);
 
     // All language generators must implement this method.
-    void GenerateClass(GenLang language = GEN_LANG_CPLUSPLUS,
+    void GenerateClass(GenLang language = GenLang::cplusplus,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 

--- a/src/generate/writers/gen_cpp_header.cpp
+++ b/src/generate/writers/gen_cpp_header.cpp
@@ -24,7 +24,7 @@ using namespace code;
 
 void CppCodeGenerator::GenerateCppClassHeader(bool class_namespace)
 {
-    ASSERT(m_language == GEN_LANG_CPLUSPLUS);
+    ASSERT(m_language == GenLang::cplusplus);
 
     if (m_form_node->is_Gen(gen_Images) || m_form_node->is_Gen(gen_Data))
     {
@@ -39,7 +39,7 @@ void CppCodeGenerator::GenerateCppClassHeader(bool class_namespace)
     }
 
     auto* generator = m_form_node->get_NodeDeclaration()->get_Generator();
-    Code code(m_form_node, GEN_LANG_CPLUSPLUS);
+    Code code(m_form_node, GenLang::cplusplus);
 
     // This may result in two blank lines, but without it there may be a case where there is no
     // blank line at all.
@@ -80,7 +80,7 @@ void CppCodeGenerator::GenerateCppClassHeader(bool class_namespace)
 
 void CppCodeGenerator::GenHdrEvents()
 {
-    ASSERT(m_language == GEN_LANG_CPLUSPLUS);
+    ASSERT(m_language == GenLang::cplusplus);
 
     if (m_events.size() || m_ctx_menu_events.size())
     {
@@ -116,7 +116,7 @@ void CppCodeGenerator::GenHdrEvents()
             WriteEventHandlerHeader();
         }
 
-        Code code(nullptr, GEN_LANG_CPLUSPLUS);
+        Code code(nullptr, GenLang::cplusplus);
         ProcessConditionalEvents(code);
     }
 }

--- a/src/generate/writers/gen_cpp_variables.cpp
+++ b/src/generate/writers/gen_cpp_variables.cpp
@@ -218,7 +218,7 @@ void CppCodeGenerator::CollectValidatorVariables(Node* node, std::set<std::strin
 
 void CppCodeGenerator::GenCppValidatorFunctions(Node* node)
 {
-    ASSERT(m_language == GEN_LANG_CPLUSPLUS);
+    ASSERT(m_language == GenLang::cplusplus);
 
     if (node->HasValue(prop_validator_variable))
     {
@@ -315,7 +315,7 @@ void CppCodeGenerator::InsertValidatorVariable(Node* node, const wxue::string& c
 void CppCodeGenerator::GenCppValVarsBase(const NodeDeclaration* declaration, Node* node,
                                          std::set<std::string>& code_lines)
 {
-    ASSERT(m_language == GEN_LANG_CPLUSPLUS);
+    ASSERT(m_language == GenLang::cplusplus);
 
     if (const auto& var_name = node->as_string(prop_validator_variable); var_name.size())
     {

--- a/src/generate/writers/gen_derived.cpp
+++ b/src/generate/writers/gen_derived.cpp
@@ -124,7 +124,7 @@ wxue::string CppCodeGenerator::DetermineDerivedFilePath(Node* form, PANEL_PAGE p
 
     if (m_is_derived_class && m_form_node->HasValue(prop_derived_file))
     {
-        derived_file = Project.get_BaseDirectory(form, GEN_LANG_CPLUSPLUS);
+        derived_file = Project.get_BaseDirectory(form, GenLang::cplusplus);
         if (!derived_file.empty())
         {
             derived_file.append_filename(m_form_node->as_string(prop_derived_file));
@@ -170,7 +170,7 @@ void CppCodeGenerator::DetermineBaseFilePath(Node* form, wxue::string& baseFile)
 {
     if (const auto& file = m_form_node->as_string(prop_base_file); !file.empty())
     {
-        baseFile = Project.get_BaseDirectory(form, GEN_LANG_CPLUSPLUS);
+        baseFile = Project.get_BaseDirectory(form, GenLang::cplusplus);
         if (!baseFile.empty())
         {
             baseFile.append_filename(file);
@@ -525,7 +525,7 @@ void CppCodeGenerator::WriteEventHandlerImplementation(NodeEvent* event,
     }
     else if (close_type_button)
     {
-        Code code(m_form_node, GEN_LANG_CPLUSPLUS);
+        Code code(m_form_node, GenLang::cplusplus);
         code.Str("if (!Validate() || !TransferDataFromWindow())");
         code.OpenBrace();
         code.Str("return;");

--- a/src/generate/writers/gen_events.cpp
+++ b/src/generate/writers/gen_events.cpp
@@ -46,16 +46,16 @@ void BaseGenerator::GenEvent(Code& code, NodeEvent* event, const std::string& cl
 
     Code handler(event->getNode(), code.get_language());
     wxue::string event_code;
-    if (code.get_language() == GEN_LANG_CPLUSPLUS)
+    if (code.get_language() == GenLang::cplusplus)
     {
         event_code = EventHandlerDlg::GetCppValue(event->get_value());
     }
 
-    else if (code.get_language() == GEN_LANG_PYTHON)
+    else if (code.get_language() == GenLang::python)
     {
         event_code = EventHandlerDlg::GetPythonValue(event->get_value());
     }
-    else if (code.get_language() == GEN_LANG_RUBY)
+    else if (code.get_language() == GenLang::ruby)
     {
         event_code = EventHandlerDlg::GetRubyValue(event->get_value());
     }
@@ -454,7 +454,7 @@ void BaseCodeGenerator::GenSrcEventBinding(Node* node, EventVector& events)
         BeginPlatformCode(code, map_entry.first);
         code.Eol();
         m_source->writeLine(code);
-        if (m_language == GEN_LANG_PYTHON || m_language == GEN_LANG_RUBY)
+        if (m_language == GenLang::python || m_language == GenLang::ruby)
         {
             m_source->Indent();
         }

--- a/src/generate/writers/gen_fortran.cpp
+++ b/src/generate/writers/gen_fortran.cpp
@@ -20,7 +20,7 @@ using namespace code;
 using namespace GenEnum;
 
 FortranCodeGenerator::FortranCodeGenerator(Node* form_node) :
-    BaseCodeGenerator(GEN_LANG_FORTRAN, form_node)
+    BaseCodeGenerator(GenLang::fortran, form_node)
 {
 }
 
@@ -29,7 +29,7 @@ void FortranCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_type
 {
     m_language = language;
     m_panel_type = panel_type;
-    ASSERT(m_language == GEN_LANG_FORTRAN);
+    ASSERT(m_language == GenLang::fortran);
     Code code(m_form_node, m_language);
 
     if (m_header)

--- a/src/generate/writers/gen_fortran.h
+++ b/src/generate/writers/gen_fortran.h
@@ -14,7 +14,7 @@ class FortranCodeGenerator : public BaseCodeGenerator
 public:
     FortranCodeGenerator(Node* form_node);
 
-    void GenerateClass(GenLang language = GEN_LANG_FORTRAN,
+    void GenerateClass(GenLang language = GenLang::fortran,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 

--- a/src/generate/writers/gen_go.cpp
+++ b/src/generate/writers/gen_go.cpp
@@ -19,14 +19,14 @@
 using namespace code;
 using namespace GenEnum;
 
-GoCodeGenerator::GoCodeGenerator(Node* form_node) : BaseCodeGenerator(GEN_LANG_GO, form_node) {}
+GoCodeGenerator::GoCodeGenerator(Node* form_node) : BaseCodeGenerator(GenLang::go, form_node) {}
 
 void GoCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_type,
                                     wxProgressDialog* /* progress */)
 {
     m_language = language;
     m_panel_type = panel_type;
-    ASSERT(m_language == GEN_LANG_GO);
+    ASSERT(m_language == GenLang::go);
     Code code(m_form_node, m_language);
 
     if (m_header)

--- a/src/generate/writers/gen_go.h
+++ b/src/generate/writers/gen_go.h
@@ -14,7 +14,7 @@ class GoCodeGenerator : public BaseCodeGenerator
 public:
     GoCodeGenerator(Node* form_node);
 
-    void GenerateClass(GenLang language = GEN_LANG_GO,
+    void GenerateClass(GenLang language = GenLang::go,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 

--- a/src/generate/writers/gen_julia.cpp
+++ b/src/generate/writers/gen_julia.cpp
@@ -20,7 +20,7 @@ using namespace code;
 using namespace GenEnum;
 
 JuliaCodeGenerator::JuliaCodeGenerator(Node* form_node) :
-    BaseCodeGenerator(GEN_LANG_JULIA, form_node)
+    BaseCodeGenerator(GenLang::julia, form_node)
 {
 }
 
@@ -29,7 +29,7 @@ void JuliaCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_type,
 {
     m_language = language;
     m_panel_type = panel_type;
-    ASSERT(m_language == GEN_LANG_JULIA);
+    ASSERT(m_language == GenLang::julia);
     Code code(m_form_node, m_language);
 
     if (m_header)

--- a/src/generate/writers/gen_julia.h
+++ b/src/generate/writers/gen_julia.h
@@ -14,7 +14,7 @@ class JuliaCodeGenerator : public BaseCodeGenerator
 public:
     JuliaCodeGenerator(Node* form_node);
 
-    void GenerateClass(GenLang language = GEN_LANG_JULIA,
+    void GenerateClass(GenLang language = GenLang::julia,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 

--- a/src/generate/writers/gen_luajit.cpp
+++ b/src/generate/writers/gen_luajit.cpp
@@ -20,7 +20,7 @@ using namespace code;
 using namespace GenEnum;
 
 LuaJITCodeGenerator::LuaJITCodeGenerator(Node* form_node) :
-    BaseCodeGenerator(GEN_LANG_LUAJIT, form_node)
+    BaseCodeGenerator(GenLang::luajit, form_node)
 {
 }
 
@@ -29,7 +29,7 @@ void LuaJITCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_type,
 {
     m_language = language;
     m_panel_type = panel_type;
-    ASSERT(m_language == GEN_LANG_LUAJIT);
+    ASSERT(m_language == GenLang::luajit);
     Code code(m_form_node, m_language);
 
     if (m_header)

--- a/src/generate/writers/gen_luajit.h
+++ b/src/generate/writers/gen_luajit.h
@@ -14,7 +14,7 @@ class LuaJITCodeGenerator : public BaseCodeGenerator
 public:
     LuaJITCodeGenerator(Node* form_node);
 
-    void GenerateClass(GenLang language = GEN_LANG_LUAJIT,
+    void GenerateClass(GenLang language = GenLang::luajit,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 

--- a/src/generate/writers/gen_python.cpp
+++ b/src/generate/writers/gen_python.cpp
@@ -57,7 +57,7 @@ namespace
 }  // anonymous namespace
 
 PythonCodeGenerator::PythonCodeGenerator(Node* form_node) :
-    BaseCodeGenerator(GEN_LANG_PYTHON, form_node)
+    BaseCodeGenerator(GenLang::python, form_node)
 {
 }
 
@@ -333,7 +333,7 @@ void PythonCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_type,
 {
     m_language = language;
     m_panel_type = panel_type;
-    ASSERT(m_language == GEN_LANG_PYTHON);
+    ASSERT(m_language == GenLang::python);
     Code code(m_form_node, m_language);
 
     m_embedded_images.clear();
@@ -422,7 +422,7 @@ void PythonCodeGenerator::GenerateImagesForm(wxProgressDialog* progress)
     m_source->writeLine();
     m_source->writeLine("from wx.lib.embeddedimage import PyEmbeddedImage");
 
-    Code code(m_form_node, GEN_LANG_PYTHON);
+    Code code(m_form_node, GenLang::python);
 
     int progress_count = 0;
     for (const auto* iter_array: m_embedded_images)
@@ -459,7 +459,7 @@ void PythonCodeGenerator::GenerateImagesForm(wxProgressDialog* progress)
         }
         auto encoded =
             base64_encode(iter_array->base_image().array_data.data(),
-                          iter_array->base_image().array_size & array_size_mask, GEN_LANG_PYTHON);
+                          iter_array->base_image().array_size & array_size_mask, GenLang::python);
         if (encoded.size())
         {
             encoded.back() += ")";
@@ -577,13 +577,13 @@ auto PythonCodeGenerator::WriteEmbeddedImageImports(Code& code, bool blank_line_
 auto PythonCodeGenerator::CollectExistingEventHandlers(std::unordered_set<std::string>& code_lines)
     -> bool
 {
-    return ScriptCommon::CollectExistingEventHandlers(m_form_node, GEN_LANG_PYTHON, m_panel_type,
+    return ScriptCommon::CollectExistingEventHandlers(m_form_node, GenLang::python, m_panel_type,
                                                       code_lines, "def ");
 }
 
 auto PythonCodeGenerator::GenerateEventHandlerComment(bool found_user_handlers, Code& code) -> void
 {
-    ScriptCommon::GenerateEventHandlerComment(found_user_handlers, code, GEN_LANG_PYTHON);
+    ScriptCommon::GenerateEventHandlerComment(found_user_handlers, code, GenLang::python);
 }
 
 auto PythonCodeGenerator::GenerateEventHandlerBody(NodeEvent* event, Code& code) -> void
@@ -592,7 +592,7 @@ auto PythonCodeGenerator::GenerateEventHandlerBody(NodeEvent* event, Code& code)
     const auto& dbg_event_name = event->get_name();
     wxUnusedVar(dbg_event_name);
 #endif  // _DEBUG
-    ScriptCommon::GenerateEventHandlerBody(event, code, GEN_LANG_PYTHON);
+    ScriptCommon::GenerateEventHandlerBody(event, code, GenLang::python);
 }
 
 auto PythonCodeGenerator::CheckIfAllEventsImplemented(
@@ -704,7 +704,7 @@ void PythonCodeGenerator::GenUnhandledEvents(EventVector& events)
     // each function once.
     std::unordered_set<std::string> code_lines;
 
-    Code code(m_form_node, GEN_LANG_PYTHON);
+    Code code(m_form_node, GenLang::python);
     auto sort_event_handlers = [](NodeEvent* event_a, NodeEvent* event_b)
     {
         return (EventHandlerDlg::GetPythonValue(event_a->get_value()) <
@@ -743,7 +743,7 @@ void PythonCodeGenerator::GenUnhandledEvents(EventVector& events)
     m_source->writeLine(code);
 
     code.clear();
-    Code undefined_handlers(m_form_node, GEN_LANG_PYTHON);
+    Code undefined_handlers(m_form_node, GenLang::python);
     GenerateUndefinedHandlers(events, code_lines, undefined_handlers);
 
     WriteEventHandlers(code, undefined_handlers, found_user_handlers, is_all_events_implemented);
@@ -869,5 +869,5 @@ void PythonBtnBitmapCode(Code& code, bool is_single)
 
 auto MakePythonPath(Node* node) -> wxue::string
 {
-    return ScriptCommon::MakeScriptPath(node, GEN_LANG_PYTHON);
+    return ScriptCommon::MakeScriptPath(node, GenLang::python);
 }

--- a/src/generate/writers/gen_python.h
+++ b/src/generate/writers/gen_python.h
@@ -13,7 +13,7 @@ public:
     PythonCodeGenerator(Node* form_node);
 
     // All language generators must implement this method.
-    void GenerateClass(GenLang language = GEN_LANG_PYTHON,
+    void GenerateClass(GenLang language = GenLang::python,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 

--- a/src/generate/writers/gen_ruby.cpp
+++ b/src/generate/writers/gen_ruby.cpp
@@ -91,7 +91,7 @@ static const std::vector<wxue::string> disable_list = {
 // clang-format on
 #endif  // _DEBUG
 
-RubyCodeGenerator::RubyCodeGenerator(Node* form_node) : BaseCodeGenerator(GEN_LANG_RUBY, form_node)
+RubyCodeGenerator::RubyCodeGenerator(Node* form_node) : BaseCodeGenerator(GenLang::ruby, form_node)
 {
 }
 
@@ -139,7 +139,7 @@ auto RubyCodeGenerator::WriteImports(std::set<std::string>& imports) -> void
     {
         if (auto* gen = node->get_Generator(); gen)
         {
-            gen->GetImports(node, imports, GEN_LANG_RUBY);
+            gen->GetImports(node, imports, GenLang::ruby);
         }
         for (auto& child: node->get_ChildNodePtrs())
         {
@@ -424,7 +424,7 @@ void RubyCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_type,
 {
     m_language = language;
     m_panel_type = panel_type;
-    ASSERT(m_language == GEN_LANG_RUBY);
+    ASSERT(m_language == GenLang::ruby);
     Code code(m_form_node, m_language);
 
     m_embedded_images.clear();
@@ -666,7 +666,7 @@ void RubyCodeGenerator::GenerateImagesForm(wxProgressDialog* progress)
 
     m_source->writeLine(txt_ruby_get_bundle, indent::auto_keep_whitespace);
 
-    Code code(m_form_node, GEN_LANG_RUBY);
+    Code code(m_form_node, GenLang::ruby);
 
     int progress_count = 0;
     for (const auto* iter_array: m_embedded_images)
@@ -701,7 +701,7 @@ void RubyCodeGenerator::GenerateImagesForm(wxProgressDialog* progress)
         }
         auto encoded =
             base64_encode(iter_array->base_image().array_data.data(),
-                          iter_array->base_image().array_size & MAX_UINT32, GEN_LANG_RUBY);
+                          iter_array->base_image().array_size & MAX_UINT32, GenLang::ruby);
         if (encoded.size())
         {
             // Remove the trailing '+' character
@@ -719,18 +719,18 @@ void RubyCodeGenerator::GenerateImagesForm(wxProgressDialog* progress)
 auto RubyCodeGenerator::CollectExistingEventHandlers(std::unordered_set<std::string>& code_lines)
     -> bool
 {
-    return ScriptCommon::CollectExistingEventHandlers(m_form_node, GEN_LANG_RUBY, m_panel_type,
+    return ScriptCommon::CollectExistingEventHandlers(m_form_node, GenLang::ruby, m_panel_type,
                                                       code_lines, "def ");
 }
 
 auto RubyCodeGenerator::GenerateEventHandlerComment(bool found_user_handlers, Code& code) -> void
 {
-    ScriptCommon::GenerateEventHandlerComment(found_user_handlers, code, GEN_LANG_RUBY);
+    ScriptCommon::GenerateEventHandlerComment(found_user_handlers, code, GenLang::ruby);
 }
 
 auto RubyCodeGenerator::GenerateEventHandlerBody(NodeEvent* event, Code& undefined_handlers) -> void
 {
-    ScriptCommon::GenerateEventHandlerBody(event, undefined_handlers, GEN_LANG_RUBY);
+    ScriptCommon::GenerateEventHandlerBody(event, undefined_handlers, GenLang::ruby);
 }
 
 auto RubyCodeGenerator::WriteEventHandlers(Code& code, Code& undefined_handlers) -> void
@@ -763,7 +763,7 @@ void RubyCodeGenerator::GenUnhandledEvents(EventVector& events)
     // each function once.
     std::unordered_set<std::string> code_lines;
 
-    Code code(m_form_node, GEN_LANG_RUBY);
+    Code code(m_form_node, GenLang::ruby);
     auto sort_event_handlers = [](NodeEvent* event_a, NodeEvent* event_b)
     {
         return (EventHandlerDlg::GetRubyValue(event_a->get_value()) <
@@ -790,7 +790,7 @@ void RubyCodeGenerator::GenUnhandledEvents(EventVector& events)
     bool found_user_handlers = CollectExistingEventHandlers(code_lines);
     GenerateEventHandlerComment(found_user_handlers, code);
 
-    Code undefined_handlers(m_form_node, GEN_LANG_RUBY);
+    Code undefined_handlers(m_form_node, GenLang::ruby);
     for (auto& event: events)
     {
         auto ruby_handler = EventHandlerDlg::GetRubyValue(event->get_value());
@@ -823,5 +823,5 @@ void RubyCodeGenerator::GenUnhandledEvents(EventVector& events)
 
 auto MakeRubyPath(Node* node) -> wxue::string
 {
-    return ScriptCommon::MakeScriptPath(node, GEN_LANG_RUBY);
+    return ScriptCommon::MakeScriptPath(node, GenLang::ruby);
 }

--- a/src/generate/writers/gen_ruby.h
+++ b/src/generate/writers/gen_ruby.h
@@ -16,7 +16,7 @@ public:
     RubyCodeGenerator(Node* form_node);
 
     // All language generators must implement this method.
-    void GenerateClass(GenLang language = GEN_LANG_RUBY,
+    void GenerateClass(GenLang language = GenLang::ruby,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 

--- a/src/generate/writers/gen_script_common.cpp
+++ b/src/generate/writers/gen_script_common.cpp
@@ -62,10 +62,10 @@ namespace ScriptCommon
             // Add appropriate extension based on language
             switch (language)
             {
-                case GEN_LANG_PYTHON:
+                case GenLang::python:
                     path += ".py";
                     break;
-                case GEN_LANG_RUBY:
+                case GenLang::ruby:
                     path += ".rb";
                     break;
                 default:
@@ -84,10 +84,10 @@ namespace ScriptCommon
         std::string_view end_comment_line;
         switch (language)
         {
-            case GEN_LANG_PYTHON:
+            case GenLang::python:
                 end_comment_line = GetPythonEndCommentLine();
                 break;
-            case GEN_LANG_RUBY:
+            case GenLang::ruby:
                 end_comment_line = GetRubyEndCommentLine();
                 break;
             default:
@@ -132,11 +132,11 @@ namespace ScriptCommon
         }
 
         // Python needs triple-quote string start, Ruby needs extra newlines
-        if (language == GEN_LANG_PYTHON)
+        if (language == GenLang::python)
         {
             code.Eol().Str(python_triple_quote).Eol();
         }
-        else if (language == GEN_LANG_RUBY)
+        else if (language == GenLang::ruby)
         {
             code.Eol().Eol();
         }
@@ -148,10 +148,10 @@ namespace ScriptCommon
         {
             switch (language)
             {
-                case GEN_LANG_PYTHON:
+                case GenLang::python:
                     code.Tab().Str("self.EndModal(wx.ID_CLOSE)").Eol().Eol();
                     return;  // Python adds extra newline
-                case GEN_LANG_RUBY:
+                case GenLang::ruby:
                     code.Tab().Str("end_modal(Wx::ID_CLOSE)");
                     break;
                 default:
@@ -162,10 +162,10 @@ namespace ScriptCommon
         {
             switch (language)
             {
-                case GEN_LANG_PYTHON:
+                case GenLang::python:
                     code.Tab().Str("self.EndModal(wx.ID_YES)").Eol().Eol();
                     return;  // Python adds extra newline
-                case GEN_LANG_RUBY:
+                case GenLang::ruby:
                     code.Tab().Str("end_modal(Wx::ID_YES)");
                     break;
                 default:
@@ -176,10 +176,10 @@ namespace ScriptCommon
         {
             switch (language)
             {
-                case GEN_LANG_PYTHON:
+                case GenLang::python:
                     code.Tab().Str("self.EndModal(wx.ID_NO)").Eol().Eol();
                     return;  // Python adds extra newline
-                case GEN_LANG_RUBY:
+                case GenLang::ruby:
                     code.Tab().Str("end_modal(Wx::ID_NO)");
                     break;
                 default:
@@ -191,10 +191,10 @@ namespace ScriptCommon
             // Default event handler - call Skip/skip
             switch (language)
             {
-                case GEN_LANG_PYTHON:
+                case GenLang::python:
                     code.Tab().Str("event.Skip()").Eol().Eol();
                     return;  // Python adds extra newline
-                case GEN_LANG_RUBY:
+                case GenLang::ruby:
                     code.Tab().Str("event.skip");
                     break;
                 default:

--- a/src/generate/writers/gen_script_common.h
+++ b/src/generate/writers/gen_script_common.h
@@ -19,7 +19,7 @@ class Code;
 
 #include "wxue_namespace/wxue_string.h"  // wxue::string
 
-enum GenLang : std::uint16_t;
+enum class GenLang : unsigned int;
 
 namespace ScriptCommon
 {

--- a/src/generate/writers/gen_typescript.cpp
+++ b/src/generate/writers/gen_typescript.cpp
@@ -20,7 +20,7 @@ using namespace code;
 using namespace GenEnum;
 
 TypeScriptCodeGenerator::TypeScriptCodeGenerator(Node* form_node) :
-    BaseCodeGenerator(GEN_LANG_TYPESCRIPT, form_node)
+    BaseCodeGenerator(GenLang::typescript, form_node)
 {
 }
 
@@ -29,7 +29,7 @@ void TypeScriptCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_t
 {
     m_language = language;
     m_panel_type = panel_type;
-    ASSERT(m_language == GEN_LANG_TYPESCRIPT);
+    ASSERT(m_language == GenLang::typescript);
     Code code(m_form_node, m_language);
 
     if (m_header)

--- a/src/generate/writers/gen_typescript.h
+++ b/src/generate/writers/gen_typescript.h
@@ -14,7 +14,7 @@ class TypeScriptCodeGenerator : public BaseCodeGenerator
 public:
     TypeScriptCodeGenerator(Node* form_node);
 
-    void GenerateClass(GenLang language = GEN_LANG_TYPESCRIPT,
+    void GenerateClass(GenLang language = GenLang::typescript,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 

--- a/src/generate/writers/gen_xrc.cpp
+++ b/src/generate/writers/gen_xrc.cpp
@@ -54,7 +54,7 @@ int GenerateXrcObject(Node* node, pugi::xml_node& object, size_t xrc_flags)
         else
         {
             auto item = InitializeXrcObject(node, object);
-            auto comment = generator->GetWarning(node, GEN_LANG_XRC);
+            auto comment = generator->GetWarning(node, GenLang::xrc);
             if (comment)
             {
                 // We need a dummy item to hold the comment but which will not show up in the UI
@@ -250,13 +250,13 @@ std::string GenerateXrcStr(Node* node_start, size_t xrc_flags)
     return xml_stream.str();
 }
 
-XrcCodeGenerator::XrcCodeGenerator(Node* form_node) : BaseCodeGenerator(GEN_LANG_XRC, form_node) {}
+XrcCodeGenerator::XrcCodeGenerator(Node* form_node) : BaseCodeGenerator(GenLang::xrc, form_node) {}
 
 void XrcCodeGenerator::GenerateClass(GenLang language, PANEL_PAGE panel_type,
                                      wxProgressDialog* /* progress */)
 {
     m_language = language;
-    ASSERT(m_language == GEN_LANG_XRC);
+    ASSERT(m_language == GenLang::xrc);
     m_panel_type = panel_type;
 
     if (m_header)
@@ -327,7 +327,7 @@ void MainFrame::OnGenSingleXRC(wxCommandEvent& /* event unused */)
 
     GenResults results;
     results.SetNodes(form);
-    results.SetLanguages(GEN_LANG_XRC);
+    results.SetLanguages(GenLang::xrc);
     results.SetMode(GenResults::Mode::generate_and_write);
     std::ignore = results.Generate();
 

--- a/src/generate/writers/gen_xrc.h
+++ b/src/generate/writers/gen_xrc.h
@@ -67,7 +67,7 @@ public:
     XrcCodeGenerator(Node* form_node);
 
     // All language generators must implement this method.
-    void GenerateClass(GenLang language = GEN_LANG_XRC,
+    void GenerateClass(GenLang language = GenLang::xrc,
                        PANEL_PAGE panel_type = PANEL_PAGE::NOT_PANEL,
                        wxProgressDialog* progress = nullptr) override;
 };

--- a/src/generate/writers/image_gen.cpp
+++ b/src/generate/writers/image_gen.cpp
@@ -126,7 +126,7 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             code.clear();
             std::vector<std::string> encoded = base64_encode(
                 iter_array->base_image().array_data.data(),
-                iter_array->base_image().array_size & ARRAY_SIZE_MASK, GEN_LANG_PYTHON);
+                iter_array->base_image().array_size & ARRAY_SIZE_MASK, GenLang::python);
             if (!encoded.empty())
             {
                 encoded.back() += ")";
@@ -156,7 +156,7 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
             code.clear();
             std::vector<std::string> encoded =
                 base64_encode(iter_array->base_image().array_data.data(),
-                              iter_array->base_image().array_size & ARRAY_SIZE_MASK, GEN_LANG_RUBY);
+                              iter_array->base_image().array_size & ARRAY_SIZE_MASK, GenLang::ruby);
             if (!encoded.empty())
             {
                 // Remove the trailing " \" suffix
@@ -187,9 +187,9 @@ void BaseCodeGenerator::WriteImageConstruction(Code& code)
 
 const std::map<GenLang, GenEnum::PropName> map_lang_to_prop = {
 
-    { GEN_LANG_CPLUSPLUS, prop_cpp_line_length },
-    { GEN_LANG_PYTHON, prop_python_line_length },
-    { GEN_LANG_RUBY, prop_ruby_line_length  },
+    { GenLang::cplusplus, prop_cpp_line_length },
+    { GenLang::python, prop_python_line_length },
+    { GenLang::ruby, prop_ruby_line_length  },
 };
 
 // clang-format on
@@ -198,7 +198,7 @@ std::vector<std::string> base64_encode(unsigned char const* data, size_t data_si
                                        GenLang language)
 {
     size_t tab_quote_prefix = PYTHON_PREFIX_SIZE;
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         tab_quote_prefix = RUBY_PREFIX_SIZE;
     }
@@ -247,12 +247,12 @@ std::vector<std::string> base64_encode(unsigned char const* data, size_t data_si
 
     std::string_view line_begin;
     std::string_view line_end;
-    if (language == GEN_LANG_PYTHON)
+    if (language == GenLang::python)
     {
         line_begin = "\tb\"";
         line_end = "\"";
     }
-    else if (language == GEN_LANG_RUBY)
+    else if (language == GenLang::ruby)
     {
         line_begin = "  '";
         line_end = "' \\";

--- a/src/generate/writers/image_gen.h
+++ b/src/generate/writers/image_gen.h
@@ -11,7 +11,7 @@ class Code;
 class EmbeddedImage;
 
 std::vector<std::string> base64_encode(unsigned char const* data, size_t data_size,
-                                       GenLang language = GEN_LANG_PYTHON);
+                                       GenLang language = GenLang::python);
 
 // Note: GenerateBundleParameter is now a Code class method.
 // See code.h for the declaration.

--- a/src/generate/writers/language_traits.cpp
+++ b/src/generate/writers/language_traits.cpp
@@ -24,7 +24,7 @@ namespace
 
 constexpr LanguageTraits cpp_traits
 {
-    .language = GEN_LANG_CPLUSPLUS,
+    .language = GenLang::cplusplus,
     .true_literal = "true",
     .false_literal = "false",
     .null_literal = "nullptr",
@@ -62,7 +62,7 @@ constexpr LanguageTraits cpp_traits
 
 constexpr LanguageTraits python_traits
 {
-    .language = GEN_LANG_PYTHON,
+    .language = GenLang::python,
     .true_literal = "True",
     .false_literal = "False",
     .null_literal = "None",
@@ -98,7 +98,7 @@ constexpr LanguageTraits python_traits
 
 constexpr LanguageTraits ruby_traits
 {
-    .language = GEN_LANG_RUBY,
+    .language = GenLang::ruby,
     .true_literal = "true",
     .false_literal = "false",
     .null_literal = "nil",
@@ -138,7 +138,7 @@ constexpr LanguageTraits ruby_traits
 
 constexpr LanguageTraits fortran_traits
 {
-    .language = GEN_LANG_FORTRAN,
+    .language = GenLang::fortran,
     .true_literal = ".TRUE.",
     .false_literal = ".FALSE.",
     .null_literal = "C_NULL_PTR",
@@ -174,7 +174,7 @@ constexpr LanguageTraits fortran_traits
 
 constexpr LanguageTraits go_traits
 {
-    .language = GEN_LANG_GO,
+    .language = GenLang::go,
     .true_literal = "true",
     .false_literal = "false",
     .null_literal = "nil",
@@ -210,7 +210,7 @@ constexpr LanguageTraits go_traits
 
 constexpr LanguageTraits julia_traits
 {
-    .language = GEN_LANG_JULIA,
+    .language = GenLang::julia,
     .true_literal = "true",
     .false_literal = "false",
     .null_literal = "nothing",
@@ -246,7 +246,7 @@ constexpr LanguageTraits julia_traits
 
 constexpr LanguageTraits luajit_traits
 {
-    .language = GEN_LANG_LUAJIT,
+    .language = GenLang::luajit,
     .true_literal = "true",
     .false_literal = "false",
     .null_literal = "nil",
@@ -282,7 +282,7 @@ constexpr LanguageTraits luajit_traits
 
 constexpr LanguageTraits typescript_traits
 {
-    .language = GEN_LANG_TYPESCRIPT,
+    .language = GenLang::typescript,
     .true_literal = "true",
     .false_literal = "false",
     .null_literal = "null",
@@ -324,23 +324,23 @@ auto GetLanguageTraits(GenLang language) -> const LanguageTraits*
 {
     switch (language)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             return &cpp_traits;
 
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             return &python_traits;
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             return &ruby_traits;
 
-        case GEN_LANG_FORTRAN:
+        case GenLang::fortran:
             return &fortran_traits;
-        case GEN_LANG_GO:
+        case GenLang::go:
             return &go_traits;
-        case GEN_LANG_JULIA:
+        case GenLang::julia:
             return &julia_traits;
-        case GEN_LANG_LUAJIT:
+        case GenLang::luajit:
             return &luajit_traits;
-        case GEN_LANG_TYPESCRIPT:
+        case GenLang::typescript:
             return &typescript_traits;
 
         default:
@@ -352,28 +352,28 @@ auto CreateLanguageStrategy(GenLang language) -> std::unique_ptr<LanguageStrateg
 {
     switch (language)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             return std::make_unique<CppStrategy>(cpp_traits);
 
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             return std::make_unique<PythonStrategy>(python_traits);
 
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             return std::make_unique<RubyStrategy>(ruby_traits);
 
-        case GEN_LANG_FORTRAN:
+        case GenLang::fortran:
             return std::make_unique<FortranStrategy>(fortran_traits);
 
-        case GEN_LANG_GO:
+        case GenLang::go:
             return std::make_unique<GoStrategy>(go_traits);
 
-        case GEN_LANG_JULIA:
+        case GenLang::julia:
             return std::make_unique<JuliaStrategy>(julia_traits);
 
-        case GEN_LANG_LUAJIT:
+        case GenLang::luajit:
             return std::make_unique<LuaJITStrategy>(luajit_traits);
 
-        case GEN_LANG_TYPESCRIPT:
+        case GenLang::typescript:
             return std::make_unique<TypeScriptStrategy>(typescript_traits);
 
         default:

--- a/src/generate/writers/verify_codegen.cpp
+++ b/src/generate/writers/verify_codegen.cpp
@@ -34,20 +34,20 @@
 
 namespace
 {
-    [[nodiscard]] auto ParseLanguageSwitch(wxCmdLineParser& parser) -> size_t
+    [[nodiscard]] auto ParseLanguageSwitch(wxCmdLineParser& parser) -> GenLang
     {
-        constexpr auto switches = std::to_array<std::pair<std::string_view, size_t>>({
-            { "verify_cpp", GEN_LANG_CPLUSPLUS },
-            { "verify_python", GEN_LANG_PYTHON },
-            { "verify_ruby", GEN_LANG_RUBY },
-            { "verify_fortran", GEN_LANG_FORTRAN },
-            { "verify_go", GEN_LANG_GO },
-            { "verify_julia", GEN_LANG_JULIA },
-            { "verify_luajit", GEN_LANG_LUAJIT },
-            { "verify_typescript", GEN_LANG_TYPESCRIPT },
-            { "verify_all", GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON | GEN_LANG_RUBY |
-                                GEN_LANG_FORTRAN | GEN_LANG_GO | GEN_LANG_JULIA | GEN_LANG_LUAJIT |
-                                GEN_LANG_TYPESCRIPT },
+        constexpr auto switches = std::to_array<std::pair<std::string_view, GenLang>>({
+            { "verify_cpp", GenLang::cplusplus },
+            { "verify_python", GenLang::python },
+            { "verify_ruby", GenLang::ruby },
+            { "verify_fortran", GenLang::fortran },
+            { "verify_go", GenLang::go },
+            { "verify_julia", GenLang::julia },
+            { "verify_luajit", GenLang::luajit },
+            { "verify_typescript", GenLang::typescript },
+            { "verify_all", GenLang::cplusplus | GenLang::python | GenLang::ruby |
+                                GenLang::fortran | GenLang::go | GenLang::julia | GenLang::luajit |
+                                GenLang::typescript },
         });
 
         for (const auto& [switch_name, lang]: switches)
@@ -57,7 +57,7 @@ namespace
                 return lang;
             }
         }
-        return GEN_LANG_NONE;
+        return GenLang::none;
     }
 
     [[nodiscard]] auto FindProjectFile(wxString& filename) -> verify_codegen::VerifyResult
@@ -74,12 +74,12 @@ namespace
         return verify_codegen::VERIFY_SUCCESS;
     }
 
-    [[nodiscard]] auto LoadProjectFile(wxFileName& project_file, size_t generate_type,
+    [[nodiscard]] auto LoadProjectFile(wxFileName& project_file, GenLang generate_type,
                                        bool& is_project_loaded) -> verify_codegen::VerifyResult
     {
         if (!project_file.FileExists())
         {
-            if (generate_type != GEN_LANG_NONE)
+            if (generate_type != GenLang::none)
             {
                 wxMessageBox("Unable to find project file: " +
                                  project_file.GetFullPath().utf8_string(),
@@ -94,15 +94,15 @@ namespace
             project_file.GetExt().IsSameAs("wxue", false))
         {
             is_project_loaded =
-                Project.LoadProject(project_file.GetFullPath(), generate_type == GEN_LANG_NONE);
+                Project.LoadProject(project_file.GetFullPath(), generate_type == GenLang::none);
         }
         else
         {
             is_project_loaded = Project.ImportProject(project_file.GetFullPath().ToStdString(),
-                                                      generate_type == GEN_LANG_NONE);
+                                                      generate_type == GenLang::none);
         }
 
-        if (generate_type != GEN_LANG_NONE && !is_project_loaded)
+        if (generate_type != GenLang::none && !is_project_loaded)
         {
             wxMessageBox("Unable to load project file: " + project_file.GetFullPath().utf8_string(),
                          "Verify");
@@ -112,7 +112,7 @@ namespace
         return verify_codegen::VERIFY_SUCCESS;
     }
 
-    [[nodiscard]] auto VerifyLanguageGeneration(GenLang language, size_t generate_type,
+    [[nodiscard]] auto VerifyLanguageGeneration(GenLang language, GenLang generate_type,
                                                 Node* form_node = nullptr)
         -> verify_codegen::VerifyResult
     {
@@ -210,8 +210,8 @@ namespace
         filename = parser.GetParam(0);
     }
 
-    size_t generate_type = ParseLanguageSwitch(parser);
-    if (generate_type == GEN_LANG_NONE)
+    auto generate_type = ParseLanguageSwitch(parser);
+    if (generate_type == GenLang::none)
     {
         wxMessageBox("Unknown Language", "Verify");
         return verify_codegen::VERIFY_INVALID;
@@ -219,7 +219,7 @@ namespace
 
     // If no project filename was given on the command line, call FindProjectFile() to look
     // for a .wxui file in the current directory.
-    if (generate_type != GEN_LANG_NONE && filename.empty())
+    if (generate_type != GenLang::none && filename.empty())
     {
         auto result = FindProjectFile(filename);
         if (result != verify_codegen::VERIFY_SUCCESS)
@@ -254,14 +254,14 @@ namespace
     }
 
     constexpr auto languages = std::to_array<GenLang>({
-        GEN_LANG_CPLUSPLUS,
-        GEN_LANG_PYTHON,
-        GEN_LANG_RUBY,
-        GEN_LANG_FORTRAN,
-        GEN_LANG_GO,
-        GEN_LANG_JULIA,
-        GEN_LANG_LUAJIT,
-        GEN_LANG_TYPESCRIPT,
+        GenLang::cplusplus,
+        GenLang::python,
+        GenLang::ruby,
+        GenLang::fortran,
+        GenLang::go,
+        GenLang::julia,
+        GenLang::luajit,
+        GenLang::typescript,
     });
 
     // Testing menu is disabled here so that VerifyLanguageGeneration() does not start/end a timer.

--- a/src/import/import_dialogblocks.h
+++ b/src/import/import_dialogblocks.h
@@ -26,7 +26,7 @@ public:
 
     bool Import(const std::string& filename, bool write_doc = true) override;
 
-    [[nodiscard]] auto GetLanguage() const -> int override { return GEN_LANG_CPLUSPLUS; }
+    [[nodiscard]] auto GetLanguage() const -> GenLang override { return GenLang::cplusplus; }
 
 protected:
     // Sets validator variable name and variable handler type

--- a/src/import/import_formblder.cpp
+++ b/src/import/import_formblder.cpp
@@ -174,15 +174,15 @@ void FormBuilder::createProjectNode(pugi::xml_node& xml_obj, Node* new_node)
                 {
                     if (xml_prop.text().as_view().find("Python") != std::string_view::npos)
                     {
-                        m_language |= GEN_LANG_PYTHON;
+                        m_language |= GenLang::python;
                     }
                     else if (xml_prop.text().as_view().find("C++") != std::string_view::npos)
                     {
-                        m_language |= GEN_LANG_CPLUSPLUS;
+                        m_language |= GenLang::cplusplus;
                     }
                     else if (xml_prop.text().as_view().find("XRC") != std::string_view::npos)
                     {
-                        m_language |= GEN_LANG_XRC;
+                        m_language |= GenLang::xrc;
                     }
 
                     // wxFormBuilder also generates wxPHP code, but wxUiEditor doesn't support that
@@ -375,15 +375,15 @@ auto FormBuilder::CreateFbpNode(pugi::xml_node& xml_obj, Node* parent, Node* siz
 
     if (newobject->is_Form() && m_baseFile.size())
     {
-        if (m_language & GEN_LANG_CPLUSPLUS)
+        if (m_language & GenLang::cplusplus)
         {
             newobject->set_value(prop_base_file, m_baseFile);
         }
-        if (m_language & GEN_LANG_PYTHON)
+        if (m_language & GenLang::python)
         {
             newobject->set_value(prop_python_file, m_baseFile);
         }
-        if (m_language & GEN_LANG_XRC)
+        if (m_language & GenLang::xrc)
         {
             newobject->set_value(prop_xrc_file, m_baseFile);
         }
@@ -876,7 +876,7 @@ auto FormBuilder::HandleNameProperty(pugi::xml_node& xml_prop, Node* newobject) 
 auto FormBuilder::HandleIncludeProperty(pugi::xml_node& xml_prop, Node* newobject, Node* parent)
     -> void
 {
-    if (m_language & GEN_LANG_PYTHON)
+    if (m_language & GenLang::python)
     {
         std::string header(xml_prop.text().as_view());
         if (parent)

--- a/src/import/import_wxcrafter.h
+++ b/src/import/import_wxcrafter.h
@@ -28,7 +28,7 @@ public:
         -> NodeSharedPtr;
 
     // wxCrafter only supports C++ code generation
-    int GetLanguage() const override { return GEN_LANG_CPLUSPLUS; }
+    GenLang GetLanguage() const override { return GenLang::cplusplus; }
 
 protected:
     auto ProcessFont(Node* node, const glz::generic& object) -> bool;

--- a/src/import/import_wxglade.cpp
+++ b/src/import/import_wxglade.cpp
@@ -35,21 +35,21 @@ auto WxGlade::Import(const std::string& filename, bool write_doc) -> bool
     {
         if (language == "XRC")
         {
-            m_language = GEN_LANG_XRC;
+            m_language = GenLang::xrc;
         }
         else if (language == "python")
         {
-            m_language = GEN_LANG_PYTHON;
+            m_language = GenLang::python;
         }
         else if (language == "C++")
         {
-            m_language = GEN_LANG_CPLUSPLUS;
+            m_language = GenLang::cplusplus;
         }
     }
     else
     {
         // We don't support Perl or Lisp
-        m_language = GEN_LANG_CPLUSPLUS;
+        m_language = GenLang::cplusplus;
     }
 
     // Using a try block means that if at any point it becomes obvious the project file is invalid
@@ -94,17 +94,17 @@ auto WxGlade::Import(const std::string& filename, bool write_doc) -> bool
                     {
                         switch (m_language)
                         {
-                            case GEN_LANG_CPLUSPLUS:
+                            case GenLang::cplusplus:
                                 new_node->set_value(prop_base_file,
                                                     new_node->as_string(prop_class_name));
                                 break;
 
-                            case GEN_LANG_PYTHON:
+                            case GenLang::python:
                                 new_node->set_value(prop_python_file,
                                                     new_node->as_string(prop_class_name));
                                 break;
 
-                            case GEN_LANG_XRC:
+                            case GenLang::xrc:
                                 new_node->set_value(prop_xrc_file,
                                                     new_node->as_string(prop_class_name));
                                 break;
@@ -113,7 +113,7 @@ auto WxGlade::Import(const std::string& filename, bool write_doc) -> bool
                 }
                 else
                 {
-                    if (m_language == GEN_LANG_PYTHON)
+                    if (m_language == GenLang::python)
                     {
                         m_project->set_value(prop_python_combine_forms, true);
                         wxString combined_filename = root.attribute("path").as_cstr();
@@ -142,12 +142,12 @@ auto WxGlade::Import(const std::string& filename, bool write_doc) -> bool
 
             if (m_project->get_ChildCount() > 1)
             {
-                if (m_language == GEN_LANG_PYTHON)
+                if (m_language == GenLang::python)
                 {
                     m_project->set_value(prop_python_combine_forms, true);
                     m_project->set_value(prop_python_combined_file, combined_filename);
                 }
-                else if (m_language == GEN_LANG_XRC)
+                else if (m_language == GenLang::xrc)
                 {
                     m_project->set_value(prop_combine_all_forms, true);
                     m_project->set_value(prop_combined_xrc_file, combined_filename);
@@ -155,11 +155,11 @@ auto WxGlade::Import(const std::string& filename, bool write_doc) -> bool
             }
             else
             {
-                if (m_language == GEN_LANG_PYTHON)
+                if (m_language == GenLang::python)
                 {
                     m_project->get_Child(0)->set_value(prop_python_file, combined_filename);
                 }
-                else if (m_language == GEN_LANG_XRC)
+                else if (m_language == GenLang::xrc)
                 {
                     m_project->get_Child(0)->set_value(prop_xrc_file, combined_filename);
                 }
@@ -619,11 +619,11 @@ auto WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
     }
     if (node_name == "extracode_post")
     {
-        if (m_language == GEN_LANG_PYTHON)
+        if (m_language == GenLang::python)
         {
             node->set_value(prop_python_insert, xml_obj.text().as_view());
         }
-        else if (m_language == GEN_LANG_CPLUSPLUS)
+        else if (m_language == GenLang::cplusplus)
         {
             node->set_value(prop_source_preamble, xml_obj.text().as_view());
         }
@@ -670,12 +670,12 @@ auto WxGlade::HandleUnknownProperty(const pugi::xml_node& xml_obj, Node* node, N
         // wxGlade specifies the construction code on the right side of the = sign, so we need to
         // insert what should be on the left side.
         std::string construction;
-        if (m_language == GEN_LANG_PYTHON)
+        if (m_language == GenLang::python)
         {
             construction = "self." + node->as_string(prop_var_name) + " = ";
             construction += xml_obj.text().as_view();
         }
-        else if (m_language == GEN_LANG_CPLUSPLUS)
+        else if (m_language == GenLang::cplusplus)
         {
             construction = node->as_string(prop_var_name) + " = ";
             construction += xml_obj.text().as_view();
@@ -776,7 +776,7 @@ auto WxGlade::CreateMenus(pugi::xml_node& xml_obj, Node* parent) -> void
                 else if (iter.name() == "id")
                 {
                     wxString id_value = iter.text().as_cstr();
-                    if (m_language == GEN_LANG_PYTHON)
+                    if (m_language == GenLang::python)
                     {
                         id_value.Replace(".", "");
                     }
@@ -840,7 +840,7 @@ auto WxGlade::CreateToolbar(pugi::xml_node& xml_obj, Node* parent) -> void
             else if (iter.name() == "id")
             {
                 wxString id_value = iter.text().as_cstr();
-                if (m_language == GEN_LANG_PYTHON)
+                if (m_language == GenLang::python)
                 {
                     id_value.Replace(".", "");
                 }

--- a/src/import/import_wxsmith.h
+++ b/src/import/import_wxsmith.h
@@ -19,7 +19,7 @@ public:
     auto Import(const std::string& filename, bool write_doc = true) -> bool override;
 
     // wxSmith only supports C++ code generation
-    auto GetLanguage() const -> int override { return GEN_LANG_CPLUSPLUS; }
+    auto GetLanguage() const -> GenLang override { return GenLang::cplusplus; }
 
     auto HandleUnknownProperty(const pugi::xml_node& /* xml_obj */, Node* /* node */,
                                Node* /* parent */) -> bool override;

--- a/src/import/import_xml.h
+++ b/src/import/import_xml.h
@@ -30,8 +30,8 @@ public:
 
     auto GetErrors() { return m_errors; }
 
-    // Returns a GEN_LANG_* value -- default is GEN_LANG_NONE
-    [[nodiscard]] virtual auto GetLanguage() const -> int { return m_language; }
+    // Returns a GenLang::* value -- default is GenLang::none
+    [[nodiscard]] virtual auto GetLanguage() const -> GenLang { return m_language; }
 
     // This will check for an obsolete event name, and if found, it will return the 3.x
     // version of the name. Otherwise, it returns name unmodified.
@@ -88,5 +88,5 @@ protected:
 
     std::set<std::string> m_errors;
 
-    int m_language = GEN_LANG_NONE;
+    GenLang m_language = GenLang::none;
 };

--- a/src/internal/import_panel.cpp
+++ b/src/internal/import_panel.cpp
@@ -60,7 +60,7 @@ ImportPanel::ImportPanel(wxWindow* parent) : wxScrolled<wxPanel>(parent)
     m_scintilla->SetTabWidth(4);
     m_scintilla->SetBackSpaceUnIndents(true);
 
-    SetStcColors(m_scintilla, GEN_LANG_XRC);
+    SetStcColors(m_scintilla, GenLang::xrc);
 
     m_scintilla->MarkerDefine(node_marker, wxSTC_MARK_BOOKMARK, wxNullColour, *wxGREEN);
     parent_sizer->Add(m_scintilla, wxSizerFlags(1).Expand().Border(wxALL));
@@ -137,7 +137,7 @@ void ImportPanel::SetImportFile(const wxue::string& file, int lexer)
             }
 
             m_scintilla->StyleSetBold(wxSTC_H_TAG, true);
-            SetStcColors(m_scintilla, GEN_LANG_XML, false, false);
+            SetStcColors(m_scintilla, GenLang::xml, false, false);
             break;
 
         case wxSTC_LEX_CPP:
@@ -148,7 +148,7 @@ void ImportPanel::SetImportFile(const wxue::string& file, int lexer)
             // m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_u8_cpp_keywords);
 
             m_scintilla->StyleSetBold(wxSTC_C_WORD, true);
-            SetStcColors(m_scintilla, GEN_LANG_CPLUSPLUS, false, false);
+            SetStcColors(m_scintilla, GenLang::cplusplus, false, false);
             break;
 
         case wxSTC_LEX_JSON:
@@ -159,7 +159,7 @@ void ImportPanel::SetImportFile(const wxue::string& file, int lexer)
             m_scintilla->SendMsg(SCI_SETKEYWORDS, 0, (wxIntPtr) g_xrc_keywords);
 
             m_scintilla->StyleSetBold(wxSTC_H_TAG, true);
-            SetStcColors(m_scintilla, GEN_LANG_XML, false, false);
+            SetStcColors(m_scintilla, GenLang::xml, false, false);
             break;
 
         default:

--- a/src/internal/msgframe.cpp
+++ b/src/internal/msgframe.cpp
@@ -122,7 +122,7 @@ MsgFrame::MsgFrame(std::vector<wxString>* pMsgs, bool* pDestroyed, wxWindow* par
     }
 
     // On Windows, this saves converting the UTF8 to UTF16 and then back to ANSI.
-    SetStcColors(m_scintilla, GEN_LANG_XRC, false, true);
+    SetStcColors(m_scintilla, GenLang::xrc, false, true);
 
     wxPersistentRegisterAndRestore(this, "MsgWindow");
 }

--- a/src/internal/xrcpreview_handlers.cpp
+++ b/src/internal/xrcpreview_handlers.cpp
@@ -57,7 +57,7 @@ extern const char* g_xrc_keywords;
 
 void XrcPreview::OnInit(wxInitDialogEvent& event)
 {
-    SetStcColors(m_scintilla, GEN_LANG_XRC, false, true);
+    SetStcColors(m_scintilla, GenLang::xrc, false, true);
 
     m_scintilla->StyleSetBold(wxSTC_H_TAG, true);
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -649,21 +649,22 @@ std::pair<size_t, bool> App::ParseGenerationType(wxCmdLineParser& parser)
 {
     // Map option names to their corresponding generation type values
     constexpr frozen::map<std::string_view, size_t, 12> gen_options = {
-        { "gen_cpp", GEN_LANG_CPLUSPLUS },
-        { "gen_python", GEN_LANG_PYTHON },
-        { "gen_fortran", GEN_LANG_FORTRAN },
-        { "gen_go", GEN_LANG_GO },
-        { "gen_julia", GEN_LANG_JULIA },
-        { "gen_luajit", GEN_LANG_LUAJIT },
-        { "gen_ruby", GEN_LANG_RUBY },
-        { "gen_typescript", GEN_LANG_TYPESCRIPT },
-        { "gen_xrc", GEN_LANG_XRC },
-        { "gen_all", (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON | GEN_LANG_RUBY) },
-        { "gen_quick", (GEN_LANG_PYTHON | GEN_LANG_RUBY) },
-        { "gen_coverage", (GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON | GEN_LANG_RUBY) },
+        { "gen_cpp", std::to_underlying(GenLang::cplusplus) },
+        { "gen_python", std::to_underlying(GenLang::python) },
+        { "gen_fortran", std::to_underlying(GenLang::fortran) },
+        { "gen_go", std::to_underlying(GenLang::go) },
+        { "gen_julia", std::to_underlying(GenLang::julia) },
+        { "gen_luajit", std::to_underlying(GenLang::luajit) },
+        { "gen_ruby", std::to_underlying(GenLang::ruby) },
+        { "gen_typescript", std::to_underlying(GenLang::typescript) },
+        { "gen_xrc", std::to_underlying(GenLang::xrc) },
+        { "gen_all", std::to_underlying(GenLang::cplusplus | GenLang::python | GenLang::ruby) },
+        { "gen_quick", std::to_underlying(GenLang::python | GenLang::ruby) },
+        { "gen_coverage",
+          std::to_underlying(GenLang::cplusplus | GenLang::python | GenLang::ruby) },
     };
 
-    size_t generate_type = GEN_LANG_NONE;
+    size_t generate_type = std::to_underlying(GenLang::none);
     bool test_only = false;
 
     // Check gen_* options (mutually exclusive)
@@ -692,10 +693,10 @@ std::pair<size_t, bool> App::ParseGenerationType(wxCmdLineParser& parser)
     // Check test_* options (can be combined)
     // REVIEW: [Randalphwa - 02-21-2026] Do we still need these?
     constexpr frozen::map<std::string_view, GenLang, 4> test_options = {
-        { "test_cpp", GEN_LANG_CPLUSPLUS },
-        { "test_python", GEN_LANG_PYTHON },
-        { "test_ruby", GEN_LANG_RUBY },
-        { "test_xrc", GEN_LANG_XRC },
+        { "test_cpp", GenLang::cplusplus },
+        { "test_python", GenLang::python },
+        { "test_ruby", GenLang::ruby },
+        { "test_xrc", GenLang::xrc },
     };
 
     for (const auto& [option_name, option_type]: test_options)
@@ -703,7 +704,7 @@ std::pair<size_t, bool> App::ParseGenerationType(wxCmdLineParser& parser)
         wxString option_filename;
         if (parser.Found(wxString(option_name), &option_filename))
         {
-            generate_type = (generate_type | option_type);
+            generate_type |= std::to_underlying(option_type);
             test_only = true;
 
             // Store the filename from the option value (first one wins)
@@ -740,11 +741,11 @@ bool App::LoadProjectFile(const wxue::string& filename, size_t generate_type,
     if (!filename.extension().is_sameas(PROJECT_FILE_EXTENSION, wxue::CASE::either) &&
         !filename.extension().is_sameas(PROJECT_LEGACY_FILE_EXTENSION, wxue::CASE::either))
     {
-        is_project_loaded = Project.ImportProject(filename, generate_type == GEN_LANG_NONE);
+        is_project_loaded = Project.ImportProject(filename, generate_type == 0);
     }
     else
     {
-        is_project_loaded = Project.LoadProject(filename, generate_type == GEN_LANG_NONE);
+        is_project_loaded = Project.LoadProject(filename, generate_type == 0);
     }
     return is_project_loaded;
 }
@@ -816,7 +817,7 @@ void App::GenerateAllLanguages(size_t generate_type, bool test_only, GenResults&
 
     auto GenCode = [&](GenLang language)
     {
-        if (generate_type & language)
+        if (generate_type & std::to_underlying(language))
         {
             results.Clear();
             class_list.clear();
@@ -854,17 +855,17 @@ void App::GenerateAllLanguages(size_t generate_type, bool test_only, GenResults&
         }
     };
 
-    GenCode(GEN_LANG_CPLUSPLUS);
-    GenCode(GEN_LANG_PYTHON);
+    GenCode(GenLang::cplusplus);
+    GenCode(GenLang::python);
 
-    GenCode(GEN_LANG_FORTRAN);
-    GenCode(GEN_LANG_GO);
-    GenCode(GEN_LANG_JULIA);
-    GenCode(GEN_LANG_LUAJIT);
-    GenCode(GEN_LANG_TYPESCRIPT);
-    GenCode(GEN_LANG_RUBY);
+    GenCode(GenLang::fortran);
+    GenCode(GenLang::go);
+    GenCode(GenLang::julia);
+    GenCode(GenLang::luajit);
+    GenCode(GenLang::typescript);
+    GenCode(GenLang::ruby);
 
-    GenCode(GEN_LANG_XRC);
+    GenCode(GenLang::xrc);
 }
 
 int App::Generate(wxCmdLineParser& parser, bool& is_project_loaded)
@@ -890,7 +891,7 @@ int App::Generate(wxCmdLineParser& parser, bool& is_project_loaded)
 
     const wxString& filename_str = GetCommandLineFilename(parser);
 
-    if (generate_type == GEN_LANG_NONE)
+    if (generate_type == 0)
     {
         if (filename_str.empty())
         {

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -458,7 +458,7 @@ MainFrame::MainFrame() :
             wxEVT_MENU,
             [](wxCommandEvent&)
             {
-                OnGenerateSingleLanguage(GEN_LANG_PYTHON);
+                OnGenerateSingleLanguage(GenLang::python);
             },
             id_GenSinglePython);
 
@@ -466,7 +466,7 @@ MainFrame::MainFrame() :
             wxEVT_MENU,
             [](wxCommandEvent&)
             {
-                OnGenerateSingleLanguage(GEN_LANG_RUBY);
+                OnGenerateSingleLanguage(GenLang::ruby);
             },
             id_GenSingleRuby);
 
@@ -474,7 +474,7 @@ MainFrame::MainFrame() :
             wxEVT_MENU,
             [](wxCommandEvent&)
             {
-                OnGenerateSingleLanguage(GEN_LANG_XRC);
+                OnGenerateSingleLanguage(GenLang::xrc);
             },
             id_GenSingleXrc);
 
@@ -482,7 +482,7 @@ MainFrame::MainFrame() :
             wxEVT_MENU,
             [](wxCommandEvent&)
             {
-                OnGenerateLanguage(GEN_LANG_RUBY);
+                OnGenerateLanguage(GenLang::ruby);
             },
             id_GenerateRuby);
 
@@ -490,7 +490,7 @@ MainFrame::MainFrame() :
             wxEVT_MENU,
             [](wxCommandEvent&)
             {
-                OnGenerateLanguage(GEN_LANG_XRC);
+                OnGenerateLanguage(GenLang::xrc);
             },
             id_GenerateXrc);
 

--- a/src/mainframe_events.cpp
+++ b/src/mainframe_events.cpp
@@ -190,7 +190,7 @@ auto MainFrame::OnAuiNotebookPageChanged(wxAuiNotebookEvent& /* event unused */)
 auto MainFrame::OnBrowseDocs(wxCommandEvent& /* event unused */) -> void
 {
     wxString url;
-    url = (Project.get_LangVersion(GEN_LANG_CPLUSPLUS) < CPP_WIDGETS_VERSION_3_3_0) ?
+    url = (Project.get_LangVersion(GenLang::cplusplus) < CPP_WIDGETS_VERSION_3_3_0) ?
               "https://docs.wxwidgets.org/3.2.8" :
               "https://docs.wxwidgets.org/latest";
 

--- a/src/mainframe_updates.cpp
+++ b/src/mainframe_updates.cpp
@@ -108,15 +108,15 @@ auto MainFrame::UpdateLanguagePanels() -> void
         }
     };
 
-    manage_panel(GEN_LANG_CPLUSPLUS, m_cppPanel, "C++");
-    manage_panel(GEN_LANG_PYTHON, m_pythonPanel, "Python");
-    manage_panel(GEN_LANG_RUBY, m_rubyPanel, "Ruby");
-    manage_panel(GEN_LANG_FORTRAN, m_fortranPanel, "Fortran");
-    manage_panel(GEN_LANG_GO, m_goPanel, "Go");
-    manage_panel(GEN_LANG_JULIA, m_juliaPanel, "Julia");
-    manage_panel(GEN_LANG_LUAJIT, m_luajitPanel, "LuaJIT");
-    manage_panel(GEN_LANG_TYPESCRIPT, m_typescriptPanel, "TypeScript");
-    manage_panel(GEN_LANG_XRC, m_xrcPanel, "XRC");
+    manage_panel(GenLang::cplusplus, m_cppPanel, "C++");
+    manage_panel(GenLang::python, m_pythonPanel, "Python");
+    manage_panel(GenLang::ruby, m_rubyPanel, "Ruby");
+    manage_panel(GenLang::fortran, m_fortranPanel, "Fortran");
+    manage_panel(GenLang::go, m_goPanel, "Go");
+    manage_panel(GenLang::julia, m_juliaPanel, "Julia");
+    manage_panel(GenLang::luajit, m_luajitPanel, "LuaJIT");
+    manage_panel(GenLang::typescript, m_typescriptPanel, "TypeScript");
+    manage_panel(GenLang::xrc, m_xrcPanel, "XRC");
 
     // Ensure the preferred language panel sits at notebook position 1.
     struct LangInfo
@@ -127,15 +127,15 @@ auto MainFrame::UpdateLanguagePanels() -> void
     };
     const auto preferred = Project.get_CodePreference();
     const std::array lang_info = {
-        LangInfo { .flag = GEN_LANG_CPLUSPLUS, .panel = m_cppPanel, .label = "C++" },
-        LangInfo { .flag = GEN_LANG_PYTHON, .panel = m_pythonPanel, .label = "Python" },
-        LangInfo { .flag = GEN_LANG_RUBY, .panel = m_rubyPanel, .label = "Ruby" },
-        LangInfo { .flag = GEN_LANG_FORTRAN, .panel = m_fortranPanel, .label = "Fortran" },
-        LangInfo { .flag = GEN_LANG_GO, .panel = m_goPanel, .label = "GO" },
-        LangInfo { .flag = GEN_LANG_JULIA, .panel = m_juliaPanel, .label = "Julia" },
-        LangInfo { .flag = GEN_LANG_LUAJIT, .panel = m_luajitPanel, .label = "LuaJIT" },
-        LangInfo { .flag = GEN_LANG_TYPESCRIPT, .panel = m_typescriptPanel, .label = "TypeScript" },
-        LangInfo { .flag = GEN_LANG_XRC, .panel = m_xrcPanel, .label = "XRC" },
+        LangInfo { .flag = GenLang::cplusplus, .panel = m_cppPanel, .label = "C++" },
+        LangInfo { .flag = GenLang::python, .panel = m_pythonPanel, .label = "Python" },
+        LangInfo { .flag = GenLang::ruby, .panel = m_rubyPanel, .label = "Ruby" },
+        LangInfo { .flag = GenLang::fortran, .panel = m_fortranPanel, .label = "Fortran" },
+        LangInfo { .flag = GenLang::go, .panel = m_goPanel, .label = "GO" },
+        LangInfo { .flag = GenLang::julia, .panel = m_juliaPanel, .label = "Julia" },
+        LangInfo { .flag = GenLang::luajit, .panel = m_luajitPanel, .label = "LuaJIT" },
+        LangInfo { .flag = GenLang::typescript, .panel = m_typescriptPanel, .label = "TypeScript" },
+        LangInfo { .flag = GenLang::xrc, .panel = m_xrcPanel, .label = "XRC" },
     };
     for (const auto& [flag, panel, label]: lang_info)
     {

--- a/src/newdialogs/new_common.cpp
+++ b/src/newdialogs/new_common.cpp
@@ -17,15 +17,15 @@ void UpdateFormClass(Node* form_node)
     auto filename = CreateBaseFilename(form_node, form_node->as_string(prop_class_name));
     form_node->set_value(prop_base_file, filename);
 
-    if (Project.get_CodePreference() == GEN_LANG_PYTHON)
+    if (Project.get_CodePreference() == GenLang::python)
     {
         form_node->set_value(prop_python_file, filename);
     }
-    else if (Project.get_CodePreference() == GEN_LANG_RUBY)
+    else if (Project.get_CodePreference() == GenLang::ruby)
     {
         form_node->set_value(prop_ruby_file, filename);
     }
-    else if (Project.get_CodePreference() == GEN_LANG_XRC)
+    else if (Project.get_CodePreference() == GenLang::xrc)
     {
         form_node->set_value(prop_xrc_file, filename);
     }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -534,7 +534,7 @@ std::string_view Node::get_NodeName(GenLang lang) const
     {
         return "unknown node";
     }
-    if (lang == GEN_LANG_CPLUSPLUS)
+    if (lang == GenLang::cplusplus)
     {
         // '@' is used for Ruby instance variables
         // '$' is commonly used for Perl package variables
@@ -549,7 +549,7 @@ std::string_view Node::get_NodeName(GenLang lang) const
 
     if (name[0] == '@')
     {
-        if (lang != GEN_LANG_RUBY)
+        if (lang != GenLang::ruby)
         {
             name.remove_prefix(1);
         }
@@ -561,8 +561,8 @@ std::string_view Node::get_NodeName(GenLang lang) const
         return name;
     }
 
-    // GEN_LANG_CPLUSPLUS is handled above
-    ASSERT(lang != GEN_LANG_CPLUSPLUS);
+    // GenLang::cplusplus is handled above
+    ASSERT(lang != GenLang::cplusplus);
     if (name.starts_with("m_"))
     {
         name.remove_prefix(2);
@@ -788,13 +788,13 @@ void Node::AdjustMemberNameForLanguage(Node* new_node)
     const auto language = Project.get_CodePreference(this);
 
     // Apply C++ naming conventions
-    if (language == GEN_LANG_CPLUSPLUS && UserPrefs.is_CppSnakeCase())
+    if (language == GenLang::cplusplus && UserPrefs.is_CppSnakeCase())
     {
         member_name = ConvertToSnakeCase(member_name);
     }
 
     // Remove m_ prefix (common in imported projects)
-    if (member_name.starts_with("m_") && language != GEN_LANG_CPLUSPLUS)
+    if (member_name.starts_with("m_") && language != GenLang::cplusplus)
     {
         member_name.erase(0, 2);
 
@@ -806,7 +806,7 @@ void Node::AdjustMemberNameForLanguage(Node* new_node)
     }
 
     // Apply Python private name convention
-    if (language == GEN_LANG_PYTHON && new_node->is_Local())
+    if (language == GenLang::python && new_node->is_Local())
     {
         member_name = "_" + member_name;
     }

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -211,14 +211,14 @@ public:
     std::string_view get_NodeName() const;
 
     // May remove prefix based on the language -- e.g., @foo become foo unless the language
-    // is GEN_LANG_RUBY
+    // is GenLang::ruby
     std::string_view get_NodeName(GenLang lang) const;
 
     // Returns the value of the parent property "var_name" or "class_name"
     std::string_view get_ParentName() const;
 
     // May remove prefix based on the language -- e.g., @foo become foo unless the language
-    // is GEN_LANG_RUBY
+    // is GenLang::ruby
     std::string_view get_ParentName(GenLang lang, bool ignore_sizers = false) const;
 
     // Returns this if the node is a form, else walks up node tree to find the parent form.

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -96,7 +96,7 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, GenLang panel_type) : w
     // generator to generate inherited classes, or just generate generation information about
     // the class.
 
-    if (m_panel_type == GEN_LANG_CPLUSPLUS)
+    if (m_panel_type == GenLang::cplusplus)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
@@ -110,56 +110,56 @@ BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, GenLang panel_type) : w
         m_derived_hdr_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_derived_hdr_panel, "derived_hdr", false, wxWithImages::NO_IMAGE);
     }
-    else if (m_panel_type == GEN_LANG_PYTHON)
+    else if (m_panel_type == GenLang::python)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
         m_hdr_info_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_hdr_info_panel, "info", false, wxWithImages::NO_IMAGE);
     }
-    else if (m_panel_type == GEN_LANG_RUBY)
+    else if (m_panel_type == GenLang::ruby)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
         m_hdr_info_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_hdr_info_panel, "info", false, wxWithImages::NO_IMAGE);
     }
-    else if (m_panel_type == GEN_LANG_FORTRAN)
+    else if (m_panel_type == GenLang::fortran)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
         m_hdr_info_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_hdr_info_panel, "info", false, wxWithImages::NO_IMAGE);
     }
-    else if (m_panel_type == GEN_LANG_GO)
+    else if (m_panel_type == GenLang::go)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
         m_hdr_info_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_hdr_info_panel, "info", false, wxWithImages::NO_IMAGE);
     }
-    else if (m_panel_type == GEN_LANG_JULIA)
+    else if (m_panel_type == GenLang::julia)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
         m_hdr_info_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_hdr_info_panel, "info", false, wxWithImages::NO_IMAGE);
     }
-    else if (m_panel_type == GEN_LANG_LUAJIT)
+    else if (m_panel_type == GenLang::luajit)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
         m_hdr_info_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_hdr_info_panel, "info", false, wxWithImages::NO_IMAGE);
     }
-    else if (m_panel_type == GEN_LANG_TYPESCRIPT)
+    else if (m_panel_type == GenLang::typescript)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
         m_hdr_info_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_hdr_info_panel, "info", false, wxWithImages::NO_IMAGE);
     }
-    else if (m_panel_type == GEN_LANG_XRC)
+    else if (m_panel_type == GenLang::xrc)
     {
         m_source_panel = new CodeDisplay(m_notebook, panel_type);
         m_notebook->AddPage(m_source_panel, "source", false, wxWithImages::NO_IMAGE);
@@ -374,7 +374,7 @@ void BasePanel::GenerateBaseClass()
 
     // All languages except C++ derived panels use GenResults for unified code generation
     // C++ base class panels (SOURCE_PANEL, HDR_INFO_PANEL) also use GenResults
-    if (m_panel_type != GEN_LANG_CPLUSPLUS || panel_page == PANEL_PAGE::SOURCE_PANEL ||
+    if (m_panel_type != GenLang::cplusplus || panel_page == PANEL_PAGE::SOURCE_PANEL ||
         panel_page == PANEL_PAGE::HDR_INFO_PANEL)
     {
         m_source_panel->Clear();
@@ -403,7 +403,7 @@ void BasePanel::GenerateBaseClass()
     }
 
     // C++ derived class panels only - generate derived code without regenerating base class
-    ASSERT(m_panel_type == GEN_LANG_CPLUSPLUS);
+    ASSERT(m_panel_type == GenLang::cplusplus);
     ASSERT(panel_page == PANEL_PAGE::DERIVED_SRC_PANEL ||
            panel_page == PANEL_PAGE::DERIVED_HDR_PANEL);
 
@@ -464,7 +464,7 @@ void BasePanel::SetCodeFont(const wxFont& font)
 {
     m_source_panel->SetCodeFont(font);
     m_hdr_info_panel->SetCodeFont(font);
-    if (m_panel_type == GEN_LANG_CPLUSPLUS)
+    if (m_panel_type == GenLang::cplusplus)
     {
         m_derived_src_panel->SetCodeFont(font);
         m_derived_hdr_panel->SetCodeFont(font);

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -140,7 +140,7 @@ void CodeDisplay::OnNodeSelected(Node* node)
         return;
     }
 
-    if (!node->HasProp(prop_var_name) && m_panel_type != GEN_LANG_XRC &&
+    if (!node->HasProp(prop_var_name) && m_panel_type != GenLang::xrc &&
         !node->is_Gen(gen_ribbonTool) && !node->is_Gen(gen_ribbonButton))
     {
         return;  // probably a form, spacer, or image
@@ -149,7 +149,7 @@ void CodeDisplay::OnNodeSelected(Node* node)
     auto is_event = wxGetFrame().get_PropPanel()->IsEventPageShowing();
     PANEL_PAGE page = wxGetFrame().GetCppPanel()->GetPanelPage();
 
-    if (m_panel_type != GEN_LANG_CPLUSPLUS && page != PANEL_PAGE::SOURCE_PANEL)
+    if (m_panel_type != GenLang::cplusplus && page != PANEL_PAGE::SOURCE_PANEL)
     {
         return;  // Nothing to search for in secondary pages of non-C++ languages
     }
@@ -197,7 +197,7 @@ void CodeDisplay::OnNodeSelected(Node* node)
             }
         }
     }
-    if (m_panel_type == GEN_LANG_XRC)
+    if (m_panel_type == GenLang::xrc)
     {
         wxue::string search("name=\"");
         ;
@@ -300,11 +300,11 @@ void CodeDisplay::OnRibbonToolSelected(Node* node)
         {
             search << parent->as_string(prop_var_name) << "->AddTool(" << node->as_string(prop_id)
                    << ",";
-            if (m_panel_type == GEN_LANG_PYTHON)
+            if (m_panel_type == GenLang::python)
             {
                 search.Replace("->", ".");
             }
-            if (m_panel_type == GEN_LANG_RUBY)
+            if (m_panel_type == GenLang::ruby)
             {
                 search.Replace("->AddTool(", ".add_tool($");
             }

--- a/src/panels/doc_view.cpp
+++ b/src/panels/doc_view.cpp
@@ -117,9 +117,9 @@ void DocViewPanel::ActivatePage()
     {
         wxBusyCursor wait;
 
-        m_toolBar->ToggleTool(ID_CPLUS, m_language == GEN_LANG_CPLUSPLUS);
-        m_toolBar->ToggleTool(ID_PYTHON, m_language == GEN_LANG_PYTHON);
-        m_toolBar->ToggleTool(ID_RUBY, m_language == GEN_LANG_RUBY);
+        m_toolBar->ToggleTool(ID_CPLUS, m_language == GenLang::cplusplus);
+        m_toolBar->ToggleTool(ID_PYTHON, m_language == GenLang::python);
+        m_toolBar->ToggleTool(ID_RUBY, m_language == GenLang::ruby);
 
 #if wxUSE_WEBVIEW
         m_webview = wxWebView::New(this, wxID_ANY, "about:blank");
@@ -131,13 +131,13 @@ void DocViewPanel::ActivatePage()
     wxCommandEvent dummy;
     switch (m_language)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             OnCPlus(dummy);
             break;
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             OnPython(dummy);
             break;
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             OnRuby(dummy);
             break;
 
@@ -158,7 +158,7 @@ void DocViewPanel::OnCPlus(wxCommandEvent& /* event */)
 {
 #if wxUSE_WEBVIEW
     wxBusyCursor wait;
-    m_language = GEN_LANG_CPLUSPLUS;
+    m_language = GenLang::cplusplus;
     if (auto* cur_sel = m_mainframe->getSelectedNode(); cur_sel)
     {
         if (auto* gen = cur_sel->get_Generator(); gen)
@@ -166,7 +166,7 @@ void DocViewPanel::OnCPlus(wxCommandEvent& /* event */)
             if (auto file = gen->GetHelpURL(cur_sel); file.size())
             {
                 wxString url;
-                url = (Project.get_LangVersion(GEN_LANG_CPLUSPLUS) < CPP_WIDGETS_VERSION_3_3_0) ?
+                url = (Project.get_LangVersion(GenLang::cplusplus) < CPP_WIDGETS_VERSION_3_3_0) ?
                           "https://docs.wxwidgets.org/3.2.8" :
                           "https://docs.wxwidgets.org/latest";
 
@@ -205,7 +205,7 @@ void DocViewPanel::OnPython(wxCommandEvent& /* event */)
 {
 #if wxUSE_WEBVIEW
     wxBusyCursor wait;
-    m_language = GEN_LANG_PYTHON;
+    m_language = GenLang::python;
     if (auto* cur_sel = m_mainframe->getSelectedNode(); cur_sel)
     {
         if (auto* gen = cur_sel->get_Generator(); gen)
@@ -231,7 +231,7 @@ void DocViewPanel::OnRuby(wxCommandEvent& /* event */)
 {
 #if wxUSE_WEBVIEW
     wxBusyCursor wait;
-    m_language = GEN_LANG_RUBY;
+    m_language = GenLang::ruby;
     if (auto* cur_sel = m_mainframe->getSelectedNode(); cur_sel)
     {
         if (auto* gen = cur_sel->get_Generator(); gen)

--- a/src/panels/doc_view.h
+++ b/src/panels/doc_view.h
@@ -85,5 +85,5 @@ private:
     MainFrame* m_mainframe { nullptr };
     wxWebView* m_webview { nullptr };
 
-    GenLang m_language { GEN_LANG_CPLUSPLUS };
+    GenLang m_language { GenLang::cplusplus };
 };

--- a/src/panels/nav_panel.cpp
+++ b/src/panels/nav_panel.cpp
@@ -287,7 +287,7 @@ void NavigationPanel::OnSelChanged(wxTreeEvent& event)
         // this should be changed to call the generator to determine if the control is
         // supported by the current language.
 
-        if (Project.get_CodePreference() == GEN_LANG_PYTHON)
+        if (Project.get_CodePreference() == GenLang::python)
         {
             const GenName gen_name = iter->second->get_GenName();
             if (std::ranges::any_of(unsupported_gen_python,
@@ -300,7 +300,7 @@ void NavigationPanel::OnSelChanged(wxTreeEvent& event)
                                             wxICON_INFORMATION);
             }
         }
-        if (Project.get_CodePreference() == GEN_LANG_RUBY)
+        if (Project.get_CodePreference() == GenLang::ruby)
         {
             const GenName gen_name = iter->second->get_GenName();
             if (std::ranges::any_of(unsupported_gen_ruby,

--- a/src/panels/navpopupmenu.cpp
+++ b/src/panels/navpopupmenu.cpp
@@ -333,13 +333,13 @@ void NavPopupMenu::OnMenuEvent(wxCommandEvent& event)
 
         case std::to_underlying(Menu::SingleGenPython):
             {
-                OnGenerateSingleLanguage(GEN_LANG_PYTHON);
+                OnGenerateSingleLanguage(GenLang::python);
             }
             break;
 
         case std::to_underlying(Menu::SingleGenRuby):
             {
-                OnGenerateSingleLanguage(GEN_LANG_RUBY);
+                OnGenerateSingleLanguage(GenLang::ruby);
             }
             break;
 

--- a/src/panels/propgrid_create.cpp
+++ b/src/panels/propgrid_create.cpp
@@ -673,7 +673,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
     auto generate_languages = Project.get_GenerateLanguages();
 
     // Ignore if the user doesn't want to generate this language
-    if (!(static_cast<size_t>(ConvertToGenLang(name)) & generate_languages))
+    if (!(ConvertToGenLang(name) & generate_languages))
     {
         return;
     }
@@ -682,14 +682,14 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
     {
         // These two validators were added to wxWidgets 3.3
         auto preferred_language = Project.get_CodePreference();
-        if (preferred_language == GEN_LANG_CPLUSPLUS &&
+        if (preferred_language == GenLang::cplusplus &&
             Project.get_LangVersion(preferred_language) < CPP_WIDGETS_VERSION_3_3_0)
         {
             return;
         }
         // REVIEW: [Randalphwa - 09-01-2025] It's possible that wxPerl does support it, but it's
         // unlikely
-        if (preferred_language == GEN_LANG_PYTHON)
+        if (preferred_language == GenLang::python)
         {
             return;
         }
@@ -753,7 +753,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
             m_prop_grid->SetPropertyBackgroundColour(category_id,
                                                      wxColour("#ccccff"));  // Light blue
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_CPLUSPLUS)
+        if (Project.get_CodePreference(node) != GenLang::cplusplus)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -770,7 +770,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
             m_prop_grid->SetPropertyBackgroundColour(category_id,
                                                      wxColour("#ccd9ff"));  // Light navy
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_PYTHON)
+        if (Project.get_CodePreference(node) != GenLang::python)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -785,7 +785,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
         {
             m_prop_grid->SetPropertyBackgroundColour(category_id, wxColour("#f8a9c7"));  // Ruby
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_RUBY)
+        if (Project.get_CodePreference(node) != GenLang::ruby)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -801,7 +801,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
             m_prop_grid->SetPropertyBackgroundColour(category_id,
                                                      wxColour("#ffe5b4"));  // Apricot
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_FORTRAN)
+        if (Project.get_CodePreference(node) != GenLang::fortran)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -817,7 +817,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
             m_prop_grid->SetPropertyBackgroundColour(category_id,
                                                      wxColour("#ccf2f4"));  // Light cyan
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_GO)
+        if (Project.get_CodePreference(node) != GenLang::go)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -833,7 +833,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
             m_prop_grid->SetPropertyBackgroundColour(category_id,
                                                      wxColour("#e6ccff"));  // Light purple
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_JULIA)
+        if (Project.get_CodePreference(node) != GenLang::julia)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -849,7 +849,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
             m_prop_grid->SetPropertyBackgroundColour(category_id,
                                                      wxColour("#ccffcc"));  // Light green
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_LUAJIT)
+        if (Project.get_CodePreference(node) != GenLang::luajit)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -865,7 +865,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
             m_prop_grid->SetPropertyBackgroundColour(category_id,
                                                      wxColour("#ffd9b3"));  // Light rust
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_TYPESCRIPT)
+        if (Project.get_CodePreference(node) != GenLang::typescript)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -882,7 +882,7 @@ void PropGridPanel::CreatePropCategory(wxue::string_view name, Node* node,
             m_prop_grid->SetPropertyBackgroundColour(category_id,
                                                      wxColour("#ccffe6"));  // Mint Cream
         }
-        if (Project.get_CodePreference(node) != GEN_LANG_XRC)
+        if (Project.get_CodePreference(node) != GenLang::xrc)
         {
             m_prop_grid->Collapse(category_id);
         }
@@ -981,7 +981,7 @@ void PropGridPanel::ProcessFormLanguageCategories(Node* node, NodeDeclaration* d
             // so we need to create the other two categories here if the preferred
             // language is C++.
 
-            if (m_preferred_lang == GEN_LANG_CPLUSPLUS &&
+            if (m_preferred_lang == GenLang::cplusplus &&
                 info_base->get_DeclName().find("Settings") != std::string_view::npos)
             {
                 info_base = declaration->GetBaseClass(++i);
@@ -1007,7 +1007,7 @@ void PropGridPanel::ProcessFormLanguageCategories(Node* node, NodeDeclaration* d
         {
             if (info_base->get_DeclName().starts_with(lang_prefix))
             {
-                if (m_preferred_lang == GEN_LANG_CPLUSPLUS &&
+                if (m_preferred_lang == GenLang::cplusplus &&
                     info_base->get_DeclName().find("Settings") != std::string_view::npos)
                 {
                     lang_start += 2;  // skip over Header Settings and Derived Class Settings

--- a/src/panels/propgrid_events.cpp
+++ b/src/panels/propgrid_events.cpp
@@ -494,7 +494,7 @@ void PropGridPanel::OnPropertyGridChanged(wxPropertyGridEvent& event)
                     {
                         CheckOutputFile(newValue, selected_node);
 
-                        if (Project.get_CodePreference() == GEN_LANG_CPLUSPLUS)
+                        if (Project.get_CodePreference() == GenLang::cplusplus)
                         {
                             if (!selected_node->as_bool(prop_use_derived_class))
                             {

--- a/src/panels/propgrid_modify.cpp
+++ b/src/panels/propgrid_modify.cpp
@@ -294,7 +294,7 @@ void PropGridPanel::ModifyFileProperty(NodeProperty* node_prop, wxPGProperty* gr
     {
         wxue::string newValue =
             grid_prop->GetValueAsString(wxPGPropValFormatFlags::FullValue).utf8_string();
-        auto result = Project.GetOutputPath(node_prop->getNode()->get_Form(), GEN_LANG_CPLUSPLUS);
+        auto result = Project.GetOutputPath(node_prop->getNode()->get_Form(), GenLang::cplusplus);
         auto path = result.first;
         if (result.second)  // true if the the base filename was returned
         {
@@ -453,19 +453,19 @@ void PropGridPanel::ModifyOptionsProperty(NodeProperty* node_prop, wxPGProperty*
             auto access = (value == "none");
             switch (Project.get_CodePreference(selected_node))
             {
-                case GEN_LANG_CPLUSPLUS:
+                case GenLang::cplusplus:
                     // If access is changed to local and the name starts with "m_", then the "m_"
                     // will be stripped off. Conversely, if the name is changed from local to a
                     // class member, a "m_" is added as a prefix if preferred language isw C++.
                     UpdateCppMemberPrefix(access, name, node, is_name_changed);
                     break;
 
-                case GEN_LANG_PYTHON:
+                case GenLang::python:
                     // The convention in Python is to use a leading underscore for local members.
                     UpdatePythonMemberPrefix(access, name, node, is_name_changed);
                     break;
 
-                case GEN_LANG_RUBY:
+                case GenLang::ruby:
                     // The convention in Ruby is to use a leading @ for non-local members.
                     UpdateRubyMemberPrefix(access, name, node, is_name_changed);
                     break;

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -50,7 +50,7 @@ std::map<GenLang, std::string> s_lang_category_prefix;
 
 PropGridPanel::PropGridPanel(wxWindow* parent, MainFrame* frame) : wxPanel(parent)
 {
-    for (size_t lang = 1; lang <= GEN_LANG_XRC; lang <<= 1)
+    for (size_t lang = 1; lang <= std::to_underlying(GenLang::xrc); lang <<= 1)
     {
         s_lang_category_prefix[static_cast<GenLang>(lang)] =
             GenLangToString(static_cast<GenLang>(lang));
@@ -630,19 +630,19 @@ void PropGridPanel::CheckOutputFile(const wxue::string& newValue, Node* node)
 
     switch (Project.get_CodePreference())
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             ChangeOutputFile(prop_base_file);
             break;
 
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             ChangeOutputFile(prop_python_file);
             break;
 
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             ChangeOutputFile(prop_ruby_file);
             break;
 
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             ChangeOutputFile(prop_xrc_file);
             break;
 

--- a/src/panels/propgrid_panel.h
+++ b/src/panels/propgrid_panel.h
@@ -148,7 +148,7 @@ private:
     // Class decorations
     wxArrayString m_astr_wx_decorations;
 
-    GenLang m_preferred_lang { GEN_LANG_CPLUSPLUS };
+    GenLang m_preferred_lang { GenLang::cplusplus };
 
     bool m_isPropChangeSuspended { false };
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Precompiled header file
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2025 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2026 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -141,30 +141,52 @@ enum class MoveDirection : std::uint8_t
 // supports a single language at a time, and passing in multiple languages will cause it to fail to
 // generate any language. As bit flags, this can be used by generators to indicate which languages
 // the generator supports.
-enum GenLang : std::uint16_t
+enum class GenLang : unsigned int
 {
-    GEN_LANG_NONE = 0,
-    GEN_LANG_CPLUSPLUS = 1,
-    GEN_LANG_PYTHON = 1 << 2,
-    GEN_LANG_RUBY = 1 << 3,
+    none = 0,
+    cplusplus = 1 << 0,
+    python = 1 << 1,
+    ruby = 1 << 2,
 
     // These 5 are the kwx languages (kwxFortran, kwxGO, etc.)
-    GEN_LANG_FORTRAN = 1 << 4,
-    GEN_LANG_GO = 1 << 5,
-    GEN_LANG_JULIA = 1 << 6,
-    GEN_LANG_LUAJIT = 1 << 7,
-    GEN_LANG_TYPESCRIPT = 1 << 8,
+    fortran = 1 << 3,
+    go = 1 << 4,
+    julia = 1 << 5,
+    luajit = 1 << 6,
+    typescript = 1 << 7,
 
     // These should always be the last languages in the list.
-    GEN_LANG_XRC = 1 << 9,
-    GEN_LANG_XML = 1 << 10,
-    GEN_LANG_RESERVED1 = 1 << 11,  // Reserved for future use
+    xrc = 1 << 8,
+    xml = 1 << 9,
+    reserved1 = 1 << 10,  // Reserved for future use
 };
+
+constexpr GenLang operator|(GenLang lang_a, GenLang lang_b)
+{
+    return static_cast<GenLang>(std::to_underlying(lang_a) | std::to_underlying(lang_b));
+}
+constexpr unsigned int operator&(GenLang lang_a, GenLang lang_b)
+{
+    return std::to_underlying(lang_a) & std::to_underlying(lang_b);
+}
+constexpr GenLang operator~(GenLang lang_a)
+{
+    return static_cast<GenLang>(~std::to_underlying(lang_a));
+}
+constexpr GenLang& operator|=(GenLang& lang_a, GenLang lang_b)
+{
+    return lang_a = lang_a | lang_b;
+}
+constexpr GenLang& operator&=(GenLang& lang_a, GenLang lang_b)
+{
+    lang_a = static_cast<GenLang>(std::to_underlying(lang_a) & std::to_underlying(lang_b));
+    return lang_a;
+}
 
 // Frozen set containing all supported code generation languages
 constexpr auto gen_lang_set = frozen::make_set<GenLang>(
-    { GEN_LANG_CPLUSPLUS, GEN_LANG_FORTRAN, GEN_LANG_GO, GEN_LANG_JULIA, GEN_LANG_LUAJIT,
-      GEN_LANG_PYTHON, GEN_LANG_RUBY, GEN_LANG_TYPESCRIPT, GEN_LANG_XRC });
+    { GenLang::cplusplus, GenLang::fortran, GenLang::go, GenLang::julia, GenLang::luajit,
+      GenLang::python, GenLang::ruby, GenLang::typescript, GenLang::xrc });
 
 // Used to index fields in a bitmap property
 enum PropIndex : std::uint8_t

--- a/src/project/data_handler.cpp
+++ b/src/project/data_handler.cpp
@@ -134,7 +134,7 @@ auto DataHandler::LoadAndCompress(Node* node) -> bool
         return false;
     }
 
-    auto [path, has_base_file] = Project.GetOutputPath(node->get_Parent(), GEN_LANG_CPLUSPLUS);
+    auto [path, has_base_file] = Project.GetOutputPath(node->get_Parent(), GenLang::cplusplus);
     if (has_base_file)
     {
         // true if the the base filename was returned, in which case we need to convert the

--- a/src/project/loadproject.cpp
+++ b/src/project/loadproject.cpp
@@ -993,13 +993,13 @@ bool ProjectHandler::Import(ImportXML& import, std::string& file, bool append, b
             }
         };
 
-        if (auto language = import.GetLanguage(); language != GEN_LANG_NONE)
+        if (auto language = import.GetLanguage(); language != GenLang::none)
         {
-            if (language & GEN_LANG_CPLUSPLUS)
+            if (language & GenLang::cplusplus)
                 project_node->set_value(prop_code_preference, "C++");
-            else if (language & GEN_LANG_PYTHON)
+            else if (language & GenLang::python)
                 project_node->set_value(prop_code_preference, "Python");
-            else if (language & GEN_LANG_XRC)
+            else if (language & GenLang::xrc)
                 project_node->set_value(prop_code_preference, "XRC");
 
             // None of the other designers generate code for wxRuby3 or wxHaskell
@@ -1007,7 +1007,7 @@ bool ProjectHandler::Import(ImportXML& import, std::string& file, bool append, b
             SetLangFilenames();
         }
 
-        if (allow_ui && import.GetLanguage() == GEN_LANG_NONE)
+        if (allow_ui && import.GetLanguage() == GenLang::none)
         {
             CodePreferenceDlg dlg(wxGetMainFrame());
             if (dlg.ShowModal() == wxID_OK)

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -633,9 +633,9 @@ bool ProjectHandler::ShouldOutputLanguage(const NodesFormChild& nodes,
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-size_t ProjectHandler::get_OutputType(int flags) const
+GenOutput ProjectHandler::get_OutputType(int flags) const
 {
-    size_t result = OUTPUT_NONE;
+    GenOutput result = GenOutput::none;
 
     auto traverse_forms_recursively = [&](Node* form, auto&& traverse_forms_recursively) -> void
     {
@@ -652,21 +652,21 @@ size_t ProjectHandler::get_OutputType(int flags) const
                 {
                     PropName base_file_property;
                     GenLang language;
-                    size_t output_flag;
+                    GenOutput output_flag;
                 };
                 static constexpr std::array<OutputLangInfo, 4> outputLangs =
                     std::to_array<OutputLangInfo>({ { .base_file_property = prop_base_file,
                                                       .language = GenLang::cplusplus,
-                                                      .output_flag = OUTPUT_CPLUS },
+                                                      .output_flag = GenOutput::cplusplus },
                                                     { .base_file_property = prop_python_file,
                                                       .language = GenLang::python,
-                                                      .output_flag = OUTPUT_PYTHON },
+                                                      .output_flag = GenOutput::python },
                                                     { .base_file_property = prop_ruby_file,
                                                       .language = GenLang::ruby,
-                                                      .output_flag = OUTPUT_RUBY },
+                                                      .output_flag = GenOutput::ruby },
                                                     { .base_file_property = prop_xrc_file,
                                                       .language = GenLang::xrc,
-                                                      .output_flag = OUTPUT_XRC } });
+                                                      .output_flag = GenOutput::xrc } });
 
                 for (const auto& info: outputLangs)
                 {
@@ -683,7 +683,7 @@ size_t ProjectHandler::get_OutputType(int flags) const
                 {
                     if (IsDerivedFileMissing(child.get()))
                     {
-                        result |= OUTPUT_DERIVED;
+                        result |= GenOutput::derived;
                     }
                 }
             }

--- a/src/project/project_handler.cpp
+++ b/src/project/project_handler.cpp
@@ -287,7 +287,7 @@ wxue::string ProjectHandler::GetFolderOutputPath(Node* folder, GenLang language,
 {
     wxue::string result;
 
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         if (folder->HasValue(prop_folder_base_directory))
         {
@@ -306,8 +306,8 @@ wxue::string ProjectHandler::GetFolderOutputPath(Node* folder, GenLang language,
     {
         static const std::map<GenLang, PropName> langFolderPropMap = {
 
-            { GEN_LANG_RUBY, prop_folder_ruby_output_folder },
-            { GEN_LANG_XRC, prop_folder_xrc_directory }
+            { GenLang::ruby, prop_folder_ruby_output_folder },
+            { GenLang::xrc, prop_folder_xrc_directory }
         };
 
         if (auto iter = langFolderPropMap.find(language);
@@ -323,10 +323,10 @@ wxue::string ProjectHandler::GetFolderOutputPath(Node* folder, GenLang language,
 wxue::string ProjectHandler::GetProjectOutputPath(GenLang language) const
 {
     static const std::map<GenLang, PropName> langProjectPropMap = {
-        { GEN_LANG_CPLUSPLUS, prop_base_directory },
-        { GEN_LANG_PYTHON, prop_python_output_folder },
-        { GEN_LANG_RUBY, prop_ruby_output_folder },
-        { GEN_LANG_XRC, prop_xrc_directory }
+        { GenLang::cplusplus, prop_base_directory },
+        { GenLang::python, prop_python_output_folder },
+        { GenLang::ruby, prop_ruby_output_folder },
+        { GenLang::xrc, prop_xrc_directory }
     };
 
     if (auto iter = langProjectPropMap.find(language);
@@ -341,16 +341,16 @@ wxue::string ProjectHandler::GetProjectOutputPath(GenLang language) const
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 wxue::string ProjectHandler::GetBaseFilename(Node* form, GenLang language) const
 {
-    if (language == GEN_LANG_CPLUSPLUS && form->is_Gen(gen_Data))
+    if (language == GenLang::cplusplus && form->is_Gen(gen_Data))
     {
         return form->as_string(prop_output_file);
     }
 
     static const std::map<GenLang, PropName> langbase_file_propertyMap = {
-        { GEN_LANG_CPLUSPLUS, prop_base_file },
-        { GEN_LANG_PYTHON, prop_python_file },
-        { GEN_LANG_RUBY, prop_ruby_file },
-        { GEN_LANG_XRC, prop_xrc_file }
+        { GenLang::cplusplus, prop_base_file },
+        { GenLang::python, prop_python_file },
+        { GenLang::ruby, prop_ruby_file },
+        { GenLang::xrc, prop_xrc_file }
     };
 
     const std::map<GenLang, PropName>::const_iterator iter =
@@ -360,7 +360,8 @@ wxue::string ProjectHandler::GetBaseFilename(Node* form, GenLang language) const
         return form->as_string(iter->second);
     }
 
-    FAIL_MSG(wxue::string() << "Unknown language: " << language);
+    FAIL_MSG(wxue::string() << "Unknown language: "
+                            << static_cast<int>(std::to_underlying(language)));
     return "";
 }
 
@@ -435,17 +436,17 @@ std::string ProjectHandler::get_DerivedDirectory(Node* node, GenLang language) c
     if (folder)
     {
         static const std::map<GenLang, PropName> folderLangPropMap = {
-            { GEN_LANG_CPLUSPLUS, prop_folder_derived_directory },
-            { GEN_LANG_PYTHON, prop_folder_python_output_folder },
-            { GEN_LANG_RUBY, prop_folder_ruby_output_folder },
-            { GEN_LANG_XRC, prop_folder_xrc_directory }
+            { GenLang::cplusplus, prop_folder_derived_directory },
+            { GenLang::python, prop_folder_python_output_folder },
+            { GenLang::ruby, prop_folder_ruby_output_folder },
+            { GenLang::xrc, prop_folder_xrc_directory }
         };
         if (auto iter = folderLangPropMap.find(language); iter != folderLangPropMap.end())
         {
             if (folder->HasValue(iter->second))
             {
                 // Special case for C++: use base directory for derived files
-                if (language == GEN_LANG_CPLUSPLUS)
+                if (language == GenLang::cplusplus)
                 {
                     result = folder->as_string(prop_folder_base_directory);
                 }
@@ -462,10 +463,10 @@ std::string ProjectHandler::get_DerivedDirectory(Node* node, GenLang language) c
     if (result.empty() || !folder)
     {
         static const std::map<GenLang, PropName> projectLangPropMap = {
-            { GEN_LANG_CPLUSPLUS, prop_derived_directory },
-            { GEN_LANG_PYTHON, prop_python_output_folder },
-            { GEN_LANG_RUBY, prop_ruby_output_folder },
-            { GEN_LANG_XRC, prop_xrc_directory }
+            { GenLang::cplusplus, prop_derived_directory },
+            { GenLang::python, prop_python_output_folder },
+            { GenLang::ruby, prop_ruby_output_folder },
+            { GenLang::xrc, prop_xrc_directory }
         };
 
         if (auto iter = projectLangPropMap.find(language); iter != projectLangPropMap.end())
@@ -473,7 +474,7 @@ std::string ProjectHandler::get_DerivedDirectory(Node* node, GenLang language) c
             if (m_project_node->HasValue(iter->second))
             {
                 // Special case for C++: use base directory for derived files
-                if (language == GEN_LANG_CPLUSPLUS)
+                if (language == GenLang::cplusplus)
                 {
                     result = m_project_node->as_string(prop_base_directory);
                 }
@@ -540,15 +541,15 @@ GenLang ProjectHandler::get_CodePreference(Node* node) const
     // Note: Be sure this list matches the languages in ../xml/project.xml
     // clang-format off
     static const std::map<std::string_view, GenLang> langStringMap = {
-        { "C++", GEN_LANG_CPLUSPLUS },
-        { "Python", GEN_LANG_PYTHON },
-        { "Ruby", GEN_LANG_RUBY },
-        { "GO", GEN_LANG_GO },
-        { "Fortran", GEN_LANG_FORTRAN },
-        { "Julia", GEN_LANG_JULIA },
-        { "LuaJIT", GEN_LANG_LUAJIT },
-        { "TypeScript", GEN_LANG_TYPESCRIPT },
-        { "XRC", GEN_LANG_XRC }
+        { "C++", GenLang::cplusplus },
+        { "Python", GenLang::python },
+        { "Ruby", GenLang::ruby },
+        { "GO", GenLang::go },
+        { "Fortran", GenLang::fortran },
+        { "Julia", GenLang::julia },
+        { "LuaJIT", GenLang::luajit },
+        { "TypeScript", GenLang::typescript },
+        { "XRC", GenLang::xrc }
     };
     // clang-format on
     if (auto iter = langStringMap.find(value); iter != langStringMap.end())
@@ -556,35 +557,35 @@ GenLang ProjectHandler::get_CodePreference(Node* node) const
         return iter->second;
     }
 
-    return GEN_LANG_CPLUSPLUS;
+    return GenLang::cplusplus;
 }
 
-size_t ProjectHandler::get_GenerateLanguages() const
+GenLang ProjectHandler::get_GenerateLanguages() const
 {
     // Always set the project's code preference to the list
-    auto languages = static_cast<size_t>(get_CodePreference(m_project_node.get()));
+    auto languages = get_CodePreference(m_project_node.get());
 
     const std::string_view value = Project.as_view(prop_generate_languages);
 
     // Note: Be sure this list matches the languages in ../xml/project.xml
     // clang-format off
     static const std::map<std::string_view, size_t> langBitMap = {
-        { "C++", GEN_LANG_CPLUSPLUS },
-        { "Fortran", GEN_LANG_FORTRAN },
-        { "GO", GEN_LANG_GO },
-        { "Julia", GEN_LANG_JULIA },
-        { "LuaJIT", GEN_LANG_LUAJIT },
-        { "Python", GEN_LANG_PYTHON },
-        { "Ruby", GEN_LANG_RUBY },
-        { "TypeScript", GEN_LANG_TYPESCRIPT },
-        { "XRC", GEN_LANG_XRC }
+        { "C++", std::to_underlying(GenLang::cplusplus) },
+        { "Fortran", std::to_underlying(GenLang::fortran) },
+        { "GO", std::to_underlying(GenLang::go) },
+        { "Julia", std::to_underlying(GenLang::julia) },
+        { "LuaJIT", std::to_underlying(GenLang::luajit) },
+        { "Python", std::to_underlying(GenLang::python) },
+        { "Ruby", std::to_underlying(GenLang::ruby) },
+        { "TypeScript", std::to_underlying(GenLang::typescript) },
+        { "XRC", std::to_underlying(GenLang::xrc) }
     };
     // clang-format on
     for (const auto& [langStr, langBit]: langBitMap)
     {
         if (value.find(langStr) != std::string_view::npos)
         {
-            languages |= langBit;
+            languages |= static_cast<GenLang>(langBit);
         }
     }
 
@@ -605,13 +606,13 @@ bool ProjectHandler::ShouldOutputLanguage(const NodesFormChild& nodes,
         nodes.child->get_PropDefaultValue(base_file_property))
     {
         // C++ always outputs with default value
-        if (language == GEN_LANG_CPLUSPLUS)
+        if (language == GenLang::cplusplus)
         {
-            return get_CodePreference(nodes.form) == GEN_LANG_CPLUSPLUS;
+            return get_CodePreference(nodes.form) == GenLang::cplusplus;
         }
 
         // Data/Image nodes with default values follow code preference (except XRC)
-        if (language != GEN_LANG_XRC)
+        if (language != GenLang::xrc)
         {
             if ((nodes.child->is_Gen(gen_Images) || nodes.child->is_Gen(gen_Data)))
             {
@@ -655,16 +656,16 @@ size_t ProjectHandler::get_OutputType(int flags) const
                 };
                 static constexpr std::array<OutputLangInfo, 4> outputLangs =
                     std::to_array<OutputLangInfo>({ { .base_file_property = prop_base_file,
-                                                      .language = GEN_LANG_CPLUSPLUS,
+                                                      .language = GenLang::cplusplus,
                                                       .output_flag = OUTPUT_CPLUS },
                                                     { .base_file_property = prop_python_file,
-                                                      .language = GEN_LANG_PYTHON,
+                                                      .language = GenLang::python,
                                                       .output_flag = OUTPUT_PYTHON },
                                                     { .base_file_property = prop_ruby_file,
-                                                      .language = GEN_LANG_RUBY,
+                                                      .language = GenLang::ruby,
                                                       .output_flag = OUTPUT_RUBY },
                                                     { .base_file_property = prop_xrc_file,
-                                                      .language = GEN_LANG_XRC,
+                                                      .language = GenLang::xrc,
                                                       .output_flag = OUTPUT_XRC } });
 
                 for (const auto& info: outputLangs)
@@ -705,7 +706,7 @@ wxue::string ProjectHandler::get_DerivedFilename(Node* form) const
         return path;
     }
 
-    path = get_DerivedDirectory(form, GEN_LANG_CPLUSPLUS);
+    path = get_DerivedDirectory(form, GenLang::cplusplus);
     path.append_filename(form->as_string(prop_derived_file));
     path.make_absolute();
 
@@ -958,10 +959,10 @@ Node* ProjectHandler::get_DataForm()
 
 // clang-format off
 static const std::map<GenLang, PropName> langPropMap = {
-    { GEN_LANG_CPLUSPLUS, prop_wxWidgets_version },
-    { GEN_LANG_PYTHON, prop_wxPython_version },
-    { GEN_LANG_RUBY, prop_wxRuby_version },
-    { GEN_LANG_XRC, prop_wxWidgets_version }
+    { GenLang::cplusplus, prop_wxWidgets_version },
+    { GenLang::python, prop_wxPython_version },
+    { GenLang::ruby, prop_wxRuby_version },
+    { GenLang::xrc, prop_wxWidgets_version }
 };
 // clang-format on
 
@@ -1054,7 +1055,8 @@ int ProjectHandler::get_LangVersion(GenLang language) const
     }
     else
     {
-        FAIL_MSG(wxue::string() << "Unknown language: " << language);
+        FAIL_MSG(wxue::string() << "Unknown language: "
+                                << static_cast<int>(std::to_underlying(language)));
     }
 
     auto [major, minor, patch] = parseVersionString(version);

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -23,16 +23,46 @@ namespace pugi
 
 class ImportXML;
 
-enum : std::uint8_t
+enum class GenOutput
 {
-    OUTPUT_NONE = 0,
-    OUTPUT_CPLUS = 1 << 0,
-    OUTPUT_DERIVED = 1 << 1,
-    OUTPUT_PYTHON = 1 << 2,
-    OUTPUT_RUBY = 1 << 3,
-    OUTPUT_XRC = 1 << 4,
-    OUTPUT_PERL = 1 << 5,
+    none = 0,
+    cplusplus = 1 << 0,
+    python = 1 << 1,
+    ruby = 1 << 2,
+
+    // These 5 are the kwx languages (kwxFortran, kwxGO, etc.)
+    fortran = 1 << 3,
+    go = 1 << 4,
+    julia = 1 << 5,
+    luajit = 1 << 6,
+    typescript = 1 << 7,
+
+    // Not a language — set when a C++ derived class file needs to be generated
+    derived = 1 << 8,
+
+    xrc = 1 << 9,
+
+    reserved1 = 1 << 10,  // Reserved for future use
+
 };
+
+constexpr GenOutput operator|(GenOutput out_a, GenOutput out_b)
+{
+    return static_cast<GenOutput>(std::to_underlying(out_a) | std::to_underlying(out_b));
+}
+constexpr unsigned int operator&(GenOutput out_a, GenOutput out_b)
+{
+    return std::to_underlying(out_a) & std::to_underlying(out_b);
+}
+constexpr GenOutput& operator|=(GenOutput& out_a, GenOutput out_b)
+{
+    return out_a = out_a | out_b;
+}
+constexpr GenOutput& operator&=(GenOutput& out_a, GenOutput out_b)
+{
+    out_a = static_cast<GenOutput>(std::to_underlying(out_a) & std::to_underlying(out_b));
+    return out_a;
+}
 
 enum : std::uint8_t
 {
@@ -79,9 +109,9 @@ public:
 
     // Get a bit flag indicating which output types are enabled.
     //
-    // OUTPUT_DERIVED is only set if the file is specified and does *not* exist.
+    // GenOutput::derived is only set if the file is specified and does *not* exist.
     // Uses an in-memory cache (m_derived_file_exists) to avoid repeated disk I/O.
-    [[nodiscard]] size_t get_OutputType(int flags = OUT_FLAG_NONE) const;
+    [[nodiscard]] GenOutput get_OutputType(int flags = OUT_FLAG_NONE) const;
 
     // Populate the derived file existence cache. Call after LoadProject or when the entire
     // cache needs to be rebuilt (e.g., derived_directory changed).

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   ProjectHandler class
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2025 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2026 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -281,7 +281,7 @@ public:
     // Sets project property value only if the property exists, returns false if it doesn't
     // exist.
     template <typename T>
-    auto set_value(PropName name, T value) -> bool
+    bool set_value(PropName name, T value)
     {
         if (auto* prop = m_project_node->get_PropPtr(name); prop)
         {

--- a/src/project/project_handler.h
+++ b/src/project/project_handler.h
@@ -108,16 +108,16 @@ public:
 
     // If the node is within a folder, and the folder specifies a directory, then that
     // directory is returned. Otherwise the project base directory is returned.
-    wxue::string get_BaseDirectory(Node* node, GenLang language = GEN_LANG_CPLUSPLUS) const;
+    wxue::string get_BaseDirectory(Node* node, GenLang language = GenLang::cplusplus) const;
 
     // Returns the absolute path to the output file for this node. If no output filename is
     // specified, first will still contain a path with no filename, and second will be false.
     std::pair<wxue::string, bool> GetOutputPath(Node* form,
-                                                GenLang language = GEN_LANG_CPLUSPLUS) const;
+                                                GenLang language = GenLang::cplusplus) const;
 
     // If the node is within a folder, and the folder specifies a directory, then that
     // directory is returned. Otherwise the project derived directory is returned.
-    std::string get_DerivedDirectory(Node* node, GenLang language = GEN_LANG_CPLUSPLUS) const;
+    std::string get_DerivedDirectory(Node* node, GenLang language = GenLang::cplusplus) const;
 
     // Returns the full path to the derived filename or an empty string if no derived file
     // was specified.
@@ -159,13 +159,13 @@ public:
 
     [[nodiscard]] size_t get_ChildCount() const { return m_project_node->get_ChildCount(); }
 
-    // Returns a GEN_LANG_... enum value. Specify a node if you want to check for a folder
+    // Returns a GenLang::... enum value. Specify a node if you want to check for a folder
     // override of the language.
     GenLang get_CodePreference(Node* node = nullptr) const;
 
     // Returns all of the languages that are enabled for this project. The project's Code
     // Preference is always included.
-    [[nodiscard]] size_t get_GenerateLanguages() const;
+    [[nodiscard]] GenLang get_GenerateLanguages() const;
 
     // Assume major, minor, and patch have 99 possible values.
     // Returns major * 10000 + minor * 100 + patch

--- a/src/tools/compare/code_compare.cpp
+++ b/src/tools/compare/code_compare.cpp
@@ -42,15 +42,15 @@ void CodeCompare::OnInit(wxInitDialogEvent& /* event */)
     wxCommandEvent dummy;
     switch (language)
     {
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             m_radio_python->SetValue(true);
             break;
 
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             m_radio_ruby->SetValue(true);
             break;
 
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             m_radio_cplusplus->SetValue(true);
             break;
 
@@ -66,7 +66,7 @@ void CodeCompare::OnInit(wxInitDialogEvent& /* event */)
                 // The dialog has not been shown yet, so we displaying a user message box won't
                 // make sense. Instead, default to C++ generation.
                 m_radio_cplusplus->SetValue(true);
-                language = GEN_LANG_CPLUSPLUS;
+                language = GenLang::cplusplus;
             }
             break;
     }
@@ -159,17 +159,17 @@ void CodeCompare::OnRadioButton(GenLang language)
 
 void CodeCompare::OnCPlusPlus(wxCommandEvent& /* event */)
 {
-    OnRadioButton(GEN_LANG_CPLUSPLUS);
+    OnRadioButton(GenLang::cplusplus);
 }
 
 void CodeCompare::OnPython(wxCommandEvent& /* event */)
 {
-    OnRadioButton(GEN_LANG_PYTHON);
+    OnRadioButton(GenLang::python);
 }
 
 void CodeCompare::OnRuby(wxCommandEvent& /* event unused */)
 {
-    OnRadioButton(GEN_LANG_RUBY);
+    OnRadioButton(GenLang::ruby);
 }
 
 void CodeCompare::OnPerl(wxCommandEvent& /* event */)
@@ -180,7 +180,7 @@ void CodeCompare::OnPerl(wxCommandEvent& /* event */)
 
 void CodeCompare::OnXRC(wxCommandEvent& /* event */)
 {
-    OnRadioButton(GEN_LANG_XRC);
+    OnRadioButton(GenLang::xrc);
 }
 
 void CodeCompare::OnDiff(wxCommandEvent& /* event unused */)

--- a/src/tools/compare/code_compare.h
+++ b/src/tools/compare/code_compare.h
@@ -53,5 +53,5 @@ protected:
 
 private:
     std::vector<FileDiff> m_file_diffs;  // Diffs collected by OnRadioButton
-    GenLang m_current_language = GEN_LANG_CPLUSPLUS;
+    GenLang m_current_language = GenLang::cplusplus;
 };

--- a/src/tools/generate_dlg.cpp
+++ b/src/tools/generate_dlg.cpp
@@ -69,11 +69,11 @@ void MainFrame::OnGenerateCode(wxCommandEvent& /* event unused */)
 
 bool MainFrame::GenerateFromOutputType(GenResults& results)
 {
-    const size_t output_type = Project.get_OutputType();
+    const GenOutput output_type = Project.get_OutputType();
 
     // If the user *only* wants the derived classes (is that even possible to
     // specify?) then generate and return.
-    if (output_type == OUTPUT_DERIVED)
+    if (output_type == GenOutput::derived)
     {
         GenInheritedClass(results);
         return true;
@@ -85,19 +85,19 @@ bool MainFrame::GenerateFromOutputType(GenResults& results)
     // show the dialog to the user to ask which languages they want to generate. dialog to the user
     // to ask which languages they want to generate.
     GenLang language = GenLang::none;
-    if (output_type == OUTPUT_CPLUS)
+    if (output_type == GenOutput::cplusplus)
     {
         language = GenLang::cplusplus;
     }
-    if (output_type == OUTPUT_PYTHON)
+    if (output_type == GenOutput::python)
     {
         language = GenLang::python;
     }
-    if (output_type == OUTPUT_RUBY)
+    if (output_type == GenOutput::ruby)
     {
         language = GenLang::ruby;
     }
-    if (output_type == OUTPUT_XRC)
+    if (output_type == GenOutput::xrc)
     {
         language = GenLang::xrc;
     }

--- a/src/tools/generate_dlg.cpp
+++ b/src/tools/generate_dlg.cpp
@@ -84,25 +84,25 @@ bool MainFrame::GenerateFromOutputType(GenResults& results)
     // '==' here for a bit flag instead of '&' because if more than one bit is set, then we need to
     // show the dialog to the user to ask which languages they want to generate. dialog to the user
     // to ask which languages they want to generate.
-    std::uint16_t language = GEN_LANG_NONE;
+    GenLang language = GenLang::none;
     if (output_type == OUTPUT_CPLUS)
     {
-        language = GEN_LANG_CPLUSPLUS;
+        language = GenLang::cplusplus;
     }
     if (output_type == OUTPUT_PYTHON)
     {
-        language = GEN_LANG_PYTHON;
+        language = GenLang::python;
     }
     if (output_type == OUTPUT_RUBY)
     {
-        language = GEN_LANG_RUBY;
+        language = GenLang::ruby;
     }
     if (output_type == OUTPUT_XRC)
     {
-        language = GEN_LANG_XRC;
+        language = GenLang::xrc;
     }
 
-    if (language != GEN_LANG_NONE)
+    if (language != GenLang::none)
     {
         results.SetNodes(Project.get_ProjectNode());
         results.SetLanguages(static_cast<GenLang>(language));
@@ -125,36 +125,36 @@ bool MainFrame::GenerateFromDialog(GenResults& results)
     bool code_generated = false;
 
     // Collect all selected languages into a combined flag
-    std::uint16_t lang_flags = GEN_LANG_NONE;
+    GenLang lang_flags = GenLang::none;
 
     // Always generate XRC files first in case the XRC files need to be added to a gen_Data
     // section of the other languages.
     gen_xrc_code = dialog.is_gen_xrc();
     if (gen_xrc_code)
     {
-        lang_flags |= GEN_LANG_XRC;
+        lang_flags |= GenLang::xrc;
     }
 
     gen_base_code = dialog.is_gen_base();
     if (gen_base_code)
     {
-        lang_flags |= GEN_LANG_CPLUSPLUS;
+        lang_flags |= GenLang::cplusplus;
     }
 
     gen_python_code = dialog.is_gen_python();
     if (gen_python_code)
     {
-        lang_flags |= GEN_LANG_PYTHON;
+        lang_flags |= GenLang::python;
     }
 
     gen_ruby_code = dialog.is_gen_ruby();
     if (gen_ruby_code)
     {
-        lang_flags |= GEN_LANG_RUBY;
+        lang_flags |= GenLang::ruby;
     }
 
     // Generate all selected languages in one call
-    if (lang_flags != GEN_LANG_NONE)
+    if (lang_flags != GenLang::none)
     {
         results.SetNodes(Project.get_ProjectNode());
         results.SetLanguages(static_cast<GenLang>(lang_flags));
@@ -277,21 +277,21 @@ void MainFrame::ShowGenerationResults(const GenResults& results)
 
 void GenerateDlg::OnInit(wxInitDialogEvent& event)
 {
-    const size_t languages = Project.get_GenerateLanguages();
+    const GenLang languages = Project.get_GenerateLanguages();
 
     switch (Project.get_CodePreference())
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             gen_base_code = true;
             break;
 
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             gen_python_code = true;
             break;
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             gen_ruby_code = true;
             break;
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             gen_xrc_code = true;
             break;
 
@@ -299,7 +299,7 @@ void GenerateDlg::OnInit(wxInitDialogEvent& event)
             break;
     }
 
-    const bool show_cpp_section = (languages & GEN_LANG_CPLUSPLUS) || gen_base_code;
+    const bool show_cpp_section = (languages & GenLang::cplusplus) || gen_base_code;
     const bool show_derived = gen_derived_code || Project.HasMissingDerivedFiles();
 
     if (show_cpp_section || show_derived)
@@ -322,21 +322,21 @@ void GenerateDlg::OnInit(wxInitDialogEvent& event)
         }
     }
 
-    if (languages & GEN_LANG_PYTHON || gen_python_code)
+    if (languages & GenLang::python || gen_python_code)
     {
         m_gen_python_code = gen_python_code;
         m_checkPython = new wxCheckBox(this, wxID_ANY, "Python");
         m_checkPython->SetValidator(wxGenericValidator(&m_gen_python_code));
         m_grid_sizer->Add(m_checkPython, wxSizerFlags().Border(wxALL));
     }
-    if (languages & GEN_LANG_RUBY || gen_ruby_code)
+    if (languages & GenLang::ruby || gen_ruby_code)
     {
         m_gen_ruby_code = gen_ruby_code;
         m_checkRuby = new wxCheckBox(this, wxID_ANY, "Ruby");
         m_checkRuby->SetValidator(wxGenericValidator(&m_gen_ruby_code));
         m_grid_sizer->Add(m_checkRuby, wxSizerFlags().Border(wxALL));
     }
-    if (languages & GEN_LANG_XRC || gen_xrc_code)
+    if (languages & GenLang::xrc || gen_xrc_code)
     {
         m_gen_xrc_code = gen_xrc_code;
         m_checkXRC = new wxCheckBox(this, wxID_ANY, "XRC");

--- a/src/utils/set_stc_colors.cpp
+++ b/src/utils/set_stc_colors.cpp
@@ -639,31 +639,31 @@ auto SetStcColors(wxStyledTextCtrl* stc, GenLang language, bool set_lexer, bool 
 
     switch (language)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             SetCppColors(stc, set_lexer, add_keywords, theme);
             break;
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             SetPythonColors(stc, set_lexer, add_keywords, theme);
             break;
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             SetRubyColors(stc, set_lexer, add_keywords, theme);
             break;
-        case GEN_LANG_FORTRAN:
+        case GenLang::fortran:
             SetFortranColors(stc, set_lexer, add_keywords, theme);
             break;
-        case GEN_LANG_GO:
+        case GenLang::go:
             SetGoColors(stc, set_lexer, add_keywords, theme);
             break;
-        case GEN_LANG_JULIA:
+        case GenLang::julia:
             SetJuliaColors(stc, set_lexer, add_keywords, theme);
             break;
-        case GEN_LANG_LUAJIT:
+        case GenLang::luajit:
             SetLuaJitColors(stc, set_lexer, add_keywords, theme);
             break;
-        case GEN_LANG_TYPESCRIPT:
+        case GenLang::typescript:
             SetTypeScriptColors(stc, set_lexer, add_keywords, theme);
             break;
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             SetXrcColors(stc, set_lexer, add_keywords, theme);
             break;
         default:  // Unknown language, default to xml

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -416,19 +416,19 @@ auto isValidVarName(const std::string& str, GenLang language) -> bool
     };
 
     // The set is only initialized the first time this function is called.
-    if (language == GEN_LANG_CPLUSPLUS)
+    if (language == GenLang::cplusplus)
     {
         return lambda(g_set_cpp_keywords, g_u8_cpp_keywords);
     }
-    if (language == GEN_LANG_PYTHON)
+    if (language == GenLang::python)
     {
         return lambda(g_set_python_keywords, g_python_keywords);
     }
-    if (language == GEN_LANG_RUBY)
+    if (language == GenLang::ruby)
     {
         return lambda(g_set_ruby_keywords, g_ruby_keywords);
     }
-    if (language == GEN_LANG_TYPESCRIPT)
+    if (language == GenLang::typescript)
     {
         return lambda(g_set_typescript_keywords, g_typescript_keywords);
     }
@@ -606,24 +606,24 @@ auto GenLangToString(GenLang language) -> std::string_view
 {
     switch (language)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             return "C++";
 
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             return "Python";
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             return "Ruby";
-        case GEN_LANG_FORTRAN:
+        case GenLang::fortran:
             return "Fortran";
-        case GEN_LANG_GO:
+        case GenLang::go:
             return "Go";
-        case GEN_LANG_JULIA:
+        case GenLang::julia:
             return "Julia";
-        case GEN_LANG_LUAJIT:
+        case GenLang::luajit:
             return "LuaJIT";
-        case GEN_LANG_TYPESCRIPT:
+        case GenLang::typescript:
             return "TypeScript";
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             return "XRC";
         default:
             return "an unknown language";
@@ -634,74 +634,74 @@ auto ConvertToGenLang(wxue::string_view language) -> GenLang
 {
     if (language.starts_with("C++") || language.starts_with("Folder C++"))
     {
-        return GEN_LANG_CPLUSPLUS;
+        return GenLang::cplusplus;
     }
 
     if (language == "Python" || language.starts_with("wxPython") ||
         language.starts_with("Folder wxPython"))
     {
-        return GEN_LANG_PYTHON;
+        return GenLang::python;
     }
     if (language == "Ruby" || language.starts_with("wxRuby") ||
         language.starts_with("Folder wxRuby"))
     {
-        return GEN_LANG_RUBY;
+        return GenLang::ruby;
     }
     if (language == "GO" || language.starts_with("kwxGO") || language.starts_with("Folder kwxGO"))
     {
-        return GEN_LANG_GO;
+        return GenLang::go;
     }
     if (language == "Fortran" || language.starts_with("kwxFortran") ||
         language.starts_with("Folder kwxFortran"))
     {
-        return GEN_LANG_FORTRAN;
+        return GenLang::fortran;
     }
     if (language == "Julia" || language.starts_with("kwxJulia") ||
         language.starts_with("Folder kwxJulia"))
     {
-        return GEN_LANG_JULIA;
+        return GenLang::julia;
     }
     if (language == "LuaJIT" || language.starts_with("kwxLuaJIT") ||
         language.starts_with("Folder kwxLuaJIT"))
     {
-        return GEN_LANG_LUAJIT;
+        return GenLang::luajit;
     }
     if (language == "TypeScript" || language.starts_with("kwxTypeScript") ||
         language.starts_with("Folder kwxTypeScript"))
     {
-        return GEN_LANG_TYPESCRIPT;
+        return GenLang::typescript;
     }
     if (language.starts_with("XRC") || language.starts_with("Folder XRC"))
     {
-        return GEN_LANG_XRC;
+        return GenLang::xrc;
     }
     // If this wasn't an actual language setting, then return all languages
-    return static_cast<GenLang>(GEN_LANG_CPLUSPLUS | GEN_LANG_PYTHON | GEN_LANG_RUBY |
-                                GEN_LANG_XRC);
+    return static_cast<GenLang>(GenLang::cplusplus | GenLang::python | GenLang::ruby |
+                                GenLang::xrc);
 }
 
 auto GetLanguageExtension(GenLang language) -> std::string
 {
     switch (language)
     {
-        case GEN_LANG_CPLUSPLUS:
+        case GenLang::cplusplus:
             return ".cpp";
 
-        case GEN_LANG_PYTHON:
+        case GenLang::python:
             return ".py";
-        case GEN_LANG_RUBY:
+        case GenLang::ruby:
             return ".rb";
-        case GEN_LANG_FORTRAN:
+        case GenLang::fortran:
             return ".f90";
-        case GEN_LANG_GO:
+        case GenLang::go:
             return ".go";
-        case GEN_LANG_JULIA:
+        case GenLang::julia:
             return ".jl";
-        case GEN_LANG_LUAJIT:
+        case GenLang::luajit:
             return ".lua";
-        case GEN_LANG_TYPESCRIPT:
+        case GenLang::typescript:
             return ".ts";
-        case GEN_LANG_XRC:
+        case GenLang::xrc:
             return ".xrc";
 
         default:

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -86,7 +86,7 @@ extern std::map<std::string, const char*> g_stc_wrap_mode;  // NOLINT () // cppc
 [[nodiscard]] auto isConvertibleMime(const wxue::string& suffix) -> bool;
 
 // Checks whether a string is a valid C++ variable name.
-[[nodiscard]] auto isValidVarName(const std::string& str, GenLang language = GEN_LANG_CPLUSPLUS)
+[[nodiscard]] auto isValidVarName(const std::string& str, GenLang language = GenLang::cplusplus)
     -> bool;
 
 // This takes the class_name of the form, converts it to lowercase, and if the class name
@@ -106,7 +106,7 @@ auto ConvertToUpperSnakeCase(wxue::string_view str) -> wxue::string;
 // Returns false if property contains a 'n', or language is C++ and wxWidgets 3.1 is being
 // used.
 [[nodiscard]] auto isScalingEnabled(Node* node, GenEnum::PropName prop_name,
-                                    GenLang m_language = GEN_LANG_NONE) -> bool;
+                                    GenLang m_language = GenLang::none) -> bool;
 
 // Convert the GEN_LANG enum to a string
 auto GenLangToString(GenLang language) -> std::string_view;


### PR DESCRIPTION
Change GenLang and GenOutput to a scoped enum with operators to make them easier to use. Both enums are now similar and support the same languages.
