### PR TITLE
Moved all global language keywords into a header file

### DIFF
--- a/src/customprops/code_string_prop.cpp
+++ b/src/customprops/code_string_prop.cpp
@@ -18,11 +18,11 @@
 #include "utils.h"                     // Miscellaneous utility functions
 #include "wxui/editcodedialog_base.h"  // auto-generated: wxui/editcodedialog_base.cpp
 
-// Defined in base_panel.cpp
-extern const char* g_u8_cpp_keywords;
+#include "keywords.h"
 
 EditCodeProperty::EditCodeProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/edit_custom_mockup.cpp
+++ b/src/customprops/edit_custom_mockup.cpp
@@ -12,11 +12,11 @@
 
 #include "edit_custom_mockup.h"
 
-// Defined in base_panel.cpp
-extern const char* g_u8_cpp_keywords;
+#include "keywords.h"
 
 EditCustomMockupProperty::EditCustomMockupProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/eventhandler_dlg.cpp
+++ b/src/customprops/eventhandler_dlg.cpp
@@ -21,9 +21,7 @@
 // List of events and suggested function names
 extern const std::unordered_map<std::string_view, const char*> s_EventNames;
 
-// Defined in base_panel.cpp
-extern const char* g_u8_cpp_keywords;
-extern const char* g_ruby_keywords;
+#include "keywords.h"
 
 constexpr int SCI_SETKEYWORDS = 4005;
 

--- a/src/customprops/html_string_prop.cpp
+++ b/src/customprops/html_string_prop.cpp
@@ -14,11 +14,11 @@
 #include "mainframe.h"           // MainFrame -- Main window frame
 #include "utils.h"               // Miscellaneous utility functions
 
-// Defined in base_panel.cpp
-extern const char* g_u8_cpp_keywords;
+#include "keywords.h"
 
 EditHtmlProperty::EditHtmlProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/rearrange_prop.cpp
+++ b/src/customprops/rearrange_prop.cpp
@@ -12,11 +12,11 @@
 #include "../nodes/node_prop.h"  // NodeProperty class
 #include "mainframe.h"           // MainFrame -- Main window frame
 
-// Defined in base_panel.cpp
-extern const char* g_u8_cpp_keywords;
+#include "keywords.h"
 
 RearrangeProperty::RearrangeProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/sb_fields_prop.cpp
+++ b/src/customprops/sb_fields_prop.cpp
@@ -12,11 +12,11 @@
 #include "../nodes/node_prop.h"  // NodeProperty class
 #include "mainframe.h"           // MainFrame -- Main window frame
 
-// Defined in base_panel.cpp
-extern const char* g_u8_cpp_keywords;
+#include "keywords.h"
 
 SBarFieldsProperty::SBarFieldsProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/keywords.h
