### PR TITLE
base file

### DIFF
--- a/src/generate/mdi/gen_view_image.cpp
+++ b/src/generate/mdi/gen_view_image.cpp
@@ -97,7 +97,7 @@ auto ImageViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
             wxString hdr_file = iter->as_string(prop_base_file).wx();
             if (!hdr_file.empty())
             {
-                AddHeaderExtension(hdr_file, false);
+                AddHeaderExtension(hdr_file, true);
                 set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
             }
             else

--- a/src/generate/mdi/gen_view_image.cpp
+++ b/src/generate/mdi/gen_view_image.cpp
@@ -97,7 +97,7 @@ auto ImageViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
             wxString hdr_file = iter->as_string(prop_base_file).wx();
             if (!hdr_file.empty())
             {
-                hdr_file += Project.as_string(prop_header_ext).wx();
+                AddHeaderExtension(hdr_file, false);
                 set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
             }
             else

--- a/src/generate/mdi/gen_view_richtext.cpp
+++ b/src/generate/mdi/gen_view_richtext.cpp
@@ -97,7 +97,7 @@ auto RichTextViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
             wxString hdr_file = iter->as_string(prop_base_file).wx();
             if (!hdr_file.empty())
             {
-                AddHeaderExtension(hdr_file, false);
+                AddHeaderExtension(hdr_file, true);
                 set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
             }
             else

--- a/src/generate/mdi/gen_view_richtext.cpp
+++ b/src/generate/mdi/gen_view_richtext.cpp
@@ -97,7 +97,7 @@ auto RichTextViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
             wxString hdr_file = iter->as_string(prop_base_file).wx();
             if (!hdr_file.empty())
             {
-                hdr_file += Project.as_string(prop_header_ext).wx();
+                AddHeaderExtension(hdr_file, false);
                 set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
             }
             else

--- a/src/generate/mdi/gen_view_scintilla.cpp
+++ b/src/generate/mdi/gen_view_scintilla.cpp
@@ -97,7 +97,7 @@ auto ScintillaViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_
             wxString hdr_file = iter->as_string(prop_base_file).wx();
             if (!hdr_file.empty())
             {
-                hdr_file += Project.as_string(prop_header_ext).wx();
+                AddHeaderExtension(hdr_file, false);
                 set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
             }
             else

--- a/src/generate/mdi/gen_view_scintilla.cpp
+++ b/src/generate/mdi/gen_view_scintilla.cpp
@@ -97,7 +97,7 @@ auto ScintillaViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_
             wxString hdr_file = iter->as_string(prop_base_file).wx();
             if (!hdr_file.empty())
             {
-                AddHeaderExtension(hdr_file, false);
+                AddHeaderExtension(hdr_file, true);
                 set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
             }
             else

--- a/src/generate/mdi/gen_view_splitter.cpp
+++ b/src/generate/mdi/gen_view_splitter.cpp
@@ -97,7 +97,7 @@ auto SplitterViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
             wxString hdr_file = iter->as_string(prop_base_file).wx();
             if (!hdr_file.empty())
             {
-                hdr_file += Project.as_string(prop_header_ext).wx();
+                AddHeaderExtension(hdr_file, false);
                 set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
             }
             else

--- a/src/generate/mdi/gen_view_splitter.cpp
+++ b/src/generate/mdi/gen_view_splitter.cpp
@@ -97,7 +97,7 @@ auto SplitterViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_s
             wxString hdr_file = iter->as_string(prop_base_file).wx();
             if (!hdr_file.empty())
             {
-                AddHeaderExtension(hdr_file, false);
+                AddHeaderExtension(hdr_file, true);
                 set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
             }
             else

--- a/src/generate/mdi/gen_view_textctrl.cpp
+++ b/src/generate/mdi/gen_view_textctrl.cpp
@@ -108,7 +108,7 @@ auto TextViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
                 wxString hdr_file = iter->as_string(prop_base_file).wx();
                 if (!hdr_file.empty())
                 {
-                    AddHeaderExtension(hdr_file, false);
+                    AddHeaderExtension(hdr_file, true);
                     set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
                 }
                 else

