### PR TITLE
Change assertion msg to indicate when to attach a debugger

### DIFF
--- a/src/assertion_dlg.cpp
+++ b/src/assertion_dlg.cpp
@@ -8,6 +8,8 @@
 #include <cstdlib>
 #include <mutex>
 
+#include <wx/ffile.h>
+#include <wx/filedlg.h>
 #include <wx/msgdlg.h>
 
 #include "mainapp.h"    // App -- Main application class
@@ -16,6 +18,26 @@
 namespace
 {
     std::mutex mutex_assert;  // NOLINT (cppcheck-suppress)
+}  // namespace
+
+// Saves assertion/crash details to a user-chosen log file via wxFileDialog.
+void SaveAssertionInfo(const wxString& content)
+{
+    wxFileDialog file_dlg(nullptr, "Save Assertion Log", "", "assertion_log.txt",
+                          "Text files (*.txt)|*.txt|Log files (*.log)|*.log|All files (*.*)|*.*",
+                          wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+    if (file_dlg.ShowModal() == wxID_CANCEL)
+    {
+        return;
+    }
+
+    const wxString filepath = file_dlg.GetPath();
+    wxFFile file(filepath, "w");
+    if (file.IsOpened())
+    {
+        file.Write(content);
+    }
 }
 
 // Note that this returns bool allowing the ASSERT macro to call wxTrap in the caller's code rather
@@ -43,10 +65,13 @@ auto AssertionDlg(const char* filename, const char* function, int line, const ch
     str << "File: " << filename << '\n';
     str << "Function: " << function << '\n';
     str << "Line: " << line << "\n\n";
-    str << "Press Yes to call wxTrap, No to continue, Cancel to exit program.";
+
+#if defined(_DEBUG)
+    str << "Run 'Attach to wxUiEditor' in VSCode, then press Yes to break into debugger.\n"
+        << "No to continue, Cancel to exit program.";
 
     wxMessageDialog dlg(nullptr, str, "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
-    dlg.SetYesNoCancelLabels("wxTrap", "Continue", "Exit program");
+    dlg.SetYesNoCancelLabels("DebugBreak", "Continue", "Exit program");
 
     const auto answer = dlg.ShowModal();
 
@@ -54,6 +79,20 @@ auto AssertionDlg(const char* filename, const char* function, int line, const ch
     {
         return true;
     }
+#else  // INTERNAL_TESTING without _DEBUG
+    str << "Press Yes to save details to log file, No to continue, Cancel to exit program.";
+
+    wxMessageDialog dlg(nullptr, str, "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
+    dlg.SetYesNoCancelLabels("Save to log", "Continue", "Exit program");
+
+    const auto answer = dlg.ShowModal();
+
+    if (answer == wxID_YES)
+    {
+        SaveAssertionInfo(str);
+        return false;
+    }
+#endif
     if (answer == wxID_CANCEL)
     {
         std::quick_exit(2);
@@ -99,10 +138,13 @@ void ttAssertionHandler(const wxString& filename, int line, const wxString& func
     str << "File: " << filename << '\n';
     str << "Function: " << function << '\n';
     str << "Line: " << line << "\n\n";
-    str << "Press Yes to call wxTrap, No to continue, Cancel to exit program.";
+
+#if defined(_DEBUG)
+    str << "Run 'Attach to wxUiEditor' in VSCode, then press Yes to break into debugger.\n"
+        << "No to continue, Cancel to exit program.";
 
     wxMessageDialog dlg(nullptr, str, "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
-    dlg.SetYesNoCancelLabels("wxTrap", "Continue", "Exit program");
+    dlg.SetYesNoCancelLabels("DebugBreak", "Continue", "Exit program");
 
     const auto answer = dlg.ShowModal();
 
@@ -110,6 +152,19 @@ void ttAssertionHandler(const wxString& filename, int line, const wxString& func
     {
         wxTrap();
     }
+#else  // INTERNAL_TESTING without _DEBUG
+    str << "Press Yes to save details to log file, No to continue, Cancel to exit program.";
+
+    wxMessageDialog dlg(nullptr, str, "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
+    dlg.SetYesNoCancelLabels("Save to log", "Continue", "Exit program");
+
+    const auto answer = dlg.ShowModal();
+
+    if (answer == wxID_YES)
+    {
+        SaveAssertionInfo(str);
+    }
+#endif
     else if (answer == wxID_CANCEL)
     {
         std::quick_exit(2);

--- a/src/assertion_dlg.h
+++ b/src/assertion_dlg.h
@@ -15,6 +15,10 @@ auto AssertionDlg(const char* filename, const char* function, int line, const ch
 void ttAssertionHandler(const wxString& filename, int line, const wxString& function,
                         const wxString& cond, const wxString& msg);
 
+// Saves assertion/crash details to a user-chosen log file via wxFileDialog.
+// Used by OnAssertFailure() in release+testing builds and by the assertion dialog.
+void SaveAssertionInfo(const wxString& content);
+
 // The advantage of using ASSERT over wxASSERT is that ASSERT allows the macro to execute wxTrap in
 // the caller's code, so that you don't have to step out of the assertion function to get back to
 // the code that threw the assert.
@@ -37,7 +41,7 @@ void ttAssertionHandler(const wxString& filename, int line, const wxString& func
         {                                                          \
             wxMessageBox((msg), "Warning", wxOK | wxICON_WARNING); \
         }
-#else  // not defined(NDEBUG) && !defined(INTERNAL_TESTING)
+#elif defined(_DEBUG)
     #define ASSERT(cond)                                                                 \
         if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, wxEmptyString)) \
         {                                                                                \
@@ -58,6 +62,32 @@ void ttAssertionHandler(const wxString& filename, int line, const wxString& func
         }
     // In debug builds, identical to ASSERT_MSG — shows file/line/condition with option
     // to break into the debugger.
+    #define ASSERT_OR_WARN(cond, msg) ASSERT_MSG(cond, msg)
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+#else  // INTERNAL_TESTING without _DEBUG
+    // In release+testing builds, show the assertion dialog but never break into the
+    // debugger. The dialog offers a "Save to log" option instead.
+    // NOLINTBEGIN(cppcoreguidelines-macro-usage)
+    #define ASSERT(cond)                                                                    \
+        if (!(cond))                                                                        \
+        {                                                                                   \
+            std::ignore = AssertionDlg(__FILE__, __func__, __LINE__, #cond, wxEmptyString); \
+        }
+
+    #define ASSERT_MSG(cond, msg)                                                   \
+        if (!(cond))                                                                \
+        {                                                                           \
+            std::ignore = AssertionDlg(__FILE__, __func__, __LINE__, #cond, (msg)); \
+        }
+
+    #define FAIL_MSG(msg)                                                              \
+        {                                                                              \
+            std::ignore = AssertionDlg(__FILE__, __func__, __LINE__, "failed", (msg)); \
+        }
+
+    // In testing builds, identical to ASSERT_MSG — shows file/line/condition with
+    // option to save to log.
     #define ASSERT_OR_WARN(cond, msg) ASSERT_MSG(cond, msg)
 // NOLINTEND(cppcoreguidelines-macro-usage)
 #endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -13,6 +13,7 @@
 #include <wx/cshelp.h>   // Context-sensitive help support classes
 #include <wx/dir.h>      // wxDir is a class for enumerating the files in a directory
 #include <wx/filedlg.h>  // wxFileDialog base header
+#include <wx/msgdlg.h>   // wxMessageDialog
 #include <wx/msgout.h>   // wxMessageOutput and related classes
 #include <wx/sysopt.h>   // wxSystemOptions
 #include <wx/utils.h>    // Miscellaneous utilities
@@ -371,7 +372,10 @@ int App::OnRun()
         g_pMsgLogging = new MsgLogging();
         wxLog::SetActiveTarget(g_pMsgLogging);
 
-        // Use our own assertion handler
+        // Replace wxWidgets' default assertion handler with our own (ttAssertionHandler
+        // in assertion_dlg.cpp). It provides a three-button dialog (DebugBreak/Continue/Exit)
+        // matching our custom ASSERT macros. Once set, wxASSERT will use this handler
+        // instead of calling App::OnAssertFailure().
         wxSetAssertHandler(ttAssertionHandler);
     }
 

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -105,7 +105,7 @@ enum class MenuIDs : int
     id_UndoInfo,
     id_DebugPythonTest,
     id_DebugRubyTest,
-    id_VerifyTtwx,
+    id_AssertionTest,
 };
 
 const std::string_view txtNewProject = "New Project";
@@ -202,8 +202,8 @@ MainFrame::MainFrame() :
                          "Current debugging test");
 
     menuInternal->AppendSeparator();
-    menuInternal->Append(std::to_underlying(MenuIDs::id_VerifyTtwx), "&Verify TTWX...",
-                         "Verify TTWX files");
+    menuInternal->Append(std::to_underlying(MenuIDs::id_AssertionTest), "&Assertion Test...",
+                         "Run assertion test");
 
     menuInternal->AppendSeparator();
     menuInternal->Append(std::to_underlying(MenuIDs::id_ConvertImage), "&Convert Image...",
@@ -346,6 +346,14 @@ MainFrame::MainFrame() :
             dialog.ShowModal();
         },
         std::to_underlying(MenuIDs::id_DebugPreferences));
+
+    Bind(
+        wxEVT_MENU,
+        [this](wxCommandEvent&)
+        {
+            ASSERT_MSG(false, wxue::string() << "Assertion test triggered");
+        },
+        std::to_underlying(MenuIDs::id_AssertionTest));
 
     Bind(wxEVT_MENU, &App::DbgCurrentTest, &wxGetApp(),
          std::to_underlying(MenuIDs::id_DebugCurrentTest));


### PR DESCRIPTION
This makes it easier to break into a debugger no matter what project is being edited.
