### PR TITLE
Fix missing comparison when base_file is changed

### DIFF
--- a/src/generate/gen_results.cpp
+++ b/src/generate/gen_results.cpp
@@ -1259,50 +1259,61 @@ void GenResults::ProcessFileDiff(wxue::string path, std::shared_ptr<std::string>
     }
 
     // Launch async task to perform diff computation
-    m_pending_diffs.emplace_back(
-        std::async(std::launch::async,
-                   [path = std::move(path), content, form]() -> std::optional<FileDiff>
-                   {
-                       // Check if generated file is too large to process diff efficiently
-                       // Files larger than max_diff_file_size are flagged as too large to avoid
-                       // performance issues
-                       if (content->size() > max_diff_file_size)
-                       {
-                           FileDiff file_diff;
-                           file_diff.filename = path.filename();
-                           file_diff.form = form;
-                           file_diff.is_too_large_to_display = true;
-                           return file_diff;
-                       }
+    m_pending_diffs.emplace_back(std::async(
+        std::launch::async,
+        [path = std::move(path), content, form]() -> std::optional<FileDiff>
+        {
+            // Check if generated file is too large to process diff efficiently
+            // Files larger than max_diff_file_size are flagged as too large to avoid
+            // performance issues
+            if (content->size() > max_diff_file_size)
+            {
+                FileDiff file_diff;
+                file_diff.filename = path.filename();
+                file_diff.form = form;
+                file_diff.is_too_large_to_display = true;
+                return file_diff;
+            }
 
-                       // If the file doesn't exist on disk (e.g. the output file was just
-                       // given a new name), leave disk_content empty so it is treated as a
-                       // new file. Diff::Compare will then report every generated line as added.
-                       // Do not attempt to open a missing file: wxFile::Open logs a system error
-                       // when opening fails, which would popup an unwanted warning during Compare.
-                       wxue::ViewVector disk_content;
-                       if (path.file_exists())
-                       {
-                           std::ignore = disk_content.ReadFile(std::string_view(path));
-                       }
+            // If the file doesn't exist on disk (e.g. the output file was just
+            // given a new name), leave disk_content empty so it is treated as a
+            // new file. Diff::Compare will then report every generated line as added.
+            // Do not attempt to open a missing file: wxFile::Open logs a system error
+            // when opening fails, which would popup an unwanted warning during Compare.
+            wxue::ViewVector disk_content;
+            if (path.file_exists())
+            {
+                // If the file exists but cannot be read (permissions, transient IO
+                // error, etc.), report the failure instead of treating the file as
+                // brand-new (which would show every line as added).
+                if (!disk_content.ReadFile(std::string_view(path)))
+                {
+                    FileDiff file_diff;
+                    file_diff.filename = path.filename();
+                    file_diff.form = form;
+                    file_diff.error_message = std::format("Unable to read the existing file: {}",
+                                                          static_cast<std::string>(path));
+                    return file_diff;
+                }
+            }
 
-                       wxue::ViewVector gen_content;
-                       gen_content.ReadString(std::string_view(*content));
+            wxue::ViewVector gen_content;
+            gen_content.ReadString(std::string_view(*content));
 
-                       DiffResult diff_result = Diff::Compare(disk_content, gen_content);
-                       if (diff_result.has_differences)
-                       {
-                           FileDiff file_diff;
-                           file_diff.filename = path.filename();
-                           file_diff.original_content = disk_content.GetBuffer();
-                           file_diff.new_content = *content;
-                           file_diff.diff_result = std::move(diff_result);
-                           file_diff.form = form;
-                           return file_diff;
-                       }
+            DiffResult diff_result = Diff::Compare(disk_content, gen_content);
+            if (diff_result.has_differences)
+            {
+                FileDiff file_diff;
+                file_diff.filename = path.filename();
+                file_diff.original_content = disk_content.GetBuffer();
+                file_diff.new_content = *content;
+                file_diff.diff_result = std::move(diff_result);
+                file_diff.form = form;
+                return file_diff;
+            }
 
-                       return std::nullopt;
-                   }));
+            return std::nullopt;
+        }));
 }
 
 void GenResults::WaitForPendingDiffs()

--- a/src/generate/gen_results.cpp
+++ b/src/generate/gen_results.cpp
@@ -717,8 +717,8 @@ bool GenResults::GenerateLanguageForm(std::string_view /* class_name */, Node* f
                 m_created_files.emplace_back(src_path);
             }
 
