### PR TITLE
docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,6 @@ add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
 if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 
-
 endif()
 
 include(FetchContent)
@@ -541,6 +540,44 @@ target_link_libraries(wxUiEditor PRIVATE
     docparser
 )
 
+# ###################### Embedded wxWidgetsDocs.zip (CMakeRC) #######################
+# build_docs.cmake guarantees the zip exists before we embed it.
+
+# ###################### Build wxWidgetsDocs.zip if missing #######################
+# Ensure build/archive/wxWidgetsDocs.zip exists before we try to embed it.
+# The build_docs.cmake script runs at configure time and is a no-op if the zip
+# is already present.
+set(_wxwidgets_docs_zip "${CMAKE_CURRENT_SOURCE_DIR}/build/archive/wxWidgetsDocs.zip")
+if(NOT EXISTS "${_wxwidgets_docs_zip}")
+    include("${CMAKE_CURRENT_LIST_DIR}/cmake/build_docs.cmake")
+endif()
+# After build_docs.cmake returns (or if the zip pre-existed), verify it exists.
+if(NOT EXISTS "${_wxwidgets_docs_zip}")
+    message(FATAL_ERROR
+        "build/archive/wxWidgetsDocs.zip not found after running build_docs.cmake")
+endif()
+
+FetchContent_Declare(
+    cmrc
+    GIT_REPOSITORY https://github.com/vector-of-bool/cmrc.git
+    GIT_TAG master
+    GIT_SHALLOW TRUE
+    DOWNLOAD_NO_PROGRESS TRUE
+)
+FetchContent_MakeAvailable(cmrc)
+# cmrc's top-level CMakeLists already includes the module, but include by full path to
+# guarantee cmrc_add_resource_library() is defined regardless of module-path resolution.
+include("${cmrc_SOURCE_DIR}/CMakeRC.cmake")
+
+message(STATUS "Embedding build/archive/wxWidgetsDocs.zip via CMakeRC")
+cmrc_add_resource_library(
+    wxuedocs
+    ALIAS wxuedocs::rc
+    NAMESPACE wxuedocs
+    WHENCE "${CMAKE_CURRENT_SOURCE_DIR}/build/archive"
+    "${_wxwidgets_docs_zip}")
+target_link_libraries(wxUiEditor PRIVATE wxuedocs::rc)
+target_compile_definitions(wxUiEditor PRIVATE HAS_EMBEDDED_WXWIDGETS_DOCS)
 # ###################### Packaging Instructions #######################
 if(UNIX AND NOT APPLE)
     INSTALL(FILES wxUiEditor.desktop DESTINATION share/applications)