+++ b/src/keywords.h
@@ -1,0 +1,65 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Language keyword strings for scintilla syntax highlighting
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2021-2026 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+inline constexpr const char* g_u8_cpp_keywords =
+    "alignas alignof and and_eq atomic_cancel atomic_commit atomic_noexcept auto"
+    " bitand bitor bool break case catch char char8_t char16_t char32_t"
+    " class compl concept const consteval constexpr constinit const_cast"
+    " continue co_await co_return co_yield __declspec"
+    " decltype default delete dllexport do double dynamic_cast else enum explicit"
+    " export extern false float for friend goto if inline int interface long"
+    " mutable namespace new noexcept not not_eq nullptr operator private or or_eq"
+    " private protected public reflexpr register reinterpret_cast requires"
+    " return short signed sizeof static static_assert static_cast"
+    " struct switch synchronized template this thread_local throw true try typedef typeid"
+    " typename union unsigned using virtual void volatile wchar_t"
+    " while xor xor_eq";
+
+inline constexpr const char* g_python_keywords =
+    "False None True and as assert async break class continue def del elif else except finally "
+    "for from global if import in is lambda "
+    "nonlocal not or pass raise return self try while with yield";
+
+inline constexpr const char* g_ruby_keywords =
+    "ENCODING LINE FILE BEGIN END alias and begin break case class def defined do else"
+    " elsif end ensure false for if in module next nil not or redo require rescue retry"
+    " return self super then true undef unless until when while yield";
+
+inline constexpr const char* g_fortran_keywords =
+    "abstract allocatable assign assignment associate asynchronous backspace bind block blockdata"
+    " call case class close common complex contains continue contiguous critical cycle data"
+    " deallocate default deferred dimension do double doubleprecision else elseif elsewhere"
+    " end endblock endblockdata endcritical enddo endfile endforall endfunction endif endinterface"
+    " endmodule endprocedure endprogram endselect endsubmodule endsubroutine endteam endtype"
+    " endwhere entry equivalence error exit extends external final flush forall format function"
+    " generic goto if images implicit import include inquire integer intent interface intrinsic"
+    " lock logical module namelist non_overridable nopass nullify only open operator optional"
+    " parameter pass pause pointer print private procedure program protected public pure read"
+    " real recursive result return rewind save select sequence stop submodule subroutine sync"
+    " target then type unlock use value volatile where write";
+
+inline constexpr const char* g_go_keywords =
+    "break case chan const continue default defer else fallthrough for func go goto if import"
+    " interface map package range return select struct switch type var";
+
+inline constexpr const char* g_julia_keywords =
+    "abstract baremodule begin break catch ccall const continue do else elseif end export"
+    " false finally for function global if import importall in isa let local macro module"
+    " mutable new primitive quote return struct true try type using where while";
+
+inline constexpr const char* g_luajit_keywords =
+    "and break do else elseif end false for function goto if in local nil not or repeat"
+    " return then true until while";
+
+inline constexpr const char* g_typescript_keywords =
+    "abstract any as async await boolean break case catch class const continue debugger"
+    " declare default delete do else enum export extends false finally for function if"
+    " implements import in instanceof interface let module new null number package private"
+    " protected public readonly return static string super switch symbol this throw true"
+    " try type typeof undefined var void while with yield";

--- a/src/panels/base_panel.cpp
+++ b/src/panels/base_panel.cpp
@@ -25,64 +25,7 @@
 #include "gen_ruby.h"     // RubyCodeGenerator -- Generate wxRuby code
 #include "gen_xrc.h"      // XrcGenerator -- Generate XRC code
 
