### PR TITLE
Reformat using updated .clang-format instructions

### DIFF
--- a/src/cstm_event.h
+++ b/src/cstm_event.h
@@ -19,12 +19,14 @@ class CustomEvent : public wxEvent
 public:
     CustomEvent(wxEventType Command, Node* node) : wxEvent(0, Command), m_node(node) {}
     CustomEvent(wxEventType Command, NodeProperty* property) :
-        wxEvent(0, Command), m_property(property)
+        wxEvent(0, Command),
+        m_property(property)
     {
     }
     CustomEvent(wxEventType Command, NodeEvent* event) : wxEvent(0, Command), m_event(event) {}
     CustomEvent(wxEventType Command, UndoAction* undo_cmd) :
-        wxEvent(0, Command), m_undo_cmd(undo_cmd)
+        wxEvent(0, Command),
+        m_undo_cmd(undo_cmd)
     {
     }
 

--- a/src/customprops/code_single_prop.cpp
+++ b/src/customprops/code_single_prop.cpp
@@ -17,7 +17,8 @@
 #include "wxui/editstringdialog_base.h"  // auto-generated: wxui/editstringdialog_base.h wxui/editstringdialog_base.cpp
 
 EditCodeSingleProperty::EditCodeSingleProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 
@@ -25,7 +26,9 @@ class EditCodeSingleDialog : public EditStringDialogBase
 {
 public:
     EditCodeSingleDialog(wxWindow* parent, NodeProperty* prop) :
-        EditStringDialogBase(parent), m_node(prop->getNode()), m_prop(prop)
+        EditStringDialogBase(parent),
+        m_node(prop->getNode()),
+        m_prop(prop)
     {
         SetTitle((wxue::string() << prop->get_DeclName() << " property editor").wx());
         m_value = prop->as_wxString();

--- a/src/customprops/custom_colour_prop.cpp
+++ b/src/customprops/custom_colour_prop.cpp
@@ -23,7 +23,8 @@
 #include "wxui/colourprop_base.h"  // auto-generated: wxui/colourprop_base.h wxui/colourprop_base.cpp
 
 EditColourProperty::EditColourProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 
@@ -79,7 +80,9 @@ bool EditColourDialogAdapter::DoShowDialog(wxPropertyGrid* propGrid,
 }
 
 EditColourDialog::EditColourDialog(wxWindow* parent, NodeProperty* prop) :
-    ColourPropBase(parent), m_node(prop->getNode()), m_prop_name(prop->get_name())
+    ColourPropBase(parent),
+    m_node(prop->getNode()),
+    m_prop_name(prop->get_name())
 {
     SetTitle((wxue::string() << prop->get_DeclName() << " property editor").wx());
     m_value = prop->as_color();

--- a/src/customprops/custom_param_prop.cpp
+++ b/src/customprops/custom_param_prop.cpp
@@ -13,7 +13,8 @@
 #include "mainframe.h"           // MainFrame -- Main window frame
 
 EditParamProperty::EditParamProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/directory_prop.cpp
+++ b/src/customprops/directory_prop.cpp
@@ -14,7 +14,8 @@
 #include "project_handler.h"  // ProjectHandler class
 
 DirectoryProperty::DirectoryProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/evt_string_prop.cpp
+++ b/src/customprops/evt_string_prop.cpp
@@ -14,7 +14,8 @@
 #include "../nodes/node_event.h"  // NodeEventInfo -- NodeEvent and NodeEventInfo classes
 
 EventStringProperty::EventStringProperty(const wxString& label, NodeEvent* event) :
-    wxStringProperty(label, wxPG_LABEL, event->get_value()), m_event(event)
+    wxStringProperty(label, wxPG_LABEL, event->get_value()),
+    m_event(event)
 {
 }
 

--- a/src/customprops/font_string_prop.cpp
+++ b/src/customprops/font_string_prop.cpp
@@ -14,7 +14,8 @@
 #include "../nodes/node_prop.h"  // NodeProperty class
 
 FontStringProperty::FontStringProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/id_prop.cpp
+++ b/src/customprops/id_prop.cpp
@@ -15,7 +15,8 @@
 #include "mainframe.h"           // MainFrame -- Main window frame
 
 ID_Property::ID_Property(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/img_string_prop.h
+++ b/src/customprops/img_string_prop.h
@@ -16,7 +16,8 @@ class ImageDialogAdapter : public wxPGEditorDialogAdapter
 {
 public:
     ImageDialogAdapter(ImageProperties& img_props) :
-        wxPGEditorDialogAdapter(), m_img_props(img_props)
+        wxPGEditorDialogAdapter(),
+        m_img_props(img_props)
     {
     }
 
@@ -31,7 +32,8 @@ class ImageStringProperty : public wxStringProperty
 {
 public:
     ImageStringProperty(const wxString& label, ImageProperties& img_props) :
-        wxStringProperty(label, wxPG_LABEL, img_props.image.wx()), m_img_props(img_props)
+        wxStringProperty(label, wxPG_LABEL, img_props.image.wx()),
+        m_img_props(img_props)
     {
     }
 

--- a/src/customprops/include_files_prop.cpp
+++ b/src/customprops/include_files_prop.cpp
@@ -14,7 +14,8 @@
 #include "../nodes/node_prop.h"  // NodeProperty class
 
 IncludeFilesProperty::IncludeFilesProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/pg_point.h
+++ b/src/customprops/pg_point.h
@@ -52,7 +52,8 @@ class CustomBoolProperty : public wxBoolProperty
 {
 public:
     CustomBoolProperty(const wxString& label = wxPG_LABEL, const wxString& name = wxPG_LABEL,
-                       bool value = false) : wxBoolProperty(label, name, value)
+                       bool value = false) :
+        wxBoolProperty(label, name, value)
     {
     }
 

--- a/src/customprops/sizer_grow_columns.cpp
+++ b/src/customprops/sizer_grow_columns.cpp
@@ -14,7 +14,8 @@
 #include "wxue_namespace/wxue_string_vector.h"  // wxue::StringVector, wxue::is_digit, wxue::atoi
 
 GrowColumnsProperty::GrowColumnsProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/sizer_grow_rows.cpp
+++ b/src/customprops/sizer_grow_rows.cpp
@@ -14,7 +14,8 @@
 #include "wxue_namespace/wxue_string_vector.h"  // wxue::StringVector, wxue::is_digit, wxue::atoi
 
 GrowRowsProperty::GrowRowsProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/customprops/txt_string_prop.cpp
+++ b/src/customprops/txt_string_prop.cpp
@@ -17,7 +17,8 @@
 #include "wxui/editstringdialog_base.h"  // auto-generated: wxui/editstringdialog_base.cpp
 
 EditStringProperty::EditStringProperty(const wxString& label, NodeProperty* prop) :
-    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()), m_prop(prop)
+    wxStringProperty(label, wxPG_LABEL, prop->as_wxString()),
+    m_prop(prop)
 {
 }
 

--- a/src/generate/writers/gen_base.cpp
+++ b/src/generate/writers/gen_base.cpp
@@ -29,7 +29,10 @@
 using namespace GenEnum;
 
 BaseCodeGenerator::BaseCodeGenerator(GenLang language, Node* form_node) :
-    m_header(nullptr), m_source(nullptr), m_form_node(form_node), m_language(language),
+    m_header(nullptr),
+    m_source(nullptr),
+    m_form_node(form_node),
+    m_language(language),
     m_strategy(CreateLanguageStrategy(language))
 {
 }

--- a/src/generate/writers/gen_cpp.h
+++ b/src/generate/writers/gen_cpp.h
@@ -241,7 +241,8 @@ class GenData
 {
 public:
     GenData(GenResults& results, std::vector<std::string>* pClassList) :
-        m_pClassList(pClassList), m_results(&results)
+        m_pClassList(pClassList),
+        m_results(&results)
     {
     }
 

--- a/src/internal/msgframe.cpp
+++ b/src/internal/msgframe.cpp
@@ -49,7 +49,9 @@ namespace
 }  // namespace
 
 MsgFrame::MsgFrame(std::vector<wxString>* pMsgs, bool* pDestroyed, wxWindow* parent) :
-    MsgFrameBase(parent), m_pMsgs(pMsgs), m_pDestroyed(pDestroyed)
+    MsgFrameBase(parent),
+    m_pMsgs(pMsgs),
+    m_pDestroyed(pDestroyed)
 {
     // These will adjust for both dark mode and high contrast mode if needed
     const auto clr_fg = UserPrefs.GetColour(wxSYS_COLOUR_WINDOWTEXT);

--- a/src/mockup/mockup_content.cpp
+++ b/src/mockup/mockup_content.cpp
@@ -39,7 +39,8 @@ constexpr double VARIANT_SCALE_FACTOR = 1.2;
 constexpr int MAGNIFY_INCREMENT = 200;
 
 MockupContent::MockupContent(wxWindow* parent, MockupParent* mockupParent) :
-    wxPanel(parent), m_mockupParent(mockupParent)
+    wxPanel(parent),
+    m_mockupParent(mockupParent)
 {
 }
 

--- a/src/mockup/mockup_wizard.cpp
+++ b/src/mockup/mockup_wizard.cpp
@@ -23,8 +23,10 @@
 #include "node.h"       // Node class
 
 MockupWizard::MockupWizard(wxWindow* parent, Node* node) :
-    wxPanel(parent), m_window_sizer(new wxBoxSizer(wxVERTICAL)),
-    m_column_sizer(new wxBoxSizer(wxVERTICAL)), m_wizard_node(node)
+    wxPanel(parent),
+    m_window_sizer(new wxBoxSizer(wxVERTICAL)),
+    m_column_sizer(new wxBoxSizer(wxVERTICAL)),
+    m_wizard_node(node)
 {
     m_window_sizer->Add(m_column_sizer, wxSizerFlags(1).Expand().Border());
 

--- a/src/nodes/node_event.h
+++ b/src/nodes/node_event.h
@@ -15,7 +15,9 @@ class NodeEventInfo
 {
 public:
     NodeEventInfo(std::string_view name, std::string_view event_class, std::string_view help) :
-        m_name(name), m_event_class(event_class), m_help(help)
+        m_name(name),
+        m_event_class(event_class),
+        m_help(help)
     {
     }
 

--- a/src/nodes/prop_decl.h
+++ b/src/nodes/prop_decl.h
@@ -30,7 +30,9 @@ public:
 
     PropDeclaration(GenEnum::PropName prop_name, GenEnum::PropType prop_type,
                     DefaultValue def_value, HelpText help) :
-        m_def_value(def_value.value), m_help(help.value), m_prop_type(prop_type),
+        m_def_value(def_value.value),
+        m_help(help.value),
+        m_prop_type(prop_type),
         m_name_enum(prop_name)
     {
     }

--- a/src/undo_cmds.cpp
+++ b/src/undo_cmds.cpp
@@ -23,7 +23,8 @@
 ///////////////////////////////// InsertNodeAction ////////////////////////////////////
 
 InsertNodeAction::InsertNodeAction(Node* node, Node* parent, std::string_view undo_str, int pos) :
-    m_old_selected(wxGetFrame().getSelectedNodePtr()), m_pos(pos)
+    m_old_selected(wxGetFrame().getSelectedNodePtr()),
+    m_pos(pos)
 {
     m_node = node->get_SharedPtr();
     m_parent = parent->get_SharedPtr();
@@ -97,7 +98,8 @@ void InsertNodeAction::Revert()
 ///////////////////////////////// RemoveNodeAction ////////////////////////////////////
 
 RemoveNodeAction::RemoveNodeAction(Node* node, std::string_view undo_str, bool AddToClipboard) :
-    m_old_selected(wxGetFrame().getSelectedNodePtr()), m_AddToClipboard(AddToClipboard)
+    m_old_selected(wxGetFrame().getSelectedNodePtr()),
+    m_AddToClipboard(AddToClipboard)
 {
     m_node = node->get_SharedPtr();
     m_parent = m_node->get_ParentPtr();
@@ -154,7 +156,8 @@ void RemoveNodeAction::Revert()
 ///////////////////////////////// ModifyPropertyAction ////////////////////////////////////
 
 ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, std::string_view value) :
-    m_property(prop), m_revert_value(prop->as_string())
+    m_property(prop),
+    m_revert_value(prop->as_string())
 {
     m_undo_string << "change " << prop->get_DeclName();
 
@@ -165,7 +168,8 @@ ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, std::string_view 
 }
 
 ModifyPropertyAction::ModifyPropertyAction(NodeProperty* prop, int value) :
-    m_property(prop), m_revert_value(prop->as_string())
+    m_property(prop),
+    m_revert_value(prop->as_string())
 {
     m_undo_string << "change " << prop->get_DeclName();
 
@@ -189,7 +193,8 @@ void ModifyPropertyAction::Revert()
 ///////////////////////////////// ModifyProperties ////////////////////////////////////
 
 ModifyProperties::ModifyProperties(std::string_view undo_string, bool fire_events) :
-    UndoAction(undo_string), m_fire_events(fire_events)
+    UndoAction(undo_string),
+    m_fire_events(fire_events)
 {
     m_RedoEventGenerated = true;
     m_UndoEventGenerated = true;
@@ -251,7 +256,9 @@ size_t ModifyProperties::GetMemorySize()
 ///////////////////////////////// ModifyEventAction ////////////////////////////////////
 
 ModifyEventAction::ModifyEventAction(NodeEvent* event, std::string_view value) :
-    m_event(event), m_revert_value(event->get_value()), m_change_value(value)
+    m_event(event),
+    m_revert_value(event->get_value()),
+    m_change_value(value)
 {
     m_undo_string << "change " << event->get_name() << " handler";
 
@@ -620,7 +627,8 @@ void ChangeParentAction::Revert()
 ///////////////////////////////// AppendGridBagAction ////////////////////////////////////
 
 AppendGridBagAction::AppendGridBagAction(Node* node, Node* parent, int pos) :
-    m_old_selected(wxGetFrame().getSelectedNodePtr()), m_old_pos(m_parent->get_ChildPosition(node)),
+    m_old_selected(wxGetFrame().getSelectedNodePtr()),
+    m_old_pos(m_parent->get_ChildPosition(node)),
     m_pos(pos)
 {
     m_node = node->get_SharedPtr();

--- a/src/winres/winres_ctrl.cpp
+++ b/src/winres/winres_ctrl.cpp
@@ -14,7 +14,9 @@
 #include "wxue_namespace/wxue_string.h"  // wxue::string, wxue::string_view
 
 resCtrl::resCtrl() :
-    m_pWinResource(nullptr), m_add_min_width_property(false), m_add_wrap_property(false)
+    m_pWinResource(nullptr),
+    m_add_min_width_property(false),
+    m_add_wrap_property(false)
 {
 }
 


### PR DESCRIPTION
Reformat files that are different due to a change in .clang-format instructions.