--- a/src/generate/mdi/gen_view_textctrl.cpp
+++ b/src/generate/mdi/gen_view_textctrl.cpp
@@ -108,7 +108,7 @@ auto TextViewGenerator::GetIncludes(Node* node, std::set<std::string>& set_src,
                 wxString hdr_file = iter->as_string(prop_base_file).wx();
                 if (!hdr_file.empty())
                 {
-                    hdr_file += Project.as_string(prop_header_ext).wx();
+                    AddHeaderExtension(hdr_file, false);
                     set_src.insert(std::string("#include \"") + hdr_file.ToStdString() + "\"");
                 }
                 else

--- a/src/panels/propgrid_panel.cpp
+++ b/src/panels/propgrid_panel.cpp
@@ -189,7 +189,7 @@ void PropGridPanel::AddProperties(wxue::string_view name, Node* node, NodeCatego
             continue;
         }
 
-        if (prop_set.find(prop_name) == prop_set.end())
+        if (!prop_set.contains(prop_name))
         {
             if (!IsPropAllowed(node, prop))
             {
@@ -283,13 +283,12 @@ void PropGridPanel::AddProperties(wxue::string_view name, Node* node, NodeCatego
         }
         else
         {
-            std::string_view decl_name = node->get_DeclName();
             if (const auto prop_it = map_PropNames.find(prop_name); prop_it != map_PropNames.end())
             {
                 MSG_WARNING((wxString("The property ")
                              << wxString(prop_it->second.data(), prop_it->second.size())
                              << " appears more than once in "
-                             << wxString(decl_name.data(), decl_name.size()))
+                             << wxString(node->get_DeclName().data(), node->get_DeclName().size()))
                                 .ToStdString());
             }
         }
@@ -393,12 +392,11 @@ void PropGridPanel::AddEvents(wxue::string_view name, Node* node, NodeCategory& 
         const NodeEventInfo* eventInfo = event->get_EventInfo();
 
         {
-            auto decl_name = node->get_DeclName();
             ASSERT_MSG(event_set.find(eventName) == event_set.end(),
                        wxString("Encountered a duplicate event in ")
-                           << wxString(decl_name.data(), decl_name.size()));
+                           << wxString(node->get_DeclName().data(), node->get_DeclName().size()));
         }
-        if (event_set.find(eventName) == event_set.end())
+        if (!event_set.contains(eventName))
         {
             auto* grid_property = new EventStringProperty(event->get_name(), event);
 
@@ -671,7 +669,7 @@ void PropGridPanel::CheckOutputFile(const wxue::string& newValue, Node* node)
 
 void PropGridPanel::ReplaceDerivedFile(const wxue::string& newValue, NodeProperty* propType)
 {
-    wxue::string derived_filename =
+    const wxue::string derived_filename =
         CreateDerivedFilename(propType->getNode()->get_Form(), newValue);
     wxPGProperty* grid_property = m_prop_grid->GetPropertyByLabel("derived_file");
     ASSERT(grid_property);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,25 +1,27 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   Utility functions that work with properties
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2025 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2026 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 // CR: [07-16-2026]
+
 #include <array>
-#include <charconv>
 #include <cstddef>
 #include <cstdio>  // For snprintf
 #include <format>
 #include <set>
 
-#include <wx/filedlg.h>  // wxFileDialog base header
-#include <wx/gdicmn.h>   // Common GDI classes, types and declarations
-#include <wx/mstream.h>  // Memory stream classes
+#include <wx/filedlg.h>   // wxFileDialog base header
+#include <wx/filename.h>  // wxFileName class
+#include <wx/gdicmn.h>    // Common GDI classes, types and declarations
+#include <wx/mstream.h>   // Memory stream classes
 
-#include "mainframe.h"     // MainFrame -- Main window frame
-#include "node.h"          // Node class
-#include "node_creator.h"  // NodeCreator class
-#include "utils.h"         // Utility functions that work with properties
+#include "mainframe.h"        // MainFrame -- Main window frame
+#include "node.h"             // Node class
+#include "node_creator.h"     // NodeCreator class
+#include "project_handler.h"  // ProjectHandler class
+#include "utils.h"            // Utility functions that work with properties
 
 #include "wxue_namespace/wxue_string.h"         // wxue::string -- std::string with utility methods
 #include "wxue_namespace/wxue_string_vector.h"  // wxue::StringVector
@@ -760,6 +762,45 @@ bool CopyStreamData(wxInputStream* inputStream, wxOutputStream* outputStream, si
     }
 
     return true;
+}
+
+void AddHeaderExtension(wxue::string& filename, bool force)
+{
+    if (Project.as_string(prop_header_ext).empty())
+    {
+        return;
+    }
+
+    if (filename.extension().empty() || force)
+    {
+        filename.replace_extension(Project.as_string(prop_header_ext));
+    }
+}
+
+void AddHeaderExtension(wxString& filename, bool force)
+{
+    wxFileName file_name(filename);
+    if (file_name.HasExt() && !force)
+    {
+        return;
+    }
+
+    const wxue::string& header_ext = Project.as_string(prop_header_ext);
+    if (header_ext.empty())
+    {
+        return;
+    }
+
+    // wxFileName::SetExt() expects the extension without a leading dot
+    const wxString new_ext =
+        header_ext.starts_with('.') ? header_ext.subview(1).wx() : header_ext.wx();
+    file_name.SetExt(new_ext);
+
+    // Replace only the filename+extension portion of the original string, preserving
+    // any path prefix exactly as it was.
+    const size_t sep_pos = filename.find_last_of("\\/");
+    const size_t name_start = (sep_pos == wxString::npos) ? 0 : sep_pos + 1;
+    filename.replace(name_start, filename.length() - name_start, file_name.GetFullName());
 }
 
 wxString ShowOpenProjectDialog(wxWindow* parent)

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -5,6 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 // CR: [07-16-2026]
+
 #pragma once
 
 #include <optional>
@@ -124,6 +125,15 @@ ClassOverrideType GetClassOverrideType(Node* node);
 // mode, and specific language colors
 void SetStcColors(wxStyledTextCtrl* stc, GenLang language, bool set_lexer = true,
                   bool add_keywords = true);
+
+// If the string is a filename without an extension, append the project's header file
+// extension. If force is true, any existing extension is replaced with the project's
+// header file extension.
+void AddHeaderExtension(wxue::string& filename, bool force);
+
+// wxFileName-based version of AddHeaderExtension. Only the filename+extension portion of
+// the string is modified.
+void AddHeaderExtension(wxString& filename, bool force);
 
 // Call this after creating a wxRibbonBar tool in order to ensure that it has a unique ID/
 void SetUniqueRibbonToolID(Node* node);


### PR DESCRIPTION
This PR insures that using a `prop_base_file` to derive a header file will correctly add the user-specified extension for the file whether the base file already has an extension or not.