--- a/cmake/build_docs.cmake
+++ b/cmake/build_docs.cmake
@@ -1,0 +1,110 @@
+# cmake/build_docs.cmake
+#
+# Builds build/archive/wxWidgetsDocs.zip if it doesn't already exist.
+#
+# Flow:
+#   1. If build/archive/wxWidgetsDocs.zip exists, return immediately.
+#   2. Create build/archive/ directory.
+#   3. Configure and build a Release version of tools/build_resources.
+#   4. Run build_resources --parse to generate the zip.
+#
+# Expected variables from the including scope:
+#   CMAKE_CURRENT_SOURCE_DIR  -- root of the wxUiEditor repository
+#   CMAKE_COMMAND            -- path to the cmake executable
+
+set(_archive_dir "${CMAKE_CURRENT_SOURCE_DIR}/build/archive")
+set(_zip_file "${_archive_dir}/wxWidgetsDocs.zip")
+
+# Step 0: If the zip already exists, we're done.
+if(EXISTS "${_zip_file}")
+    message(STATUS "wxWidgetsDocs.zip already exists at ${_zip_file}")
+    return()
+endif()
+
+# Step 1: Create the archive directory.
+file(MAKE_DIRECTORY "${_archive_dir}")
+
+# Step 2: Configure and build a Release version of tools/build_resources.
+# This is a standalone CMake project -- invoked as a separate process to avoid
+# target-name collisions (miniz, snowball_stemmer, etc.) with the parent project.
+set(_br_src_dir "${CMAKE_CURRENT_SOURCE_DIR}/tools/build_resources")
+set(_br_build_dir "${_br_src_dir}/build")
+
+message(STATUS "Configuring build_resources (Release)...")
+execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+        -B "${_br_build_dir}"
+        -S "${_br_src_dir}"
+        -DCMAKE_BUILD_TYPE=Release
+    RESULT_VARIABLE _configure_result
+    OUTPUT_VARIABLE _configure_output
+    ERROR_VARIABLE _configure_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+if(NOT _configure_result EQUAL 0)
+    message(FATAL_ERROR
+        "Failed to configure build_resources (exit code ${_configure_result}).\n"
+        "stdout:\n${_configure_output}\n"
+        "stderr:\n${_configure_error}")
+endif()
+
+message(STATUS "Building build_resources (Release)...")
+execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+        --build "${_br_build_dir}"
+        --config Release
+    RESULT_VARIABLE _build_result
+    OUTPUT_VARIABLE _build_output
+    ERROR_VARIABLE _build_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+if(NOT _build_result EQUAL 0)
+    message(FATAL_ERROR
+        "Failed to build build_resources (exit code ${_build_result}).\n"
+        "stdout:\n${_build_output}\n"
+        "stderr:\n${_build_error}")
+endif()
+
+# Locate the built executable. Multi-config generators (Visual Studio) place
+# it in build/Release/, single-config generators place it in build/.
+set(_br_exe "")
+foreach(_candidate
+    "${_br_build_dir}/Release/build_resources${CMAKE_EXECUTABLE_SUFFIX}"
+    "${_br_build_dir}/build_resources${CMAKE_EXECUTABLE_SUFFIX}"
+)
+    if(EXISTS "${_candidate}")
+        set(_br_exe "${_candidate}")
+        break()
+    endif()
+endforeach()
+if(_br_exe STREQUAL "")
+    message(FATAL_ERROR "Could not locate build_resources executable in ${_br_build_dir}")
+endif()
+
+# Step 3: Run build_resources --parse to generate the zip.
+set(_interface_wx "${_br_build_dir}/_deps/interface-src/wx")
+set(_output_dir "${CMAKE_CURRENT_SOURCE_DIR}/build/docs")
+
+message(STATUS "Generating wxWidgetsDocs.zip via build_resources...")
+execute_process(
+    COMMAND "${_br_exe}"
+        --parse
+        --srcdir "${_interface_wx}"
+        --outdir "${_output_dir}"
+        --zip-path "${_zip_file}"
+    RESULT_VARIABLE _parse_result
+    OUTPUT_VARIABLE _parse_output
+    ERROR_VARIABLE _parse_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+)
+if(NOT _parse_result EQUAL 0)
+    message(FATAL_ERROR
+        "build_resources --parse failed (exit code ${_parse_result}).\n"
+        "stdout:\n${_parse_output}\n"
+        "stderr:\n${_parse_error}")
+endif()
+
+message(STATUS "wxWidgetsDocs.zip generated at ${_zip_file}")

--- a/src/helptext/archive_handler.cpp
+++ b/src/helptext/archive_handler.cpp
@@ -8,7 +8,6 @@
 #include "archive_handler.h"
 
 #include <cstddef>
-#include <filesystem>
 #include <span>
 #include <string>
 #include <vector>
@@ -26,7 +25,7 @@ ArchiveHandler& wxueArchive = ArchiveHandler::get_Instance();
 
 // ###################### OpenArchive #######################
 