-            // Capture detailed diff information if file exists on disk
-            if (result == code::write_needed && src_path.file_exists())
+            // Capture detailed diff information, including for newly-created files
+            if (result == code::write_needed)
             {
                 auto content = std::make_shared<std::string>(src_cw->GetString());
                 ProcessFileDiff(src_path, content, form);
@@ -827,8 +827,8 @@ bool GenResults::GenerateCppForm(Node* form, bool comparison_only, wxProgressDia
             }
             any_updated = true;
 
-            // Capture detailed diff information if file exists on disk
-            if (hdr_result == code::write_needed && hdr_path.file_exists())
+            // Capture detailed diff information, including for newly-created files
+            if (hdr_result == code::write_needed)
             {
                 auto content = std::make_shared<std::string>(hdr_cw->GetString());
                 ProcessFileDiff(hdr_path, content, form);
@@ -881,8 +881,8 @@ bool GenResults::GenerateCppForm(Node* form, bool comparison_only, wxProgressDia
             }
             any_updated = true;
 
-            // Capture detailed diff information if file exists on disk
-            if (src_result == code::write_needed && src_path.file_exists())
+            // Capture detailed diff information, including for newly-created files
+            if (src_result == code::write_needed)
             {
                 auto content = std::make_shared<std::string>(src_cw->GetString());
                 ProcessFileDiff(src_path, content, form);
@@ -1153,6 +1153,8 @@ bool GenResults::GenerateCombinedXrcFile(bool comparison_only)
         if (!file_existed)
         {
             m_created_files.emplace_back(output_path);
+            auto content = std::make_shared<std::string>(xml_content);
+            ProcessFileDiff(output_path, content, nullptr);
             return true;
         }
 
@@ -1273,11 +1275,15 @@ void GenResults::ProcessFileDiff(wxue::string path, std::shared_ptr<std::string>
                            return file_diff;
                        }
 
+                       // If the file doesn't exist on disk (e.g. the output file was just
+                       // given a new name), leave disk_content empty so it is treated as a
+                       // new file. Diff::Compare will then report every generated line as added.
+                       // Do not attempt to open a missing file: wxFile::Open logs a system error
+                       // when opening fails, which would popup an unwanted warning during Compare.
                        wxue::ViewVector disk_content;
-                       if (!disk_content.ReadFile(std::string_view(path)))
+                       if (path.file_exists())
                        {
-                           // File doesn't exist or can't be read - skip diff
-                           return std::nullopt;
+                           std::ignore = disk_content.ReadFile(std::string_view(path));
                        }
 
                        wxue::ViewVector gen_content;

--- a/src/generate/writers/verify_codegen.cpp
+++ b/src/generate/writers/verify_codegen.cpp
@@ -141,6 +141,13 @@ namespace
             log.emplace_back(std::format("File: {}", diff.filename));
             log.emplace_back(std::string(80, '-'));
 
+            if (!diff.error_message.empty())
+            {
+                log.emplace_back(diff.error_message);
+                log.emplace_back("");
+                continue;
+            }
+
             // Write diff details from left side (original/disk)
             for (const auto& line_diff: diff.diff_result.left_lines)
             {

--- a/src/tools/compare/diff.h
+++ b/src/tools/compare/diff.h
@@ -50,6 +50,10 @@ struct FileDiff
     DiffResult diff_result;
     Node* form { nullptr };                  // The form node that generated this file
     bool is_too_large_to_display { false };  // Indicates diff is too large to process/display
+    // Set when the file exists on disk but could not be read (permissions, transient
+    // IO error, etc.). When set, no diff is available and the message should be shown
+    // instead of a misleading empty-original comparison.
+    std::string error_message;
 };
 
 class Diff

--- a/src/tools/compare/diff_viewer.cpp
+++ b/src/tools/compare/diff_viewer.cpp
@@ -199,6 +199,19 @@ void DiffViewer::DisplayDiff(size_t index)
         return;
     }
 
+    // Handle files that could not be read from disk
+    if (!diff.error_message.empty())
+    {
+        wxue::string info;
+        info << "File " << (index + 1) << " of " << m_diffs.size() << " - " << diff.error_message;
+        m_diff_info->SetLabel(info.wx());
+
+        m_original_text->AppendText(diff.error_message);
+        m_original_text->SetReadOnly(true);
+        m_modified_text->SetReadOnly(true);
+        return;
+    }
+
     // Update info text
     if (diff.diff_result.has_differences)
     {


### PR DESCRIPTION
If the user changed the name of the prop_base_file to a new name that doesn't exist, the Comparison tool was not indicating that anything changed. The PR changes that so that the entire new file is listed as a diff so that the user will know that something *will* be changed if the project is generated.