-// These are used everywhere we use scintilla to edit C++ code. It is also used to verify valid
-// var_name values.
-const char* g_u8_cpp_keywords =
-    "alignas alignof and and_eq atomic_cancel atomic_commit atomic_noexcept auto"
-    " bitand bitor bool break case catch char char8_t char16_t char32_t"
-    " class compl concept const consteval constexpr constinit const_cast"
-    " continue co_await co_return co_yield __declspec"
-    " decltype default delete dllexport do double dynamic_cast else enum explicit"
-    " export extern false float for friend goto if inline int interface long"
-    " mutable namespace new noexcept not not_eq nullptr operator private or or_eq"
-    " private protected public reflexpr register reinterpret_cast requires"
-    " return short signed sizeof static static_assert static_cast"
-    " struct switch synchronized template this thread_local throw true try typedef typeid"
-    " typename union unsigned using virtual void volatile wchar_t"
-    " while xor xor_eq";
-
-const char* g_python_keywords =
-    "False None True and as assert async break class continue def del elif else except finally "
-    "for from global if import in is lambda "
-    "nonlocal not or pass raise return self try while with yield";
-
-const char* g_ruby_keywords =
-    "ENCODING LINE FILE BEGIN END alias and begin break case class def defined do else"
-    " elsif end ensure false for if in module next nil not or redo require rescue retry"
-    " return self super then true undef unless until when while yield";
-
-const char* g_fortran_keywords =
-    "abstract allocatable assign assignment associate asynchronous backspace bind block blockdata"
-    " call case class close common complex contains continue contiguous critical cycle data"
-    " deallocate default deferred dimension do double doubleprecision else elseif elsewhere"
-    " end endblock endblockdata endcritical enddo endfile endforall endfunction endif endinterface"
-    " endmodule endprocedure endprogram endselect endsubmodule endsubroutine endteam endtype"
-    " endwhere entry equivalence error exit extends external final flush forall format function"
-    " generic goto if images implicit import include inquire integer intent interface intrinsic"
-    " lock logical module namelist non_overridable nopass nullify only open operator optional"
-    " parameter pass pause pointer print private procedure program protected public pure read"
-    " real recursive result return rewind save select sequence stop submodule subroutine sync"
-    " target then type unlock use value volatile where write";
-
-const char* g_go_keywords =
-    "break case chan const continue default defer else fallthrough for func go goto if import"
-    " interface map package range return select struct switch type var";
-
-const char* g_julia_keywords =
-    "abstract baremodule begin break catch ccall const continue do else elseif end export"
-    " false finally for function global if import importall in isa let local macro module"
-    " mutable new primitive quote return struct true try type using where while";
-
-const char* g_luajit_keywords =
-    "and break do else elseif end false for function goto if in local nil not or repeat"
-    " return then true until while";
-
-const char* g_typescript_keywords =
-    "abstract any as async await boolean break case catch class const continue debugger"
-    " declare default delete do else enum export extends false finally for function if"
-    " implements import in instanceof interface let module new null number package private"
-    " protected public readonly return static string super switch symbol this throw true"
-    " try type typeof undefined var void while with yield";
+#include "keywords.h"
 
 BasePanel::BasePanel(wxWindow* parent, MainFrame* frame, GenLang panel_type) : wxPanel(parent)
 {

--- a/src/panels/code_display.cpp
+++ b/src/panels/code_display.cpp
@@ -32,10 +32,7 @@
 // For the actual Scintilla constants, see the following file.
 // ../../wxWidgets/src/stc/lexilla/include/SciLexer.h
 
-extern const char* g_u8_cpp_keywords;
-extern const char* g_python_keywords;
-extern const char* g_ruby_keywords;
-extern const char* g_typescript_keywords;
+#include "keywords.h"
 
 // XRC Keywords are defined in gen_xrc_utils.cpp so they can easily be updated as XRC
 // generators support more XRC controls.
@@ -44,7 +41,8 @@ extern const char* g_xrc_keywords;
 const int node_marker = 1;
 
 CodeDisplay::CodeDisplay(wxWindow* parent, GenLang panel_type) :
-    CodeDisplayBase(parent), m_panel_type(panel_type)
+    CodeDisplayBase(parent),
+    m_panel_type(panel_type)
 {
     SetStcColors(m_scintilla, panel_type);
 

--- a/src/utils/set_stc_colors.cpp
+++ b/src/utils/set_stc_colors.cpp
@@ -20,14 +20,7 @@
 // For the actual Scintilla constants, see the following file.
 // ../../wxWidgets/src/stc/lexilla/include/SciLexer.h
 
-extern const char* g_u8_cpp_keywords;
-extern const char* g_python_keywords;
-extern const char* g_ruby_keywords;
-extern const char* g_fortran_keywords;
-extern const char* g_go_keywords;
-extern const char* g_julia_keywords;
-extern const char* g_luajit_keywords;
-extern const char* g_typescript_keywords;
+#include "keywords.h"
 
 // XRC Keywords are defined in gen_xrc_utils.cpp so they can easily be updated as XRC
 // generators support more XRC controls.

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -25,6 +25,8 @@
 #include "wxue_namespace/wxue_string_vector.h"  // wxue::StringVector
 #include "wxue_namespace/wxue_view_vector.h"    // wxue::ViewVector
 
+#include "keywords.h"
+
 // Look for search string in line, and if found, replace with replace_with string. If all
 // is true, replace all instances, otherwise only the first instance is replaced.
 auto utils::replace_in_line(std::string& line, std::string_view search,
@@ -358,15 +360,6 @@ auto isConvertibleMime(const wxue::string& suffix) -> bool
                                    return !suffix.is_sameas(iter);
                                });
 }
-
-extern const char* g_u8_cpp_keywords;  // defined in ../panels/base_panel.cpp
-extern const char* g_python_keywords;
-extern const char* g_ruby_keywords;
-extern const char* g_typescript_keywords;
-extern const char* g_fortran_keywords;
-extern const char* g_go_keywords;
-extern const char* g_julia_keywords;
-extern const char* g_luajit_keywords;
 
 std::set<std::string> g_set_cpp_keywords;
 std::set<std::string> g_set_python_keywords;


### PR DESCRIPTION
This is just to make it easier to find/read where the keywords are.

clang-format failures are to be expected for awhile -- I changed how class member ctor initialization is formatted -- will have to take a pass through the entire database before that gets cleaned up.