-std::expected<void, std::string> ArchiveHandler::OpenArchive(const std::filesystem::path& zip_path)
+std::expected<void, std::string> ArchiveHandler::OpenArchive(const wxString& zip_path)
 {
     if (m_archive)
     {
@@ -34,7 +33,7 @@ std::expected<void, std::string> ArchiveHandler::OpenArchive(const std::filesyst
     }
 
     std::expected<std::shared_ptr<DocArchive>, std::string> archive_result =
-        OpenDocArchive(zip_path);
+        OpenDocArchive(zip_path.utf8_string());
     if (!archive_result)
     {
         return std::unexpected(std::move(archive_result.error()));

--- a/src/helptext/archive_handler.h
+++ b/src/helptext/archive_handler.h
@@ -8,12 +8,13 @@
 #pragma once
 
 #include <expected>
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+
+#include <wx/string.h>
 
 #include "data/ftsrch/ftsrch.h"
 #include "data/include/utils.h"
@@ -50,8 +51,7 @@ public:
 
     // Open a documentation ZIP archive and prepare the in-memory file
     // system for embedded images.
-    [[nodiscard]] std::expected<void, std::string>
-        OpenArchive(const std::filesystem::path& zip_path);
+    [[nodiscard]] std::expected<void, std::string> OpenArchive(const wxString& zip_path);
 
     bool IsOpen() const noexcept { return m_archive != nullptr; }
 

--- a/src/helptext/data/include/utils.h
+++ b/src/helptext/data/include/utils.h
@@ -46,7 +46,7 @@ class DocArchive;
 // Open a .zip archive produced by the parser. On failure the unexpected
 // value contains a human-readable error message (including archive details).
 [[nodiscard]] std::expected<std::shared_ptr<DocArchive>, std::string>
-    OpenDocArchive(const std::filesystem::path& zip_path);
+    OpenDocArchive(const std::string& zip_path);
 
 // Read a markdown file from an open DocArchive by its archive-relative
 // name (for example, "docs/event.md"). On failure the unexpected value

--- a/src/helptext/data/parser/zip_reader.cpp
+++ b/src/helptext/data/parser/zip_reader.cpp
@@ -46,14 +46,13 @@ public:
     DocArchive(DocArchive&&) = delete;
     DocArchive& operator=(DocArchive&&) = delete;
 
-    [[nodiscard]] std::expected<void, std::string> Open(const std::filesystem::path& zip_path)
+    [[nodiscard]] std::expected<void, std::string> Open(const std::string& zip_path)
     {
         std::memset(&archive_, 0, sizeof(archive_));
-        const std::string path_str = zip_path.string();
-        if (!mz_zip_reader_init_file(&archive_, path_str.c_str(), 0))
+        if (!mz_zip_reader_init_file(&archive_, zip_path.c_str(), 0))
         {
             return std::unexpected(
-                std::format("Failed to open ZIP '{}': {}", path_str, MinizError(archive_)));
+                std::format("Failed to open ZIP '{}': {}", zip_path, MinizError(archive_)));
         }
         is_open_ = true;
         return {};
@@ -108,8 +107,7 @@ private:
     bool is_open_ { false };
 };
 
-std::expected<std::shared_ptr<DocArchive>, std::string>
-    OpenDocArchive(const std::filesystem::path& zip_path)
+std::expected<std::shared_ptr<DocArchive>, std::string> OpenDocArchive(const std::string& zip_path)
 {
     std::shared_ptr<DocArchive> archive = std::make_shared<DocArchive>();
     std::expected<void, std::string> result = archive->Open(zip_path);

--- a/src/helptext/data/parser/zip_test.cpp
+++ b/src/helptext/data/parser/zip_test.cpp
@@ -19,7 +19,7 @@ int RunZipTest(const std::filesystem::path& zip_path)
 
     // Open the archive with the high-level DocArchive reader.
     std::expected<std::shared_ptr<DocArchive>, std::string> archive_result =
-        OpenDocArchive(zip_path);
+        OpenDocArchive(zip_path.string());
     if (!archive_result)
     {
         parser::AddErrorMessage("FAIL: " + archive_result.error());

--- a/src/helptext/doc_view_frame.cpp
+++ b/src/helptext/doc_view_frame.cpp
@@ -5,22 +5,26 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include <filesystem>
+#include <fstream>
+#include <stdexcept>
 #include <string>
 
 #include <wx/filedlg.h>
+#include <wx/filename.h>
 
 #include "doc_view_frame.h"
 #include "doc_view_panel.h"
 
 #include "archive_handler.h"
 
+#include <cmrc/cmrc.hpp>
+CMRC_DECLARE(wxuedocs);
+
 // ---------------------------------------------------------------------------
 //  Constructor
 // ---------------------------------------------------------------------------
 
-DocViewFrame::DocViewFrame(wxWindow* parent, const std::filesystem::path& zip_path) :
-    DocViewFrame_base(parent)
+DocViewFrame::DocViewFrame(wxWindow* parent, const wxString& zip_path) : DocViewFrame_base(parent)
 {
     if (!zip_path.empty())
     {
@@ -32,7 +36,7 @@ DocViewFrame::DocViewFrame(wxWindow* parent, const std::filesystem::path& zip_pa
 //  OpenArchive
 // ---------------------------------------------------------------------------
 
-bool DocViewFrame::OpenArchive(const std::filesystem::path& zip_path)
+bool DocViewFrame::OpenArchive(const wxString& zip_path)
 {
     if (!m_DocViewPanel->OpenArchive(zip_path))
     {
@@ -40,7 +44,8 @@ bool DocViewFrame::OpenArchive(const std::filesystem::path& zip_path)
     }
 
     // Update the title bar to reflect the loaded archive.
-    const wxString archive_name = wxString::FromUTF8(zip_path.filename().string());
+    wxFileName fn(zip_path);
+    const wxString archive_name = fn.GetFullName();
     SetTitle(wxString::Format("Doc Viewer - %s", archive_name));
     SetStatusText(wxString::Format("Loaded %s", archive_name));
 
@@ -104,6 +109,37 @@ void DocViewFrame::OnOpenArchive([[maybe_unused]] wxCommandEvent& event)
         return;
     }
 
-    const std::filesystem::path zip_path(file_dlg.GetPath().ToStdWstring());
+    const wxString zip_path = file_dlg.GetPath();
     std::ignore = OpenArchive(zip_path);
+}
+
+// ---------------------------------------------------------------------------
+//  ResolveDocsZipPath
+// ---------------------------------------------------------------------------
+
+wxString ResolveDocsZipPath()
+{
+    try
+    {
+        cmrc::embedded_filesystem docs_fs = cmrc::wxuedocs::get_filesystem();
+        if (docs_fs.is_file("wxWidgetsDocs.zip"))
+        {
+            cmrc::file docs_rc = docs_fs.open("wxWidgetsDocs.zip");
+            wxFileName temp_fn(wxFileName::GetTempDir(), "wxueditor_wxWidgetsDocs.zip");
+            const wxString temp_path = temp_fn.GetFullPath();
+            {
+                std::ofstream out_file(temp_path.utf8_string(), std::ios::binary | std::ios::trunc);
+                out_file.write(docs_rc.begin(), static_cast<std::streamsize>(docs_rc.size()));
+            }
+            return temp_path;
+        }
+    }
+    catch (...)
+    {
+        // The embedded archive is guaranteed at build time — rethrow so the
+        // caller sees a genuine runtime_error rather than a silent bad path.
+        throw;
+    }
+    // Should be unreachable: archive guaranteed by build_docs.cmake.
+    throw std::runtime_error("wxWidgetsDocs.zip not found in embedded filesystem");
 }

--- a/src/helptext/doc_view_frame.h
+++ b/src/helptext/doc_view_frame.h
@@ -7,10 +7,14 @@
 
 #pragma once
 
-#include <filesystem>
+#include <wx/string.h>
 
 #include "doc_view_frame_base.h"
 
+// Resolve the path to the wxWidgets docs ZIP. Materializes the CMakeRC-embedded
+// archive to a temp file and returns its path. Throws on failure (archive is
+// guaranteed to be embedded at build time).
+wxString ResolveDocsZipPath();
 // DocViewFrame_base host with two operational modes:
 //   Top-level  (parent == nullptr): launched via --docview CLI; title
 //              "wxUiEditor Doc Viewer"; Close() terminates the app.
@@ -29,12 +33,12 @@ public:
 
     // Construct and show the frame.  Pass zip_path as an empty path to start
     // without an archive (the user can open one via File > Open Archive).
-    DocViewFrame(wxWindow* parent, const std::filesystem::path& zip_path);
+    DocViewFrame(wxWindow* parent, const wxString& zip_path);
 
     // Open (or re-open) a documentation ZIP archive.
     // Updates the title bar to "Doc Viewer - <filename>" on success.
     // Returns false when the archive could not be opened.
-    [[nodiscard]] bool OpenArchive(const std::filesystem::path& zip_path);
+    [[nodiscard]] bool OpenArchive(const wxString& zip_path);
 
     // True when an archive has been successfully opened.
     [[nodiscard]] bool IsArchiveOpen() const;

--- a/src/helptext/doc_view_panel.cpp
+++ b/src/helptext/doc_view_panel.cpp
@@ -6,12 +6,12 @@
 /////////////////////////////////////////////////////////////////////////////
 // CR: [07-04-2026]
 
-#include <filesystem>
 #include <sstream>
 #include <string>
 
 #include <wx/button.h>
 #include <wx/dialog.h>
+#include <wx/filename.h>
 #include <wx/frame.h>
 #include <wx/fs_mem.h>
 #include <wx/listbox.h>
@@ -94,7 +94,7 @@ void DocViewPanel::InitPanel()
 //  OpenArchive
 // ---------------------------------------------------------------------------
 
-bool DocViewPanel::OpenArchive(const std::filesystem::path& zip_path)
+bool DocViewPanel::OpenArchive(const wxString& zip_path)
 {
     // Reset state for the new archive
     m_inherit_map.clear();
@@ -182,7 +182,8 @@ void DocViewPanel::DisplayArchivePage(const std::string& archive_name)
     m_find_last_pos = 0;
 
     // Inject inheritance graph after </h1> if data is available for this page.
-    const std::string class_name = std::filesystem::path(archive_name).stem().string();
+    wxFileName fn(wxString::FromUTF8(archive_name));
+    const std::string class_name = fn.GetName().utf8_string();
     const std::string img_block = BuildInheritanceImage(class_name);
     if (!img_block.empty())
     {
@@ -479,7 +480,8 @@ void DocViewPanel::OnSearchTextChanged(wxCommandEvent& event)
         if (!archive_path.empty())
         {
             // Strip the .md extension for display
-            const std::string display_name = std::filesystem::path(archive_path).stem().string();
+            wxFileName fn(wxString::FromUTF8(archive_path));
+            const std::string display_name = fn.GetName().utf8_string();
             m_search_listbox->Append(wxString::FromUTF8(display_name));
         }
     }

--- a/src/helptext/doc_view_panel.h
+++ b/src/helptext/doc_view_panel.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <filesystem>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -41,7 +40,7 @@ public:
 
     // Open (or re-open) a documentation ZIP archive.
     // Returns false when the archive could not be opened.
-    [[nodiscard]] bool OpenArchive(const std::filesystem::path& zip_path);
+    [[nodiscard]] bool OpenArchive(const wxString& zip_path);
 
     // True when an archive has been successfully opened.
     [[nodiscard]] bool IsArchiveOpen() const;

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -4,6 +4,7 @@
 // Copyright: Copyright (c) 2020-2026 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
+// CR: [07-04-2026]
 
 #include <chrono>
 
@@ -114,7 +115,8 @@ static void ProcessFilename(wxString& filename)
     {
         wxDir dir;
         dir.Open("./");
-        if (!dir.GetFirst(&filename, filename, wxDIR_FILES))
+        const wxString filespec = filename;
+        if (!dir.GetFirst(&filename, filespec, wxDIR_FILES))
         {
             // No match found
             filename.clear();
@@ -208,9 +210,16 @@ int App::OnRun()
     // This must be done early, before any output attempts
     if (AttachConsole(ATTACH_PARENT_PROCESS))
     {
-        FILE* file_ptr {};  // NOLINT (cppcheck-suppress)
-        freopen_s(&file_ptr, "CONOUT$", "w", stdout);
-        freopen_s(&file_ptr, "CONOUT$", "w", stderr);
+        FILE* fp_out { nullptr };
+        FILE* fp_err { nullptr };
+        if (freopen_s(&fp_out, "CONOUT$", "w", stdout) != 0)
+        {
+            OutputDebugStringW(L"Failed to redirect stdout to console\n");
+        }
+        if (freopen_s(&fp_err, "CONOUT$", "w", stderr) != 0)
+        {
+            OutputDebugStringW(L"Failed to redirect stderr to console\n");
+        }
     }
     #else
     // On Unix/Mac, stdout/stderr are automatically connected when run from terminal
@@ -499,6 +508,20 @@ int App::OnRun()
         is_project_loaded = DisplayStartupDlg(nullptr);
     }
 
+    // If the user launched the documentation viewer from the startup dialog,
+    // switch to docview mode (same as the --docview command-line option).
+    if (m_docViewFrame)
+    {
+        // The MainFrame was created above but is no longer needed; destroy it
+        // before running the doc-viewer event loop.
+        if (m_frame)
+        {
+            m_frame->Destroy();
+            m_frame = nullptr;
+        }
+        return wxApp::OnRun();
+    }
+
     if (is_project_loaded)
     {
         m_frame->Show();
@@ -512,7 +535,7 @@ int App::OnRun()
         return wxApp::OnRun();
     }
 
-    if (!m_frame)
+    if (m_frame)
     {
         m_frame->Close();
         m_frame = nullptr;
@@ -522,6 +545,12 @@ int App::OnRun()
 
 int App::OnExit()
 {
+    if (g_pMsgLogging)
+    {
+        wxLog::SetActiveTarget(nullptr);
+        delete g_pMsgLogging;
+        g_pMsgLogging = nullptr;
+    }
     return wxApp::OnExit();
 }
 
@@ -680,7 +709,9 @@ std::pair<size_t, bool> App::ParseGenerationType(wxCmdLineParser& parser)
         { "gen_all", std::to_underlying(GenLang::cplusplus | GenLang::python | GenLang::ruby) },
         { "gen_quick", std::to_underlying(GenLang::python | GenLang::ruby) },
         { "gen_coverage",
-          std::to_underlying(GenLang::cplusplus | GenLang::python | GenLang::ruby) },
+          std::to_underlying(GenLang::cplusplus | GenLang::python | GenLang::ruby |
+                             GenLang::fortran | GenLang::go | GenLang::julia | GenLang::luajit |
+                             GenLang::typescript | GenLang::xrc) },
     };
 
     size_t generate_type = std::to_underlying(GenLang::none);

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -371,7 +371,7 @@ int App::OnRun()
     // --docview: launch standalone documentation viewer, skipping MainFrame and project loading
     if (wxString zip_str; parser.Found("docview", &zip_str))
     {
-        const std::filesystem::path zip_path = zip_str.ToStdWstring();
+        const wxString zip_path = zip_str;
         m_docViewFrame = new DocViewFrame(nullptr, zip_path);
         m_docViewFrame->Show();
         SetTopWindow(m_docViewFrame);

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -370,9 +370,7 @@ MainFrame::MainFrame() :
             }
             else
             {
-                const std::filesystem::path zip_path {
-                    "C:/rwCode/wxLanguages/wxUiEditor/tests/wxWidgetsDocs.zip"
-                };
+                const wxString zip_path = ResolveDocsZipPath();
                 doc_frame = new DocViewFrame(this, zip_path);
                 wxGetApp().setDocViewFrame(doc_frame);
                 doc_frame->Show();

--- a/src/ui/startup_dlg.cpp
+++ b/src/ui/startup_dlg.cpp
@@ -13,8 +13,6 @@
 
 #include "startup_dlg.h"  // #include "../wxui/startup_dlg_base.h"
 
-#include <filesystem>
-
 #include "helptext/doc_view_frame.h"  // DocViewFrame
 
 #include "mainframe.h"                   // Main frame
@@ -265,8 +263,7 @@ bool DisplayStartupDlg(wxWindow* parent)
                 {
                     // Launch the documentation viewer as if --docview was passed on the
                     // command line. Path is hardcoded for now.
-                    const std::filesystem::path zip_path =
-                        "C:/rwCode/wxLanguages/wxUiEditor2/tests/wxWidgetsDocs.zip";
+                    const wxString zip_path = ResolveDocsZipPath();
                     auto* doc_frame = new DocViewFrame(nullptr, zip_path);
                     doc_frame->Show();
                     wxGetApp().setDocViewFrame(doc_frame);

--- a/src/ui/startup_dlg.cpp
+++ b/src/ui/startup_dlg.cpp
@@ -1,9 +1,10 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Dialog to display if wxUiEditor is launched with no arguments
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2022-2025 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2022-2026 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
+// CR: [07-04-2026]
 
 #include <wx/display.h>   // wxDisplay
 #include <wx/filedlg.h>   // wxFileDialog base header
@@ -11,6 +12,10 @@
 #include <wx/wupdlock.h>  // wxWindowUpdateLocker prevents window redrawing
 
 #include "startup_dlg.h"  // #include "../wxui/startup_dlg_base.h"
+
+#include <filesystem>
+
+#include "helptext/doc_view_frame.h"  // DocViewFrame
 
 #include "mainframe.h"                   // Main frame
 #include "project_handler.h"             // ProjectHandler class
@@ -114,7 +119,7 @@ void StartupDlg::OnInit(wxInitDialogEvent& event)
 
     wxFileHistory& history = wxGetMainFrame()->getFileHistory();
     bool file_added = false;
-    for (size_t idx = 0; idx < history.GetCount(); ++idx)
+    for (size_t idx = history.GetCount(); idx-- > 0;)
     {
         wxString const history_file = history.GetHistoryFile(idx);
         wxFileName const project_file(history_file);
@@ -130,7 +135,6 @@ void StartupDlg::OnInit(wxInitDialogEvent& event)
         {
             // Assume that if the file doesn't exist now, it won't exist later either
             history.RemoveFileFromHistory(idx);
-            --idx;  // Adjust index after removal
         }
     }
 
@@ -237,6 +241,17 @@ void StartupDlg::RemoveProjectFilename(wxCommandEvent& event)
 
     Fit();
     Refresh();
+
+    if (history.GetCount() == 0)
+    {
+        m_staticTextRecentProjects->Show();
+    }
+}
+
+void StartupDlg::OnDocs([[maybe_unused]] wxHyperlinkEvent& event)
+{
+    m_command = Command::start_docs;
+    EndModal(wxID_OK);
 }
 
 bool DisplayStartupDlg(wxWindow* parent)
@@ -246,13 +261,27 @@ bool DisplayStartupDlg(wxWindow* parent)
     {
         switch (start_dlg.GetCommand())
         {
+            case StartupDlg::Command::start_docs:
+                {
+                    // Launch the documentation viewer as if --docview was passed on the
+                    // command line. Path is hardcoded for now.
+                    const std::filesystem::path zip_path =
+                        "C:/rwCode/wxLanguages/wxUiEditor2/tests/wxWidgetsDocs.zip";
+                    auto* doc_frame = new DocViewFrame(nullptr, zip_path);
+                    doc_frame->Show();
+                    wxGetApp().setDocViewFrame(doc_frame);
+                    wxGetApp().SetTopWindow(doc_frame);
+                    return false;
+                }
+
             case StartupDlg::Command::start_mru:
                 {
                     wxFileName const& project_file = start_dlg.GetProjectFile();
-                    std::string ext = project_file.GetExt().Lower().ToStdString();
-                    ext.insert(ext.begin(), '.');
+                    std::string extension = project_file.GetExt().Lower().ToStdString();
+                    extension.insert(extension.begin(), '.');
 
-                    if (ext != PROJECT_FILE_EXTENSION && ext != PROJECT_LEGACY_FILE_EXTENSION)
+                    if (extension != PROJECT_FILE_EXTENSION &&
+                        extension != PROJECT_LEGACY_FILE_EXTENSION)
                     {
                         return Project.ImportProject(project_file.GetFullPath().ToStdString());
                     }

--- a/src/ui/startup_dlg.h
+++ b/src/ui/startup_dlg.h
@@ -31,6 +31,7 @@ public:
         start_convert,
         start_open,
         start_empty,
+        start_docs,
     };
 
     [[nodiscard]] Command GetCommand() const { return m_command; }
@@ -39,6 +40,7 @@ public:
 protected:
     // Event handlers
 
+    void OnDocs(wxHyperlinkEvent& event) override;
     void OnImport(wxHyperlinkEvent& event) override;
     void OnInit(wxInitDialogEvent& event) override;
     void OnNew(wxHyperlinkEvent& event) override;

--- a/src/wxui/startup_dlg_base.cpp
+++ b/src/wxui/startup_dlg_base.cpp
@@ -131,6 +131,18 @@ bool StartupDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& tit
 
     box_sizer_2->Add(box_sizer_5, wxSizerFlags().Border(wxALL));
 
+    auto* box_sizer2 = new wxBoxSizer(wxHORIZONTAL);
+
+    auto* bmp2 = new wxStaticBitmap(this, wxID_ANY, wxue_img::bundle_wxlogo_svg(24, 24));
+    box_sizer2->Add(bmp2, wxSizerFlags().Border(wxALL));
+
+    //  wxGenericHyperlinkCtrl is used in order to remove the underline from the font.
+    auto* hyperlink2 = new wxGenericHyperlinkCtrl(this, wxID_ANY, "Docs", wxEmptyString);
+    hyperlink2->SetFont(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
+    box_sizer2->Add(hyperlink2, wxSizerFlags().Center().Border(wxALL));
+
+    box_sizer_2->Add(box_sizer2, wxSizerFlags().Border(wxALL));
+
     box_sizer_8->Add(box_sizer_2, wxSizerFlags().Border(wxLEFT|wxRIGHT, 15));
 
     dlg_sizer->Add(box_sizer_8, wxSizerFlags().Border(wxALL));
@@ -170,6 +182,7 @@ bool StartupDlgBase::Create(wxWindow* parent, wxWindowID id, const wxString& tit
     }
 
     // Event handlers
+    hyperlink2->Bind(wxEVT_HYPERLINK, &StartupDlgBase::OnDocs, this);
     hyperlink->Bind(wxEVT_HYPERLINK, &StartupDlgBase::OnImport, this);
     hyperlink_3->Bind(wxEVT_HYPERLINK, &StartupDlgBase::OnNew, this);
     hyperlink_2->Bind(wxEVT_HYPERLINK, &StartupDlgBase::OnOpen, this);

--- a/src/wxui/startup_dlg_base.h
+++ b/src/wxui/startup_dlg_base.h
@@ -39,6 +39,7 @@ protected:
 
     // Virtual event handlers -- override them in your derived class
 
+    virtual void OnDocs(wxHyperlinkEvent& event) = 0;
     virtual void OnImport(wxHyperlinkEvent& event) = 0;
     virtual void OnInit(wxInitDialogEvent& event) = 0;
     virtual void OnNew(wxHyperlinkEvent& event) = 0;

--- a/src/wxui/wxUiEditor.wxui
+++ b/src/wxui/wxUiEditor.wxui
@@ -7826,6 +7826,23 @@
                 alignment="wxALIGN_CENTER_VERTICAL"
                 wxEVT_HYPERLINK="OnNew" />
             </node>
+            <node
+              class="wxBoxSizer"
+              var_name="box_sizer2">
+              <node
+                class="wxStaticBitmap"
+                bitmap="SVG;../art_src/wxlogo.svg;[24,24]"
+                var_name="bmp2" />
+              <node
+                class="wxHyperlinkCtrl"
+                class_access="none"
+                label="Docs"
+                sync_hover_colour="1"
+                underlined="0"
+                var_name="hyperlink2"
+                alignment="wxALIGN_CENTER_VERTICAL"
+                wxEVT_HYPERLINK="OnDocs" />
+            </node>
           </node>
         </node>
         <node

--- a/tests/scripts/full_run.ts
+++ b/tests/scripts/full_run.ts
@@ -4,7 +4,7 @@
  *
  * Equivalent of full_run.ps1 but for build_resources.exe.
  *
- * Usage: deno run --allow-read --allow-write --allow-run tests/scripts/full_run.ts
+ * Usage: deno run --allow-read --allow-write --allow-run build/scripts/full_run.ts
  */
 
 import * as path from "@std/path";
@@ -18,10 +18,8 @@ const repoRoot = path.resolve(scriptDir, "..", "..");
 
 const exe = path.join(
     repoRoot,
-    "tools",
-    "build_resources",
-    "build",
-    "Debug",
+    "bin",
+    "Release",
     "build_resources.exe",
 );
 const interfaceWx = path.join(
@@ -33,9 +31,8 @@ const interfaceWx = path.join(
     "interface-src",
     "wx",
 );
-const testsDir = path.join(repoRoot, "tests");
-const outputDir = path.join(testsDir, "full_build");
-const zipFile = path.join(testsDir, "wxWidgetsDocs.zip");
+const outputDir = path.join(repoRoot, "build", "docs");
+const zipFile = path.join(repoRoot, "build", "archive", "wxWidgetsDocs.zip");
 
 // ---------------------------------------------------------------------------
 // Stage 0 – Sanity checks
@@ -76,6 +73,7 @@ await Deno.remove(outputDir, { recursive: true }).catch(() =>
 await Deno.remove(zipFile).catch(() =>
 {});
 await Deno.mkdir(outputDir, { recursive: true });
+await Deno.mkdir(path.join(repoRoot, "build", "archive"), { recursive: true });
 
 // ---------------------------------------------------------------------------
 // Stage 2 – Run parser
@@ -155,18 +153,24 @@ for await (const entry of Deno.readDir(outputDir))
 
 const zipSize = (await Deno.stat(zipFile)).size;
 
-// Format elapsed time as hh:mm:ss.fff
+// Format elapsed time as mm:ss
 const totalSeconds = elapsedMs / 1000;
-const hours = Math.floor(totalSeconds / 3600);
-const minutes = Math.floor((totalSeconds % 3600) / 60);
-const seconds = totalSeconds % 60;
-const elapsedStr = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${
-    seconds.toFixed(3).padStart(7, "0")
-}`;
+const minutes = Math.floor(totalSeconds / 60);
+const seconds = Math.floor(totalSeconds % 60);
+const elapsedStr = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+
+let megabytes = Math.floor(zipSize / 1_048_576);
+let tenths = Math.ceil((zipSize % 1_048_576) / 104_857.6);
+if (tenths === 10)
+{
+    megabytes++;
+    tenths = 0;
+}
+const zipSizeDisplay = `${megabytes}.${tenths} MB`;
 
 console.log(`Elapsed:        ${elapsedStr}`);
-console.log(`Markdown files: ${markdownCount}`);
-console.log(`ZIP size:       ${zipSize} bytes`);
+console.log(`Markdown files: ${markdownCount.toLocaleString("en-US")}`);
+console.log(`ZIP size:       ${zipSizeDisplay}`);
 console.log(`Output dir:     ${outputDir}`);
 console.log(`ZIP file:       ${zipFile}`);
 

--- a/tests/scripts/test_run.ts
+++ b/tests/scripts/test_run.ts
@@ -20,10 +20,8 @@ const repoRoot = path.resolve(scriptDir, "..", "..");
 
 const exe = path.join(
     repoRoot,
-    "tools",
-    "build_resources",
-    "build",
-    "Debug",
+    "bin",
+    "Release",
     "build_resources.exe",
 );
 const interfaceWx = path.join(
@@ -221,7 +219,15 @@ for (
 try
 {
     const zipSize = await fileSize(zipFile);
-    console.log(`[PASS] ${zipFile}  (${zipSize} bytes)`);
+    let megabytes = Math.floor(zipSize / 1_048_576);
+    let tenths = Math.ceil((zipSize % 1_048_576) / 104_857.6);
+    if (tenths === 10)
+    {
+        megabytes++;
+        tenths = 0;
+    }
+    const zipSizeDisplay = `${megabytes}.${tenths} MB`;
+    console.log(`[PASS] ${zipFile}  (${zipSizeDisplay})`);
 
     // List ZIP contents via PowerShell
     const psCmd = new Deno.Command("powershell", {

--- a/tools/build_resources/CMakeLists.txt
+++ b/tools/build_resources/CMakeLists.txt
@@ -111,12 +111,18 @@ add_subdirectory(../../src/helptext/data/ftsrch ${CMAKE_BINARY_DIR}/libs/ftsrch)
 add_subdirectory(../../src/helptext/data/cppmark ${CMAKE_BINARY_DIR}/libs/cppmark)
 add_subdirectory(../../src/helptext/data/parser ${CMAKE_BINARY_DIR}/libs/docparser)
 
+# Output binary alongside wxUiEditor in ${CMAKE_SOURCE_DIR}/../bin/<config>/
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/../../bin)
+
 ####################### Resource Builder Executable ######################
 
 add_executable(build_resources
     main.cpp
     # ${CMAKE_CURRENT_SOURCE_DIR}/../../src/pugixml/pugixml.cpp
 )
+
+# Debug builds produce build_resourcesD.exe / build_resourcesD
+set_target_properties(build_resources PROPERTIES DEBUG_POSTFIX "D")
 
 target_include_directories(build_resources PRIVATE
     # ${CMAKE_CURRENT_SOURCE_DIR}/../../src/pugixml


### PR DESCRIPTION
Starting with this PR, wxWidgets documentation is now built and stored as part of the executable. The Startup Splash screen has a 'Docs' link below the 'New' for users that just want to look at the documentation.
